### PR TITLE
cmake fix to rocm-export-targets

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -106,7 +106,7 @@ rocm_install_targets(
 rocm_export_targets(
   TARGETS roc::hipblas
   PREFIX hipblas
-  DEPENDS PACKAGE hip
+  DEPENDS PACKAGE HIP
   NAMESPACE roc::
  )
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -106,7 +106,7 @@ rocm_install_targets(
 rocm_export_targets(
   TARGETS roc::hipblas
   PREFIX hipblas
-  DEPENDS PACKAGE HIP
+  DEPENDS PACKAGE hip
   NAMESPACE roc::
  )
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -104,7 +104,7 @@ rocm_install_targets(
 #         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
 
 rocm_export_targets(
-  TARGETS hipblas-targets
+  TARGETS roc::hipblas
   PREFIX hipblas
   DEPENDS PACKAGE hip
   NAMESPACE roc::


### PR DESCRIPTION
Fixes cmake issue with ${HIPBLAS_LIBRARIES} environment variable that was previously pointing to libhipblas-targets.so.