### PR TITLE
Jenkins fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ def docker_build_image( docker_data docker_args, project_paths paths )
 ////////////////////////////////////////////////////////////////////////
 // This encapsulates the cmake configure, build and package commands
 // Leverages docker containers to encapsulate the build in a fixed environment
-def docker_build_inside_image( def build_image, compiler_data compiler_args, docker_data docker_args, project_paths paths )
+Boolean docker_build_inside_image( def build_image, compiler_data compiler_args, docker_data docker_args, project_paths paths )
 {
   // Construct a relative path from build directory to src directory; used to invoke cmake
   String rel_path_to_src = g_relativize( pwd( ), paths.project_src_prefix, paths.project_build_prefix )
@@ -157,61 +157,82 @@ def docker_build_inside_image( def build_image, compiler_data compiler_args, doc
     build_type_postfix = "-d"
   }
 
+  // For the nvidia path, we somewhat arbitrarily choose to use the hcc-ctu rocblas package
+  String rocblas_archive_path=compiler_args.compiler_name;
+  if( rocblas_archive_path.toLowerCase( ).startsWith( 'nvcc-' ) )
+  {
+    rocblas_archive_path='hcc-ctu'
+  }
+
   // This invokes 'copy artifact plugin' to copy latest archive from rocblas project
-  step([$class: 'CopyArtifact', filter: 'archive/**/*.deb',
-    fingerprintArtifacts: true, projectName: 'ROCm-Developer-Tools/rocBLAS/develop', flatten: true,
-    selector: [$class: 'TriggeredBuildSelector', allowUpstreamDependencies: false, fallbackToLastSuccessful: false, upstreamFilterStrategy: 'UseGlobalSetting'],
+  step([$class: 'CopyArtifact', filter: "Release/${rocblas_archive_path}/*.deb",
+    fingerprintArtifacts: true, projectName: 'ROCmSoftwarePlatform/rocBLAS/develop', flatten: true,
+    selector: [$class: 'StatusBuildSelector', stable: false],
     target: '.' ])
 
   build_image.inside( docker_args.docker_run_args )
   {
-      withEnv(["CXX=${compiler_args.compiler_path}", 'CLICOLOR_FORCE=1'])
-      {
-        // Build library & clients
-        sh  """#!/usr/bin/env bash
-            set -x
-            dpkg -i rocblas-*.deb
-            rm -rf ${paths.project_build_prefix} && mkdir -p ${paths.project_build_prefix} && cd ${paths.project_build_prefix}
-            cmake -DBUILD_CLIENTS_TESTS=ON ${rel_path_to_src}
-            make -j \$(nproc)
-          """
-      }
-
-    stage( "Test ${compiler_args.compiler_name} ${compiler_args.build_config}" )
+    withEnv(["CXX=${compiler_args.compiler_path}", 'CLICOLOR_FORCE=1'])
     {
-      // Cap the maximum amount of testing to be a few hours; assume failure if the time limit is hit
-      timeout(time: 1, unit: 'HOURS')
-      {
-        sh """#!/usr/bin/env bash
-              set -x
-              cd ${paths.project_build_prefix}/clients/staging
-              ./hipblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes
-          """
-        junit "${paths.project_build_prefix}/clients/staging/*.xml"
-      }
-
-      String docker_context = "${compiler_args.build_config}/${compiler_args.compiler_name}"
-      if( compiler_args.compiler_name.toLowerCase( ).startsWith( 'hcc-' ) )
-      {
-        sh  """#!/usr/bin/env bash
-            set -x
-            cd ${paths.project_build_prefix}
-            make package
-          """
-
-        sh  """#!/usr/bin/env bash
-            set -x
-            rm -rf ${docker_context} && mkdir -p ${docker_context}
-            mv ${paths.project_build_prefix}/*.deb ${docker_context}
-            dpkg -c ${docker_context}/*.deb
+      // Build library & clients
+      sh  """#!/usr/bin/env bash
+          set -x
+          sudo dpkg -i rocblas-*.deb
+          rm -rf ${paths.project_build_prefix} && mkdir -p ${paths.project_build_prefix} && cd ${paths.project_build_prefix}
+          cmake -DBUILD_CLIENTS_TESTS=ON ${rel_path_to_src}
+          make -j \$(nproc)
         """
+    }
 
-        archiveArtifacts artifacts: "${docker_context}/*.deb", fingerprint: true
+    try
+    {
+      stage( "Test ${compiler_args.compiler_name} ${compiler_args.build_config}" )
+      {
+        // Cap the maximum amount of testing to be a few hours; assume failure if the time limit is hit
+        timeout(time: 1, unit: 'HOURS')
+        {
+          sh """#!/usr/bin/env bash
+                set -x
+                cd ${paths.project_build_prefix}/clients/staging
+                ./hipblas-test${build_type_postfix} --gtest_output=xml --gtest_color=yes
+            """
+          junit "${paths.project_build_prefix}/clients/staging/*.xml"
+        }
+
+        String docker_context = "${compiler_args.build_config}/${compiler_args.compiler_name}"
+        if( compiler_args.compiler_name.toLowerCase( ).startsWith( 'hcc-' ) )
+        {
+          sh  """#!/usr/bin/env bash
+              set -x
+              cd ${paths.project_build_prefix}
+              make package
+            """
+
+          sh  """#!/usr/bin/env bash
+              set -x
+              rm -rf ${docker_context} && mkdir -p ${docker_context}
+              mv ${paths.project_build_prefix}/*.deb ${docker_context}
+              dpkg -c ${docker_context}/*.deb
+          """
+
+          archiveArtifacts artifacts: "${docker_context}/*.deb", fingerprint: true
+        }
       }
+    }
+    catch( err )
+    {
+      // There are failures using the cuda stack, which we believe that we can
+      // safely ignore in the future with a gtest filter
+      if( compiler_args.compiler_name.toLowerCase( ).startsWith( 'nvcc-' ) )
+      {
+        printf "\033[31m nvcc unit test error: ${err}\033[0m"
+        currentBuild.result = 'UNSTABLE'
+      }
+      return false
     }
   }
 
-  return void
+  return true
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -227,7 +248,11 @@ String docker_upload_artifactory( compiler_data compiler_args, docker_data docke
   stage( "Artifactory ${compiler_args.compiler_name} ${compiler_args.build_config}" )
   {
     //  We copy the docker files into the bin directory where the .deb lives so that it's a clean build everytime
-    sh "cp -r ${hipblas_paths.project_src_prefix}/docker/* ${docker_context}"
+    sh  """#!/usr/bin/env bash
+        set -x
+        mkdir -p ${docker_context}
+        cp -r ${hipblas_paths.project_src_prefix}/docker/* ${docker_context}
+      """
 
     // Docker 17.05 introduced the ability to use ARG values in FROM statements
     // Docker inspect failing on FROM statements with ARG https://issues.jenkins-ci.org/browse/JENKINS-44836
@@ -413,6 +438,8 @@ def build_pipeline( compiler_data compiler_args, docker_data docker_args, projec
 {
   ansiColor( 'vga' )
   {
+    def build_succeeded = false;
+
     stage( "Build ${compiler_args.compiler_name} ${compiler_args.build_config}" )
     {
       // Checkout source code, dependencies and version files
@@ -428,19 +455,22 @@ def build_pipeline( compiler_data compiler_args, docker_data docker_args, projec
       hipblas_build_image.inside( docker_args.docker_run_args, docker_inside_closure )
 
       // Build hipblas inside of the build environment
-      docker_build_inside_image( hipblas_build_image, compiler_args, docker_args, hipblas_paths )
+      build_succeeded = docker_build_inside_image( hipblas_build_image, compiler_args, docker_args, hipblas_paths )
     }
 
     // After a successful build, upload a docker image of the results
-    String job_name = env.JOB_NAME.toLowerCase( )
-    String hipblas_image_name = docker_upload_artifactory( compiler_args, docker_args, hipblas_paths, job_name )
+    if( build_succeeded == true )
+    {
+      String job_name = env.JOB_NAME.toLowerCase( )
+      String hipblas_image_name = docker_upload_artifactory( compiler_args, docker_args, hipblas_paths, job_name )
 
-    // if( params.push_image_to_docker_hub )
-    // {
-    //   docker_upload_dockerhub( job_name, hipblas_image_name, 'rocm' )
-    //   docker_clean_images( 'rocm', hipblas_image_name )
-    // }
-    docker_clean_images( job_name, hipblas_image_name )
+      // if( params.push_image_to_docker_hub )
+      // {
+      //   docker_upload_dockerhub( job_name, hipblas_image_name, 'rocm' )
+      //   docker_clean_images( 'rocm', hipblas_image_name )
+      // }
+      docker_clean_images( job_name, hipblas_image_name )
+    }
   }
 }
 
@@ -516,7 +546,7 @@ nvcc:
     def hcc_docker_args = new docker_data(
         from_image:'nvidia/cuda:8.0-devel',
         build_docker_file:'dockerfile-build-nvidia-cuda-8',
-        install_docker_file:'dockerfile-hipblas-nvidia-cuda-8'
+        install_docker_file:'dockerfile-hipblas-nvidia-cuda-8',
         docker_run_args:'--device=/dev/nvidiactl --device=/dev/nvidia0 --device=/dev/nvidia-uvm --device=/dev/nvidia-uvm-tools --volume-driver=nvidia-docker --volume=nvidia_driver_375.74:/usr/local/nvidia:ro',
         docker_build_args:' --pull' )
 

--- a/docker/dockerfile-install-hip-hcc-ctu-ubuntu-16.04
+++ b/docker/dockerfile-install-hip-hcc-ctu-ubuntu-16.04
@@ -13,7 +13,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     && rm -f /tmp/*.deb \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && printf "cat /etc/ld.so.conf.d/hipblas-dev.conf\n" && cat /etc/ld.so.conf.d/hipblas-dev.conf \
+    && printf "ls -la /etc/ld.so.conf.d/\n" && ls -la /etc/ld.so.conf.d/ \
     && printf "ls -la /opt/rocm/include\n" && ls -la /opt/rocm/include \
     && printf "ls -la /opt/rocm/lib\n" && ls -la /opt/rocm/lib \
     && printf "ls -la /opt/rocm/lib/cmake\n" && ls -la /opt/rocm/lib/cmake \

--- a/docker/dockerfile-install-nvidia-cuda-8
+++ b/docker/dockerfile-install-nvidia-cuda-8
@@ -1,0 +1,5 @@
+# Parameters related to building rocblas
+ARG base_image
+
+FROM ${base_image}
+LABEL maintainer="kent.knox@amd"

--- a/docker/dockerfile-install-rocm-terminal
+++ b/docker/dockerfile-install-rocm-terminal
@@ -13,7 +13,7 @@ RUN sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -
     && sudo rm -f /tmp/*.deb \
     && sudo apt-get clean \
     && sudo rm -rf /var/lib/apt/lists/* \
-    && printf "cat /etc/ld.so.conf.d/hipblas-dev.conf\n" && cat /etc/ld.so.conf.d/hipblas-dev.conf \
+    && printf "ls -la /etc/ld.so.conf.d/\n" && ls -la /etc/ld.so.conf.d/ \
     && printf "ls -la /opt/rocm/include\n" && ls -la /opt/rocm/include \
     && printf "ls -la /opt/rocm/lib\n" && ls -la /opt/rocm/lib \
     && printf "ls -la /opt/rocm/lib/cmake\n" && ls -la /opt/rocm/lib/cmake \


### PR DESCRIPTION
This enables jenkins to build on 3 platforms
- hcc-ctu (build with latest commits)
- hcc-rocm (released stack)
- cuda

The build will look like it fails, because of known failures on the cuda side.  All unit tests pass on the rocm side.  