### PR TITLE
Add missing L2 functions

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -368,6 +368,30 @@ void cblas_ger<double>(
     cblas_dger(CblasColMajor, m, n, alpha, x, incx, y, incy, A, lda);
 }
 
+template <>
+void cblas_syr<float>(hipblasFillMode_t uplo,
+                      int               n,
+                      float             alpha,
+                      float*            x,
+                      int               incx,
+                      float*            A,
+                      int               lda)
+{
+    cblas_ssyr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
+}
+
+template <>
+void cblas_syr<double>(hipblasFillMode_t uplo,
+                       int               n,
+                       double            alpha,
+                       double*           x,
+                       int               incx,
+                       double*           A,
+                       int               lda)
+{
+    cblas_dsyr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
+}
+
 /*
  * ===========================================================================
  *    level 3 BLAS

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -373,39 +373,29 @@ void cblas_ger<double>(
 
 // syr
 template <>
-void cblas_syr<float>(hipblasFillMode_t uplo,
-                      int               n,
-                      float             alpha,
-                      float*            x,
-                      int               incx,
-                      float*            A,
-                      int               lda)
+void cblas_syr<float>(
+    hipblasFillMode_t uplo, int n, float alpha, float* x, int incx, float* A, int lda)
 {
     cblas_ssyr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
 }
 
 template <>
-void cblas_syr<double>(hipblasFillMode_t uplo,
-                       int               n,
-                       double            alpha,
-                       double*           x,
-                       int               incx,
-                       double*           A,
-                       int               lda)
+void cblas_syr<double>(
+    hipblasFillMode_t uplo, int n, double alpha, double* x, int incx, double* A, int lda)
 {
     cblas_dsyr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
 }
 
 // trmv
 template <>
-void cblas_trmv(hipblasFillMode_t      uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int       m,
-                       const float*      A,
-                       int       lda,
-                       float*            x,
-                       int       incx)
+void cblas_trmv(hipblasFillMode_t  uplo,
+                hipblasOperation_t transA,
+                hipblasDiagType_t  diag,
+                int                m,
+                const float*       A,
+                int                lda,
+                float*             x,
+                int                incx)
 {
     cblas_strmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -419,14 +409,14 @@ void cblas_trmv(hipblasFillMode_t      uplo,
 }
 
 template <>
-void cblas_trmv(hipblasFillMode_t      uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int       m,
-                       const double*     A,
-                       int       lda,
-                       double*           x,
-                       int       incx)
+void cblas_trmv(hipblasFillMode_t  uplo,
+                hipblasOperation_t transA,
+                hipblasDiagType_t  diag,
+                int                m,
+                const double*      A,
+                int                lda,
+                double*            x,
+                int                incx)
 {
     cblas_dtrmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -481,14 +471,14 @@ void cblas_trsv<float>(hipblasHandle_t    handle,
 
 template <>
 void cblas_trsv<double>(hipblasHandle_t    handle,
-                       hipblasFillMode_t  uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int                m,
-                       const double*      A,
-                       int                lda,
-                       double*            x,
-                       int                incx)
+                        hipblasFillMode_t  uplo,
+                        hipblasOperation_t transA,
+                        hipblasDiagType_t  diag,
+                        int                m,
+                        const double*      A,
+                        int                lda,
+                        double*            x,
+                        int                incx)
 {
     cblas_dtrsv(CblasColMajor,
                 CBLAS_UPLO(uplo),

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -29,6 +29,9 @@ void dgetrf_(int* m, int* n, double* A, int* lda, int* ipiv, int* info);
 //  void    cgetrf_(int* m, int* n, hipComplex* A, int* lda, int* ipiv, int *info);
 //  void    zgetrf_(int* m, int* n, hipDoubleComplex* A, int* lda, int* ipiv, int *info);
 
+void spotrf_(char* uplo, int* m, float* A, int* lda, int* info);
+void dpotrf_(char* uplo, int* m, double* A, int* lda, int* info);
+
 #ifdef __cplusplus
 }
 #endif
@@ -368,6 +371,7 @@ void cblas_ger<double>(
     cblas_dger(CblasColMajor, m, n, alpha, x, incx, y, incy, A, lda);
 }
 
+// syr
 template <>
 void cblas_syr<float>(hipblasFillMode_t uplo,
                       int               n,
@@ -390,6 +394,111 @@ void cblas_syr<double>(hipblasFillMode_t uplo,
                        int               lda)
 {
     cblas_dsyr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
+}
+
+// trmv
+template <>
+void cblas_trmv(hipblasFillMode_t      uplo,
+                       hipblasOperation_t transA,
+                       hipblasDiagType_t  diag,
+                       int       m,
+                       const float*      A,
+                       int       lda,
+                       float*            x,
+                       int       incx)
+{
+    cblas_strmv(CblasColMajor,
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
+                m,
+                A,
+                lda,
+                x,
+                incx);
+}
+
+template <>
+void cblas_trmv(hipblasFillMode_t      uplo,
+                       hipblasOperation_t transA,
+                       hipblasDiagType_t  diag,
+                       int       m,
+                       const double*     A,
+                       int       lda,
+                       double*           x,
+                       int       incx)
+{
+    cblas_dtrmv(CblasColMajor,
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
+                m,
+                A,
+                lda,
+                x,
+                incx);
+}
+
+// potrf
+template <>
+int cblas_potrf(char uplo, int m, float* A, int lda)
+{
+    int info;
+    spotrf_(&uplo, &m, A, &lda, &info);
+    return info;
+}
+
+template <>
+int cblas_potrf(char uplo, int m, double* A, int lda)
+{
+    int info;
+    dpotrf_(&uplo, &m, A, &lda, &info);
+    return info;
+}
+
+// trsv
+template <>
+void cblas_trsv<float>(hipblasHandle_t    handle,
+                       hipblasFillMode_t  uplo,
+                       hipblasOperation_t transA,
+                       hipblasDiagType_t  diag,
+                       int                m,
+                       const float*       A,
+                       int                lda,
+                       float*             x,
+                       int                incx)
+{
+    cblas_strsv(CblasColMajor,
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
+                m,
+                A,
+                lda,
+                x,
+                incx);
+}
+
+template <>
+void cblas_trsv<double>(hipblasHandle_t    handle,
+                       hipblasFillMode_t  uplo,
+                       hipblasOperation_t transA,
+                       hipblasDiagType_t  diag,
+                       int                m,
+                       const double*      A,
+                       int                lda,
+                       double*            x,
+                       int                incx)
+{
+    cblas_dtrsv(CblasColMajor,
+                CBLAS_UPLO(uplo),
+                CBLAS_TRANSPOSE(transA),
+                CBLAS_DIAG(diag),
+                m,
+                A,
+                lda,
+                x,
+                incx);
 }
 
 /*

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -442,7 +442,6 @@ hipblasStatus_t hipblasTrsv<double>(hipblasHandle_t    handle,
     return hipblasDtrsv(handle, uplo, transA, diag, m, A, lda, x, incx);
 }
 
-
 /*
  * ===========================================================================
  *    level 3 BLAS

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -386,6 +386,7 @@ hipblasStatus_t hipblasGer<double>(hipblasHandle_t handle,
     return hipblasDger(handle, m, n, alpha, x, incx, y, incy, A, lda);
 }
 
+// syr
 template <>
 hipblasStatus_t hipblasSyr<float>(hipblasHandle_t   handle,
                                   hipblasFillMode_t uplo,
@@ -411,6 +412,36 @@ hipblasStatus_t hipblasSyr<double>(hipblasHandle_t   handle,
 {
     return hipblasDsyr(handle, uplo, n, alpha, x, incx, A, lda);
 }
+
+// trsv
+template <>
+hipblasStatus_t hipblasTrsv<float>(hipblasHandle_t    handle,
+                                   hipblasFillMode_t  uplo,
+                                   hipblasOperation_t transA,
+                                   hipblasDiagType_t  diag,
+                                   int                m,
+                                   const float*       A,
+                                   int                lda,
+                                   float*             x,
+                                   int                incx)
+{
+    return hipblasStrsv(handle, uplo, transA, diag, m, A, lda, x, incx);
+}
+
+template <>
+hipblasStatus_t hipblasTrsv<double>(hipblasHandle_t    handle,
+                                    hipblasFillMode_t  uplo,
+                                    hipblasOperation_t transA,
+                                    hipblasDiagType_t  diag,
+                                    int                m,
+                                    const double*      A,
+                                    int                lda,
+                                    double*            x,
+                                    int                incx)
+{
+    return hipblasDtrsv(handle, uplo, transA, diag, m, A, lda, x, incx);
+}
+
 
 /*
  * ===========================================================================

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -386,6 +386,32 @@ hipblasStatus_t hipblasGer<double>(hipblasHandle_t handle,
     return hipblasDger(handle, m, n, alpha, x, incx, y, incy, A, lda);
 }
 
+template <>
+hipblasStatus_t hipblasSyr<float>(hipblasHandle_t   handle,
+                                  hipblasFillMode_t uplo,
+                                  int               n,
+                                  const float*      alpha,
+                                  const float*      x,
+                                  int               incx,
+                                  float*            A,
+                                  int               lda)
+{
+    return hipblasSsyr(handle, uplo, n, alpha, x, incx, A, lda);
+}
+
+template <>
+hipblasStatus_t hipblasSyr<double>(hipblasHandle_t   handle,
+                                   hipblasFillMode_t uplo,
+                                   int               n,
+                                   const double*     alpha,
+                                   const double*     x,
+                                   int               incx,
+                                   double*           A,
+                                   int               lda)
+{
+    return hipblasDsyr(handle, uplo, n, alpha, x, incx, A, lda);
+}
+
 /*
  * ===========================================================================
  *    level 3 BLAS

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -44,6 +44,7 @@ set(hipblas_test_source
   blas1_gtest.cpp
   gemv_gtest.cpp
   ger_gtest.cpp
+  syr_gtest.cpp
   gemm_gtest.cpp
   gemm_ex_gtest.cpp
   gemm_strided_batched_gtest.cpp

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -45,6 +45,7 @@ set(hipblas_test_source
   gemv_gtest.cpp
   ger_gtest.cpp
   syr_gtest.cpp
+  trsv_gtest.cpp
   gemm_gtest.cpp
   gemm_ex_gtest.cpp
   gemm_strided_batched_gtest.cpp

--- a/clients/gtest/syr_gtest.cpp
+++ b/clients/gtest/syr_gtest.cpp
@@ -1,0 +1,186 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include "testing_syr.hpp"
+#include "utility.h"
+#include <gtest/gtest.h>
+#include <math.h>
+#include <stdexcept>
+#include <vector>
+
+using ::testing::Combine;
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using namespace std;
+
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+
+typedef std::tuple<vector<int>, vector<int>, double> syr_tuple;
+
+/* =====================================================================
+README: This file contains testers to verify the correctness of
+        BLAS routines with google test
+
+        It is supposed to be played/used by advance / expert users
+        Normal users only need to get the library routines without testers
+     =================================================================== */
+
+/* =====================================================================
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
+like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers
+inside API of course.
+Yet, the goal of this file is to verify result correctness not argument-checkers.
+
+Representative sampling is sufficient, endless brute-force sampling is not necessary
+=================================================================== */
+
+// vector of vector, each vector is a {M, N, lda};
+// add/delete as a group
+const vector<vector<int>> matrix_size_range = {
+    {-1, -1, -1}, {11, 11, 11}, {16, 16, 16}, {32, 32, 32}, {65, 65, 65}
+    //   {10, 10, 2},
+    //   {600,500, 500},
+    //   {1000, 1000, 1000},
+    //   {2000, 2000, 2000},
+    //   {4011, 4011, 4011},
+    //   {8000, 8000, 8000}
+};
+
+// vector of vector, each element is an {incx}
+const vector<vector<int>> incx_incy_range = {
+    {-2}, {1}, {0}, {2}
+    //     {10, 100}
+};
+
+// vector, each entry is  {alpha};
+// add/delete single values, like {2.0}
+const vector<double> alpha_range = {-0.5, 2.0, 0.0};
+
+/* ===============Google Unit Test==================================================== */
+
+/* =====================================================================
+     BLAS-2 syr:
+=================================================================== */
+
+/* ============================Setup Arguments======================================= */
+
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
+
+Arguments setup_syr_arguments(syr_tuple tup)
+{
+    vector<int> matrix_size = std::get<0>(tup);
+    vector<int> incx        = std::get<1>(tup);
+    double      alpha       = std::get<2>(tup);
+
+    Arguments arg;
+
+    // see the comments about matrix_size_range above
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
+    arg.lda = matrix_size[2];
+
+    // see the comments about matrix_size_range above
+    arg.incx = incx[0];
+
+    arg.alpha = alpha;
+
+    arg.timing = 0;
+
+    return arg;
+}
+
+class blas2_syr_gtest : public ::TestWithParam<syr_tuple>
+{
+protected:
+    blas2_syr_gtest() {}
+    virtual ~blas2_syr_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+TEST_P(blas2_syr_gtest, float)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_syr_arguments(GetParam());
+
+    hipblasStatus_t status = testing_syr<float>(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.lda < arg.M)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx <= 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy <= 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+    }
+}
+
+TEST_P(blas2_syr_gtest, double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_syr_arguments(GetParam());
+
+    hipblasStatus_t status = testing_syr<double>(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.lda < arg.M)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx <= 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy <= 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+    }
+}
+
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
+// The combinations are  { {M, N, lda}, {incx,incy} {alpha} }
+
+INSTANTIATE_TEST_CASE_P(hipblasSyr,
+                        blas2_syr_gtest,
+                        Combine(ValuesIn(matrix_size_range),
+                                ValuesIn(incx_incy_range),
+                                ValuesIn(alpha_range)));

--- a/clients/gtest/trsv_gtest.cpp
+++ b/clients/gtest/trsv_gtest.cpp
@@ -1,0 +1,175 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include "testing_trsv.hpp"
+#include "utility.h"
+#include <gtest/gtest.h>
+#include <math.h>
+#include <stdexcept>
+#include <vector>
+
+using ::testing::Combine;
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using namespace std;
+
+// only GCC/VS 2010 comes with std::tr1::tuple, but it is unnecessary,  std::tuple is good enough;
+
+typedef std::tuple<vector<int>, vector<int>, double> trsv_tuple;
+
+/* =====================================================================
+README: This file contains testers to verify the correctness of
+        BLAS routines with google test
+
+        It is supposed to be played/used by advance / expert users
+        Normal users only need to get the library routines without testers
+     =================================================================== */
+
+/* =====================================================================
+Advance users only: BrainStorm the parameters but do not make artificial one which invalidates the
+matrix.
+like lda pairs with M, and "lda must >= M". case "lda < M" will be guarded by argument-checkers
+inside API of course.
+Yet, the goal of this file is to verify result correctness not argument-checkers.
+
+Representative sampling is sufficient, endless brute-force sampling is not necessary
+=================================================================== */
+
+// vector of vector, each vector is a {M, N, lda};
+// add/delete as a group
+const vector<vector<int>> matrix_size_range = {
+    {-1, 0, -1}, {11, 0, 11}, {16, 0, 16}, {32, 0, 32}, {65, 0, 65}
+    //   {10, 10, 2},
+    //   {600,500, 500},
+    //   {1000, 1000, 1000},
+    //   {2000, 2000, 2000},
+    //   {4011, 4011, 4011},
+    //   {8000, 8000, 8000}
+};
+
+// vector of vector, each element is an {incx, incy}
+const vector<vector<int>> incx_incy_range = {
+    {-2, 0}, {1, 0}, {0, 0}, {2, 0}
+    //     {10, 100}
+};
+
+// vector, each entry is  {alpha};
+// add/delete single values, like {2.0}
+const vector<double> alpha_range = {0.0};
+
+/* ===============Google Unit Test==================================================== */
+
+/* =====================================================================
+     BLAS-2 trsv:
+=================================================================== */
+
+/* ============================Setup Arguments======================================= */
+
+// Please use "class Arguments" (see utility.hpp) to pass parameters to templated testers;
+// Some routines may not touch/use certain "members" of objects "argus".
+// like BLAS-1 Scal does not have lda, BLAS-2 GEMV does not have ldb, ldc;
+// That is fine. These testers & routines will leave untouched members alone.
+// Do not use std::tuple to directly pass parameters to testers
+// by std:tuple, you have unpack it with extreme care for each one by like "std::get<0>" which is
+// not intuitive and error-prone
+
+Arguments setup_trsv_arguments(trsv_tuple tup)
+{
+    vector<int> matrix_size = std::get<0>(tup);
+    vector<int> incx        = std::get<1>(tup);
+
+    Arguments arg;
+
+    // see the comments about matrix_size_range above
+    arg.M   = matrix_size[0];
+    arg.N   = matrix_size[1];
+    arg.lda = matrix_size[2];
+
+    // see the comments about matrix_size_range above
+    arg.incx = incx[0];
+
+    arg.timing = 0;
+
+    return arg;
+}
+
+class blas2_trsv_gtest : public ::TestWithParam<trsv_tuple>
+{
+protected:
+    blas2_trsv_gtest() {}
+    virtual ~blas2_trsv_gtest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+TEST_P(blas2_trsv_gtest, float)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_trsv_arguments(GetParam());
+
+    hipblasStatus_t status = testing_trsv<float>(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.lda < arg.M)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx <= 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+    }
+}
+
+TEST_P(blas2_trsv_gtest, double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+
+    Arguments arg = setup_trsv_arguments(GetParam());
+
+    hipblasStatus_t status = testing_trsv<double>(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.lda < arg.M)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx <= 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+    }
+}
+
+// notice we are using vector of vector
+// so each elment in xxx_range is a avector,
+// ValuesIn take each element (a vector) and combine them and feed them to test_p
+// The combinations are  { {M, N, lda}, {incx,incy} {alpha} }
+
+INSTANTIATE_TEST_CASE_P(hipblastrsv,
+                        blas2_trsv_gtest,
+                        Combine(ValuesIn(matrix_size_range),
+                                ValuesIn(incx_incy_range),
+                                ValuesIn(alpha_range)));

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -63,6 +63,15 @@ template <typename T>
 void cblas_ger(int m, int n, T alpha, T* x, int incx, T* y, int incy, T* A, int lda);
 
 template <typename T>
+void cblas_syr(hipblasFillMode_t uplo,
+               int               n,
+               T                 alpha,
+               T*                x,
+               int               incx,
+               T*                A,
+               int               lda);
+
+template <typename T>
 void cblas_hemv(
     hipblasFillMode_t uplo, int n, T alpha, T* A, int lda, T* x, int incx, T beta, T* y, int incy);
 

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -14,6 +14,7 @@
  * not part of the GPU library
 */
 
+
 /*
  * ===========================================================================
  *    level 1 BLAS
@@ -70,6 +71,33 @@ void cblas_syr(hipblasFillMode_t uplo,
                int               incx,
                T*                A,
                int               lda);
+
+// potrf
+template <typename T>
+int cblas_potrf(char uplo, int m, T* A, int lda);
+
+// trmv
+template <typename T>
+void cblas_trmv(hipblasFillMode_t      uplo,
+                hipblasOperation_t transA,
+                hipblasDiagType_t  diag,
+                int       m,
+                const T*          A,
+                int       lda,
+                T*                x,
+                int       incx);
+
+// trsv
+template <typename T>
+void cblas_trsv(hipblasHandle_t    handle,
+                hipblasFillMode_t  uplo,
+                hipblasOperation_t transA,
+                hipblasDiagType_t  diag,
+                int                m,
+                const T*           A,
+                int                lda,
+                T*                 x,
+                int                incx);
 
 template <typename T>
 void cblas_hemv(

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -14,7 +14,6 @@
  * not part of the GPU library
 */
 
-
 /*
  * ===========================================================================
  *    level 1 BLAS
@@ -64,13 +63,7 @@ template <typename T>
 void cblas_ger(int m, int n, T alpha, T* x, int incx, T* y, int incy, T* A, int lda);
 
 template <typename T>
-void cblas_syr(hipblasFillMode_t uplo,
-               int               n,
-               T                 alpha,
-               T*                x,
-               int               incx,
-               T*                A,
-               int               lda);
+void cblas_syr(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* A, int lda);
 
 // potrf
 template <typename T>
@@ -78,14 +71,14 @@ int cblas_potrf(char uplo, int m, T* A, int lda);
 
 // trmv
 template <typename T>
-void cblas_trmv(hipblasFillMode_t      uplo,
+void cblas_trmv(hipblasFillMode_t  uplo,
                 hipblasOperation_t transA,
                 hipblasDiagType_t  diag,
-                int       m,
-                const T*          A,
-                int       lda,
-                T*                x,
-                int       incx);
+                int                m,
+                const T*           A,
+                int                lda,
+                T*                 x,
+                int                incx);
 
 // trsv
 template <typename T>

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -65,6 +65,7 @@ hipblasStatus_t hipblasGer(hipblasHandle_t handle,
                            T*              A,
                            int             lda);
 
+// syr
 template <typename T>
 hipblasStatus_t hipblasSyr(hipblasHandle_t   handle,
                            hipblasFillMode_t uplo,
@@ -74,6 +75,18 @@ hipblasStatus_t hipblasSyr(hipblasHandle_t   handle,
                            int               incx,
                            T*                A,
                            int               lda);
+
+// trsv
+template <typename T>
+hipblasStatus_t hipblasTrsv(hipblasHandle_t    handle,
+                            hipblasFillMode_t  uplo,
+                            hipblasOperation_t transA,
+                            hipblasDiagType_t  diag,
+                            int                m,
+                            const T*           A,
+                            int                lda,
+                            T*                 x,
+                            int                incx);
 
 template <typename T>
 hipblasStatus_t hipblasGemv(hipblasHandle_t    handle,

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -66,6 +66,16 @@ hipblasStatus_t hipblasGer(hipblasHandle_t handle,
                            int             lda);
 
 template <typename T>
+hipblasStatus_t hipblasSyr(hipblasHandle_t   handle,
+                           hipblasFillMode_t uplo,
+                           int               n,
+                           const T*          alpha,
+                           const T*          x,
+                           int               incx,
+                           T*                A,
+                           int               lda);
+
+template <typename T>
 hipblasStatus_t hipblasGemv(hipblasHandle_t    handle,
                             hipblasOperation_t transA,
                             int                m,

--- a/clients/include/testing_syr.hpp
+++ b/clients/include/testing_syr.hpp
@@ -1,0 +1,135 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <fstream>
+#include <iostream>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "flops.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_syr(Arguments argus)
+{
+    int M                  = argus.M;
+    int N                  = argus.N;
+    int incx               = argus.incx;
+    int lda                = argus.lda;
+    char char_uplo = argus.uplo_option;
+    hipblasFillMode_t uplo = char2hipblas_fill(char_uplo);
+
+    int abs_incx = incx < 0 ? -incx : incx;
+    int A_size = lda * N;
+    int x_size = abs_incx * N;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(M < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    if(N < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    else if(lda < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    else if(incx == 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    vector<T> hA(A_size);
+    vector<T> hA_cpu(A_size);
+    vector<T> hx(x_size);
+
+    T *dA, *dx;
+
+    double gpu_time_used, cpu_time_used;
+    double hipblasGflops, cblas_gflops, hipblasBandwidth;
+    double rocblas_error;
+
+    T alpha = (T)argus.alpha;
+
+    hipblasHandle_t handle;
+
+    hipblasCreate(&handle);
+
+    // allocate memory on device
+    CHECK_HIP_ERROR(hipMalloc(&dA, A_size * sizeof(T)));
+    CHECK_HIP_ERROR(hipMalloc(&dx, x_size * sizeof(T)));
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T>(hA, M, N, lda);
+    hipblas_init<T>(hx, 1, N, abs_incx);
+    hA_cpu = hA;
+
+    // copy data from CPU to device
+    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
+    hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice);
+
+    /* =====================================================================
+           ROCBLAS
+    =================================================================== */
+    if(argus.timing)
+    {
+        gpu_time_used = get_time_us(); // in microseconds
+    }
+
+    for(int iter = 0; iter < 1; iter++)
+    {
+        status = hipblasSyr<T>(handle, uplo, N, (T*)&alpha, dx, incx, dA, lda);
+
+        if(status != HIPBLAS_STATUS_SUCCESS)
+        {
+            CHECK_HIP_ERROR(hipFree(dA));
+            CHECK_HIP_ERROR(hipFree(dx));
+            hipblasDestroy(handle);
+            return status;
+        }
+    }
+
+    // copy output from device to CPU
+    hipMemcpy(hA.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost);
+
+    if(argus.unit_check)
+    {
+        /* =====================================================================
+           CPU BLAS
+        =================================================================== */
+        cblas_syr<T>(uplo, N, alpha, hx.data(), incx, hA_cpu.data(), lda);
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, lda, hA.data(), hA_cpu.data());
+        }
+    }
+
+    CHECK_HIP_ERROR(hipFree(dA));
+    CHECK_HIP_ERROR(hipFree(dx));
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_syr.hpp
+++ b/clients/include/testing_syr.hpp
@@ -22,16 +22,16 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_syr(Arguments argus)
 {
-    int M                  = argus.M;
-    int N                  = argus.N;
-    int incx               = argus.incx;
-    int lda                = argus.lda;
-    char char_uplo = argus.uplo_option;
-    hipblasFillMode_t uplo = char2hipblas_fill(char_uplo);
+    int               M         = argus.M;
+    int               N         = argus.N;
+    int               incx      = argus.incx;
+    int               lda       = argus.lda;
+    char              char_uplo = argus.uplo_option;
+    hipblasFillMode_t uplo      = char2hipblas_fill(char_uplo);
 
     int abs_incx = incx < 0 ? -incx : incx;
-    int A_size = lda * N;
-    int x_size = abs_incx * N;
+    int A_size   = lda * N;
+    int x_size   = abs_incx * N;
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 

--- a/clients/include/testing_trsv.hpp
+++ b/clients/include/testing_trsv.hpp
@@ -25,19 +25,19 @@ hipblasStatus_t testing_trsv(Arguments argus)
     constexpr T eps      = std::numeric_limits<T>::epsilon();
     constexpr T eps_mult = 40; // arbitrary
 
-    int M                     = argus.M;
-    int incx                  = argus.incx;
-    int lda                   = argus.lda;
-    char char_uplo            = argus.uplo_option;
-    char char_diag            = argus.diag_option;
-    char char_transA          = argus.transA_option;
-    hipblasFillMode_t uplo    = char2hipblas_fill(char_uplo);
-    hipblasDiagType_t diag    = char2hipblas_diagonal(char_diag);
-    hipblasOperation_t transA = char2hipblas_operation(char_transA);
+    int                M           = argus.M;
+    int                incx        = argus.incx;
+    int                lda         = argus.lda;
+    char               char_uplo   = argus.uplo_option;
+    char               char_diag   = argus.diag_option;
+    char               char_transA = argus.transA_option;
+    hipblasFillMode_t  uplo        = char2hipblas_fill(char_uplo);
+    hipblasDiagType_t  diag        = char2hipblas_diagonal(char_diag);
+    hipblasOperation_t transA      = char2hipblas_operation(char_transA);
 
     int abs_incx = incx < 0 ? -incx : incx;
-    int size_A = lda * M;
-    int size_x = abs_incx * M;
+    int size_A   = lda * M;
+    int size_x   = abs_incx * M;
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
@@ -78,8 +78,6 @@ hipblasStatus_t testing_trsv(Arguments argus)
 
     hipblasHandle_t handle;
     hipblasCreate(&handle);
-
-    
 
     // Initial Data on CPU
     srand(1);
@@ -138,9 +136,9 @@ hipblasStatus_t testing_trsv(Arguments argus)
 
     // Calculate hb = hA*hx;
     cblas_trmv<T>(uplo, transA, diag, M, hA.data(), lda, hb.data(), incx);
-    cpu_x_or_b    = hb; // cpuXorB <- B
-    hx_or_b_1     = hb;
-    hx_or_b_2     = hb;
+    cpu_x_or_b = hb; // cpuXorB <- B
+    hx_or_b_1  = hb;
+    hx_or_b_2  = hb;
 
     // copy data from CPU to device
     hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice);
@@ -178,7 +176,8 @@ hipblasStatus_t testing_trsv(Arguments argus)
             for(int i = 0; i < M; i++)
             {
                 if(hx[i * abs_incx] != 0)
-                    error += std::abs((hx[i * abs_incx] - hx_or_b_1[i * abs_incx]) / hx[i * abs_incx]);
+                    error += std::abs((hx[i * abs_incx] - hx_or_b_1[i * abs_incx])
+                                      / hx[i * abs_incx]);
                 else
                     error += std::abs(hx_or_b_1[i * abs_incx]);
             }

--- a/clients/include/testing_trsv.hpp
+++ b/clients/include/testing_trsv.hpp
@@ -1,0 +1,193 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <fstream>
+#include <iostream>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "flops.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_trsv(Arguments argus)
+{
+    constexpr T eps      = std::numeric_limits<T>::epsilon();
+    constexpr T eps_mult = 40; // arbitrary
+
+    int M                     = argus.M;
+    int incx                  = argus.incx;
+    int lda                   = argus.lda;
+    char char_uplo            = argus.uplo_option;
+    char char_diag            = argus.diag_option;
+    char char_transA          = argus.transA_option;
+    hipblasFillMode_t uplo    = char2hipblas_fill(char_uplo);
+    hipblasDiagType_t diag    = char2hipblas_diagonal(char_diag);
+    hipblasOperation_t transA = char2hipblas_operation(char_transA);
+
+    int abs_incx = incx < 0 ? -incx : incx;
+    int size_A = lda * M;
+    int size_x = abs_incx * M;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(M < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    else if(lda < 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+    else if(incx == 0)
+    {
+        status = HIPBLAS_STATUS_INVALID_VALUE;
+        return status;
+    }
+
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    vector<T> hA(size_A);
+    vector<T> AAT(size_A);
+    vector<T> hb(size_x);
+    vector<T> hx(size_x);
+    vector<T> hx_or_b_1(size_x);
+    vector<T> hx_or_b_2(size_x);
+    vector<T> cpu_x_or_b(size_x);
+
+    T *dA, *dx_or_b;
+    // allocate memory on device
+    CHECK_HIP_ERROR(hipMalloc(&dA, size_A * sizeof(T)));
+    CHECK_HIP_ERROR(hipMalloc(&dx_or_b, size_x * sizeof(T)));
+
+    double gpu_time_used, cpu_time_used;
+    double hipblasGflops, cblas_gflops, hipblasBandwidth;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T>(hA, M, M, lda);
+
+    //  calculate AAT = hA * hA ^ T
+    cblas_gemm<T>(HIPBLAS_OP_N,
+                  HIPBLAS_OP_T,
+                  M,
+                  M,
+                  M,
+                  1.0,
+                  hA.data(),
+                  lda,
+                  hA.data(),
+                  lda,
+                  0.0,
+                  AAT.data(),
+                  lda);
+
+    //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
+    for(int i = 0; i < M; i++)
+    {
+        T t = 0.0;
+        for(int j = 0; j < M; j++)
+        {
+            hA[i + j * lda] = AAT[i + j * lda];
+            t += AAT[i + j * lda] > 0 ? AAT[i + j * lda] : -AAT[i + j * lda];
+        }
+        hA[i + i * lda] = t;
+    }
+    //  calculate Cholesky factorization of SPD matrix hA
+    cblas_potrf<T>(char_uplo, M, hA.data(), lda);
+
+    //  make hA unit diagonal if diag == rocblas_diagonal_unit
+    if(char_diag == 'U' || char_diag == 'u')
+    {
+        if('L' == char_uplo || 'l' == char_uplo)
+            for(int i = 0; i < M; i++)
+            {
+                T diag = hA[i + i * lda];
+                for(int j = 0; j <= i; j++)
+                    hA[i + j * lda] = hA[i + j * lda] / diag;
+            }
+        else
+            for(int j = 0; j < M; j++)
+            {
+                T diag = hA[j + j * lda];
+                for(int i = 0; i <= j; i++)
+                    hA[i + j * lda] = hA[i + j * lda] / diag;
+            }
+    }
+
+    hipblas_init<T>(hx, 1, M, abs_incx);
+    hb = hx;
+
+    // Calculate hb = hA*hx;
+    cblas_trmv<T>(uplo, transA, diag, M, hA.data(), lda, hb.data(), incx);
+    cpu_x_or_b    = hb; // cpuXorB <- B
+    hx_or_b_1     = hb;
+    hx_or_b_2     = hb;
+
+    // copy data from CPU to device
+    hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice);
+    hipMemcpy(dx_or_b, hx_or_b_1.data(), sizeof(T) * size_x, hipMemcpyHostToDevice);
+
+    /* =====================================================================
+           ROCBLAS
+    =================================================================== */
+    if(argus.timing)
+    {
+        gpu_time_used = get_time_us(); // in microseconds
+    }
+
+    for(int iter = 0; iter < 1; iter++)
+    {
+        status = hipblasTrsv<T>(handle, uplo, transA, diag, M, dA, lda, dx_or_b, incx);
+
+        if(status != HIPBLAS_STATUS_SUCCESS)
+        {
+            CHECK_HIP_ERROR(hipFree(dA));
+            CHECK_HIP_ERROR(hipFree(dx_or_b));
+            hipblasDestroy(handle);
+            return status;
+        }
+    }
+
+    // copy output from device to CPU
+    hipMemcpy(hx_or_b_1.data(), dx_or_b, sizeof(T) * size_x, hipMemcpyDeviceToHost);
+
+    if(argus.unit_check)
+    {
+        double error = 0.0;
+        if(argus.unit_check)
+        {
+            for(int i = 0; i < M; i++)
+            {
+                if(hx[i * abs_incx] != 0)
+                    error += std::abs((hx[i * abs_incx] - hx_or_b_1[i * abs_incx]) / hx[i * abs_incx]);
+                else
+                    error += std::abs(hx_or_b_1[i * abs_incx]);
+            }
+        }
+        unit_check_trsv(error, M, eps_mult, eps);
+    }
+
+    CHECK_HIP_ERROR(hipFree(dA));
+    CHECK_HIP_ERROR(hipFree(dx_or_b));
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -50,4 +50,12 @@ void unit_check_nrm2(T cpu_result, T gpu_result, T tolerance)
 #endif
 }
 
+template <typename T>
+void unit_check_trsv(double max_error, int M, T forward_tolerance, T eps)
+{
+#ifdef GOOGLE_TEST
+    ASSERT_LE(max_error, forward_tolerance * eps * M);
+#endif
+}
+
 #endif

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -309,6 +309,24 @@ HIPBLAS_EXPORT hipblasStatus_t  hipblasSgerBatched(hipblasHandle_t handle, int m
 *alpha, const float *x, int incx, const float *y, int incy, float *A, int lda, int batchCount);
 */
 
+HIPBLAS_EXPORT hipblasStatus_t hipblasSsyr(hipblasHandle_t   handle,
+                                           hipblasFillMode_t uplo,
+                                           int               n,
+                                           const float*      alpha,
+                                           const float*      x,
+                                           int               incx,
+                                           float*            A,
+                                           int               lda);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
+                                           hipblasFillMode_t uplo,
+                                           int               n,
+                                           const double*     alpha,
+                                           const double*     x,
+                                           int               incx,
+                                           double*           A,
+                                           int               lda);
+
 HIPBLAS_EXPORT hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,
                                             hipblasSideMode_t  side,
                                             hipblasFillMode_t  uplo,

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -327,6 +327,28 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
                                            double*           A,
                                            int               lda);
 
+// trsv
+HIPBLAS_EXPORT hipblasStatus_t hipblasStrsv(hipblasHandle_t    handle,
+                                            hipblasFillMode_t  uplo,
+                                            hipblasOperation_t transA,
+                                            hipblasDiagType_t  diag,
+                                            int                m,
+                                            const float*       A,
+                                            int                lda,
+                                            float*             x,
+                                            int                incx);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDtrsv(hipblasHandle_t    handle,
+                                            hipblasFillMode_t  uplo,
+                                            hipblasOperation_t transA,
+                                            hipblasDiagType_t  diag,
+                                            int                m,
+                                            const double*      A,
+                                            int                lda,
+                                            double*            x,
+                                            int                incx);
+
+// trsm
 HIPBLAS_EXPORT hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,
                                             hipblasSideMode_t  side,
                                             hipblasFillMode_t  uplo,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -638,6 +638,7 @@ float *x, int incx, const float *y, int incy, float *A, int lda, int batchCount)
 HIPBLAS_STATUS_NOT_SUPPORTED;}
 */
 
+// syr
 hipblasStatus_t hipblasSsyr(hipblasHandle_t   handle,
                             hipblasFillMode_t uplo,
                             int               n,
@@ -660,6 +661,49 @@ hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
                             int               lda)
 {
     return rocBLASStatusToHIPStatus(rocblas_dsyr((rocblas_handle)handle, (rocblas_fill)uplo, n, alpha, x, incx, A, lda));
+}
+
+// trsv
+hipblasStatus_t hipblasStrsv(hipblasHandle_t    handle,
+                             hipblasFillMode_t  uplo,
+                             hipblasOperation_t transA,
+                             hipblasDiagType_t  diag,
+                             int                m,
+                             const float*       A,
+                             int                lda,
+                             float*             x,
+                             int                incx)
+{
+    return rocBLASStatusToHIPStatus(rocblas_strsv((rocblas_handle)handle,
+                                                  (rocblas_fill)uplo,
+                                                  hipOperationToHCCOperation(transA),
+                                                  hipDiagonalToHCCDiagonal(diag),
+                                                  m,
+                                                  A,
+                                                  lda,
+                                                  x,
+                                                  incx));
+}
+
+hipblasStatus_t hipblasDtrsv(hipblasHandle_t    handle,
+                             hipblasFillMode_t  uplo,
+                             hipblasOperation_t transA,
+                             hipblasDiagType_t  diag,
+                             int                m,
+                             const double*      A,
+                             int                lda,
+                             double*            x,
+                             int                incx)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dtrsv((rocblas_handle)handle,
+                                                  (rocblas_fill)uplo,
+                                                  hipOperationToHCCOperation(transA),
+                                                  hipDiagonalToHCCDiagonal(diag),
+                                                  m,
+                                                  A,
+                                                  lda,
+                                                  x,
+                                                  incx));
 }
 
 //------------------------------------------------------------------------------------------------------------

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -648,7 +648,8 @@ hipblasStatus_t hipblasSsyr(hipblasHandle_t   handle,
                             float*            A,
                             int               lda)
 {
-    return rocBLASStatusToHIPStatus(rocblas_ssyr((rocblas_handle)handle, (rocblas_fill)uplo, n, alpha, x, incx, A, lda));
+    return rocBLASStatusToHIPStatus(
+        rocblas_ssyr((rocblas_handle)handle, (rocblas_fill)uplo, n, alpha, x, incx, A, lda));
 }
 
 hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
@@ -660,7 +661,8 @@ hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
                             double*           A,
                             int               lda)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dsyr((rocblas_handle)handle, (rocblas_fill)uplo, n, alpha, x, incx, A, lda));
+    return rocBLASStatusToHIPStatus(
+        rocblas_dsyr((rocblas_handle)handle, (rocblas_fill)uplo, n, alpha, x, incx, A, lda));
 }
 
 // trsv

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -638,6 +638,30 @@ float *x, int incx, const float *y, int incy, float *A, int lda, int batchCount)
 HIPBLAS_STATUS_NOT_SUPPORTED;}
 */
 
+hipblasStatus_t hipblasSsyr(hipblasHandle_t   handle,
+                            hipblasFillMode_t uplo,
+                            int               n,
+                            const float*      alpha,
+                            const float*      x,
+                            int               incx,
+                            float*            A,
+                            int               lda)
+{
+    return rocBLASStatusToHIPStatus(rocblas_ssyr((rocblas_handle)handle, (rocblas_fill)uplo, n, alpha, x, incx, A, lda));
+}
+
+hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
+                            hipblasFillMode_t uplo,
+                            int               n,
+                            const double*     alpha,
+                            const double*     x,
+                            int               incx,
+                            double*           A,
+                            int               lda)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dsyr((rocblas_handle)handle, (rocblas_fill)uplo, n, alpha, x, incx, A, lda));
+}
+
 //------------------------------------------------------------------------------------------------------------
 
 hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -574,6 +574,30 @@ hipblasStatus_t hipblasSgerBatched(hipblasHandle_t handle,
         cublasSger((cublasHandle_t)handle, m, n, alpha, x, incx, y, incy, A, lda));
 }
 
+hipblasStatus_t hipblasSsyr(hipblasHandle_t   handle,
+                            hipblasFillMode_t uplo,
+                            int               n,
+                            const float*      alpha,
+                            const float*      x,
+                            int               incx,
+                            float*            A,
+                            int               lda)
+{
+    return hipCUBLASStatusToHIPStatus(cublasSsyr((cublasHandle_t)handle, uplo, n, alpha, x, incx, A, lda));
+}
+
+hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
+                            hipblasFillMode_t uplo,
+                            int               n,
+                            const double*     alpha,
+                            const double*     x,
+                            int               incx,
+                            double*           A,
+                            int               lda);
+{
+    return hipCUBLASStatusToHIPStatus(cublasDsyr((cublasHandle_t)handle, uplo, n, alpha, x, incx, A, lda));
+}
+
 hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,
                              hipblasSideMode_t  side,
                              hipblasFillMode_t  uplo,

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -574,6 +574,7 @@ hipblasStatus_t hipblasSgerBatched(hipblasHandle_t handle,
         cublasSger((cublasHandle_t)handle, m, n, alpha, x, incx, y, incy, A, lda));
 }
 
+// syr
 hipblasStatus_t hipblasSsyr(hipblasHandle_t   handle,
                             hipblasFillMode_t uplo,
                             int               n,
@@ -598,6 +599,50 @@ hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
     return hipCUBLASStatusToHIPStatus(cublasDsyr((cublasHandle_t)handle, uplo, n, alpha, x, incx, A, lda));
 }
 
+// trsv
+hipblasStatus_t hipblasStrsv(hipblasHandle_t    handle,
+                             hipblasFillMode_t  uplo,
+                             hipblasOperation_t transA,
+                             hipblasDiagType_t  diag,
+                             int                m,
+                             const float*       A,
+                             int                lda,
+                             float*             x,
+                             int                incx)
+{
+    return hipCUBLASStatusToHIPStatus(cublasStrsv((cublasHandle_t)handle,
+                                                   hipFillToCudaFill(uplo),
+                                                   hipOperationToCudaOperation(transA),
+                                                   hipDiagonalToCudaDiagonal(diag),
+                                                   m,
+                                                   A,
+                                                   lda,
+                                                   x,
+                                                   incx));
+}
+
+hipblasStatus_t hipblasDtrsv(hipblasHandle_t    handle,
+                             hipblasFillMode_t  uplo,
+                             hipblasOperation_t transA,
+                             hipblasDiagType_t  diag,
+                             int                m,
+                             const double*      A,
+                             int                lda,
+                             double*            x,
+                             int                incx)
+{
+    return hipCUBLASStatusToHIPStatus(cublasDtrsv((cublasHandle_t)handle,
+                                                   hipFillToCudaFill(uplo),
+                                                   hipOperationToCudaOperation(transA),
+                                                   hipDiagonalToCudaDiagonal(diag),
+                                                   m,
+                                                   A,
+                                                   lda,
+                                                   x,
+                                                   incx));
+}
+
+// trsm
 hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,
                              hipblasSideMode_t  side,
                              hipblasFillMode_t  uplo,

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -584,7 +584,7 @@ hipblasStatus_t hipblasSsyr(hipblasHandle_t   handle,
                             float*            A,
                             int               lda)
 {
-    return hipCUBLASStatusToHIPStatus(cublasSsyr((cublasHandle_t)handle, uplo, n, alpha, x, incx, A, lda));
+    return hipCUBLASStatusToHIPStatus(cublasSsyr((cublasHandle_t)handle, hipFillToCudaFill(uplo), n, alpha, x, incx, A, lda));
 }
 
 hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
@@ -594,9 +594,9 @@ hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
                             const double*     x,
                             int               incx,
                             double*           A,
-                            int               lda);
+                            int               lda)
 {
-    return hipCUBLASStatusToHIPStatus(cublasDsyr((cublasHandle_t)handle, uplo, n, alpha, x, incx, A, lda));
+    return hipCUBLASStatusToHIPStatus(cublasDsyr((cublasHandle_t)handle, hipFillToCudaFill(uplo), n, alpha, x, incx, A, lda));
 }
 
 // trsv

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -584,7 +584,8 @@ hipblasStatus_t hipblasSsyr(hipblasHandle_t   handle,
                             float*            A,
                             int               lda)
 {
-    return hipCUBLASStatusToHIPStatus(cublasSsyr((cublasHandle_t)handle, hipFillToCudaFill(uplo), n, alpha, x, incx, A, lda));
+    return hipCUBLASStatusToHIPStatus(
+        cublasSsyr((cublasHandle_t)handle, hipFillToCudaFill(uplo), n, alpha, x, incx, A, lda));
 }
 
 hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
@@ -596,7 +597,8 @@ hipblasStatus_t hipblasDsyr(hipblasHandle_t   handle,
                             double*           A,
                             int               lda)
 {
-    return hipCUBLASStatusToHIPStatus(cublasDsyr((cublasHandle_t)handle, hipFillToCudaFill(uplo), n, alpha, x, incx, A, lda));
+    return hipCUBLASStatusToHIPStatus(
+        cublasDsyr((cublasHandle_t)handle, hipFillToCudaFill(uplo), n, alpha, x, incx, A, lda));
 }
 
 // trsv
@@ -611,14 +613,14 @@ hipblasStatus_t hipblasStrsv(hipblasHandle_t    handle,
                              int                incx)
 {
     return hipCUBLASStatusToHIPStatus(cublasStrsv((cublasHandle_t)handle,
-                                                   hipFillToCudaFill(uplo),
-                                                   hipOperationToCudaOperation(transA),
-                                                   hipDiagonalToCudaDiagonal(diag),
-                                                   m,
-                                                   A,
-                                                   lda,
-                                                   x,
-                                                   incx));
+                                                  hipFillToCudaFill(uplo),
+                                                  hipOperationToCudaOperation(transA),
+                                                  hipDiagonalToCudaDiagonal(diag),
+                                                  m,
+                                                  A,
+                                                  lda,
+                                                  x,
+                                                  incx));
 }
 
 hipblasStatus_t hipblasDtrsv(hipblasHandle_t    handle,
@@ -632,14 +634,14 @@ hipblasStatus_t hipblasDtrsv(hipblasHandle_t    handle,
                              int                incx)
 {
     return hipCUBLASStatusToHIPStatus(cublasDtrsv((cublasHandle_t)handle,
-                                                   hipFillToCudaFill(uplo),
-                                                   hipOperationToCudaOperation(transA),
-                                                   hipDiagonalToCudaDiagonal(diag),
-                                                   m,
-                                                   A,
-                                                   lda,
-                                                   x,
-                                                   incx));
+                                                  hipFillToCudaFill(uplo),
+                                                  hipOperationToCudaOperation(transA),
+                                                  hipDiagonalToCudaDiagonal(diag),
+                                                  m,
+                                                  A,
+                                                  lda,
+                                                  x,
+                                                  incx));
 }
 
 // trsm


### PR DESCRIPTION
Adding (real precision) L2 functions:
- syr
- trsv

Complex support will come in another PR. This makes hipBlas support all L2 functions which rocBlas supports.