### PR TITLE
Use CMake modules rather than find package to deduce HIP configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,15 @@
 # The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
 cmake_minimum_required( VERSION 3.5 )
 
+# HIP_PATH
+IF(NOT DEFINED $ENV{HIP_PATH})
+      SET(HIP_PATH "/opt/rocm/hip")
+ELSE()
+        SET(HIP_PATH $ENV{HIP_PATH})
+ENDIF()
+
+
+
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
 if( WIN32 )
@@ -12,6 +21,7 @@ if( WIN32 )
 else( )
   set( CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories" )
 endif( )
+
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
@@ -46,7 +56,8 @@ rocm_setup_version( VERSION 0.11.1.0 NO_GIT_TAG_VERSION )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+# Adding FindHIP.cmake
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake  ${HIP_PATH}/cmake)
 
 # NOTE:  workaround until hcc & hip cmake modules fixes symlink logic in their config files; remove when fixed
 list( APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip )
@@ -63,9 +74,6 @@ if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
   message( STATUS "Building with ROCm tools" )
   find_package( hcc REQUIRED CONFIG PATHS /opt/rocm )
 endif( )
-
-# Hip headers required of all clients; clients use hip to allocate device memory
-find_package( hip REQUIRED CONFIG PATHS /opt/rocm )
 
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -5,7 +5,7 @@
 # This is incremented when the ABI to the library changes
 set( hipblas_SOVERSION 0 )
 
-list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
+list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake  ${HIP_PATH}/cmake /opt/rocm/hip/cmake)
 
 # This option only works for make/nmake and the ninja generators, but no reason it shouldn't be on all the time
 # This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim
@@ -27,8 +27,6 @@ if( BUILD_VERBOSE )
   message( STATUS "\t==>CMAKE_EXE_LINKER link flags: " ${CMAKE_EXE_LINKER_FLAGS} )
 endif( )
 
-find_package( hip REQUIRED CONFIG PATHS /opt/rocm )
-
 # configure a header file to pass the CMake version settings to the source, and package the header files in the output archive
 configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/hipblas-version.h.in" "${PROJECT_BINARY_DIR}/include/hipblas-version.h" )
 
@@ -45,6 +43,8 @@ set( BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR} )
 set( LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR} )
 set( INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR} )
 
+include_directories( ${HIP_PATH}/include )
+
 # Build into subdirectories
 add_subdirectory( src )
 
@@ -57,9 +57,14 @@ add_subdirectory( src )
 #     set( CPACK_GENERATOR "DEB;RPM" CACHE STRING "cpack list: 7Z, DEB, IFW, NSIS, NSIS64, RPM, STGZ, TBZ2, TGZ, TXZ, TZ, ZIP" )
 # endif( )
 
+EXECUTE_PROCESS(COMMAND ${HIP_PATH}/bin/hipconfig -P OUTPUT_VARIABLE PLATFORM)
+
+
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3), rocblas (>= 0.10.3)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3, rocblas >= 0.10.3" )
+IF (${PLATFORM} MATCHES "hcc")
+  set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3), rocblas (>= 0.10.3)" )
+  set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3, rocblas >= 0.10.3" )
+ENDIF()
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )
@@ -76,6 +81,7 @@ else( )
 endif( )
 
 set( HIPBLAS_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file" )
+
 
 rocm_create_package(
     NAME ${package_name}

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -50,8 +50,10 @@ if( NOT CUDA_FOUND )
 
   target_compile_definitions( hipblas PRIVATE __HIP_PLATFORM_HCC__ )
 
+IF (${PLATFORM} MATCHES "hcc")
   get_target_property( HIPHCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
   target_link_libraries( hipblas PRIVATE roc::rocblas ${HIPHCC_LOCATION} )
+ENDIF()
 
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.3
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
-  Avoid need for hipConfig.cmake that would get generated currently only as part of ROCM installation 
-  Instead makes use of FindHIP.cmake module that gets shipped with HIP to set and deduce hip build and link configs
-  TODO: The install script still looks for hip_hcc and rocBLAS on NV stack. This needs to be conditionallychecked based on target platform 


