### PR TITLE
formatting using clang-format-9

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,7 @@
 # are installed, and if so, uses the installed version to format
 # the staged changes.
 
-base=clang-format-3.8
+base=/opt/rocm/hcc/bin/clang-format
 format=""
 
 # Redirect output to stderr.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins') _
+@Library('rocJenkins@clang9') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.

--- a/clients/common/norm.cpp
+++ b/clients/common/norm.cpp
@@ -25,12 +25,12 @@
 extern "C" {
 #endif
 
-float slange_(char* norm_type, int* m, int* n, float* A, int* lda, float* work);
+float  slange_(char* norm_type, int* m, int* n, float* A, int* lda, float* work);
 double dlange_(char* norm_type, int* m, int* n, double* A, int* lda, double* work);
 //  float  clange_(char* norm_type, int* m, int* n, hipComplex* A, int* lda, float* work);
 //  double zlange_(char* norm_type, int* m, int* n, hipDoubleComplex* A, int* lda, double* work);
 
-float slansy_(char* norm_type, char* uplo, int* n, float* A, int* lda, float* work);
+float  slansy_(char* norm_type, char* uplo, int* n, float* A, int* lda, float* work);
 double dlansy_(char* norm_type, char* uplo, int* n, double* A, int* lda, double* work);
 //  float  clanhe_(char* norm_type, char* uplo, int* n, hipComplex* A, int* lda, float* work);
 //  double zlanhe_(char* norm_type, char* uplo, int* n, hipDoubleComplex* A, int* lda, double*

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -14,10 +14,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -65,7 +65,8 @@ vector<vector<double>> alpha_beta_range = {{1.0, 0.0}, {2.0, -1.0}};
 // incx , incy must > 0, otherwise there is no real computation taking place,
 // but throw a message, which will still be detected by gtest
 vector<vector<int>> incx_incy_range = {
-    {1, 1}, {-1, -1},
+    {1, 1},
+    {-1, -1},
 };
 
 /* ===============Google Unit Test==================================================== */
@@ -77,18 +78,10 @@ vector<vector<int>> incx_incy_range = {
 class blas1_gtest : public ::TestWithParam<blas1_tuple>
 {
 protected:
-    blas1_gtest()
-    {
-    }
-    virtual ~blas1_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    blas1_gtest() {}
+    virtual ~blas1_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 Arguments setup_blas1_arguments(blas1_tuple tup)

--- a/clients/gtest/geam_gtest.cpp
+++ b/clients/gtest/geam_gtest.cpp
@@ -9,10 +9,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -41,7 +41,10 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.4, 0.0}, {3.1, 0.3}, {0.0, 1.3}, {0.0, 0.0},
+    {1.4, 0.0},
+    {3.1, 0.3},
+    {0.0, 1.3},
+    {0.0, 0.0},
 };
 
 // vector of vector, each pair is a {transA, transB};
@@ -97,18 +100,10 @@ Arguments setup_geam_arguments(geam_tuple tup)
 class geam_gtest : public ::TestWithParam<geam_tuple>
 {
 protected:
-    geam_gtest()
-    {
-    }
-    virtual ~geam_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    geam_gtest() {}
+    virtual ~geam_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(geam_gtest, geam_gtest_float)

--- a/clients/gtest/gemm_batched_gtest.cpp
+++ b/clients/gtest/gemm_batched_gtest.cpp
@@ -10,10 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 /*
@@ -59,7 +59,8 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0}, {-1.0, -1.0},
+    {1.0, 0.0},
+    {-1.0, -1.0},
 };
 
 // vector of vector, each pair is a {transA, transB};
@@ -123,18 +124,10 @@ Arguments setup_gemm_batched_arguments(gemm_batched_tuple tup)
 class gemm_batched_gtest : public ::TestWithParam<gemm_batched_tuple>
 {
 protected:
-    gemm_batched_gtest()
-    {
-    }
-    virtual ~gemm_batched_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    gemm_batched_gtest() {}
+    virtual ~gemm_batched_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(gemm_batched_gtest, float)

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -9,10 +9,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 /* =====================================================================
@@ -273,18 +273,10 @@ Arguments setup_gemm_ex_arguments(gemm_ex_tuple tup)
 class parameterized_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
 {
 protected:
-    parameterized_gemm_ex()
-    {
-    }
-    virtual ~parameterized_gemm_ex()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    parameterized_gemm_ex() {}
+    virtual ~parameterized_gemm_ex() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(parameterized_gemm_ex, standard)
@@ -319,18 +311,10 @@ TEST_P(parameterized_gemm_ex, standard)
 class parameterized_chunk_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
 {
 protected:
-    parameterized_chunk_gemm_ex()
-    {
-    }
-    virtual ~parameterized_chunk_gemm_ex()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    parameterized_chunk_gemm_ex() {}
+    virtual ~parameterized_chunk_gemm_ex() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(parameterized_chunk_gemm_ex, float)
@@ -365,18 +349,10 @@ TEST_P(parameterized_chunk_gemm_ex, float)
 class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
 {
 protected:
-    parameterized_half_gemm_ex()
-    {
-    }
-    virtual ~parameterized_half_gemm_ex()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    parameterized_half_gemm_ex() {}
+    virtual ~parameterized_half_gemm_ex() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 // TEST(pre_checkin_blas_ex_bad_arg, float) { testing_gemm_ex_bad_arg(); }

--- a/clients/gtest/gemm_gtest.cpp
+++ b/clients/gtest/gemm_gtest.cpp
@@ -10,10 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -97,18 +97,10 @@ Arguments setup_gemm_arguments(gemm_tuple tup)
 class gemm_gtest : public ::TestWithParam<gemm_tuple>
 {
 protected:
-    gemm_gtest()
-    {
-    }
-    virtual ~gemm_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    gemm_gtest() {}
+    virtual ~gemm_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(gemm_gtest, gemm_gtest_float)

--- a/clients/gtest/gemm_strided_batched_gtest.cpp
+++ b/clients/gtest/gemm_strided_batched_gtest.cpp
@@ -10,10 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -51,7 +51,8 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0}, {-1.0, -1.0},
+    {1.0, 0.0},
+    {-1.0, -1.0},
 };
 
 // vector of vector, each pair is a {transA, transB};
@@ -116,18 +117,10 @@ Arguments setup_gemm_strided_batched_arguments(gemm_strided_batched_tuple tup)
 class gemm_strided_batched_gtest : public ::TestWithParam<gemm_strided_batched_tuple>
 {
 protected:
-    gemm_strided_batched_gtest()
-    {
-    }
-    virtual ~gemm_strided_batched_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    gemm_strided_batched_gtest() {}
+    virtual ~gemm_strided_batched_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(gemm_strided_batched_gtest, float)

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -10,10 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -60,13 +60,18 @@ const vector<vector<int>> incx_incy_range = {
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0}, {-1.0, -1.0}, {2.0, 1.0}, {0.0, 1.0},
+    {1.0, 0.0},
+    {-1.0, -1.0},
+    {2.0, 1.0},
+    {0.0, 1.0},
 };
 
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
 // sgemv/dgemv,
 const vector<char> transA_range = {
-    'N', 'T', 'C',
+    'N',
+    'T',
+    'C',
 };
 
 /* ===============Google Unit Test==================================================== */
@@ -118,18 +123,10 @@ Arguments setup_gemv_arguments(gemv_tuple tup)
 class gemv_gtest : public ::TestWithParam<gemv_tuple>
 {
 protected:
-    gemv_gtest()
-    {
-    }
-    virtual ~gemv_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    gemv_gtest() {}
+    virtual ~gemv_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(gemv_gtest, gemv_gtest_float)

--- a/clients/gtest/ger_gtest.cpp
+++ b/clients/gtest/ger_gtest.cpp
@@ -10,10 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -105,18 +105,10 @@ Arguments setup_ger_arguments(ger_tuple tup)
 class blas2_ger_gtest : public ::TestWithParam<ger_tuple>
 {
 protected:
-    blas2_ger_gtest()
-    {
-    }
-    virtual ~blas2_ger_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    blas2_ger_gtest() {}
+    virtual ~blas2_ger_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(blas2_ger_gtest, float)

--- a/clients/gtest/set_get_matrix_gtest.cpp
+++ b/clients/gtest/set_get_matrix_gtest.cpp
@@ -12,10 +12,10 @@
 #include <tuple>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -103,18 +103,10 @@ Arguments setup_set_get_matrix_arguments(set_get_matrix_tuple tup)
 class set_matrix_get_matrix_gtest : public ::TestWithParam<set_get_matrix_tuple>
 {
 protected:
-    set_matrix_get_matrix_gtest()
-    {
-    }
-    virtual ~set_matrix_get_matrix_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    set_matrix_get_matrix_gtest() {}
+    virtual ~set_matrix_get_matrix_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(set_matrix_get_matrix_gtest, float)

--- a/clients/gtest/set_get_vector_gtest.cpp
+++ b/clients/gtest/set_get_vector_gtest.cpp
@@ -10,10 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -93,18 +93,10 @@ Arguments setup_set_get_vector_arguments(set_get_vector_tuple tup)
 class set_vector_get_vector_gtest : public ::TestWithParam<set_get_vector_tuple>
 {
 protected:
-    set_vector_get_vector_gtest()
-    {
-    }
-    virtual ~set_vector_get_vector_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    set_vector_get_vector_gtest() {}
+    virtual ~set_vector_get_vector_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 // TEST_P(set_vector_get_vector_gtest, set_get_vector_float)

--- a/clients/gtest/trsm_gtest.cpp
+++ b/clients/gtest/trsm_gtest.cpp
@@ -10,10 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 // only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
@@ -65,7 +65,9 @@ const vector<double> alpha_range = {1.0, -5.0};
 // Each letter is capitalizied, e.g. do not use 'l', but use 'L' instead.
 
 const vector<vector<char>> side_uplo_transA_diag_range = {
-    {'L', 'L', 'N', 'N'}, {'R', 'L', 'N', 'N'}, {'L', 'U', 'C', 'N'},
+    {'L', 'L', 'N', 'N'},
+    {'R', 'L', 'N', 'N'},
+    {'L', 'U', 'C', 'N'},
 };
 
 // has all the 16 options
@@ -134,18 +136,10 @@ Arguments setup_trsm_arguments(trsm_tuple tup)
 class trsm_gtest : public ::TestWithParam<trsm_tuple>
 {
 protected:
-    trsm_gtest()
-    {
-    }
-    virtual ~trsm_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    trsm_gtest() {}
+    virtual ~trsm_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(trsm_gtest, trsm_gtest_float)

--- a/clients/gtest/trtri_gtest.cpp
+++ b/clients/gtest/trtri_gtest.cpp
@@ -10,10 +10,10 @@
 #include <stdexcept>
 #include <vector>
 
+using ::testing::Combine;
 using ::testing::TestWithParam;
 using ::testing::Values;
 using ::testing::ValuesIn;
-using ::testing::Combine;
 using namespace std;
 
 typedef std::tuple<vector<int>, char, char, int> trtri_tuple;
@@ -88,18 +88,10 @@ Arguments setup_trtri_arguments(trtri_tuple tup)
 class trtri_gtest : public ::TestWithParam<trtri_tuple>
 {
 protected:
-    trtri_gtest()
-    {
-    }
-    virtual ~trtri_gtest()
-    {
-    }
-    virtual void SetUp()
-    {
-    }
-    virtual void TearDown()
-    {
-    }
+    trtri_gtest() {}
+    virtual ~trtri_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
 };
 
 TEST_P(trtri_gtest, trtri_float)

--- a/clients/include/hipblas_unique_ptr.hpp
+++ b/clients/include/hipblas_unique_ptr.hpp
@@ -13,8 +13,7 @@
                     TMP_STATUS_FOR_CHECK,                         \
                     __FILE__,                                     \
                     __LINE__);                                    \
-        \
-}                                                      \
+        }                                                         \
     }
 
 namespace hipblas

--- a/clients/include/testing_geam.hpp
+++ b/clients/include/testing_geam.hpp
@@ -88,15 +88,15 @@ hipblasStatus_t testing_geam(Arguments argus)
 
     // allocate memory on device
     auto dA_managed
-        = hipblas_unique_ptr{hipblas::device_malloc(sizeof(T) * A_size), hipblas::device_free};
+        = hipblas_unique_ptr {hipblas::device_malloc(sizeof(T) * A_size), hipblas::device_free};
     auto dB_managed
-        = hipblas_unique_ptr{hipblas::device_malloc(sizeof(T) * B_size), hipblas::device_free};
+        = hipblas_unique_ptr {hipblas::device_malloc(sizeof(T) * B_size), hipblas::device_free};
     auto dC_managed
-        = hipblas_unique_ptr{hipblas::device_malloc(sizeof(T) * C_size), hipblas::device_free};
+        = hipblas_unique_ptr {hipblas::device_malloc(sizeof(T) * C_size), hipblas::device_free};
     auto d_alpha_managed
-        = hipblas_unique_ptr{hipblas::device_malloc(sizeof(T)), hipblas::device_free};
+        = hipblas_unique_ptr {hipblas::device_malloc(sizeof(T)), hipblas::device_free};
     auto d_beta_managed
-        = hipblas_unique_ptr{hipblas::device_malloc(sizeof(T)), hipblas::device_free};
+        = hipblas_unique_ptr {hipblas::device_malloc(sizeof(T)), hipblas::device_free};
     T* dA      = (T*)dA_managed.get();
     T* dB      = (T*)dB_managed.get();
     T* dC      = (T*)dC_managed.get();

--- a/clients/include/testing_gemm_batched.hpp
+++ b/clients/include/testing_gemm_batched.hpp
@@ -188,8 +188,7 @@ hipblasStatus_t testing_GemmBatched(Arguments argus)
     T** dC2_array_dev = NULL;
 
     if((!hA_array) || (!hB_array) || (!hC_array) || (!hC_copy_array) || (!dA_array) || (!dB_array)
-       || (!dC1_array)
-       || (!dC2_array))
+       || (!dC1_array) || (!dC2_array))
     {
         CLEANUP();
         hipblasDestroy(handle);
@@ -207,9 +206,7 @@ hipblasStatus_t testing_GemmBatched(Arguments argus)
     err_beta  = hipMalloc(&d_beta, sizeof(T));
 
     if((err_A != hipSuccess) || (err_C_1 != hipSuccess) || (err_alpha != hipSuccess)
-       || (err_B != hipSuccess)
-       || (err_C_2 != hipSuccess)
-       || (err_beta != hipSuccess))
+       || (err_B != hipSuccess) || (err_C_2 != hipSuccess) || (err_beta != hipSuccess))
     {
         CLEANUP();
         hipblasDestroy(handle);
@@ -274,9 +271,7 @@ hipblasStatus_t testing_GemmBatched(Arguments argus)
         err_beta  = hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice);
 
         if((err_A != hipSuccess) || (err_C_1 != hipSuccess) || (err_alpha != hipSuccess)
-           || (err_B != hipSuccess)
-           || (err_C_2 != hipSuccess)
-           || (err_beta != hipSuccess))
+           || (err_B != hipSuccess) || (err_C_2 != hipSuccess) || (err_beta != hipSuccess))
         {
             CLEANUP();
             hipblasDestroy(handle);

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -244,16 +244,16 @@ hipblasStatus_t testing_gemm_ex_template(hipblasOperation_t transA,
                    hC_gold.data(),
                    ldc);
 
-//      std::cout << std::endl << "---gold---gold---gold---------------------" << std::endl;
-//      if(is_same<Td, hipblasHalf>::value)
-//      {
-//          for(int i = 0; i < size_D; i++){ std::cout << half_to_float(hD_gold[i]) << "  "; }
-//      }
-//      else
-//      {
-//          for(int i = 0; i < size_D; i++){ std::cout << hD_gold[i] << "  "; }
-//      }
-//      std::cout << std::endl << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
+    //      std::cout << std::endl << "---gold---gold---gold---------------------" << std::endl;
+    //      if(is_same<Td, hipblasHalf>::value)
+    //      {
+    //          for(int i = 0; i < size_D; i++){ std::cout << half_to_float(hD_gold[i]) << "  "; }
+    //      }
+    //      else
+    //      {
+    //          for(int i = 0; i < size_D; i++){ std::cout << hD_gold[i] << "  "; }
+    //      }
+    //      std::cout << std::endl << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
 
 #ifndef NDEBUG
 // print_matrix(hC_gold, hC, min(M, 3), min(N, 3), ldc);
@@ -304,8 +304,7 @@ hipblasStatus_t testing_gemm_ex(Arguments argus)
     int unit_check = argus.unit_check;
 
     if(a_type == HIPBLAS_R_16F && b_type == HIPBLAS_R_16F && c_type == HIPBLAS_R_16F
-       && c_type == HIPBLAS_R_16F
-       && compute_type == HIPBLAS_R_16F)
+       && c_type == HIPBLAS_R_16F && compute_type == HIPBLAS_R_16F)
     {
         status = testing_gemm_ex_template<hipblasHalf, hipblasHalf>(transA,
                                                                     transB,
@@ -325,8 +324,7 @@ hipblasStatus_t testing_gemm_ex(Arguments argus)
                                                                     compute_type);
     }
     else if(a_type == HIPBLAS_R_16F && b_type == HIPBLAS_R_16F && c_type == HIPBLAS_R_16F
-            && c_type == HIPBLAS_R_16F
-            && compute_type == HIPBLAS_R_32F)
+            && c_type == HIPBLAS_R_16F && compute_type == HIPBLAS_R_32F)
     {
         status = testing_gemm_ex_template<hipblasHalf, float>(transA,
                                                               transB,
@@ -346,8 +344,7 @@ hipblasStatus_t testing_gemm_ex(Arguments argus)
                                                               compute_type);
     }
     else if(a_type == HIPBLAS_R_32F && b_type == HIPBLAS_R_32F && c_type == HIPBLAS_R_32F
-            && c_type == HIPBLAS_R_32F
-            && compute_type == HIPBLAS_R_32F)
+            && c_type == HIPBLAS_R_32F && compute_type == HIPBLAS_R_32F)
     {
         status = testing_gemm_ex_template<float, float>(transA,
                                                         transB,
@@ -367,8 +364,7 @@ hipblasStatus_t testing_gemm_ex(Arguments argus)
                                                         compute_type);
     }
     else if(a_type == HIPBLAS_R_64F && b_type == HIPBLAS_R_64F && c_type == HIPBLAS_R_64F
-            && c_type == HIPBLAS_R_64F
-            && compute_type == HIPBLAS_R_64F)
+            && c_type == HIPBLAS_R_64F && compute_type == HIPBLAS_R_64F)
     {
         status = testing_gemm_ex_template<double, double>(transA,
                                                           transB,

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -76,8 +76,7 @@ hipblasStatus_t testing_nrm2(Arguments argus)
     status_4 = hipblasNrm2<T1, T2>(handle, N, dx, incx, &rocblas_result_1);
 
     if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
-       || (status_3 != HIPBLAS_STATUS_SUCCESS)
-       || (status_4 != HIPBLAS_STATUS_SUCCESS))
+       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
     {
         CHECK_HIP_ERROR(hipFree(dx));
         CHECK_HIP_ERROR(hipFree(d_rocblas_result));

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -103,16 +103,16 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasGetPointerMode(hipblasHandle_t       handl
                                                      hipblasPointerMode_t* mode);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSetVector(int n, int elemSize, const void* x, int incx, void* y, int incy);
+               hipblasSetVector(int n, int elemSize, const void* x, int incx, void* y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasGetVector(int n, int elemSize, const void* x, int incx, void* y, int incy);
+               hipblasGetVector(int n, int elemSize, const void* x, int incx, void* y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSetMatrix(int rows, int cols, int elemSize, const void* A, int lda, void* B, int ldb);
+               hipblasSetMatrix(int rows, int cols, int elemSize, const void* A, int lda, void* B, int ldb);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasGetMatrix(int rows, int cols, int elemSize, const void* A, int lda, void* B, int ldb);
+               hipblasGetMatrix(int rows, int cols, int elemSize, const void* A, int lda, void* B, int ldb);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgeam(hipblasHandle_t    handle,
                                             hipblasOperation_t transa,
@@ -143,16 +143,16 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDgeam(hipblasHandle_t    handle,
                                             int                ldc);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasIsamax(hipblasHandle_t handle, int n, const float* x, int incx, int* result);
+               hipblasIsamax(hipblasHandle_t handle, int n, const float* x, int incx, int* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasIdamax(hipblasHandle_t handle, int n, const double* x, int incx, int* result);
+               hipblasIdamax(hipblasHandle_t handle, int n, const double* x, int incx, int* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSasum(hipblasHandle_t handle, int n, const float* x, int incx, float* result);
+               hipblasSasum(hipblasHandle_t handle, int n, const float* x, int incx, float* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDasum(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
+               hipblasDasum(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
 /* not implemented
 HIPBLAS_EXPORT hipblasStatus_t  hipblasSasumBatched(hipblasHandle_t handle, int n, float *x, int
@@ -184,10 +184,10 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasSaxpyBatched(hipblasHandle_t handle, int n
 */
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasScopy(hipblasHandle_t handle, int n, const float* x, int incx, float* y, int incy);
+               hipblasScopy(hipblasHandle_t handle, int n, const float* x, int incx, float* y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDcopy(hipblasHandle_t handle, int n, const double* x, int incx, double* y, int incy);
+               hipblasDcopy(hipblasHandle_t handle, int n, const double* x, int incx, double* y, int incy);
 
 /* not implemented
 HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float *x,
@@ -222,16 +222,16 @@ int incx, const double *y, int incy, double *result, int batchCount);
 */
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSnrm2(hipblasHandle_t handle, int n, const float* x, int incx, float* result);
+               hipblasSnrm2(hipblasHandle_t handle, int n, const float* x, int incx, float* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDnrm2(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
+               hipblasDnrm2(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSscal(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx);
+               hipblasSscal(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDscal(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx);
+               hipblasDscal(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx);
 
 /* not implemented, requires complex support
 hipblasStatus_t  hipblasCscal(hipblasHandle_t handle, int n, const hipComplex *alpha,  hipComplex


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
-  Changed clang-formatting to /opt/rocm/hcc/bin/clang-format, which is clang9
-  Needs to pass CI