### PR TITLE
add compile flag -mf16c for _cvtss_sh in samples directory

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -93,7 +93,6 @@ if( NOT CUDA_FOUND )
   get_target_property( HIP_HCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
   target_link_libraries( hipblas-test PRIVATE ${HIP_HCC_LOCATION} )
 
-
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
     # Remove following when hcc is fixed; hcc emits following spurious warning
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -34,27 +34,33 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
   set_target_properties( ${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
   target_include_directories( ${exe} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> )
 
-if( NOT CUDA_FOUND )
-  target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
-
-  get_target_property( HIP_HCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
-  target_link_libraries( ${exe} PRIVATE ${HIP_HCC_LOCATION} )
-
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
-    # Remove following when hcc is fixed; hcc emits following spurious warning
-    # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-    target_compile_options( ${exe} PRIVATE -Wno-unused-command-line-argument )
+  if( NOT CUDA_FOUND )
+    target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
+  
+    get_target_property( HIP_HCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
+    target_link_libraries( ${exe} PRIVATE ${HIP_HCC_LOCATION} )
+  
+    if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
+      # Remove following when hcc is fixed; hcc emits following spurious warning
+      # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
+      target_compile_options( ${exe} PRIVATE -Wno-unused-command-line-argument -mf16c)
+      
+    elseif( CMAKE_COMPILER_IS_GNUCXX )
+      # GCC needs specific flag to turn on f16c intrinsics
+      target_compile_options( ${exe} PRIVATE -mf16c )
+  
+    endif( )
+  
+  else( )
+    target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVCC__ )
+  
+    target_include_directories( ${exe}
+      PRIVATE
+        $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
+    )
+  
+    target_link_libraries( ${exe} PRIVATE ${CUDA_LIBRARIES} )
   endif( )
-else( )
-  target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVCC__ )
-
-  target_include_directories( ${exe}
-    PRIVATE
-      $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
-  )
-
-  target_link_libraries( ${exe} PRIVATE ${CUDA_LIBRARIES} )
-endif( )
 
 endforeach( )
 


### PR DESCRIPTION
- hot fix for ROCm 2.9 CentOS no-npi-dkms SWDEV-203393 http://ontrack-internal.amd.com/browse/SWDEV-203393 
- samples directory did not have -mf16c compile directive. Copy the directive from gtest directory
- also correct tabbing in clients/samples/CMakeLists.txt
