### PR TITLE
gemm_batched function and tests

### DIFF
--- a/clients/common/arg_check.cpp
+++ b/clients/common/arg_check.cpp
@@ -1,0 +1,19 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include <iostream>
+#include "hipblas.h"
+#include "arg_check.h"
+
+void verify_hipblas_status_invalid_value(hipblasStatus_t status, const char* message)
+{
+#ifdef GOOGLE_TEST
+    ASSERT_EQ(status, HIPBLAS_STATUS_INVALID_VALUE);
+#endif
+    if (status != HIPBLAS_STATUS_INVALID_VALUE)
+    {
+        std::cout << message << std::endl;
+    }
+}
+

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -501,6 +501,37 @@
         return hipblasDgemmStridedBatched(handle, transA, transB, m, n, k, alpha, A, lda, bsa, B, ldb, bsb, beta, C, ldc, bsc, batch_count);
     }
 
+
+    template<>
+    hipblasStatus_t hipblasGemmBatched<float>(
+        hipblasHandle_t handle,
+        hipblasOperation_t transA, hipblasOperation_t transB,
+        int m, int n, int k,
+        const float *alpha,
+        const float *A[], int lda,
+        const float *B[], int ldb,
+        const float *beta,
+        float *C[], int ldc,
+        int batch_count){
+
+        return hipblasSgemmBatched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count);
+    }
+
+    template<>
+    hipblasStatus_t hipblasGemmBatched<double>(
+        hipblasHandle_t handle,
+        hipblasOperation_t transA, hipblasOperation_t transB,
+        int m, int n, int k,
+        const double *alpha,
+        const double *A[], int lda,
+        const double *B[], int ldb,
+        const double *beta,
+        double *C[], int ldc,
+        int batch_count){
+
+        return hipblasDgemmBatched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count);
+    }
+
 /*
     template<>
     hipblasStatus_t hipblasTrsm<float>(hipblasHandle_t handle,

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -73,6 +73,7 @@ find_library( HIPBLAS_LIBRARY NAMES hipblas-hcc PATHS ${CMAKE_HIPBLAS_INSTALL_DI
 set(Tensile_TEST_SRC
     gemm_gtest.cpp
     gemm_strided_batched_gtest.cpp
+    gemm_batched_gtest.cpp
 #   trsm_gtest.cpp
     )
 #endif()
@@ -94,6 +95,7 @@ set( hipblas_benchmark_common
       ../common/flops.cpp
       ../common/norm.cpp
       ../common/unit.cpp
+      ../common/arg_check.cpp
       ../common/hipblas_template_specialization.cpp
     )
 

--- a/clients/gtest/gemm_batched_gtest.cpp
+++ b/clients/gtest/gemm_batched_gtest.cpp
@@ -7,7 +7,7 @@
 #include <math.h>
 #include <stdexcept>
 #include <vector>
-#include "testing_gemm_strided_batched.hpp"
+#include "testing_gemm_batched.hpp"
 #include "utility.h"
 
 using ::testing::TestWithParam;
@@ -16,9 +16,16 @@ using ::testing::ValuesIn;
 using ::testing::Combine;
 using namespace std;
 
+/*
+TEST(hipblas_blas3, gemm_batched_float_bad_arg)
+{
+    testing_GemmBatched_device_array<float>();
+}
+*/
+
 //only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
 
-typedef std::tuple<vector<int>, vector<double>, vector<char>, int> gemm_strided_batched_tuple;
+typedef std::tuple<vector<int>, vector<double>, vector<char>, int> gemm_batched_tuple;
 
 /* =====================================================================
 README: This file contains testers to verify the correctness of
@@ -43,11 +50,12 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 const
 vector<vector<int>> matrix_size_range = {
                                             {-1, -1, -1, -1, 1, 1},
+                                            {10, 10, 10, 10, 10, 10},
                                             {32, 32, 32, 100, 100, 100},
                                             {64, 64, 64, 128, 128, 128},
                                             {128, 128, 128, 128, 128, 128},
                             //              {500, 500, 500, 500, 600, 500},
-                                       };
+                                        };
 
 //vector of vector, each pair is a {alpha, beta};
 //add/delete this list in pairs, like {2.0, 4.0}
@@ -59,33 +67,32 @@ vector<vector<double>> alpha_beta_range = {
 
 //vector of vector, each pair is a {transA, transB};
 //add/delete this list in pairs, like {'N', 'T'}
-//for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in sgemm_strided_batched/dgemm_strided_batched,
+//for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in sgemm_batched/dgemm_batched,
 const
 vector<vector<char>> transA_transB_range = {
-                                            {'N', 'N'},
-                                            {'N', 'T'},
-                                            {'C', 'N'},
-                                            {'T', 'C'}
+                                                {'N', 'N'},
+                                                {'N', 'T'},
+                                                {'C', 'N'},
+                                                {'T', 'C'}
                                            };
 
 //number of gemms in batched gemm
 const
 vector<int> batch_count_range = {
-                                     -1,
-                                      0,
-                                      1,
-                                      2,
-                                     10,
+                                    -1,
+                                    0,
+                                    1,
+                                    2,
+                                    10,
                        //           100,
                                 };
-
 
 
 /* ===============Google Unit Test==================================================== */
 
 
 /* =====================================================================
-     BLAS-3 gemm_strided_batched:
+     BLAS-3 gemm_batched:
 =================================================================== */
 
 /* ============================Setup Arguments======================================= */
@@ -97,9 +104,8 @@ vector<int> batch_count_range = {
 //Do not use std::tuple to directly pass parameters to testers
 //by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is not intuitive and error-prone
 
-Arguments setup_gemm_strided_batched_arguments(gemm_strided_batched_tuple tup)
+Arguments setup_gemm_batched_arguments(gemm_batched_tuple tup)
 {
-
     vector<int> matrix_size = std::get<0>(tup);
     vector<double> alpha_beta = std::get<1>(tup);
     vector<char> transA_transB = std::get<2>(tup);
@@ -128,26 +134,25 @@ Arguments setup_gemm_strided_batched_arguments(gemm_strided_batched_tuple tup)
     return arg;
 }
 
-
-class gemm_strided_batched_gtest: public :: TestWithParam <gemm_strided_batched_tuple>
+class gemm_batched_gtest: public :: TestWithParam <gemm_batched_tuple>
 {
     protected:
-        gemm_strided_batched_gtest(){}
-        virtual ~gemm_strided_batched_gtest(){}
+        gemm_batched_gtest(){}
+        virtual ~gemm_batched_gtest(){}
         virtual void SetUp(){}
         virtual void TearDown(){}
 };
 
-TEST_P(gemm_strided_batched_gtest, float)
+TEST_P(gemm_batched_gtest, float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_gemm_strided_batched_arguments( GetParam() );
+    Arguments arg = setup_gemm_batched_arguments( GetParam() );
 
-    hipblasStatus_t status = testing_GemmStridedBatched<float>( arg );
+    hipblasStatus_t status = testing_GemmBatched<float>( arg );
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -175,16 +180,16 @@ TEST_P(gemm_strided_batched_gtest, float)
     }
 }
 
-TEST_P(gemm_strided_batched_gtest, double)
+TEST_P(gemm_batched_gtest, double)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_gemm_strided_batched_arguments( GetParam() );
+    Arguments arg = setup_gemm_batched_arguments( GetParam() );
 
-    hipblasStatus_t status = testing_GemmStridedBatched<double>( arg );
+    hipblasStatus_t status = testing_GemmBatched<double>( arg );
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -217,8 +222,8 @@ TEST_P(gemm_strided_batched_gtest, double)
 //ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, K, lda, ldb, ldc}, {alpha, beta}, {transA, transB}, {batch_count} }
 
-INSTANTIATE_TEST_CASE_P(hipblasGemmStridedBatched,
-                        gemm_strided_batched_gtest,
+INSTANTIATE_TEST_CASE_P(hipblasGemmBatched,
+                        gemm_batched_gtest,
                         Combine(
                                   ValuesIn(matrix_size_range), 
                                   ValuesIn(alpha_beta_range), 

--- a/clients/gtest/ger_gtest.cpp
+++ b/clients/gtest/ger_gtest.cpp
@@ -117,18 +117,16 @@ Arguments setup_ger_arguments(ger_tuple tup)
     return arg;
 }
 
-
-class ger_gtest: public :: TestWithParam <ger_tuple>
+class blas2_ger_gtest: public :: TestWithParam <ger_tuple>
 {
     protected:
-        ger_gtest(){}
-        virtual ~ger_gtest(){}
+        blas2_ger_gtest(){}
+        virtual ~blas2_ger_gtest(){}
         virtual void SetUp(){}
         virtual void TearDown(){}
 };
 
-
-TEST_P(ger_gtest, ger_gtest_float)
+TEST_P(blas2_ger_gtest, float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
@@ -156,7 +154,36 @@ TEST_P(ger_gtest, ger_gtest_float)
             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
         }
     }
+}
 
+TEST_P(blas2_ger_gtest, double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+
+    Arguments arg = setup_ger_arguments( GetParam() );
+
+    hipblasStatus_t status = testing_ger<double>( arg );
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS){
+
+        if( arg.M < 0 || arg.N < 0 ){
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.lda < arg.M){
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx <= 0){
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy <= 0){
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+    }
 }
 
 //notice we are using vector of vector
@@ -164,8 +191,8 @@ TEST_P(ger_gtest, ger_gtest_float)
 //ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda}, {incx,incy} {alpha} }
 
-INSTANTIATE_TEST_CASE_P(hipblasGer,
-                        ger_gtest,
+INSTANTIATE_TEST_CASE_P(hipblasBlas2,
+                        blas2_ger_gtest,
                         Combine(
                                   ValuesIn(matrix_size_range), ValuesIn(incx_incy_range), ValuesIn(alpha_range)
                                )

--- a/clients/include/arg_check.h
+++ b/clients/include/arg_check.h
@@ -1,0 +1,17 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+#ifndef _ARG_CHECK_H
+#define _ARG_CHECK_H
+
+#include "hipblas.h"
+
+#ifdef GOOGLE_TEST
+#include "gtest/gtest.h"
+#endif
+
+void verify_hipblas_status_invalid_value(hipblasStatus_t status, const char* message);
+
+#endif

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -142,6 +142,18 @@
         T *C, int ldc, int bsc,
         int batch_count);
 
+    template<typename T>
+    hipblasStatus_t hipblasGemmBatched(
+        hipblasHandle_t handle,
+        hipblasOperation_t transA, hipblasOperation_t transB,
+        int m, int n, int k,
+        const T *alpha,
+        const T *A[], int lda,
+        const T *B[], int ldb,
+        const T *beta,
+        T *C[], int ldc,
+        int batch_count);
+
 
     template<typename T>
     hipblasStatus_t hipblasTrsm(hipblasHandle_t handle,

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -24,7 +24,6 @@ using namespace std;
 template<typename T>
 hipblasStatus_t testing_gemm(Arguments argus)
 {
-
     int M = argus.M;
     int N = argus.N;
     int K = argus.K;

--- a/clients/include/testing_gemm_batched.hpp
+++ b/clients/include/testing_gemm_batched.hpp
@@ -1,0 +1,301 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <sys/time.h>
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+#include "hipblas.hpp"
+#include "utility.h"
+#include "cblas_interface.h"
+#include "norm.h"
+#include "unit.h"
+#include "arg_check.h"
+#include "flops.h"
+#include <typeinfo>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+#define CLEANUP()                                        \
+do {                                                     \
+    for (int i = 0; i < batch_count; i++)                \
+    {                                                    \
+        if(dA_array[i]) hipFree(dA_array[i]);            \
+        if(dB_array[i]) hipFree(dB_array[i]);            \
+        if(dC1_array[i]) hipFree(dC1_array[i]);          \
+        if(dC2_array[i]) hipFree(dC2_array[i]);          \
+                                                         \
+        if(hA_array[i]) free(hA_array[i]);               \
+        if(hB_array[i]) free(hB_array[i]);               \
+        if(hC_array[i]) free(hC_array[i]);               \
+        if(hC_copy_array[i]) free(hC_copy_array[i]);     \
+    }                                                    \
+    if (hA_array) free (hA_array);                       \
+    if (hB_array) free (hB_array);                       \
+    if (hC_array) free (hC_array);                       \
+    if (hC_copy_array) free (hC_copy_array);             \
+                                                         \
+    if (dA_array) free (dA_array);                       \
+    if (dB_array) free (dB_array);                       \
+    if (dC1_array) free (dC1_array);                     \
+    if (dC2_array) free (dC2_array);                     \
+                                                         \
+    if (dA_array_dev) hipFree (dA_array_dev);            \
+    if (dB_array_dev) hipFree (dB_array_dev);            \
+    if (dC1_array_dev) hipFree (dC1_array_dev);          \
+} while (0)
+
+template<typename T>
+hipblasStatus_t testing_GemmBatched(Arguments argus)
+{
+    int M = argus.M;
+    int N = argus.N;
+    int K = argus.K;
+
+    int lda = argus.lda;
+    int ldb = argus.ldb;
+    int ldc = argus.ldc;
+
+    T alpha = argus.alpha;
+    T beta = argus.beta;
+
+    hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
+    hipblasOperation_t transB = char2hipblas_operation(argus.transB_option);
+
+    int batch_count = argus.batch_count;
+
+    if (batch_count < 0 || M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0)
+    {
+        hipblasHandle_t handle;
+        hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+        hipblasCreate(&handle);
+
+        const T *dA_array[1], *dB_array[1];
+        T *dC1_array[1];
+
+        status = hipblasGemmBatched<T>(handle, transA, transB,
+                    M, N, K, &alpha, 
+                    dA_array, lda,
+                    dB_array, ldb, &beta, 
+                    dC1_array, ldc, batch_count);
+
+        verify_hipblas_status_invalid_value(status, 
+        "ERROR: batch_count < 0 || M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0 ");
+
+        return status;
+    }
+
+    T rocblas_error = 0.0;
+
+    double gpu_time_used, cpu_time_used;
+    double hipblasGflops, cblas_gflops;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    int  A_row, A_col, B_row, B_col;
+
+    if(transA == HIPBLAS_OP_N)
+    {
+        A_row =  M; A_col = K;
+    }
+    else
+    {
+        A_row = K; A_col = M;
+    }
+
+    if(transB == HIPBLAS_OP_N)
+    {
+        B_row =  K; B_col = N;
+    }
+    else
+    {
+        B_row = N; B_col = K;
+    }
+
+    if (lda < A_row || ldb < B_row || ldc < M)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+
+    int A_mat_size = A_col * lda;
+    int B_mat_size = B_col * ldb;
+    int C_mat_size = N * ldc;
+
+    // malloc arrays of pointers-to-host on host
+    T **hA_array =(T **)malloc(batch_count * sizeof(*hA_array));
+    T **hB_array =(T **)malloc(batch_count * sizeof(*hB_array));
+    T **hC_array =(T **)malloc(batch_count * sizeof(*hC_array));
+    T **hC_copy_array =(T **)malloc(batch_count * sizeof(*hC_copy_array));
+
+    // malloc arrays of pointers-to-device on host
+    T **dA_array =(T **)malloc(batch_count * sizeof(*dA_array));
+    T **dB_array =(T **)malloc(batch_count * sizeof(*dB_array));
+    T **dC1_array =(T **)malloc(batch_count * sizeof(*dC1_array));
+    T **dC2_array =(T **)malloc(batch_count * sizeof(*dC2_array));
+
+    // Arrays of pointers-to-device on device
+    T **dA_array_dev = NULL, **dB_array_dev = NULL, **dC1_array_dev = NULL;
+
+    if ((!hA_array) || (!hB_array) || (!hC_array) || (!hC_copy_array) ||
+            (!dA_array) || (!dB_array) || (!dC1_array) || (!dC2_array)) 
+    {
+        CLEANUP();
+        std::cerr << "malloc error" << std::endl;
+    }
+
+    // malloc arrays of pointers-to-device on device
+    hipError_t err_A, err_B, err_C;
+    err_A = hipMalloc((void **)&dA_array_dev, batch_count * sizeof(*dA_array));
+    err_B = hipMalloc((void **)&dB_array_dev, batch_count * sizeof(*dB_array));
+    err_C = hipMalloc((void **)&dC1_array_dev, batch_count * sizeof(*dC1_array));
+
+    if ((err_A != hipSuccess) || (err_B != hipSuccess) || (err_C != hipSuccess))
+    {
+        CLEANUP();
+        std::cerr << "hipMalloc error" << std::endl;
+    }
+
+    srand(1);
+    for (int i = 0; i < batch_count ; i++)
+    {   
+        // malloc matrices on host
+        hA_array[i] = (T *) malloc(A_mat_size * sizeof(hA_array[0][0]));
+        hB_array[i] = (T *) malloc(B_mat_size * sizeof(hB_array[0][0]));
+        hC_array[i] = (T *) malloc(C_mat_size * sizeof(hC_array[0][0]));
+        hC_copy_array[i] = (T *) malloc(C_mat_size * sizeof(hC_copy_array[0][0]));
+
+        if ((!hA_array[i]) || (!hB_array[i]) || (!hC_array[i]) || (!hC_copy_array[i]))
+        {
+            CLEANUP();
+            std::cerr << "hX_array[i] malloc error" << std::endl;
+        }
+
+        // malloc matrices on device
+        err_A = hipMalloc((void **)&dA_array[i], A_mat_size * sizeof(dA_array[0][0]));
+        err_B = hipMalloc((void **)&dB_array[i], B_mat_size * sizeof(dB_array[0][0]));
+        err_C = hipMalloc((void **)&dC1_array[i], C_mat_size * sizeof(dC1_array[0][0]));
+        err_C = hipMalloc((void **)&dC2_array[i], C_mat_size * sizeof(dC2_array[0][0]));
+
+        if ((err_A != hipSuccess) || (err_B != hipSuccess) || (err_C != hipSuccess))
+        {
+            CLEANUP();
+            std::cerr << "dX_array[i] hipMalloc error" << std::endl;
+        }
+
+        // initialize matrices on host
+        srand(1);
+        hipblas_init<T>(hA_array[i], A_row, A_col, lda);
+        hipblas_init<T>(hB_array[i], B_row, B_col, ldb);
+        hipblas_init<T>(hC_array[i], M, N, ldc);
+
+        for (int i1 = 0; i1 < M; i1++)
+        {
+            for (int i2 = 0; i2 < N; i2++)
+            {
+                hC_copy_array[i][i1+i2*ldc] = hC_array[i][i1+i2*ldc];
+            }
+        }
+
+        // copy initialized matrices from host to device
+        err_A = hipMemcpy(dA_array[i], hA_array[i], sizeof(T)*A_mat_size,  hipMemcpyHostToDevice);
+        err_B = hipMemcpy(dB_array[i], hB_array[i], sizeof(T)*B_mat_size,  hipMemcpyHostToDevice);
+        err_C = hipMemcpy(dC1_array[i], hC_array[i], sizeof(T)*C_mat_size,  hipMemcpyHostToDevice);
+        err_C = hipMemcpy(dC2_array[i], hC_array[i], sizeof(T)*C_mat_size,  hipMemcpyHostToDevice);
+
+        if ((err_A != hipSuccess) || (err_A != hipSuccess) || (err_A != hipSuccess))
+        {
+            CLEANUP();
+            std::cerr << "dX_array[i] hipMemcpy error" << std::endl;
+        }
+    }
+    
+    // copy array of pointers-to-device from host to device
+    err_A = hipMemcpy(dA_array_dev, dA_array, batch_count * sizeof(*dA_array), hipMemcpyHostToDevice);
+    err_B = hipMemcpy(dB_array_dev, dB_array, batch_count * sizeof(*dB_array), hipMemcpyHostToDevice);
+    err_C = hipMemcpy(dC1_array_dev, dC1_array, batch_count * sizeof(*dC1_array), hipMemcpyHostToDevice);
+    if ((err_A != hipSuccess) || (err_B != hipSuccess) || (err_C != hipSuccess))
+    {
+        CLEANUP();
+        std::cerr << "dX_array[i] hipMemcpy error" << std::endl;
+    }
+
+    // calculate "golden" result on CPU
+    for (int i=0; i < batch_count; i++)
+    {
+        cblas_gemm<T>(
+                 transA, transB, 
+                 M, N, K,
+                 alpha, 
+                 hA_array[i], lda,
+                 hB_array[i], ldb,
+                 beta, 
+                 hC_copy_array[i], ldc);
+    }
+
+    // test hipBLAS batched gemm with array on host
+    {
+        status = hipblasGemmBatched<T>(handle, 
+                        transA, transB,
+                        M, N, K, 
+                        &alpha, 
+                        (const T**) dA_array, lda,
+                        (const T**) dB_array, ldb, 
+                        &beta, 
+                        dC2_array, ldc, batch_count);
+
+        for (int i = 0; i < batch_count; i++)
+        {   
+            // copy result matrices from device to host
+            err_C = hipMemcpy(hC_array[i], dC2_array[i], sizeof(T)*C_mat_size,  hipMemcpyDeviceToHost);
+
+            if (err_C != hipSuccess)
+            {
+                CLEANUP();
+                std::cerr << "dX_array[i] hipMemcpy error" << std::endl;
+            }
+
+            // check hipBLAS result against "golden" result
+            unit_check_general<T>(M, N, lda, hC_copy_array[i], hC_array[i]);
+        }
+    }
+
+    // test hipBLAS batched gemm with array on device
+    {
+        status = hipblasGemmBatched<T>(handle, 
+                        transA, transB,
+                        M, N, K, 
+                        &alpha, 
+                        (const T**) dA_array_dev, lda,
+                        (const T**) dB_array_dev, ldb, 
+                        &beta, 
+                        dC1_array_dev, ldc, batch_count);
+
+        for (int i = 0; i < batch_count; i++)
+        {   
+            // copy result matrices from device to host
+            err_C = hipMemcpy(hC_array[i], dC1_array[i], sizeof(T)*C_mat_size,  hipMemcpyDeviceToHost);
+
+            if (err_C != hipSuccess)
+            {
+                CLEANUP();
+                std::cerr << "dX_array[i] hipMemcpy error" << std::endl;
+            }
+
+            // check hipBLAS result against "golden" result
+            unit_check_general<T>(M, N, lda, hC_copy_array[i], hC_array[i]);
+        }
+    }
+
+    CLEANUP();
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -69,6 +69,7 @@ hipblasStatus_t testing_GemmStridedBatched(Arguments argus)
         B_row = N; B_col = K;
     }
 
+    // test where bsa != lda*A_col, also test with bsc = ldc * N
     bsa = lda * A_col * 2; bsb = ldb * B_col * 2; bsc = ldc * N;
     A_size = bsa * batch_count;
     B_size = bsb * batch_count;

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -63,6 +63,14 @@ using namespace std;
             }
         }
     };
+    template<typename T>
+    void hipblas_init(T* A, int M, int N, int lda){
+        for (int i = 0; i < M; ++i){
+            for (int j = 0; j < N; ++j){
+                A[i+j*lda] = random_generator<T>();
+            }
+        }
+    };
 
     /*! \brief  symmetric matrix initialization: */
     // for real matrix only

--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -40,21 +40,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
 RUN useradd --create-home -u 1000 -G sudo --shell /bin/bash jenkins && \
     echo '%sudo   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
 
-# Build static version of rocBLAS with -fPIC enabled
-RUN cd /usr/local/src && \
-    git clone --depth 1 -b develop https://github.com/RadeonOpenCompute/rocBLAS.git && \
-    mkdir -p rocBLAS/build && \
-    cd rocBLAS/build && \
-    cmake \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DCMAKE_BUILD_TYPE=${build_type} \
-        -DCMAKE_CXX_FLAGS="-fPIC" \
-        -DCMAKE_C_FLAGS="-fPIC" \
-        -DBUILD_LIBRARY=ON \
-        -DBUILD_SHARED_LIBS=ON \
-        -DBUILD_WITH_TENSILE=ON \
-        -DBUILD_CLIENTS=OFF \
-        /usr/local/src/rocBLAS && \
-    make -j $(nproc) && \
-    cd library-build && \
-    make install
+# Build and install rocBLAS with -fPIC enabled
+ARG ROCBLAS_SRC_ROOT=/usr/local/src/rocBLAS
+
+# Clone rocblas repo
+RUN mkdir -p ${ROCBLAS_SRC_ROOT} && cd ${ROCBLAS_SRC_ROOT} && \
+    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocBLAS . && \
+
+# Build library; build package and install from package so ldconfig is updated
+    mkdir ${ROCBLAS_SRC_ROOT}/build && \
+    cd ${ROCBLAS_SRC_ROOT}/build && \
+    CXX=/opt/rocm/bin/hcc cmake ${ROCBLAS_SRC_ROOT} && \
+    make -j $(nproc) package && \
+    dpkg -i *.deb

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -167,9 +167,23 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasSgemmStridedBatched(hipblasHandle_t handle
 HIPBLAS_EXPORT hipblasStatus_t hipblasDgemmStridedBatched(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t transb,
         int m, int n, int k,  const double *alpha, const double *A, int lda, long long bsa, const double *B, int ldb, long long bsb, const double *beta, double *C, int ldc, long long bsc, int batchCount);
 
+HIPBLAS_EXPORT hipblasStatus_t hipblasSgemmBatched(hipblasHandle_t handle,
+hipblasOperation_t transa, hipblasOperation_t transb,
+int m, int n, int k,  const float *alpha,
+const float * const A[], int lda,
+const float * const B[], int ldb,
+const float *beta,
+float * const C[], int ldc, int batchCount) __attribute__((deprecated("low performance implementation", "hipblasSgemmStridedBatched")));
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDgemmBatched(hipblasHandle_t handle,
+hipblasOperation_t transa, hipblasOperation_t transb,
+int m, int n, int k,  const double *alpha,
+const double * const A[], int lda,
+const double * const B[], int ldb,
+const double *beta,
+double * const C[], int ldc, int batchCount) __attribute__((deprecated("low performance implementation", "hipblasDgemmStridedBatched")));
 
 #ifdef __cplusplus
 }
 #endif
-
 #endif


### PR DESCRIPTION
- add low performance implementation of hipblasGemmBatched. It calls hipblasGemm batch_count times.
- To get a performance improvement, hipblasGemmStridedBatched should be used in place of hipblasGemmBatched. 