### PR TITLE
remove complex and half functions from API

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -88,32 +88,39 @@ HIPBLAS_EXPORT hipblasStatus_t  hipblasSasum(hipblasHandle_t handle, int n, cons
 
 HIPBLAS_EXPORT hipblasStatus_t  hipblasDasum(hipblasHandle_t handle, int n, const double *x, int incx, double *result);
 
+/* not implemented
 HIPBLAS_EXPORT hipblasStatus_t  hipblasSasumBatched(hipblasHandle_t handle, int n, float *x, int incx, float  *result, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t  hipblasDasumBatched(hipblasHandle_t handle, int n, double *x, int incx, double *result, int batchCount);
+*/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSaxpy(hipblasHandle_t handle, int n, const float *alpha,   const float *x, int incx, float *y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDaxpy(hipblasHandle_t handle, int n, const double *alpha,   const double *x, int incx, double *y, int incy) ;
 
+/* not implemented
 HIPBLAS_EXPORT hipblasStatus_t hipblasSaxpyBatched(hipblasHandle_t handle, int n, const float *alpha, const float *x, int incx,  float *y, int incy, int batchCount);
+*/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScopy(hipblasHandle_t handle, int n, const float *x, int incx, float *y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDcopy(hipblasHandle_t handle, int n, const double *x, int incx, double *y, int incy);
 
+/* not implemented
 HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float *x, int incx, float *y, int incy, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double *x, int incx, double *y, int incy, int batchCount);
-
+*/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSdot (hipblasHandle_t handle, int n, const float *x, int incx, const float *y, int incy, float *result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDdot (hipblasHandle_t handle, int n, const double *x, int incx, const double *y, int incy, double *result);
 
+/*
 HIPBLAS_EXPORT hipblasStatus_t hipblasSdotBatched (hipblasHandle_t handle, int n, const float *x, int incx, const float *y, int incy, float *result, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDdotBatched (hipblasHandle_t handle, int n, const double *x, int incx, const double *y, int incy, double *result, int batchCount);
+*/
 
 HIPBLAS_EXPORT hipblasStatus_t  hipblasSscal(hipblasHandle_t handle, int n, const float *alpha,  float *x, int incx);
 
@@ -125,9 +132,11 @@ hipblasStatus_t  hipblasCscal(hipblasHandle_t handle, int n, const hipComplex *a
 hipblasStatus_t  hipblasZscal(hipblasHandle_t handle, int n, const hipDoubleComplex *alpha,  hipDoubleComplex *x, int incx);
 */
 
+/* not implemented
 HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float *alpha,  float *x, int incx, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double *alpha,  double *x, int incx, int batchCount);
+*/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgemv(hipblasHandle_t handle, hipblasOperation_t trans, int m, int n, const float *alpha, const float *A, int lda,
                            const float *x, int incx,  const float *beta,  float *y, int incy);
@@ -135,14 +144,18 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasSgemv(hipblasHandle_t handle, hipblasOpera
 HIPBLAS_EXPORT hipblasStatus_t hipblasDgemv(hipblasHandle_t handle, hipblasOperation_t trans, int m, int n, const double *alpha, const double *A, int lda,
                            const double *x, int incx,  const double *beta,  double *y, int incy);
 
+/* not implemented
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgemvBatched(hipblasHandle_t handle, hipblasOperation_t trans, int m, int n, const float *alpha, float *A, int lda,
                            float *x, int incx,  const float *beta,  float *y, int incy, int batchCount);
+*/
 
 HIPBLAS_EXPORT hipblasStatus_t  hipblasSger(hipblasHandle_t handle, int m, int n, const float *alpha, const float *x, int incx, const float *y, int incy, float *A, int lda);
 
 HIPBLAS_EXPORT hipblasStatus_t  hipblasDger(hipblasHandle_t handle, int m, int n, const double *alpha, const double *x, int incx, const double *y, int incy, double *A, int lda);
 
+/* not implemented
 HIPBLAS_EXPORT hipblasStatus_t  hipblasSgerBatched(hipblasHandle_t handle, int m, int n, const float *alpha, const float *x, int incx, const float *y, int incy, float *A, int lda, int batchCount);
+*/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgemm(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t transb,
                            int m, int n, int k,  const float *alpha, const float *A, int lda, const float *B, int ldb, const float *beta, float *C, int ldc);

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -164,10 +164,11 @@ hipblasStatus_t  hipblasDasum(hipblasHandle_t handle, int n, const double *x, in
 	return rocBLASStatusToHIPStatus(rocblas_dasum((rocblas_handle)handle, n, const_cast<double*>(x), incx, result));
 }
 
+/* not implemented
 hipblasStatus_t  hipblasSasumBatched(hipblasHandle_t handle, int n, float *x, int incx, float  *result, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
 
 hipblasStatus_t  hipblasDasumBatched(hipblasHandle_t handle, int n, double *x, int incx, double *result, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
-
+*/
 
 hipblasStatus_t hipblasSaxpy(hipblasHandle_t handle, int n, const float *alpha,   const float *x, int incx, float *y, int incy) {
 	return rocBLASStatusToHIPStatus(rocblas_saxpy((rocblas_handle)handle, n, alpha, x, incx, y, incy));
@@ -177,8 +178,9 @@ hipblasStatus_t hipblasDaxpy(hipblasHandle_t handle, int n, const double *alpha,
 	return rocBLASStatusToHIPStatus(rocblas_daxpy((rocblas_handle)handle, n, alpha, x, incx, y, incy));
 }
 
+/* not implemented
 hipblasStatus_t hipblasSaxpyBatched(hipblasHandle_t handle, int n, const float *alpha, const float *x, int incx,  float *y, int incy, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
-
+*/
 
 hipblasStatus_t hipblasScopy(hipblasHandle_t handle, int n, const float *x, int incx, float *y, int incy){
 	return rocBLASStatusToHIPStatus(rocblas_scopy((rocblas_handle)handle, n, x, incx, y, incy));
@@ -188,9 +190,11 @@ hipblasStatus_t hipblasDcopy(hipblasHandle_t handle, int n, const double *x, int
 	return rocBLASStatusToHIPStatus(rocblas_dcopy((rocblas_handle)handle, n, x, incx, y, incy));
 }
 
+/* not implemented
 hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float *x, int incx, float *y, int incy, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
 
 hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double *x, int incx, double *y, int incy, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+*/
 
 
 hipblasStatus_t hipblasSdot (hipblasHandle_t handle, int n, const float *x, int incx, const float *y, int incy, float *result){
@@ -201,9 +205,11 @@ hipblasStatus_t hipblasDdot (hipblasHandle_t handle, int n, const double *x, int
 	return rocBLASStatusToHIPStatus(rocblas_ddot((rocblas_handle)handle, n, x, incx, y, incy, result));
 }
 
+/* not implemented
 hipblasStatus_t hipblasSdotBatched (hipblasHandle_t handle, int n, const float *x, int incx, const float *y, int incy, float *result, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
 
 hipblasStatus_t hipblasDdotBatched (hipblasHandle_t handle, int n, const double *x, int incx, const double *y, int incy, double *result, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+*/
 
 hipblasStatus_t  hipblasSscal(hipblasHandle_t handle, int n, const float *alpha,  float *x, int incx){
 	return rocBLASStatusToHIPStatus(rocblas_sscal((rocblas_handle)handle, n, alpha, x, incx));
@@ -223,9 +229,11 @@ hipblasStatus_t  hipblasZscal(hipblasHandle_t handle, int n, const hipDoubleComp
 }
 */
 
+/* not implemented
 hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float *alpha,  float *x, int incx, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
 
 hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double *alpha,  double *x, int incx, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+*/
 
 hipblasStatus_t hipblasSgemv(hipblasHandle_t handle, hipblasOperation_t trans, int m, int n, const float *alpha, const float *A, int lda,
                            const float *x, int incx,  const float *beta,  float *y, int incy){
@@ -239,8 +247,10 @@ hipblasStatus_t hipblasDgemv(hipblasHandle_t handle, hipblasOperation_t trans, i
 	return rocBLASStatusToHIPStatus(rocblas_dgemv((rocblas_handle)handle, hipOperationToHCCOperation(trans), m, n, alpha, const_cast<double*>(A), lda, const_cast<double*>(x), incx, beta, y, incy));
 }
 
+/* not implemented
 hipblasStatus_t hipblasSgemvBatched(hipblasHandle_t handle, hipblasOperation_t trans, int m, int n, const float *alpha, float *A, int lda,
                            float *x, int incx,  const float *beta,  float *y, int incy, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+*/
 
 hipblasStatus_t  hipblasSger(hipblasHandle_t handle, int m, int n, const float *alpha, const float *x, int incx, const float *y, int incy, float *A, int lda){
 	return rocBLASStatusToHIPStatus(rocblas_sger((rocblas_handle)handle, m, n, alpha, x, incx, y, incy, A, lda));
@@ -250,7 +260,9 @@ hipblasStatus_t  hipblasDger(hipblasHandle_t handle, int m, int n, const double 
 	return rocBLASStatusToHIPStatus(rocblas_dger((rocblas_handle)handle, m, n, alpha, x, incx, y, incy, A, lda));
 }
 
+/* not implemented
 hipblasStatus_t  hipblasSgerBatched(hipblasHandle_t handle, int m, int n, const float *alpha, const float *x, int incx, const float *y, int incy, float *A, int lda, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+*/
 
 hipblasStatus_t hipblasSgemm(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t transb,
                            int m, int n, int k,  const float *alpha, const float *A, int lda, const float *B, int ldb, const float *beta, float *C, int ldc){


### PR DESCRIPTION

Complex and half functions are not tested or supported. Remove them from hipblas.h and hipblas.cpp