### PR TITLE
Guard condition for linking with hcc library

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -90,8 +90,13 @@ if( NOT CUDA_FOUND )
   target_compile_definitions( hipblas-test PRIVATE __HIP_PLATFORM_HCC__ )
 
   get_target_property( HIP_HCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
-  get_target_property( HCC_AM_LOCATION hcc::hc_am IMPORTED_LOCATION_RELEASE )
-  target_link_libraries( hipblas-test PRIVATE ${HIP_HCC_LOCATION} ${HCC_AM_LOCATION} )
+
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+    get_target_property( HCC_AM_LOCATION hcc::hc_am IMPORTED_LOCATION_RELEASE )
+    target_link_libraries( hipblas-test PRIVATE ${HIP_HCC_LOCATION} ${HCC_AM_LOCATION} )
+  else( )
+    target_link_libraries( hipblas-test PRIVATE ${HIP_HCC_LOCATION} )
+  endif()
 
 
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -37,8 +37,13 @@ if( NOT CUDA_FOUND )
   target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
 
   get_target_property( HIP_HCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
-  get_target_property( HCC_AM_LOCATION hcc::hc_am IMPORTED_LOCATION_RELEASE )
-  target_link_libraries( ${exe} PRIVATE ${HIP_HCC_LOCATION} ${HCC_AM_LOCATION} )
+
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$" )
+    get_target_property( HCC_AM_LOCATION hcc::hc_am IMPORTED_LOCATION_RELEASE )
+    target_link_libraries( ${exe} PRIVATE ${HIP_HCC_LOCATION} ${HCC_AM_LOCATION} )
+  else( )
+    target_link_libraries( ${exe} PRIVATE ${HIP_HCC_LOCATION} )
+  endif( )
 
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
     # Remove following when hcc is fixed; hcc emits following spurious warning


### PR DESCRIPTION
Added guard condition for linking with hcc library only when compiled with hcc compiler, and not with default c++ compiler.

Error: cmake was searching for non-existent "hcc shared library location (HCC_AM_LOCATION)" even with default c++ compiler.

Fix: Put a guard condition around hcc library linking step in CMakeLists.txt files of "samples" and "gtest".

Output: All test cases are now passing.

resolves # SWDEV-198086

Summary of proposed changes:
Add guard condition in following files:
1. hipblas/clients/samples/CMakeLists.txt
2. hipblas/clients/gtest/CMakeLists.txt