### PR TITLE
Clean up hip clang install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,6 @@ function display_help()
   echo "    [-c|--clients] build library clients too (combines with -i & -d)"
   echo "    [-g|--debug] -DCMAKE_BUILD_TYPE=Debug (default is =Release)"
   echo "    [--cuda] build library for cuda backend"
-  echo "    [--hip-clang] build library for hip-clang"
   echo "    [-p|--cmakepp] addition to CMAKE_PREFIX_PATH"
 }
 
@@ -192,7 +191,6 @@ install_prefix=hipblas-install
 build_clients=false
 build_cuda=false
 build_release=true
-build_hip_clang=false
 cmake_prefix_path=/opt/rocm
 
 # #################################################
@@ -202,7 +200,7 @@ cmake_prefix_path=/opt/rocm
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,cuda,cmakepp: --options hicdgp: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,cuda,cmakepp: --options hicdgp: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -235,9 +233,6 @@ while true; do
         shift ;;
     --cuda)
         build_cuda=true
-        shift ;;
-    --hip-clang)
-        build_hip_clang=true
         shift ;;
     -p|--cmakepp)
         cmake_prefix_path=${2}
@@ -318,7 +313,7 @@ pushd .
 
   # Build library
   CXX=g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" ../..
-  VERBOSE=1 make -j$(nproc)
+  make -j$(nproc)
 
   # #################################################
   # install


### PR DESCRIPTION
Just to clean up old hip-clang artifacts. We don't need any specific --hip-clang flag since we will use g++ for hipBLAS compilation. Also removing the VERBOSE=1 output.

resolves #N/A

Summary of proposed changes:
-  Remove --hip-clang flag
-  Remove VERBOSE=1 noise
