### PR TITLE
hot_fix: use default compiler like c++ not hcc or hipcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ include( ROCMInstallTargets )
 include( ROCMPackageConfigHelpers )
 include( ROCMInstallSymlinks )
 
-set ( VERSION_STRING "0.14.0" )
+set ( VERSION_STRING "0.14.1" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)

--- a/install.sh
+++ b/install.sh
@@ -316,13 +316,6 @@ pushd .
     cmake_client_options="${cmake_client_options} -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_CLIENTS_TESTS=ON"
   fi
 
-  # hip-clang
-  if [[ "${build_hip_clang}" == true ]]; then
-    cmake_client_options="${cmake_client_options} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc"
-  else
-    cmake_client_options="${cmake_client_options} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hcc"
-  fi
-
   # Build library
   ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" ../..
   make -j$(nproc)


### PR DESCRIPTION
- for hot fix increment the patch number in the version number
- hipBLAS does not have any device code, so use default compiler (c++ on Ubuntu) in place of hcc or hipcc