### PR TITLE
platform dependent typedefs to avoid conflicts wrt hgemm

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -20,7 +20,11 @@
 
 typedef void * hipblasHandle_t;
 
+#ifdef __HIP_PLATFORM_HCC__
 typedef uint16_t hipblasHalf;
+#elif defined __HIP_PLATFORM_NVCC__
+typedef __half hipblasHalf;
+#endif
 
 enum hipblasStatus_t {
   HIPBLAS_STATUS_SUCCESS = 0,          // Function succeeds
@@ -211,8 +215,8 @@ hipblasStatus_t hipblasZgemm(hipblasHandle_t handle,  hipblasOperation_t transa,
 HIPBLAS_EXPORT hipblasStatus_t hipblasHgemm(hipblasHandle_t handle,  
         hipblasOperation_t transa, hipblasOperation_t transb,
         int m, int n, int k,  const hipblasHalf *alpha, 
-        hipblasHalf *A, int lda, 
-        hipblasHalf *B, int ldb, const hipblasHalf *beta, 
+        const hipblasHalf *A, int lda,
+        const hipblasHalf *B, int ldb, const hipblasHalf *beta,
         hipblasHalf *C, int ldc);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgemmStridedBatched(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t transb,

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -286,16 +286,9 @@ hipblasStatus_t hipblasCgemm(hipblasHandle_t handle,  hipblasOperation_t transa,
 */
 
 hipblasStatus_t hipblasHgemm(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t transb,
-                           int m, int n, int k,  const hipblasHalf *alpha, hipblasHalf *A, int lda, hipblasHalf *B, int ldb, const hipblasHalf *beta, hipblasHalf *C, int ldc)
-{
-  return hipCUBLASStatusToHIPStatus(cublasHgemm((cublasHandle_t) handle, 
-              hipOperationToCudaOperation(transa),  hipOperationToCudaOperation(transb), 
-              m,  n,  k, (__half*)alpha, 
-              (__half*)A,  lda, 
-              (__half*)B,  ldb, (__half*)beta, 
-              (__half*)C,  ldc));
+                                   int m, int n, int k,  const hipblasHalf *alpha, const hipblasHalf *A, int lda, const hipblasHalf *B, int ldb, const hipblasHalf *beta, hipblasHalf *C, int ldc){
+      return hipCUBLASStatusToHIPStatus(cublasHgemm((cublasHandle_t) handle, hipOperationToCudaOperation(transa),  hipOperationToCudaOperation(transb), m,  n,  k, alpha, A,  lda, B,  ldb, beta, C,  ldc));
 }
-
 
 /*  complex not supported in hcc
 hipblasStatus_t hipblasCgemmBatched(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t transb,


### PR DESCRIPTION
use native cuda __half type on nvcc platform as of now.
