### PR TITLE
build .so that does not contain hipBLAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ if( NOT DEFINED CMAKE_C_COMPILER AND NOT DEFINED ENV{CC} )
   set( CMAKE_C_COMPILER clang )
 endif( )
 
+# Defaults for common use
+set( CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm/hipblas" CACHE STRING "Directory for packages")
+set( CMAKE_PREFIX_PATH  "/opt/rocm/rocblas" CACHE STRING "Directory to find rocBLAS")
+
 # The superbuild does not build anything itself, all compiling is done in external projects
 project( hipblas-superbuild NONE )
 
@@ -131,6 +135,8 @@ if( BUILD_LIBRARY )
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${LIBRARY_CXX_COMPILER}
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCPACK_PACKAGING_INSTALL_PREFIX=${CPACK_PACKAGING_INSTALL_PREFIX}
+    -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
   )
 
   if( DEFINED CPACK_PACKAGING_INSTALL_PREFIX )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,7 +202,7 @@ def hipblas_build_pipeline( String build_type )
 ////////////////////////////////////////////////////////////////////////
 // -- MAIN
 // This following are build nodes; start of build pipeline
-node('docker && rocm')
+node('docker && rocm && fiji')
 {
   hipblas_build_pipeline( 'Release' )
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,7 @@ def docker_upload_artifactory( String build_config, String workspace_dir_abs )
       //  We copy the docker files into the bin directory where the .deb lives so that it's a clean
       //  build everytime
       sh "cp -r ${workspace_dir_abs}/docker/* .; cp ${build_dir_abs}/library-build/*.deb ."
-      rocblas_install_image = docker.build( "${artifactory_org}/${image_name}:${env.BUILD_NUMBER}", "-f dockerfile-${image_name} ." )
+      rocblas_install_image = docker.build( "${artifactory_org}/${image_name}:${env.BUILD_NUMBER}", "-f dockerfile-${image_name} --build-arg REPO_RADEON=10.255.8.5 ." )
     }
 
     // docker.withRegistry('http://compute-artifactory:5001', 'artifactory-cred' )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ def docker_build_image(  )
   {
     dir('docker')
     {
-      build_image = docker.build( "${project}/${build_image_name}:latest", "-f ${dockerfile_name} --build-arg REPO_RADEON=10.255.8.5 ." )
+      build_image = docker.build( "${project}/${build_image_name}:latest", "-f ${dockerfile_name} ." )
     }
   }
 
@@ -137,7 +137,7 @@ def docker_upload_artifactory( String build_config, String workspace_dir_abs )
       //  We copy the docker files into the bin directory where the .deb lives so that it's a clean
       //  build everytime
       sh "cp -r ${workspace_dir_abs}/docker/* .; cp ${build_dir_abs}/library-build/*.deb ."
-      rocblas_install_image = docker.build( "${artifactory_org}/${image_name}:${env.BUILD_NUMBER}", "-f dockerfile-${image_name} --build-arg REPO_RADEON=10.255.8.5 ." )
+      rocblas_install_image = docker.build( "${artifactory_org}/${image_name}:${env.BUILD_NUMBER}", "-f dockerfile-${image_name} ." )
     }
 
     // docker.withRegistry('http://compute-artifactory:5001', 'artifactory-cred' )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ def docker_build_image(  )
   {
     dir('docker')
     {
-      build_image = docker.build( "${project}/${build_image_name}:latest", "-f ${dockerfile_name} ." )
+      build_image = docker.build( "${project}/${build_image_name}:latest", "-f ${dockerfile_name} --build-arg REPO_RADEON=10.255.8.5 ." )
     }
   }
 

--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -2,15 +2,16 @@ FROM ubuntu:16.04
 MAINTAINER Kent Knox <kent.knox@amd>
 
 ARG build_type=Release
+ARG REPO_RADEON=repo.radeon.com
 
 # Install Packages
 # RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl && \
-#     curl -sL http://packages.amd.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-#     echo 'deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
+#     curl -sL http://${REPO_RADEON}/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+#     echo 'deb [arch=amd64] http://${REPO_RADEON}/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
 #     apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl && \
-    curl -sL http://packages.amd.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-    echo 'deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
+    curl -sL http://${REPO_RADEON}/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+    echo 'deb [arch=amd64] http://${REPO_RADEON}/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     sudo \
     file \
@@ -49,7 +50,7 @@ RUN cd /usr/local/src && \
         -DCMAKE_CXX_FLAGS="-fPIC" \
         -DCMAKE_C_FLAGS="-fPIC" \
         -DBUILD_LIBRARY=ON \
-        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_SHARED_LIBS=ON \
         -DBUILD_WITH_TENSILE=ON \
         -DBUILD_CLIENTS=OFF \
         /usr/local/src/rocBLAS && \

--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -6,12 +6,13 @@ ARG REPO_RADEON=repo.radeon.com
 
 # Install Packages
 # RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl && \
-#     curl -sL http://${REPO_RADEON}/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-#     echo 'deb [arch=amd64] http://${REPO_RADEON}/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
-#     apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+#     curl -sL http://$REPO_RADEON/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+#     echo 'deb [arch=amd64] http://$REPO_RADEON/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
+#     apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends 
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl && \
-    curl -sL http://${REPO_RADEON}/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-    echo 'deb [arch=amd64] http://${REPO_RADEON}/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
+    curl -sL http://$REPO_RADEON/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+    echo 'deb [arch=amd64] http://$REPO_RADEON/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     sudo \
     file \

--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -11,8 +11,8 @@ ARG REPO_RADEON=repo.radeon.com
 #     apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends 
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl && \
-    curl -sL http://$REPO_RADEON/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-    echo 'deb [arch=amd64] http://$REPO_RADEON/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
+    curl -sL http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+    echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     sudo \
     file \

--- a/docker/dockerfile-hipblas-ubuntu-16.04
+++ b/docker/dockerfile-hipblas-ubuntu-16.04
@@ -6,8 +6,8 @@ ARG REPO_RADEON=repo.radeon.com
 
 # Initialize the image we are working with
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl && \
-    curl -sL http://$REPO_RADEON/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-    echo 'deb [arch=amd64] http://$REPO_RADEON/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
+    curl -sL http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+    echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     rocm-dev \
     && \

--- a/docker/dockerfile-hipblas-ubuntu-16.04
+++ b/docker/dockerfile-hipblas-ubuntu-16.04
@@ -1,10 +1,13 @@
 FROM ubuntu:16.04
 MAINTAINER Kent Knox <kent.knox@amd>
 
+# Parameters related to building hipblas
+ARG REPO_RADEON=repo.radeon.com
+
 # Initialize the image we are working with
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl && \
-    curl -sL http://packages.amd.com/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-    echo 'deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
+    curl -sL http://${REPO_RADEON}/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+    echo 'deb [arch=amd64] http://${REPO_RADEON}/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     rocm-dev \
     && \

--- a/docker/dockerfile-hipblas-ubuntu-16.04
+++ b/docker/dockerfile-hipblas-ubuntu-16.04
@@ -6,8 +6,8 @@ ARG REPO_RADEON=repo.radeon.com
 
 # Initialize the image we are working with
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl && \
-    curl -sL http://${REPO_RADEON}/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
-    echo 'deb [arch=amd64] http://${REPO_RADEON}/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
+    curl -sL http://$REPO_RADEON/rocm/apt/debian/rocm.gpg.key | apt-key add - && \
+    echo 'deb [arch=amd64] http://$REPO_RADEON/rocm/apt/debian/ xenial main' | tee /etc/apt/sources.list.d/rocm.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     rocm-dev \
     && \

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -114,8 +114,8 @@ set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/../LICENSE" )
 set( CPACK_SOURCE_IGNORE_FILES "/\\\\.git/" )
 
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.0.17174)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.0.17174" )
+set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.0.17174), rocblas" )
+set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.0.17174, rocblas" )
 
 if( "${CPACK_PACKAGING_INSTALL_PREFIX}" MATCHES "^/opt/rocm.*$")
     include( package-functions )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -72,7 +72,7 @@ elseif (${PLATFORM} MATCHES "nvcc")
 
   target_compile_definitions( hipblas PRIVATE __HIP_PLATFORM_NVCC__ )
   set_target_properties( hipblas PROPERTIES DEBUG_POSTFIX "-d" OUTPUT_NAME hipblas-nvcc )
-endif() # (${PLATFORM} MATCHES "hcc")
+endif() # (${PLATFORM} MATCHES "hcc" or "nvcc")
 
 target_include_directories( hipblas
   PUBLIC  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>


### PR DESCRIPTION
Build libhipblas-hcc.so from librocblas-hcc.so, not from librocblas-hcc.a and libtensile.a. With this change rocBLAS and Tensile are not included in libhipblas-hcc.so. This means that an application using hipblas will need to link to both libhipblas-hcc.so and librocblas-hcc.so.

Also add default configuration options in CMakeList.txt files for the common path. 