### PR TITLE
Adding missing L1 functions

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -242,6 +242,59 @@ void cblas_iamax<double>(int n, const double* x, int incx, int* result)
 //  {
 //      *result = (int)cblas_izamax(n, x, incx);
 //  }
+
+// amin
+
+// amin is not implemented in cblas, make local version
+template <typename T>
+int cblas_iamin_helper(int N, const T* X, int incx)
+{
+    int minpos = -1;
+    if(N > 0 && incx > 0)
+    {
+        auto min = X[0] < 0 ? -X[0] : X[0];
+        minpos   = 0;
+        for(size_t i = 1; i < N; ++i)
+        {
+            auto a = X[i * incx] < 0 ? -X[i * incx] : X[i * incx];
+            if(a < min)
+            {
+                min    = a;
+                minpos = i;
+            }
+        }
+    }
+    return minpos;
+}
+
+template <>
+void cblas_iamin<float>(int n, const float* x, int incx, int* result)
+{
+    *result = (int)cblas_iamin_helper(n, x, incx);
+}
+
+template <>
+void cblas_iamin<double>(int n, const double* x, int incx, int* result)
+{
+    *result = (int)cblas_iamin_helper(n, x, incx);
+}
+
+//  template<>
+//  void cblas_iamin<hipComplex>( int n,
+//                          const hipComplex *x, int incx,
+//                          int *result)
+//  {
+//      *result = (int)cblas_icamin(n, x, incx);
+//  }
+
+//  template<>
+//  void cblas_iamin<hipDoubleComplex>( int n,
+//                          const hipDoubleComplex *x, int incx,
+//                          int *result)
+//  {
+//      *result = (int)cblas_izamin(n, x, incx);
+//  }
+
 /*
  * ===========================================================================
  *    level 2 BLAS

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -53,44 +53,46 @@ hipblasStatus_t
         return hipblasZscal(handle, n, alpha, x, incx);
     }
 */
+#include <iostream>
+//swap
+template<>
+hipblasStatus_t
+hipblasSwap<float>(hipblasHandle_t handle, int n,
+                   float *x, int incx,
+                   float *y, int incy)
+{
+    return hipblasSswap(handle, n, x, incx, y, incy);
+}
+
+template<>
+hipblasStatus_t
+hipblasSwap<double>(hipblasHandle_t handle, int n,
+                    double *x, int incx,
+                    double *y, int incy)
+{
+    return hipblasDswap(handle, n, x, incx, y, incy);
+}
+
 /*
-    //swap
-    template<>
-    hipblasStatus_t
-    hipblasSwap<float>(    hipblasHandle_t handle, int n,
-                            float *x, int incx,
-                            float *y, int incy)
-    {
-        return hipblasSwap(handle, n, x, incx, y, incy);
-    }
+template<>
+hipblasStatus_t
+hipblasSwap<hipComplex>(    hipblasHandle_t handle, int n,
+                        hipComplex *x, int incx,
+                        hipComplex *y, int incy)
+{
+    return hipblasCswap(handle, n, x, incx, y, incy);
+}
 
-    template<>
-    hipblasStatus_t
-    hipblasSwap<double>(   hipblasHandle_t handle, int n,
-                            double *x, int incx,
-                            double *y, int incy)
-    {
-        return hipblasDswap(handle, n, x, incx, y, incy);
-    }
-
-    template<>
-    hipblasStatus_t
-    hipblasSwap<hipComplex>(    hipblasHandle_t handle, int n,
-                            hipComplex *x, int incx,
-                            hipComplex *y, int incy)
-    {
-        return hipblasCswap(handle, n, x, incx, y, incy);
-    }
-
-    template<>
-    hipblasStatus_t
-    hipblasSwap<hipDoubleComplex>(    hipblasHandle_t handle, int n,
-                            hipDoubleComplex *x, int incx,
-                            hipDoubleComplex *y, int incy)
-    {
-        return hipblasZswap(handle, n, x, incx, y, incy);
-    }
+template<>
+hipblasStatus_t
+hipblasSwap<hipDoubleComplex>(    hipblasHandle_t handle, int n,
+                        hipDoubleComplex *x, int incx,
+                        hipDoubleComplex *y, int incy)
+{
+    return hipblasZswap(handle, n, x, incx, y, incy);
+}
 */
+
 // copy
 template <>
 hipblasStatus_t

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -316,6 +316,44 @@ hipblasStatus_t
         return hipblasDzamax(handle, n, x, incx, result);
     }
 */
+
+// amin
+template <>
+hipblasStatus_t
+    hipblasIamin<float>(hipblasHandle_t handle, int n, const float* x, int incx, int* result)
+{
+    return hipblasIsamin(handle, n, x, incx, result);
+}
+
+template <>
+hipblasStatus_t
+    hipblasIamin<double>(hipblasHandle_t handle, int n, const double* x, int incx, int* result)
+{
+    return hipblasIdamin(handle, n, x, incx, result);
+}
+
+/*
+    template<>
+    hipblasStatus_t
+    hipblasAmin<hipComplex>(hipblasHandle_t handle,
+        int n,
+        const hipComplex *x, int incx,
+        int *result){
+
+        return hipblasScamin(handle, n, x, incx, result);
+    }
+
+    template<>
+    hipblasStatus_t
+    hipblasAmin<hipDoubleComplex>(hipblasHandle_t handle,
+        int n,
+        const hipDoubleComplex *x, int incx,
+        int *result){
+
+        return hipblasDzamin(handle, n, x, incx, result);
+    }
+*/
+
 /*
  * ===========================================================================
  *    level 2 BLAS

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -53,22 +53,18 @@ hipblasStatus_t
         return hipblasZscal(handle, n, alpha, x, incx);
     }
 */
-#include <iostream>
+
 //swap
-template<>
+template <>
 hipblasStatus_t
-hipblasSwap<float>(hipblasHandle_t handle, int n,
-                   float *x, int incx,
-                   float *y, int incy)
+    hipblasSwap<float>(hipblasHandle_t handle, int n, float* x, int incx, float* y, int incy)
 {
     return hipblasSswap(handle, n, x, incx, y, incy);
 }
 
-template<>
+template <>
 hipblasStatus_t
-hipblasSwap<double>(hipblasHandle_t handle, int n,
-                    double *x, int incx,
-                    double *y, int incy)
+    hipblasSwap<double>(hipblasHandle_t handle, int n, double* x, int incx, double* y, int incy)
 {
     return hipblasDswap(handle, n, x, incx, y, incy);
 }

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -6,6 +6,7 @@
 #include "testing_asum.hpp"
 #include "testing_dot.hpp"
 #include "testing_iamax.hpp"
+#include "testing_iamin.hpp"
 #include "testing_nrm2.hpp"
 #include "testing_scal.hpp"
 #include "testing_swap.hpp"
@@ -73,7 +74,7 @@ vector<vector<int>> incx_incy_range = {
 /* ===============Google Unit Test==================================================== */
 
 /* =====================================================================
-     BLAS-1: scal, dot, nrm2, asum, amax, swap
+     BLAS-1: scal, dot, nrm2, asum, amax, amin, swap
 =================================================================== */
 
 class blas1_gtest : public ::TestWithParam<blas1_tuple>
@@ -248,6 +249,38 @@ TEST_P(blas1_gtest, amax_double)
     hipblasStatus_t status = testing_amax<double>(arg);
 
     EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+}
+
+TEST_P(blas1_gtest, amin_float)
+{
+    // TODO: min is broken in rocblas currently (fixed in 2.10?)
+
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    // Arguments arg = setup_blas1_arguments(GetParam());
+
+    // hipblasStatus_t status = testing_amin<float>(arg);
+
+    // EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+}
+
+TEST_P(blas1_gtest, amin_double)
+{
+    // TODO: min is broken in rocblas currently (fixed in 2.10?)
+
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    // Arguments arg = setup_blas1_arguments(GetParam());
+
+    // hipblasStatus_t status = testing_amin<double>(arg);
+
+    // EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
 }
 
 // Values is for a single item; ValuesIn is for an array

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -8,6 +8,7 @@
 #include "testing_iamax.hpp"
 #include "testing_nrm2.hpp"
 #include "testing_scal.hpp"
+#include "testing_swap.hpp"
 #include "utility.h"
 #include <gtest/gtest.h>
 #include <math.h>
@@ -72,7 +73,7 @@ vector<vector<int>> incx_incy_range = {
 /* ===============Google Unit Test==================================================== */
 
 /* =====================================================================
-     BLAS-1: scal, dot, nrm2, asum, amax
+     BLAS-1: scal, dot, nrm2, asum, amax, swap
 =================================================================== */
 
 class blas1_gtest : public ::TestWithParam<blas1_tuple>
@@ -119,6 +120,24 @@ TEST_P(blas1_gtest, scal_float)
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_scal<float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+    }
+}
+
+TEST_P(blas1_gtest, swap_float)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_swap<float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -47,7 +47,7 @@ template <typename T>
 hipblasStatus_t hipblasIamax(hipblasHandle_t handle, int n, const T* x, int incx, int* result);
 
 template <typename T>
-hipblasStatus_t hipblasAmin(hipblasHandle_t handle, int n, const T* x, int incx, int* result);
+hipblasStatus_t hipblasIamin(hipblasHandle_t handle, int n, const T* x, int incx, int* result);
 
 template <typename T>
 hipblasStatus_t hipblasAxpy(

--- a/clients/include/testing_iamin.hpp
+++ b/clients/include/testing_iamin.hpp
@@ -62,13 +62,6 @@ hipblasStatus_t testing_amin(Arguments argus)
         // Initial Data on CPU
         srand(1);
         hipblas_init<T>(hx, 1, N, incx);
-        std::cout << "\n";
-        // std::cout << "incx: " << incx <<"\n";
-        for(int i = 0; i < 20; i++)
-        {
-            std::cout << "hx[" << i << "] = " << hx[i] << ",";
-        }
-        std::cout << "\n";
 
         // copy data from CPU to device, does not work for incx != 1
         CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));

--- a/clients/include/testing_iamin.hpp
+++ b/clients/include/testing_iamin.hpp
@@ -1,0 +1,134 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_amin(Arguments argus)
+{
+    int N    = argus.N;
+    int incx = argus.incx;
+
+    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    T*   dx;
+    int* d_rocblas_result;
+
+    int cpu_result, rocblas_result1, rocblas_result2;
+    int zero = 0;
+
+    // check to prevent undefined memory allocation error
+    if(N < 1 || incx <= 0)
+    {
+        CHECK_HIP_ERROR(hipMalloc(&dx, 100 * sizeof(T)));
+        CHECK_HIP_ERROR(hipMalloc(&d_rocblas_result, sizeof(int)));
+
+        status_1 = hipblasIamin<T>(handle, N, dx, incx, &rocblas_result1);
+
+        unit_check_general<int>(1, 1, 1, &zero, &rocblas_result1);
+    }
+    else
+    {
+        int sizeX = N * incx;
+
+        // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this
+        // practice
+        vector<T> hx(sizeX);
+
+        // allocate memory on device
+        CHECK_HIP_ERROR(hipMalloc(&dx, sizeX * sizeof(T)));
+        CHECK_HIP_ERROR(hipMalloc(&d_rocblas_result, sizeof(int)));
+
+        // Initial Data on CPU
+        srand(1);
+        hipblas_init<T>(hx, 1, N, incx);
+        std::cout << "\n";
+        // std::cout << "incx: " << incx <<"\n";
+        for(int i = 0; i < 20; i++)
+        {
+            std::cout << "hx[" << i << "] = " << hx[i] << ",";
+        }
+        std::cout << "\n";
+
+        // copy data from CPU to device, does not work for incx != 1
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
+
+        /* =====================================================================
+                    HIP BLAS
+        =================================================================== */
+        // device_pointer for d_rocblas_result
+        {
+
+            status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+
+            status_1 = hipblasIamin<T>(handle, N, dx, incx, d_rocblas_result);
+
+            CHECK_HIP_ERROR(
+                hipMemcpy(&rocblas_result1, d_rocblas_result, sizeof(int), hipMemcpyDeviceToHost));
+        }
+        // host_pointer for rocblas_result2
+        if((status_1 == HIPBLAS_STATUS_SUCCESS) && (status_3 == HIPBLAS_STATUS_SUCCESS))
+        {
+            status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
+
+            status_2 = hipblasIamin<T>(handle, N, dx, incx, &rocblas_result2);
+        }
+
+        if((status_1 == HIPBLAS_STATUS_SUCCESS) && (status_2 == HIPBLAS_STATUS_SUCCESS)
+           && (status_3 == HIPBLAS_STATUS_SUCCESS))
+        {
+            /* =====================================================================
+                        CPU BLAS
+            =================================================================== */
+            cblas_iamin<T>(N, hx.data(), incx, &cpu_result);
+
+            // change to Fortran 1 based indexing as in BLAS standard, not cblas zero based indexing
+            cpu_result += 1;
+
+            unit_check_general<int>(1, 1, 1, &cpu_result, &rocblas_result1);
+            unit_check_general<int>(1, 1, 1, &cpu_result, &rocblas_result2);
+
+        } // end of if unit/norm check
+    }
+
+    CHECK_HIP_ERROR(hipFree(dx));
+    CHECK_HIP_ERROR(hipFree(d_rocblas_result));
+    hipblasDestroy(handle);
+
+    if(status_1 != HIPBLAS_STATUS_SUCCESS)
+    {
+        return status_1;
+    }
+    else if(status_2 != HIPBLAS_STATUS_SUCCESS)
+    {
+        return status_2;
+    }
+    else if(status_3 != HIPBLAS_STATUS_SUCCESS)
+    {
+        return status_3;
+    }
+    else
+    {
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+}

--- a/clients/include/testing_swap.hpp
+++ b/clients/include/testing_swap.hpp
@@ -1,0 +1,121 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_swap(Arguments argus)
+{
+
+    int N    = argus.N;
+    int incx = argus.incx;
+    int incy = argus.incy;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    else if(incx < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    else if(incy < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+
+    int sizeX = N * incx;
+    int sizeY = N * incy;
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    vector<T> hx(sizeX);
+    vector<T> hy(sizeY);
+    vector<T> hx_cpu(sizeX);
+    vector<T> hy_cpu(sizeY);
+
+    T *dx, *dy;
+    int device_pointer = 1;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // allocate memory on device
+    CHECK_HIP_ERROR(hipMalloc(&dx, sizeX * sizeof(T)));
+    CHECK_HIP_ERROR(hipMalloc(&dy, sizeY * sizeof(T)));
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T>(hx, 1, N, incx);
+    hipblas_init<T>(hy, 1, N, incy);
+    hx_cpu = hx;
+    hy_cpu = hy;
+
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    status = hipblasSwap<T>(handle, N, dx, incx, dy, incy);
+
+    if((status != HIPBLAS_STATUS_SUCCESS))
+    {
+        CHECK_HIP_ERROR(hipFree(dx));
+        CHECK_HIP_ERROR(hipFree(dy));
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
+    {
+
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        cblas_swap<T>(N, hx.data(), incx, hy.data(), incy);
+
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, incx, hx_cpu.data(), hx.data());
+            unit_check_general<T>(1, N, incy, hy_cpu.data(), hy.data());
+        }
+
+    } // end of if unit/norm check
+
+    //  BLAS_1_RESULT_PRINT
+
+    CHECK_HIP_ERROR(hipFree(dx));
+    CHECK_HIP_ERROR(hipFree(dy));
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_swap.hpp
+++ b/clients/include/testing_swap.hpp
@@ -55,7 +55,7 @@ hipblasStatus_t testing_swap(Arguments argus)
     vector<T> hx_cpu(sizeX);
     vector<T> hy_cpu(sizeY);
 
-    T *dx, *dy;
+    T * dx, *dy;
     int device_pointer = 1;
 
     double gpu_time_used, cpu_time_used;

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -227,6 +227,52 @@ HIPBLAS_EXPORT hipblasStatus_t
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasDnrm2(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
+/*
+HIPBLAS_EXPORT hipblasStatus_t
+    hipBlasScnrm2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipBlasDznrm2(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
+*/
+
+// HIPBLAS_EXPORT hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
+//                                            int             n,
+//                                            float*          x,
+//                                            int             incx,
+//                                            float*          y,
+//                                            int             incy,
+//                                            const float*    c,
+//                                            const float*    s);
+
+// HIPBLAS_EXPORT hipblasStatus_t hipblasDrot(hipblasHandle_t handle,
+//                                            int             n,
+//                                            double*         x,
+//                                            int             incx,
+//                                            double*         y,
+//                                            int             incy,
+//                                            const double*   c,
+//                                            const double*   s);
+
+/*
+HIPBLAS_EXPORT hipblasStatus_t hipblasCrot(hipblasHandle_t   handle,
+                                           int               n,
+                                           hipComplex*       x,
+                                           int               incx,
+                                           hipComplex*       y,
+                                           int               incy,
+                                           const hipComplex* c,
+                                           const hipComplex* s);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
+                                           int                     n,
+                                           hipDoubleComplex*       x,
+                                           int                     incx,
+                                           hipDoubleComplex*       y,
+                                           int                     incy,
+                                           const hipDoubleComplex* c,
+                                           const hipDoubleComplex* s);
+*/
+
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasSscal(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx);
 
@@ -248,6 +294,34 @@ HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int 
 HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double
 *alpha,  double *x, int incx, int batchCount);
 */
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasSswap(hipblasHandle_t handle,
+                                            int             n,
+                                            float*          x,
+                                            int             incx,
+                                            float*          y,
+                                            int             incy);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDswap(hipblasHandle_t handle,
+                                            int             n,
+                                            double*         x,
+                                            int             incx,
+                                            double*         y,
+                                            int             incy);
+
+// HIPBLAS_EXPORT hipblasStatus_t hipblasCswap(hipblasHandle_t handle,
+//                                             int             n,
+//                                             hipComplex*     x,
+//                                             int             incx,
+//                                             hipComplex*          y,
+//                                             int             incy);
+
+// HIPBLAS_EXPORT hipblasStatus_t hipblasZswap(hipblasHandle_t   handle,
+//                                             int               n,
+//                                             hipDoubleComplex* x,
+//                                             int               incx,
+//                                             hipDoubleComplex* y,
+//                                             int               incy);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgemv(hipblasHandle_t    handle,
                                             hipblasOperation_t trans,

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -160,13 +160,12 @@ HIPBLAS_EXPORT hipblasStatus_t
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasDasum(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
-/* not implemented
-HIPBLAS_EXPORT hipblasStatus_t  hipblasSasumBatched(hipblasHandle_t handle, int n, float *x, int
-incx, float  *result, int batchCount);
+// not implemented
+// HIPBLAS_EXPORT hipblasStatus_t  hipblasSasumBatched(hipblasHandle_t handle, int n, float *x, int
+// incx, float  *result, int batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasDasumBatched(hipblasHandle_t handle, int n, double *x, int
-incx, double *result, int batchCount);
-*/
+// HIPBLAS_EXPORT hipblasStatus_t  hipblasDasumBatched(hipblasHandle_t handle, int n, double *x, int
+// incx, double *result, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSaxpy(hipblasHandle_t handle,
                                             int             n,
@@ -184,10 +183,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDaxpy(hipblasHandle_t handle,
                                             double*         y,
                                             int             incy);
 
-/* not implemented
-HIPBLAS_EXPORT hipblasStatus_t hipblasSaxpyBatched(hipblasHandle_t handle, int n, const float
-*alpha, const float *x, int incx,  float *y, int incy, int batchCount);
-*/
+// not implemented
+// HIPBLAS_EXPORT hipblasStatus_t hipblasSaxpyBatched(hipblasHandle_t handle, int n, const float
+// *alpha, const float *x, int incx,  float *y, int incy, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasScopy(hipblasHandle_t handle, int n, const float* x, int incx, float* y, int incy);
@@ -195,13 +193,12 @@ HIPBLAS_EXPORT hipblasStatus_t
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasDcopy(hipblasHandle_t handle, int n, const double* x, int incx, double* y, int incy);
 
-/* not implemented
-HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float *x,
-int incx, float *y, int incy, int batchCount);
+// not implemented
+// HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float *x,
+// int incx, float *y, int incy, int batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double *x,
-int incx, double *y, int incy, int batchCount);
-*/
+// HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double *x,
+// int incx, double *y, int incy, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSdot(hipblasHandle_t handle,
                                            int             n,
@@ -219,13 +216,11 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDdot(hipblasHandle_t handle,
                                            int             incy,
                                            double*         result);
 
-/*
-HIPBLAS_EXPORT hipblasStatus_t hipblasSdotBatched (hipblasHandle_t handle, int n, const float *x,
-int incx, const float *y, int incy, float *result, int batchCount);
+// HIPBLAS_EXPORT hipblasStatus_t hipblasSdotBatched (hipblasHandle_t handle, int n, const float *x,
+// int incx, const float *y, int incy, float *result, int batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasDdotBatched (hipblasHandle_t handle, int n, const double *x,
-int incx, const double *y, int incy, double *result, int batchCount);
-*/
+// HIPBLAS_EXPORT hipblasStatus_t hipblasDdotBatched (hipblasHandle_t handle, int n, const double *x,
+// int incx, const double *y, int incy, double *result, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasSnrm2(hipblasHandle_t handle, int n, const float* x, int incx, float* result);
@@ -233,13 +228,11 @@ HIPBLAS_EXPORT hipblasStatus_t
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasDnrm2(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
-/*
-HIPBLAS_EXPORT hipblasStatus_t
-    hipBlasScnrm2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
+// HIPBLAS_EXPORT hipblasStatus_t
+//     hipBlasScnrm2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipBlasDznrm2(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
-*/
+// HIPBLAS_EXPORT hipblasStatus_t
+//     hipBlasDznrm2(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
 
 // HIPBLAS_EXPORT hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
 //                                            int             n,
@@ -259,25 +252,23 @@ HIPBLAS_EXPORT hipblasStatus_t
 //                                            const double*   c,
 //                                            const double*   s);
 
-/*
-HIPBLAS_EXPORT hipblasStatus_t hipblasCrot(hipblasHandle_t   handle,
-                                           int               n,
-                                           hipComplex*       x,
-                                           int               incx,
-                                           hipComplex*       y,
-                                           int               incy,
-                                           const hipComplex* c,
-                                           const hipComplex* s);
+// HIPBLAS_EXPORT hipblasStatus_t hipblasCrot(hipblasHandle_t   handle,
+//                                            int               n,
+//                                            hipComplex*       x,
+//                                            int               incx,
+//                                            hipComplex*       y,
+//                                            int               incy,
+//                                            const hipComplex* c,
+//                                            const hipComplex* s);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
-                                           int                     n,
-                                           hipDoubleComplex*       x,
-                                           int                     incx,
-                                           hipDoubleComplex*       y,
-                                           int                     incy,
-                                           const hipDoubleComplex* c,
-                                           const hipDoubleComplex* s);
-*/
+// HIPBLAS_EXPORT hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
+//                                            int                     n,
+//                                            hipDoubleComplex*       x,
+//                                            int                     incx,
+//                                            hipDoubleComplex*       y,
+//                                            int                     incy,
+//                                            const hipDoubleComplex* c,
+//                                            const hipDoubleComplex* s);
 
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasSscal(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx);
@@ -285,21 +276,19 @@ HIPBLAS_EXPORT hipblasStatus_t
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasDscal(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx);
 
-/* not implemented, requires complex support
-hipblasStatus_t  hipblasCscal(hipblasHandle_t handle, int n, const hipComplex *alpha,  hipComplex
-*x, int incx);
+// not implemented, requires complex support
+// hipblasStatus_t  hipblasCscal(hipblasHandle_t handle, int n, const hipComplex *alpha,  hipComplex
+// *x, int incx);
 
-hipblasStatus_t  hipblasZscal(hipblasHandle_t handle, int n, const hipDoubleComplex *alpha,
-hipDoubleComplex *x, int incx);
-*/
+// hipblasStatus_t  hipblasZscal(hipblasHandle_t handle, int n, const hipDoubleComplex *alpha,
+// hipDoubleComplex *x, int incx);
 
-/* not implemented
-HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float
-*alpha,  float *x, int incx, int batchCount);
+// not implemented
+// HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float
+// *alpha,  float *x, int incx, int batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double
-*alpha,  double *x, int incx, int batchCount);
-*/
+// HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double
+// *alpha,  double *x, int incx, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasSswap(hipblasHandle_t handle, int n, float* x, int incx, float* y, int incy);
@@ -347,12 +336,11 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDgemv(hipblasHandle_t    handle,
                                             double*            y,
                                             int                incy);
 
-/* not implemented
-HIPBLAS_EXPORT hipblasStatus_t hipblasSgemvBatched(hipblasHandle_t handle, hipblasOperation_t trans,
-int m, int n, const float *alpha, float *A, int lda,
-                           float *x, int incx,  const float *beta,  float *y, int incy, int
-batchCount);
-*/
+// not implemented
+// HIPBLAS_EXPORT hipblasStatus_t hipblasSgemvBatched(hipblasHandle_t handle, hipblasOperation_t trans,
+// int m, int n, const float *alpha, float *A, int lda,
+//                            float *x, int incx,  const float *beta,  float *y, int incy, int
+// batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSger(hipblasHandle_t handle,
                                            int             m,
@@ -376,10 +364,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDger(hipblasHandle_t handle,
                                            double*         A,
                                            int             lda);
 
-/* not implemented
-HIPBLAS_EXPORT hipblasStatus_t  hipblasSgerBatched(hipblasHandle_t handle, int m, int n, const float
-*alpha, const float *x, int incx, const float *y, int incy, float *A, int lda, int batchCount);
-*/
+// not implemented
+// HIPBLAS_EXPORT hipblasStatus_t  hipblasSgerBatched(hipblasHandle_t handle, int m, int n, const float
+// *alpha, const float *x, int incx, const float *y, int incy, float *A, int lda, int batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,
                                             hipblasSideMode_t  side,
@@ -489,18 +476,17 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasGemmEx(hipblasHandle_t    handle,
                                              hipblasDatatype_t  compute_type,
                                              hipblasGemmAlgo_t  algo);
 
-/* not implemented, requires complex support
-hipblasStatus_t hipblasCgemm(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t
-transb,
-                           int m, int n, int k,  const hipComplex *alpha, const hipComplex *A, int
-lda, const hipComplex *B, int ldb, const hipComplex *beta, hipComplex *C, int ldc);
+// not implemented, requires complex support
+// hipblasStatus_t hipblasCgemm(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t
+// transb,
+//                            int m, int n, int k,  const hipComplex *alpha, const hipComplex *A, int
+// lda, const hipComplex *B, int ldb, const hipComplex *beta, hipComplex *C, int ldc);
 
-hipblasStatus_t hipblasZgemm(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t
-transb,
-                           int m, int n, int k,  const hipDoubleComplex *alpha, const
-hipDoubleComplex *A, int lda, const hipDoubleComplex *B, int ldb, const hipDoubleComplex *beta,
-hipDoubleComplex *C, int ldc);
-*/
+// hipblasStatus_t hipblasZgemm(hipblasHandle_t handle,  hipblasOperation_t transa, hipblasOperation_t
+// transb,
+//                            int m, int n, int k,  const hipDoubleComplex *alpha, const
+// hipDoubleComplex *A, int lda, const hipDoubleComplex *B, int ldb, const hipDoubleComplex *beta,
+// hipDoubleComplex *C, int ldc);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasHgemm(hipblasHandle_t    handle,
                                             hipblasOperation_t transa,

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -149,6 +149,12 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasIdamax(hipblasHandle_t handle, int n, const double* x, int incx, int* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
+    hipblasIsamin(hipblasHandle_t handle, int n, const float* x, int incx, int* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasIdamin(hipblasHandle_t handle, int n, const double* x, int incx, int* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
     hipblasSasum(hipblasHandle_t handle, int n, const float* x, int incx, float* result);
 
 HIPBLAS_EXPORT hipblasStatus_t

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -301,19 +301,11 @@ HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int 
 *alpha,  double *x, int incx, int batchCount);
 */
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasSswap(hipblasHandle_t handle,
-                                            int             n,
-                                            float*          x,
-                                            int             incx,
-                                            float*          y,
-                                            int             incy);
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasSswap(hipblasHandle_t handle, int n, float* x, int incx, float* y, int incy);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasDswap(hipblasHandle_t handle,
-                                            int             n,
-                                            double*         x,
-                                            int             incx,
-                                            double*         y,
-                                            int             incy);
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDswap(hipblasHandle_t handle, int n, double* x, int incx, double* y, int incy);
 
 // HIPBLAS_EXPORT hipblasStatus_t hipblasCswap(hipblasHandle_t handle,
 //                                             int             n,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -392,6 +392,7 @@ hipblasStatus_t hipblasDgeam(hipblasHandle_t    handle,
                                                   ldc));
 }
 
+// MAX
 hipblasStatus_t hipblasIsamax(hipblasHandle_t handle, int n, const float* x, int incx, int* result)
 {
     return rocBLASStatusToHIPStatus(rocblas_isamax((rocblas_handle)handle, n, x, incx, result));
@@ -402,6 +403,18 @@ hipblasStatus_t hipblasIdamax(hipblasHandle_t handle, int n, const double* x, in
     return rocBLASStatusToHIPStatus(rocblas_idamax((rocblas_handle)handle, n, x, incx, result));
 }
 
+// MIN
+hipblasStatus_t hipblasIsamin(hipblasHandle_t handle, int n,  const float* x, int incx, int* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_isamin((rocblas_handle)handle, n, x, incx, result));
+}
+
+hipblasStatus_t hipblasIdamin(hipblasHandle_t handle, int n,  const double* x, int incx, int* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_idamin((rocblas_handle)handle, n, x, incx, result));
+}
+
+// ASUM
 hipblasStatus_t hipblasSasum(hipblasHandle_t handle, int n, const float* x, int incx, float* result)
 {
     return rocBLASStatusToHIPStatus(rocblas_sasum((rocblas_handle)handle, n, x, incx, result));

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -508,6 +508,69 @@ hipblasStatus_t
     return rocBLASStatusToHIPStatus(rocblas_dnrm2((rocblas_handle)handle, n, x, incx, result));
 }
 
+/*
+hipblasStatus_t hipblasCnrm2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_snrm2((rocblas_handle)handle, n, x, incx, result));
+}
+
+hipblasStatus_t
+    hipblasZnrm2(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dnrm2((rocblas_handle)handle, n, x, incx, result));
+}
+*/
+
+// hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
+//                             int             n,
+//                             float*          x,
+//                             int             incx,
+//                             float*          y,
+//                             int             incy,
+//                             const float*    c,
+//                             const float*    s)
+// {
+//     return rocBLASStatusToHIPStatus(rocblas_srot((rocblas_handle)handle, n, x, incx, y, incy, c, s));
+// }
+
+// hipblasStatus_t hipblasDrot(hipblasHandle_t handle,
+//                             int             n,
+//                             double*         x,
+//                             int             incx,
+//                             double*         y,
+//                             int             incy,
+//                             const double*   c,
+//                             const double*   s)
+// {
+//     return rocBLASStatusToHIPStatus(rocblas_drot((rocblas_handle)handle, n, x, incx, y, incy, c, s));
+// }
+
+/*
+hipblasStatus_t hipblasCrot(hipblasHandle_t      handle,
+                            int                  n,
+                            hipComplex*          x,
+                            int                  incx,
+                            hipComplex*          y,
+                            int                  incy,
+                            const hipComplex*    c,
+                            const hipComplex*    s)
+{
+    return rocBLASStatusToHIPStatus(rocblas_crot((rocblas_handle)handle, n, x, incx, y, incy, c, s));
+}
+
+hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
+                            int                     n,
+                            hipDoubleComplex*       x,
+                            int                     incx,
+                            hipDoubleComplex*       y,
+                            int                     incy,
+                            const hipDoubleComplex* c,
+                            const hipDoubleComplex* s)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zrot((rocblas_handle)handle, n, x, incx, y, incy, c, s));
+}
+*/
+
 hipblasStatus_t hipblasSscal(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx)
 {
     return rocBLASStatusToHIPStatus(rocblas_sscal((rocblas_handle)handle, n, alpha, x, incx));
@@ -539,6 +602,48 @@ int incx, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
 
 hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double *alpha,  double *x,
 int incx, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+*/
+
+hipblasStatus_t hipblasSswap(hipblasHandle_t handle,
+                             int             n,
+                             float*          x,
+                             int             incx,
+                             float*          y,
+                             int             incy)
+{
+    return rocBLASStatusToHIPStatus(rocblas_sswap((rocblas_handle)handle, n, x, incx, y, incy));
+}
+
+hipblasStatus_t hipblasDswap(hipblasHandle_t handle,
+                             int             n,
+                             double*         x,
+                             int             incx,
+                             double*         y,
+                             int             incy)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dswap((rocblas_handle)handle, n, x, incx, y, incy));
+}
+
+/*
+hipblasStatus_t hipblasCswap(hipblasHandle_t handle,
+                             int             n,
+                             hipComplex*     x,
+                             int             incx,
+                             hipComplex*          y,
+                             int             incy)
+{
+    return rocBLASStatusToHIPStatus(rocblas_cswap((rocblas_handle)handle, n, x, incx, y, incy));
+}
+
+hipblasStatus_t hipblasZswap(hipblasHandle_t handle,
+                             int             n,
+                             hipDoubleComplex*         x,
+                             int             incx,
+                             hipDoubleComplex*         y,
+                             int             incy)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zswap((rocblas_handle)handle, n, x, incx, y, incy));
+}
 */
 
 hipblasStatus_t hipblasSgemv(hipblasHandle_t    handle,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -404,12 +404,12 @@ hipblasStatus_t hipblasIdamax(hipblasHandle_t handle, int n, const double* x, in
 }
 
 // MIN
-hipblasStatus_t hipblasIsamin(hipblasHandle_t handle, int n,  const float* x, int incx, int* result)
+hipblasStatus_t hipblasIsamin(hipblasHandle_t handle, int n, const float* x, int incx, int* result)
 {
     return rocBLASStatusToHIPStatus(rocblas_isamin((rocblas_handle)handle, n, x, incx, result));
 }
 
-hipblasStatus_t hipblasIdamin(hipblasHandle_t handle, int n,  const double* x, int incx, int* result)
+hipblasStatus_t hipblasIdamin(hipblasHandle_t handle, int n, const double* x, int incx, int* result)
 {
     return rocBLASStatusToHIPStatus(rocblas_idamin((rocblas_handle)handle, n, x, incx, result));
 }
@@ -617,22 +617,13 @@ hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double
 int incx, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
 */
 
-hipblasStatus_t hipblasSswap(hipblasHandle_t handle,
-                             int             n,
-                             float*          x,
-                             int             incx,
-                             float*          y,
-                             int             incy)
+hipblasStatus_t hipblasSswap(hipblasHandle_t handle, int n, float* x, int incx, float* y, int incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_sswap((rocblas_handle)handle, n, x, incx, y, incy));
 }
 
-hipblasStatus_t hipblasDswap(hipblasHandle_t handle,
-                             int             n,
-                             double*         x,
-                             int             incx,
-                             double*         y,
-                             int             incy)
+hipblasStatus_t
+    hipblasDswap(hipblasHandle_t handle, int n, double* x, int incx, double* y, int incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_dswap((rocblas_handle)handle, n, x, incx, y, incy));
 }

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -508,22 +508,13 @@ hipblasStatus_t hipblasDscalBatched(
     return hipCUBLASStatusToHIPStatus(cublasDscal((cublasHandle_t)handle, n, alpha, x, incx));
 }
 
-hipblasStatus_t hipblasSswap(hipblasHandle_t handle,
-                             int             n,
-                             float*          x,
-                             int             incx,
-                             float*          y,
-                             int             incy)
+hipblasStatus_t hipblasSswap(hipblasHandle_t handle, int n, float* x, int incx, float* y, int incy)
 {
     return hipCUBLASStatusToHIPStatus(cublasSswap((cublasHandle_t)handle, n, x, incx, y, incy));
 }
 
-hipblasStatus_t hipblasDswap(hipblasHandle_t handle,
-                             int             n,
-                             double*         x,
-                             int             incx,
-                             double*         y,
-                             int             incy)
+hipblasStatus_t
+    hipblasDswap(hipblasHandle_t handle, int n, double* x, int incx, double* y, int incy)
 {
     return hipCUBLASStatusToHIPStatus(cublasDswap((cublasHandle_t)handle, n, x, incx, y, incy));
 }

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -449,6 +449,30 @@ hipblasStatus_t
     return hipCUBLASStatusToHIPStatus(cublasDnrm2((cublasHandle_t)handle, n, x, incx, result));
 }
 
+// hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
+//                             int             n,
+//                             float*          x,
+//                             int             incx,
+//                             float*          y,
+//                             int             incy,
+//                             const float*    c,
+//                             const float*    s)
+// {
+//     return hipCUBLASStatusToHIPStatus(cublasSrot((cublasHandle_t)handle, n, x, incx, y, incy, c, s));
+// }
+
+// hipblasStatus_t hipblasDrot(hipblasHandle_t handle,
+//                             int             n,
+//                             double*         x,
+//                             int             incx,
+//                             double*         y,
+//                             int             incy,
+//                             const double*   c,
+//                             const double*   s)
+// {
+//     return hipCUBLASStatusToHIPStatus(cublasDrot((cublasHandle_t)handle, n, x, incx, y, incy, c, s));
+// }
+
 hipblasStatus_t hipblasSscal(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx)
 {
     return hipCUBLASStatusToHIPStatus(cublasSscal((cublasHandle_t)handle, n, alpha, x, incx));
@@ -470,6 +494,48 @@ hipblasStatus_t hipblasDscalBatched(
     // TODO warn user that function was demoted to ignore batch
     return hipCUBLASStatusToHIPStatus(cublasDscal((cublasHandle_t)handle, n, alpha, x, incx));
 }
+
+hipblasStatus_t hipblasSswap(hipblasHandle_t handle,
+                             int             n,
+                             float*          x,
+                             int             incx,
+                             float*          y,
+                             int             incy)
+{
+    return hipCUBLASStatusToHIPStatus(cublasSswap((cublasHandle_t)handle, n, x, incx, y, incy));
+}
+
+hipblasStatus_t hipblasDswap(hipblasHandle_t handle,
+                             int             n,
+                             double*         x,
+                             int             incx,
+                             double*         y,
+                             int             incy)
+{
+    return hipCUBLASStatusToHIPStatus(cublasDswap((cublasHandle_t)handle, n, x, incx, y, incy));
+}
+
+/*
+hipblasStatus_t hipblasCswap(hipblasHandle_t handle,
+                             int             n,
+                             hipComplex*     x,
+                             int             incx,
+                             hipComplex*          y,
+                             int             incy)
+{
+    return hipCUBLASStatusToHIPStatus(cublasCswap((cublasHandle_t)handle, n, x, incx, y, incy));
+}
+
+hipblasStatus_t hipblasZswap(hipblasHandle_t handle,
+                             int             n,
+                             hipDoubleComplex*         x,
+                             int             incx,
+                             hipDoubleComplex*         y,
+                             int             incy)
+{
+    return hipCUBLASStatusToHIPStatus(cublasZswap((cublasHandle_t)handle, n, x, incx, y, incy));
+}
+*/
 
 hipblasStatus_t hipblasSgemv(hipblasHandle_t    handle,
                              hipblasOperation_t trans,

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -304,6 +304,7 @@ hipblasStatus_t hipblasDgeam(hipblasHandle_t    handle,
                                                   ldc));
 }
 
+// MAX
 hipblasStatus_t hipblasIsamax(hipblasHandle_t handle, int n, const float* x, int incx, int* result)
 {
     return hipCUBLASStatusToHIPStatus(cublasIsamax((cublasHandle_t)handle, n, x, incx, result));
@@ -314,6 +315,18 @@ hipblasStatus_t hipblasIdamax(hipblasHandle_t handle, int n, const double* x, in
     return hipCUBLASStatusToHIPStatus(cublasIdamax((cublasHandle_t)handle, n, x, incx, result));
 }
 
+// MIN
+hipblasStatus_t hipblasIsamin(hipblasHandle_t handle, int n, const float* x, int incx, int* result)
+{
+    return hipCUBLASStatusToHIPStatus(cublasIsamin((cublasHandle_t)handle, n, x, incx, result));
+}
+
+hipblasStatus_t hipblasIdamin(hipblasHandle_t handle, int n, const double* x, int incx, int* result)
+{
+    return hipCUBLASStatusToHIPStatus(cublasIdamin((cublasHandle_t)handle, n, x, incx, result));
+}
+
+// ASUM
 hipblasStatus_t hipblasSasum(hipblasHandle_t handle, int n, const float* x, int incx, float* result)
 {
     return hipCUBLASStatusToHIPStatus(cublasSasum((cublasHandle_t)handle, n, x, incx, result));


### PR DESCRIPTION
Adding (real precision) L1 functions:
- swap
- iamin

iamin is not currently tested as it is still broken in rocBLAS 2.9. Rotation functions (rot(m)(g)) not in rocBLAS 2.9, so not being supported right now. Complex functionality coming in a future PR as well.