### PR TITLE
add /opt/rocm/hsa/include to target_include_directories

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -98,6 +98,7 @@ if( NOT CUDA_FOUND )
     # Remove following when hcc is fixed; hcc emits following spurious warning
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
     target_compile_options( hipblas-test PRIVATE -Wno-unused-command-line-argument -mf16c)
+    target_include_directories( hipblas-test PRIVATE /opt/rocm/hsa/include)
 
   elseif( CMAKE_COMPILER_IS_GNUCXX )
     # GCC needs specific flag to turn on f16c intrinsics

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -44,6 +44,7 @@ if( NOT CUDA_FOUND )
     # Remove following when hcc is fixed; hcc emits following spurious warning
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
     target_compile_options( ${exe} PRIVATE -Wno-unused-command-line-argument )
+    target_include_directories( ${exe} PRIVATE /opt/rocm/hsa/include)
   endif( )
 else( )
   target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVCC__ )


### PR DESCRIPTION
-  need to add include directory /opt/rocm/hsa/include for file hsa/hsa.h
