### PR TITLE
add tolerance for nrm2 tests

### DIFF
--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -44,7 +44,7 @@
     template<typename T>
     void unit_check_nrm2(T cpu_result, T gpu_result, T tolerance)
 {
-    T allowable_error = tolerance * std::numeric_limits<T>::epsilon() * (cpu_result + gpu_result) / 2.0;
+    T allowable_error = tolerance * std::numeric_limits<T>::epsilon() * cpu_result;
     if (allowable_error == 0) allowable_error = tolerance * std::numeric_limits<T>::epsilon();
 #ifdef GOOGLE_TEST
         ASSERT_NEAR(cpu_result, gpu_result, allowable_error);

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -41,4 +41,15 @@
     template<typename T>
     T get_trsm_tolerance();
 
+    template<typename T>
+    void unit_check_nrm2(T cpu_result, T gpu_result, T tolerance)
+{
+    T allowable_error = tolerance * std::numeric_limits<T>::epsilon() * (cpu_result + gpu_result) / 2.0;
+    if (allowable_error == 0) allowable_error = tolerance * std::numeric_limits<T>::epsilon();
+#ifdef GOOGLE_TEST
+        ASSERT_NEAR(cpu_result, gpu_result, allowable_error);
+#endif
+
+}
+
 #endif


### PR DESCRIPTION
nrm2 has a sqrt operation, so add tolerance to check against cblas result
