### PR TITLE
Add missing tests for BLAS L1

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -41,23 +41,13 @@ void dgetrf_(int* m, int* n, double* A, int* lda, int* ipiv, int* info);
 
 // axpy
 template <>
-void cblas_axpy<float>(int          n,
-                       const float  alpha,
-                       const float* x,
-                       int          incx,
-                       float*       y,
-                       int          incy)
+void cblas_axpy<float>(int n, const float alpha, const float* x, int incx, float* y, int incy)
 {
     cblas_saxpy(n, alpha, x, incx, y, incy);
 }
 
 template <>
-void cblas_axpy<double>(int           n,
-                        const double  alpha,
-                        const double* x,
-                        int           incx,
-                        double*       y,
-                        int           incy)
+void cblas_axpy<double>(int n, const double alpha, const double* x, int incx, double* y, int incy)
 {
     cblas_daxpy(n, alpha, x, incx, y, incy);
 }

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -38,6 +38,30 @@ void dgetrf_(int* m, int* n, double* A, int* lda, int* ipiv, int* info);
  *    level 1 BLAS
  * ===========================================================================
  */
+
+// axpy
+template <>
+void cblas_axpy<float>(int          n,
+                       const float  alpha,
+                       const float* x,
+                       int          incx,
+                       float*       y,
+                       int          incy)
+{
+    cblas_saxpy(n, alpha, x, incx, y, incy);
+}
+
+template <>
+void cblas_axpy<double>(int           n,
+                        const double  alpha,
+                        const double* x,
+                        int           incx,
+                        double*       y,
+                        int           incy)
+{
+    cblas_daxpy(n, alpha, x, incx, y, incy);
+}
+
 // scal
 template <>
 void cblas_scal<float>(int n, const float alpha, float* x, int incx)

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -16,6 +16,32 @@
  *    level 1 BLAS
  * ===========================================================================
  */
+
+// axpy
+template <>
+hipblasStatus_t hipblasAxpy<float>(hipblasHandle_t handle,
+                                   int             n,
+                                   const float*    alpha,
+                                   const float*    x,
+                                   int             incx,
+                                   float*          y,
+                                   int             incy)
+{
+    return hipblasSaxpy(handle, n, alpha, x, incx, y, incy);
+}
+
+template <>
+hipblasStatus_t hipblasAxpy<double>(hipblasHandle_t handle,
+                                    int             n,
+                                    const double*   alpha,
+                                    const double*   x,
+                                    int             incx,
+                                    double*         y,
+                                    int             incy)
+{
+    return hipblasDaxpy(handle, n, alpha, x, incx, y, incy);
+}
+
 // scal
 template <>
 hipblasStatus_t

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -19,13 +19,8 @@
 
 // axpy
 template <>
-hipblasStatus_t hipblasAxpy<float>(hipblasHandle_t handle,
-                                   int             n,
-                                   const float*    alpha,
-                                   const float*    x,
-                                   int             incx,
-                                   float*          y,
-                                   int             incy)
+hipblasStatus_t hipblasAxpy<float>(
+    hipblasHandle_t handle, int n, const float* alpha, const float* x, int incx, float* y, int incy)
 {
     return hipblasSaxpy(handle, n, alpha, x, incx, y, incy);
 }

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -5,6 +5,7 @@
 
 #include "testing_asum.hpp"
 #include "testing_axpy.hpp"
+#include "testing_copy.hpp"
 #include "testing_dot.hpp"
 #include "testing_iamax.hpp"
 #include "testing_nrm2.hpp"
@@ -73,7 +74,7 @@ vector<vector<int>> incx_incy_range = {
 /* ===============Google Unit Test==================================================== */
 
 /* =====================================================================
-     BLAS-1: scal, dot, nrm2, asum, amax, axpy
+     BLAS-1: scal, dot, nrm2, asum, amax, axpy, copy
 =================================================================== */
 
 class blas1_gtest : public ::TestWithParam<blas1_tuple>
@@ -114,8 +115,26 @@ Arguments setup_blas1_arguments(blas1_tuple tup)
 
 TEST_P(blas1_gtest, axpy_float)
 {
-    Arguments arg = setup_blas1_arguments(GetParam());
+    Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_axpy<float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+    }
+}
+
+TEST_P(blas1_gtest, copy_float)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_copy<float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -4,6 +4,7 @@
  * ************************************************************************ */
 
 #include "testing_asum.hpp"
+#include "testing_axpy.hpp"
 #include "testing_dot.hpp"
 #include "testing_iamax.hpp"
 #include "testing_nrm2.hpp"
@@ -72,7 +73,7 @@ vector<vector<int>> incx_incy_range = {
 /* ===============Google Unit Test==================================================== */
 
 /* =====================================================================
-     BLAS-1: scal, dot, nrm2, asum, amax
+     BLAS-1: scal, dot, nrm2, asum, amax, axpy
 =================================================================== */
 
 class blas1_gtest : public ::TestWithParam<blas1_tuple>
@@ -109,6 +110,24 @@ Arguments setup_blas1_arguments(blas1_tuple tup)
         = 0; // disable timing data print out. Not supposed to collect performance data in gtest
 
     return arg;
+}
+
+TEST_P(blas1_gtest, axpy_float)
+{
+    Arguments arg = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_axpy<float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+    }
 }
 
 TEST_P(blas1_gtest, scal_float)

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -21,7 +21,7 @@
  */
 
 template <typename T>
-void cblas_axpy(int n , const T alpha, const T* x, int incx, T* y, int incy);
+void cblas_axpy(int n, const T alpha, const T* x, int incx, T* y, int incy);
 template <typename T>
 void cblas_scal(int n, const T alpha, T* x, int incx);
 template <typename T>

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -21,6 +21,8 @@
  */
 
 template <typename T>
+void cblas_axpy(int n , const T alpha, const T* x, int incx, T* y, int incy);
+template <typename T>
 void cblas_scal(int n, const T alpha, T* x, int incx);
 template <typename T>
 void cblas_copy(int n, T* x, int incx, T* y, int incy);

--- a/clients/include/testing_axpy.hpp
+++ b/clients/include/testing_axpy.hpp
@@ -1,0 +1,118 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_axpy(Arguments argus)
+{
+    int N    = argus.N;
+    int incx = argus.incx;
+    int incy = argus.incy;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    else if(incx < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+
+    int sizeX = N * incx;
+    int sizeY = N * incy;
+    T   alpha = argus.alpha;
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    vector<T> hx(sizeX);
+    vector<T> hy(sizeY);
+    vector<T> hx_cpu(sizeX);
+    vector<T> hy_cpu(sizeY);
+    T*        dx;
+    T*        dy;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error = 0.0;
+
+    hipblasHandle_t handle;
+
+    hipblasCreate(&handle);
+
+    // allocate memory on device
+    CHECK_HIP_ERROR(hipMalloc(&dx, sizeX * sizeof(T)));
+    CHECK_HIP_ERROR(hipMalloc(&dy, sizeY * sizeof(T)));
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T>(hx, 1, N, incx);
+    hipblas_init<T>(hy, 1, N, incy);
+
+    // copy vector is easy in STL; hx_cpu = hx: save a copy in hx_cpu which will be output of CPU BLAS
+    hx_cpu = hx;
+    hy_cpu = hy;
+
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    status = hipblasAxpy<T>(handle, N, &alpha, dx, incx, dy, incy);
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        CHECK_HIP_ERROR(hipFree(dx));
+        CHECK_HIP_ERROR(hipFree(dy));
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        cblas_axpy<T>(N, alpha, hx_cpu.data(), incx, hy_cpu.data(), incy);
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, incx, hx_cpu.data(), hx.data());
+            unit_check_general<T>(1, N, incx, hy_cpu.data(), hy.data());
+        }
+
+    } // end of if unit check
+
+    //  BLAS_1_RESULT_PRINT
+
+    CHECK_HIP_ERROR(hipFree(dx));
+    CHECK_HIP_ERROR(hipFree(dy));
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_copy.hpp
+++ b/clients/include/testing_copy.hpp
@@ -1,0 +1,115 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_copy(Arguments argus)
+{
+    int N    = argus.N;
+    int incx = argus.incx;
+    int incy = argus.incy;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    else if(incx < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+
+    int sizeX = N * incx;
+    int sizeY = N * incy;
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    vector<T> hx(sizeX);
+    vector<T> hy(sizeY);
+    vector<T> hx_cpu(sizeX);
+    vector<T> hy_cpu(sizeY);
+    T*        dx;
+    T*        dy;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error = 0.0;
+
+    hipblasHandle_t handle;
+
+    hipblasCreate(&handle);
+
+    // allocate memory on device
+    CHECK_HIP_ERROR(hipMalloc(&dx, sizeX * sizeof(T)));
+    CHECK_HIP_ERROR(hipMalloc(&dy, sizeY * sizeof(T)));
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T>(hx, 1, N, incx);
+    hipblas_init<T>(hy, 1, N, incy);
+
+    hx_cpu = hx;
+    hy_cpu = hy;
+
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    status = hipblasCopy<T>(handle, N, dx, incx, dy, incy);
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        CHECK_HIP_ERROR(hipFree(dx));
+        CHECK_HIP_ERROR(hipFree(dy));
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        cblas_copy<T>(N, hx_cpu.data(), incx, hy_cpu.data(), incy);
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, incx, hx_cpu.data(), hx.data());
+            unit_check_general<T>(1, N, incx, hy_cpu.data(), hy.data());
+        }
+
+    } // end of if unit check
+
+    //  BLAS_1_RESULT_PRINT
+
+    CHECK_HIP_ERROR(hipFree(dx));
+    CHECK_HIP_ERROR(hipFree(dy));
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}


### PR DESCRIPTION
Adding missing tests to hipBlas. We already have hipAxpy and hipCopy implemented, but no testing for them. This PR adds testing for these two functions.