### PR TITLE
Remove unnecessary yum -y update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,9 @@ install_packages( )
       ;;
 
     centos|rhel)
-      elevate_if_not_root yum -y update
+#     yum -y update brings *all* installed packages up to date
+#     without seeking user approval
+#     elevate_if_not_root yum -y update
       install_yum_packages "${library_dependencies_centos[@]}"
 
       if [[ "${build_clients}" == true ]]; then
@@ -140,7 +142,7 @@ install_packages( )
       ;;
 
     fedora)
-      elevate_if_not_root dnf -y update
+#     elevate_if_not_root dnf -y update
       install_dnf_packages "${library_dependencies_fedora[@]}"
 
       if [[ "${build_clients}" == true ]]; then


### PR DESCRIPTION
Too many internal developers ran into our yum -y update forcing its way into upgrading their CentOS 7.4 to 7.5 - without even asking for permission. This has the unfortunate consequence of breaking our own rocm-dkms drivers, in particular amdgpu. On Ubuntu, apt update is needed to refresh the repo database. On CentOS/Fedora, there is no need to do so.