### PR TITLE
ROCm v1.7 does not provide fedora builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -527,40 +527,40 @@ parallel rocm_ubuntu:
     build_pipeline( hcc_compiler_args, hcc_docker_args, hipblas_paths, print_version_closure )
   }
 },
-rocm_fedora:
-{
-  node( 'docker && rocm' )
-  {
-    def hcc_docker_args = new docker_data(
-        from_image:'rocm/dev-fedora-24:latest',
-        build_docker_file:'dockerfile-build-fedora',
-        install_docker_file:'dockerfile-install-fedora',
-        docker_run_args:'--device=/dev/kfd',
-        docker_build_args:' --pull' )
+// rocm_fedora:
+// {
+//   node( 'docker && rocm' )
+//   {
+//     def hcc_docker_args = new docker_data(
+//         from_image:'rocm/dev-fedora-24:latest',
+//         build_docker_file:'dockerfile-build-fedora',
+//         install_docker_file:'dockerfile-install-fedora',
+//         docker_run_args:'--device=/dev/kfd',
+//         docker_build_args:' --pull' )
 
-    def hcc_compiler_args = new compiler_data(
-        compiler_name:'hcc-rocm-fedora',
-        build_config:'Release',
-        compiler_path:'g++' )
+//     def hcc_compiler_args = new compiler_data(
+//         compiler_name:'hcc-rocm-fedora',
+//         build_config:'Release',
+//         compiler_path:'g++' )
 
-    def hipblas_paths = new project_paths(
-        project_name:'hipblas-fedora',
-        src_prefix:'src',
-        build_prefix:'src',
-        build_command: 'sudo rpm -iv rocblas-*.rpm; ./install.sh -c' )
-//        build_command: 'sudo dnf install -y rocblas-*.rpm; ./install.sh -c' )
+//     def hipblas_paths = new project_paths(
+//         project_name:'hipblas-fedora',
+//         src_prefix:'src',
+//         build_prefix:'src',
+//         build_command: 'sudo rpm -iv rocblas-*.rpm; ./install.sh -c' )
+// //        build_command: 'sudo dnf install -y rocblas-*.rpm; ./install.sh -c' )
 
-    def print_version_closure = {
-      sh  """
-          set -x
-          /opt/rocm/bin/rocm_agent_enumerator -t ALL
-          /opt/rocm/bin/hcc --version
-        """
-    }
+//     def print_version_closure = {
+//       sh  """
+//           set -x
+//           /opt/rocm/bin/rocm_agent_enumerator -t ALL
+//           /opt/rocm/bin/hcc --version
+//         """
+//     }
 
-    build_pipeline( hcc_compiler_args, hcc_docker_args, hipblas_paths, print_version_closure )
-  }
-},
+//     build_pipeline( hcc_compiler_args, hcc_docker_args, hipblas_paths, print_version_closure )
+//   }
+// },
 nvcc:
 {
   node( 'docker && cuda' )


### PR DESCRIPTION
Summary of proposed changes:
-  Disable generation of fedora RPM's until such a time as fedora is available
