### PR TITLE
Remove library suffix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -212,10 +212,12 @@ Boolean docker_build_inside_image( def build_image, compiler_data compiler_args,
               set -x
               rm -rf ${docker_context} && mkdir -p ${docker_context}
               mv ${paths.project_build_prefix}/*.deb ${docker_context}
+              mv ${paths.project_build_prefix}/*.rpm ${docker_context}
               dpkg -c ${docker_context}/*.deb
           """
 
           archiveArtifacts artifacts: "${docker_context}/*.deb", fingerprint: true
+          archiveArtifacts artifacts: "${docker_context}/*.rpm", fingerprint: true
         }
       }
     }

--- a/docker/dockerfile-build-hip-hcc-ctu-ubuntu-16.04
+++ b/docker/dockerfile-build-hip-hcc-ctu-ubuntu-16.04
@@ -23,6 +23,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     pkg-config \
     gfortran \
     libboost-program-options-dev \
+    rpm \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/dockerfile-build-rocm-terminal
+++ b/docker/dockerfile-build-rocm-terminal
@@ -22,6 +22,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     pkg-config \
     gfortran \
     libboost-program-options-dev \
+    rpm \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -63,8 +63,15 @@ set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.0.17174)" )
 set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.0.17174" )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
+# Give hipblas compiled for CUDA backend a different name
+if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
+    set( package_name hipblas )
+else( )
+    set( package_name hipblas-alt )
+endif( )
+
 rocm_create_package(
-    NAME hipblas
+    NAME ${package_name}
     DESCRIPTION "Radeon Open Compute BLAS marshelling library"
     MAINTAINER "Kent Knox <kent.knox@amd.com>"
     LDCONFIG

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -52,7 +52,7 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
     target_link_libraries( hipblas PRIVATE --amdgpu-target=${target} )
   endforeach( )
 
-  set_target_properties( hipblas PROPERTIES DEBUG_POSTFIX "-d" OUTPUT_NAME hipblas-hcc )
+  set_target_properties( hipblas PROPERTIES DEBUG_POSTFIX "-d" )
 else( )
   # If HiP is not installed in default path, user can append to CMAKE_MODULE_PATH
   list( APPEND CMAKE_MODULE_PATH /opt/rocm/hip/cmake )
@@ -76,7 +76,7 @@ else( )
       )
 
   target_compile_definitions( hipblas PUBLIC __HIP_PLATFORM_NVCC__ )
-  set_target_properties( hipblas PROPERTIES DEBUG_POSTFIX "-d" OUTPUT_NAME hipblas-nvcc )
+  set_target_properties( hipblas PROPERTIES DEBUG_POSTFIX "-d" )
 endif( )
 
 target_include_directories( hipblas


### PR DESCRIPTION
- Removing library suffixes, giving cuda builds different package names
- Build both .deb & .rpm's