### PR TITLE
Remove hipBLAS dependency on hc_am

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ hipBLASCI:
 
     def hipblas = new rocProject('hipBLAS')
     // customize for project
-    hipblas.paths.build_command = './install.sh -cd -p /opt/rocm/rocblas/lib/cmake'
+    hipblas.paths.build_command = './install.sh -cd -p /opt/rocm/lib/cmake'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(['gfx900 && ubuntu', 'gfx906 && ubuntu', 'gfx900 && centos7', 'gfx906 && centos7'], hipblas)
@@ -49,7 +49,7 @@ hipBLASCI:
             command = """#!/usr/bin/env bash
                     set -x
                     cd ${project.paths.project_build_prefix}
-                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=/usr/bin/g++ ${project.paths.build_command} --hip-clang
+                    LD_LIBRARY_PATH=/opt/rocm/lib CXX=g++ ${project.paths.build_command} --hip-clang
                     """
         }
         else
@@ -57,7 +57,7 @@ hipBLASCI:
             command = """#!/usr/bin/env bash
                     set -x
                     cd ${project.paths.project_build_prefix}
-                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=/usr/bin/g++ ${project.paths.build_command}
+                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=g++ ${project.paths.build_command}
                     """
         }
         platform.runCommand(this, command)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ hipBLASCI:
             command = """#!/usr/bin/env bash
                     set -x
                     cd ${project.paths.project_build_prefix}
-                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=/opt/rocm/bin/hipcc ${project.paths.build_command} --hip-clang
+                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=/usr/bin/g++ ${project.paths.build_command} --hip-clang
                     """
         }
         else
@@ -57,7 +57,7 @@ hipBLASCI:
             command = """#!/usr/bin/env bash
                     set -x
                     cd ${project.paths.project_build_prefix}
-                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=${project.compiler.compiler_path} ${project.paths.build_command}
+                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=/usr/bin/g++ ${project.paths.build_command}
                     """
         }
         platform.runCommand(this, command)

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -82,6 +82,7 @@ target_include_directories( hipblas-test
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+    /opt/rocm/hsa/include
 )
 
 target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack ${GTEST_LIBRARIES} ${Boost_LIBRARIES} )
@@ -97,7 +98,6 @@ if( NOT CUDA_FOUND )
     # Remove following when hcc is fixed; hcc emits following spurious warning
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
     target_compile_options( hipblas-test PRIVATE -Wno-unused-command-line-argument -mf16c)
-    target_include_directories( hipblas-test PRIVATE /opt/rocm/hsa/include)
 
   elseif( CMAKE_COMPILER_IS_GNUCXX )
     # GCC needs specific flag to turn on f16c intrinsics

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -90,8 +90,7 @@ if( NOT CUDA_FOUND )
   target_compile_definitions( hipblas-test PRIVATE __HIP_PLATFORM_HCC__ )
 
   get_target_property( HIP_HCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
-  get_target_property( HCC_AM_LOCATION hcc::hc_am IMPORTED_LOCATION_RELEASE )
-  target_link_libraries( hipblas-test PRIVATE ${HIP_HCC_LOCATION} ${HCC_AM_LOCATION} )
+  target_link_libraries( hipblas-test PRIVATE ${HIP_HCC_LOCATION} )
 
 
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -24,6 +24,7 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
   target_include_directories( ${exe}
     SYSTEM PRIVATE
       $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+      /opt/rocm/hsa/include
   )
 
   # Try to test for specific compiler features if cmake version is recent enough
@@ -43,7 +44,6 @@ if( NOT CUDA_FOUND )
     # Remove following when hcc is fixed; hcc emits following spurious warning
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
     target_compile_options( ${exe} PRIVATE -Wno-unused-command-line-argument )
-    target_include_directories( ${exe} PRIVATE /opt/rocm/hsa/include)
   endif( )
 else( )
   target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVCC__ )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -37,8 +37,7 @@ if( NOT CUDA_FOUND )
   target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
 
   get_target_property( HIP_HCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
-  get_target_property( HCC_AM_LOCATION hcc::hc_am IMPORTED_LOCATION_RELEASE )
-  target_link_libraries( ${exe} PRIVATE ${HIP_HCC_LOCATION} ${HCC_AM_LOCATION} )
+  target_link_libraries( ${exe} PRIVATE ${HIP_HCC_LOCATION} )
 
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
     # Remove following when hcc is fixed; hcc emits following spurious warning

--- a/install.sh
+++ b/install.sh
@@ -318,7 +318,7 @@ pushd .
 
   # Build library
   CXX=/usr/bin/g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" ../..
-  make -j$(nproc)
+  VERBOSE=1 make -j$(nproc)
 
   # #################################################
   # install

--- a/install.sh
+++ b/install.sh
@@ -317,7 +317,7 @@ pushd .
   fi
 
   # Build library
-  ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" ../..
+  CXX=/usr/bin/g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" ../..
   make -j$(nproc)
 
   # #################################################

--- a/install.sh
+++ b/install.sh
@@ -317,7 +317,7 @@ pushd .
   fi
 
   # Build library
-  CXX=/usr/bin/g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" ../..
+  CXX=g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" ../..
   VERBOSE=1 make -j$(nproc)
 
   # #################################################


### PR DESCRIPTION
There is no regression in ROCm 2.7 Releas HIP/HCC environment or HIP-Clang environment
when I remove these dependencies on hcc:hc_am.

resolves 201928.

Summary of proposed changes:
-  Remove dependency on hc_am, which is not needed anymore

