### PR TITLE
add CMAKE_CXX_STANDARD 14 for c++14 use in rocblas_bfloat16.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@
 # The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
 cmake_minimum_required( VERSION 3.5 )
 
+# We use C++14 features, this will add compile option: -std=c++14
+set( CMAKE_CXX_STANDARD 14 )
+
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
 if( WIN32 )


### PR DESCRIPTION
- rocBLAS uses c++14. Modify CMakeLists.txt in hipBLAS to use c++14
