### PR TITLE
Batched & strided_batched additions

### DIFF
--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -219,6 +219,64 @@ hipblasStatus_t hipblasSwap<hipDoubleComplex>(
     return hipblasZswap(handle, n, x, incx, y, incy);
 }
 
+// swap_batched
+template <>
+hipblasStatus_t
+    hipblasSwapBatched<float>(hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batch_count)
+{
+    return hipblasSswapBatched(handle, n, x, incx, y, incy, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasSwapBatched<double>(hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batch_count)
+{
+    return hipblasDswapBatched(handle, n, x, incx, y, incy, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasSwapBatched<hipComplex>(hipblasHandle_t handle, int n, hipComplex* x[], int incx, hipComplex* y[], int incy, int batch_count)
+{
+    return hipblasCswapBatched(handle, n, x, incx, y, incy, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasSwapBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, hipDoubleComplex* x[], int incx, hipDoubleComplex* y[], int incy, int batch_count)
+{
+    return hipblasZswapBatched(handle, n, x, incx, y, incy, batch_count);
+}
+
+// swap_strided_batched
+template <>
+hipblasStatus_t
+    hipblasSwapStridedBatched<float>(hipblasHandle_t handle, int n, float* x, int incx, int stridex, float* y, int incy, int stridey, int batch_count)
+{
+    return hipblasSswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasSwapStridedBatched<double>(hipblasHandle_t handle, int n, double* x, int incx, int stridex, double* y, int incy, int stridey, int batch_count)
+{
+    return hipblasDswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasSwapStridedBatched<hipComplex>(hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batch_count)
+{
+    return hipblasCswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasSwapStridedBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batch_count)
+{
+    return hipblasZswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
 // copy
 template <>
 hipblasStatus_t

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -743,6 +743,72 @@ hipblasStatus_t hipblasNrm2<hipDoubleComplex, double>(
     return hipblasDznrm2(handle, n, x, incx, result);
 }
 
+// nrm2_batched
+template <>
+hipblasStatus_t hipblasNrm2Batched<float, float>(
+    hipblasHandle_t handle, int n, const float* const x[], int incx, int batch_count, float* result)
+{
+
+    return hipblasSnrm2Batched(handle, n, x, incx, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasNrm2Batched<double, double>(
+    hipblasHandle_t handle, int n, const double* const x[], int incx, int batch_count, double* result)
+{
+
+    return hipblasDnrm2Batched(handle, n, x, incx, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasNrm2Batched<hipComplex, float>(
+    hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batch_count, float* result)
+{
+
+    return hipblasScnrm2Batched(handle, n, x, incx, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasNrm2Batched<hipDoubleComplex, double>(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batch_count, double* result)
+{
+
+    return hipblasDznrm2Batched(handle, n, x, incx, batch_count, result);
+}
+
+// nrm2_strided_batched
+template <>
+hipblasStatus_t hipblasNrm2StridedBatched<float, float>(
+    hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batch_count, float* result)
+{
+
+    return hipblasSnrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasNrm2StridedBatched<double, double>(
+    hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batch_count, double* result)
+{
+
+    return hipblasDnrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasNrm2StridedBatched<hipComplex, float>(
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batch_count, float* result)
+{
+
+    return hipblasScnrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasNrm2StridedBatched<hipDoubleComplex, double>(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batch_count, double* result)
+{
+
+    return hipblasDznrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
+}
+
 // amax
 template <>
 hipblasStatus_t

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -104,6 +104,92 @@ hipblasStatus_t hipblasScal<hipDoubleComplex, double>(
     return hipblasZdscal(handle, n, alpha, x, incx);
 }
 
+// scal_batched
+template <>
+hipblasStatus_t
+    hipblasScalBatched<float>(hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batch_count)
+{
+    return hipblasSscalBatched(handle, n, alpha, x, incx, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalBatched<double>(hipblasHandle_t handle, int n, const double* alpha, double* const x[], int incx, int batch_count)
+{
+    return hipblasDscalBatched(handle, n, alpha, x, incx, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalBatched<hipComplex>(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* const x[], int incx, int batch_count)
+{
+    return hipblasCscalBatched(handle, n, alpha, x, incx, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* const x[], int incx, int batch_count)
+{
+    return hipblasZscalBatched(handle, n, alpha, x, incx, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalBatched<hipComplex, float>(hipblasHandle_t handle, int n, const float* alpha, hipComplex* const x[], int incx, int batch_count)
+{
+    return hipblasCsscalBatched(handle, n, alpha, x, incx, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalBatched<hipDoubleComplex, double>(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* const x[], int incx, int batch_count)
+{
+    return hipblasZdscalBatched(handle, n, alpha, x, incx, batch_count);
+}
+
+// scal_strided_batched
+template <>
+hipblasStatus_t
+    hipblasScalStridedBatched<float>(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx, int stridex, int batch_count)
+{
+    return hipblasSscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalStridedBatched<double>(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx, int stridex, int batch_count)
+{
+    return hipblasDscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalStridedBatched<hipComplex>(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx, int stridex, int batch_count)
+{
+    return hipblasCscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalStridedBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx, int stridex, int batch_count)
+{
+    return hipblasZscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalStridedBatched<hipComplex, float>(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx, int stridex, int batch_count)
+{
+    return hipblasCsscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasScalStridedBatched<hipDoubleComplex, double>(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx, int stridex, int batch_count)
+{
+    return hipblasZdscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+}
+
 //swap
 template <>
 hipblasStatus_t

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -383,6 +383,176 @@ hipblasStatus_t hipblasDotc<hipDoubleComplex>(hipblasHandle_t         handle,
     return hipblasZdotc(handle, n, x, incx, y, incy, result);
 }
 
+// dot_batched
+template <>
+hipblasStatus_t hipblasDotBatched<float>(hipblasHandle_t    handle,
+                                         int                n,
+                                         const float* const x[],
+                                         int                incx,
+                                         const float* const y[],
+                                         int                incy,
+                                         int                batch_count,
+                                         float*             result)
+{
+    return hipblasSdotBatched(handle, n, x, incx, y, incy, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotBatched<double>(hipblasHandle_t     handle,
+                                          int                 n,
+                                          const double* const x[],
+                                          int                 incx,
+                                          const double* const y[],
+                                          int                 incy,
+                                          int                 batch_count,
+                                          double*             result)
+{
+    return hipblasDdotBatched(handle, n, x, incx, y, incy, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotBatched<hipComplex>(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipComplex* const x[],
+                                              int                     incx,
+                                              const hipComplex* const y[],
+                                              int                     incy,
+                                              int                     batch_count,
+                                              hipComplex*             result)
+{
+    return hipblasCdotuBatched(handle, n, x, incx, y, incy, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotcBatched<hipComplex>(hipblasHandle_t        handle,
+                                              int                     n,
+                                              const hipComplex* const x[],
+                                              int                     incx,
+                                              const hipComplex* const y[],
+                                              int                     incy,
+                                              int                     batch_count,
+                                              hipComplex*             result)
+{
+    return hipblasCdotcBatched(handle, n, x, incx, y, incy, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotBatched<hipDoubleComplex>(hipblasHandle_t               handle,
+                                                    int                           n,
+                                                    const hipDoubleComplex* const x[],
+                                                    int                           incx,
+                                                    const hipDoubleComplex* const y[],
+                                                    int                           incy,
+                                                    int                           batch_count,
+                                                    hipDoubleComplex*             result)
+{
+    return hipblasZdotuBatched(handle, n, x, incx, y, incy, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotcBatched<hipDoubleComplex>(hipblasHandle_t               handle,
+                                                     int                           n,
+                                                     const hipDoubleComplex* const x[],
+                                                     int                           incx,
+                                                     const hipDoubleComplex* const y[],
+                                                     int                           incy,
+                                                     int                           batch_count,
+                                                     hipDoubleComplex*             result)
+{
+    return hipblasZdotcBatched(handle, n, x, incx, y, incy, batch_count, result);
+}
+
+// dot_strided_batched
+template <>
+hipblasStatus_t hipblasDotStridedBatched<float>(hipblasHandle_t handle,
+                                                int             n,
+                                                const float*    x,
+                                                int             incx,
+                                                int             stridex,
+                                                const float*    y,
+                                                int             incy,
+                                                int             stridey,
+                                                int             batch_count,
+                                                float*          result)
+{
+    return hipblasSdotStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotStridedBatched<double>(hipblasHandle_t handle,
+                                                 int             n,
+                                                 const double*   x,
+                                                 int             incx,
+                                                 int             stridex,
+                                                 const double*   y,
+                                                 int             incy,
+                                                 int             stridey,
+                                                 int             batch_count,
+                                                 double*         result)
+{
+    return hipblasDdotStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotStridedBatched<hipComplex>(hipblasHandle_t   handle,
+                                                     int               n,
+                                                     const hipComplex* x,
+                                                     int               incx,
+                                                     int               stridex,
+                                                     const hipComplex* y,
+                                                     int               incy,
+                                                     int               stridey,
+                                                     int               batch_count,
+                                                     hipComplex*       result)
+{
+    return hipblasCdotuStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotcStridedBatched<hipComplex>(hipblasHandle_t   handle,
+                                                     int               n,
+                                                     const hipComplex* x,
+                                                     int               incx,
+                                                     int               stridex,
+                                                     const hipComplex* y,
+                                                     int               incy,
+                                                     int               stridey,
+                                                     int               batch_count,
+                                                     hipComplex*       result)
+{
+    return hipblasCdotcStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+                                                           int                     n,
+                                                           const hipDoubleComplex* x,
+                                                           int                     incx,
+                                                           int                     stridex,
+                                                           const hipDoubleComplex* y,
+                                                           int                     incy,
+                                                           int                     stridey,
+                                                           int                     batch_count,
+                                                           hipDoubleComplex*       result)
+{
+    return hipblasZdotuStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasDotcStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+                                                           int                     n,
+                                                           const hipDoubleComplex* x,
+                                                           int                     incx,
+                                                           int                     stridex,
+                                                           const hipDoubleComplex* y,
+                                                           int                     incy,
+                                                           int                     stridey,
+                                                           int                     batch_count,
+                                                           hipDoubleComplex*       result)
+{
+    return hipblasZdotcStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+}
+
 // asum
 template <>
 hipblasStatus_t hipblasAsum<float, float>(

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -644,6 +644,72 @@ hipblasStatus_t hipblasAsum<hipDoubleComplex, double>(
     return hipblasDzasum(handle, n, x, incx, result);
 }
 
+// asum_batched
+template <>
+hipblasStatus_t hipblasAsumBatched<float, float>(
+    hipblasHandle_t handle, int n, const float* const x[], int incx, int batch_count, float* result)
+{
+
+    return hipblasSasumBatched(handle, n, x, incx, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasAsumBatched<double, double>(
+    hipblasHandle_t handle, int n, const double* const x[], int incx, int batch_count, double* result)
+{
+
+    return hipblasDasumBatched(handle, n, x, incx, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasAsumBatched<hipComplex, float>(
+    hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batch_count, float* result)
+{
+
+    return hipblasScasumBatched(handle, n, x, incx, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasAsumBatched<hipDoubleComplex, double>(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batch_count, double* result)
+{
+
+    return hipblasDzasumBatched(handle, n, x, incx, batch_count, result);
+}
+
+// asum_strided_batched
+template <>
+hipblasStatus_t hipblasAsumStridedBatched<float, float>(
+    hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batch_count, float* result)
+{
+
+    return hipblasSasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasAsumStridedBatched<double, double>(
+    hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batch_count, double* result)
+{
+
+    return hipblasDasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasAsumStridedBatched<hipComplex, float>(
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batch_count, float* result)
+{
+
+    return hipblasScasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
+}
+
+template <>
+hipblasStatus_t hipblasAsumStridedBatched<hipDoubleComplex, double>(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batch_count, double* result)
+{
+
+    return hipblasDzasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
+}
+
 // nrm2
 template <>
 hipblasStatus_t hipblasNrm2<float, float>(

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -106,86 +106,136 @@ hipblasStatus_t hipblasScal<hipDoubleComplex, double>(
 
 // scal_batched
 template <>
-hipblasStatus_t
-    hipblasScalBatched<float>(hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batch_count)
+hipblasStatus_t hipblasScalBatched<float>(
+    hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batch_count)
 {
     return hipblasSscalBatched(handle, n, alpha, x, incx, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalBatched<double>(hipblasHandle_t handle, int n, const double* alpha, double* const x[], int incx, int batch_count)
+hipblasStatus_t hipblasScalBatched<double>(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   alpha,
+                                           double* const   x[],
+                                           int             incx,
+                                           int             batch_count)
 {
     return hipblasDscalBatched(handle, n, alpha, x, incx, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalBatched<hipComplex>(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* const x[], int incx, int batch_count)
+hipblasStatus_t hipblasScalBatched<hipComplex>(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* alpha,
+                                               hipComplex* const x[],
+                                               int               incx,
+                                               int               batch_count)
 {
     return hipblasCscalBatched(handle, n, alpha, x, incx, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* const x[], int incx, int batch_count)
+hipblasStatus_t hipblasScalBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+                                                     int                     n,
+                                                     const hipDoubleComplex* alpha,
+                                                     hipDoubleComplex* const x[],
+                                                     int                     incx,
+                                                     int                     batch_count)
 {
     return hipblasZscalBatched(handle, n, alpha, x, incx, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalBatched<hipComplex, float>(hipblasHandle_t handle, int n, const float* alpha, hipComplex* const x[], int incx, int batch_count)
+hipblasStatus_t hipblasScalBatched<hipComplex, float>(hipblasHandle_t   handle,
+                                                      int               n,
+                                                      const float*      alpha,
+                                                      hipComplex* const x[],
+                                                      int               incx,
+                                                      int               batch_count)
 {
     return hipblasCsscalBatched(handle, n, alpha, x, incx, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalBatched<hipDoubleComplex, double>(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* const x[], int incx, int batch_count)
+hipblasStatus_t hipblasScalBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
+                                                             int                     n,
+                                                             const double*           alpha,
+                                                             hipDoubleComplex* const x[],
+                                                             int                     incx,
+                                                             int                     batch_count)
 {
     return hipblasZdscalBatched(handle, n, alpha, x, incx, batch_count);
 }
 
 // scal_strided_batched
 template <>
-hipblasStatus_t
-    hipblasScalStridedBatched<float>(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx, int stridex, int batch_count)
+hipblasStatus_t hipblasScalStridedBatched<float>(hipblasHandle_t handle,
+                                                 int             n,
+                                                 const float*    alpha,
+                                                 float*          x,
+                                                 int             incx,
+                                                 int             stridex,
+                                                 int             batch_count)
 {
     return hipblasSscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalStridedBatched<double>(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx, int stridex, int batch_count)
+hipblasStatus_t hipblasScalStridedBatched<double>(hipblasHandle_t handle,
+                                                  int             n,
+                                                  const double*   alpha,
+                                                  double*         x,
+                                                  int             incx,
+                                                  int             stridex,
+                                                  int             batch_count)
 {
     return hipblasDscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalStridedBatched<hipComplex>(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx, int stridex, int batch_count)
+hipblasStatus_t hipblasScalStridedBatched<hipComplex>(hipblasHandle_t   handle,
+                                                      int               n,
+                                                      const hipComplex* alpha,
+                                                      hipComplex*       x,
+                                                      int               incx,
+                                                      int               stridex,
+                                                      int               batch_count)
 {
     return hipblasCscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalStridedBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx, int stridex, int batch_count)
+hipblasStatus_t hipblasScalStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+                                                            int                     n,
+                                                            const hipDoubleComplex* alpha,
+                                                            hipDoubleComplex*       x,
+                                                            int                     incx,
+                                                            int                     stridex,
+                                                            int                     batch_count)
 {
     return hipblasZscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalStridedBatched<hipComplex, float>(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx, int stridex, int batch_count)
+hipblasStatus_t hipblasScalStridedBatched<hipComplex, float>(hipblasHandle_t handle,
+                                                             int             n,
+                                                             const float*    alpha,
+                                                             hipComplex*     x,
+                                                             int             incx,
+                                                             int             stridex,
+                                                             int             batch_count)
 {
     return hipblasCsscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasScalStridedBatched<hipDoubleComplex, double>(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx, int stridex, int batch_count)
+hipblasStatus_t hipblasScalStridedBatched<hipDoubleComplex, double>(hipblasHandle_t   handle,
+                                                                    int               n,
+                                                                    const double*     alpha,
+                                                                    hipDoubleComplex* x,
+                                                                    int               incx,
+                                                                    int               stridex,
+                                                                    int               batch_count)
 {
     return hipblasZdscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
 }
@@ -221,58 +271,96 @@ hipblasStatus_t hipblasSwap<hipDoubleComplex>(
 
 // swap_batched
 template <>
-hipblasStatus_t
-    hipblasSwapBatched<float>(hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batch_count)
+hipblasStatus_t hipblasSwapBatched<float>(
+    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batch_count)
 {
     return hipblasSswapBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasSwapBatched<double>(hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batch_count)
+hipblasStatus_t hipblasSwapBatched<double>(
+    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batch_count)
 {
     return hipblasDswapBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasSwapBatched<hipComplex>(hipblasHandle_t handle, int n, hipComplex* x[], int incx, hipComplex* y[], int incy, int batch_count)
+hipblasStatus_t hipblasSwapBatched<hipComplex>(hipblasHandle_t handle,
+                                               int             n,
+                                               hipComplex*     x[],
+                                               int             incx,
+                                               hipComplex*     y[],
+                                               int             incy,
+                                               int             batch_count)
 {
     return hipblasCswapBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasSwapBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, hipDoubleComplex* x[], int incx, hipDoubleComplex* y[], int incy, int batch_count)
+hipblasStatus_t hipblasSwapBatched<hipDoubleComplex>(hipblasHandle_t   handle,
+                                                     int               n,
+                                                     hipDoubleComplex* x[],
+                                                     int               incx,
+                                                     hipDoubleComplex* y[],
+                                                     int               incy,
+                                                     int               batch_count)
 {
     return hipblasZswapBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 // swap_strided_batched
 template <>
-hipblasStatus_t
-    hipblasSwapStridedBatched<float>(hipblasHandle_t handle, int n, float* x, int incx, int stridex, float* y, int incy, int stridey, int batch_count)
+hipblasStatus_t hipblasSwapStridedBatched<float>(hipblasHandle_t handle,
+                                                 int             n,
+                                                 float*          x,
+                                                 int             incx,
+                                                 int             stridex,
+                                                 float*          y,
+                                                 int             incy,
+                                                 int             stridey,
+                                                 int             batch_count)
 {
     return hipblasSswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasSwapStridedBatched<double>(hipblasHandle_t handle, int n, double* x, int incx, int stridex, double* y, int incy, int stridey, int batch_count)
+hipblasStatus_t hipblasSwapStridedBatched<double>(hipblasHandle_t handle,
+                                                  int             n,
+                                                  double*         x,
+                                                  int             incx,
+                                                  int             stridex,
+                                                  double*         y,
+                                                  int             incy,
+                                                  int             stridey,
+                                                  int             batch_count)
 {
     return hipblasDswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasSwapStridedBatched<hipComplex>(hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batch_count)
+hipblasStatus_t hipblasSwapStridedBatched<hipComplex>(hipblasHandle_t handle,
+                                                      int             n,
+                                                      hipComplex*     x,
+                                                      int             incx,
+                                                      int             stridex,
+                                                      hipComplex*     y,
+                                                      int             incy,
+                                                      int             stridey,
+                                                      int             batch_count)
 {
     return hipblasCswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasSwapStridedBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batch_count)
+hipblasStatus_t hipblasSwapStridedBatched<hipDoubleComplex>(hipblasHandle_t   handle,
+                                                            int               n,
+                                                            hipDoubleComplex* x,
+                                                            int               incx,
+                                                            int               stridex,
+                                                            hipDoubleComplex* y,
+                                                            int               incy,
+                                                            int               stridey,
+                                                            int               batch_count)
 {
     return hipblasZswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
@@ -312,58 +400,106 @@ hipblasStatus_t hipblasCopy<hipDoubleComplex>(hipblasHandle_t         handle,
 
 // copy_batched
 template <>
-hipblasStatus_t
-    hipblasCopyBatched<float>(hipblasHandle_t handle, int n, const float* const x[], int incx, float* const y[], int incy, int batch_count)
+hipblasStatus_t hipblasCopyBatched<float>(hipblasHandle_t    handle,
+                                          int                n,
+                                          const float* const x[],
+                                          int                incx,
+                                          float* const       y[],
+                                          int                incy,
+                                          int                batch_count)
 {
     return hipblasScopyBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasCopyBatched<double>(hipblasHandle_t handle, int n, const double* const x[], int incx, double* const y[], int incy, int batch_count)
+hipblasStatus_t hipblasCopyBatched<double>(hipblasHandle_t     handle,
+                                           int                 n,
+                                           const double* const x[],
+                                           int                 incx,
+                                           double* const       y[],
+                                           int                 incy,
+                                           int                 batch_count)
 {
     return hipblasDcopyBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasCopyBatched<hipComplex>(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, hipComplex* const y[], int incy, int batch_count)
+hipblasStatus_t hipblasCopyBatched<hipComplex>(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipComplex* const x[],
+                                               int                     incx,
+                                               hipComplex* const       y[],
+                                               int                     incy,
+                                               int                     batch_count)
 {
     return hipblasCcopyBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasCopyBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, hipDoubleComplex* const y[], int incy, int batch_count)
+hipblasStatus_t hipblasCopyBatched<hipDoubleComplex>(hipblasHandle_t               handle,
+                                                     int                           n,
+                                                     const hipDoubleComplex* const x[],
+                                                     int                           incx,
+                                                     hipDoubleComplex* const       y[],
+                                                     int                           incy,
+                                                     int                           batch_count)
 {
     return hipblasZcopyBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 // copy_strided_batched
 template <>
-hipblasStatus_t
-    hipblasCopyStridedBatched<float>(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, float* y, int incy, int stridey, int batch_count)
+hipblasStatus_t hipblasCopyStridedBatched<float>(hipblasHandle_t handle,
+                                                 int             n,
+                                                 const float*    x,
+                                                 int             incx,
+                                                 int             stridex,
+                                                 float*          y,
+                                                 int             incy,
+                                                 int             stridey,
+                                                 int             batch_count)
 {
     return hipblasScopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasCopyStridedBatched<double>(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, double* y, int incy, int stridey, int batch_count)
+hipblasStatus_t hipblasCopyStridedBatched<double>(hipblasHandle_t handle,
+                                                  int             n,
+                                                  const double*   x,
+                                                  int             incx,
+                                                  int             stridex,
+                                                  double*         y,
+                                                  int             incy,
+                                                  int             stridey,
+                                                  int             batch_count)
 {
     return hipblasDcopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasCopyStridedBatched<hipComplex>(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batch_count)
+hipblasStatus_t hipblasCopyStridedBatched<hipComplex>(hipblasHandle_t   handle,
+                                                      int               n,
+                                                      const hipComplex* x,
+                                                      int               incx,
+                                                      int               stridex,
+                                                      hipComplex*       y,
+                                                      int               incy,
+                                                      int               stridey,
+                                                      int               batch_count)
 {
     return hipblasCcopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
 
 template <>
-hipblasStatus_t
-    hipblasCopyStridedBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batch_count)
+hipblasStatus_t hipblasCopyStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+                                                            int                     n,
+                                                            const hipDoubleComplex* x,
+                                                            int                     incx,
+                                                            int                     stridex,
+                                                            hipDoubleComplex*       y,
+                                                            int                     incy,
+                                                            int                     stridey,
+                                                            int                     batch_count)
 {
     return hipblasZcopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
 }
@@ -482,14 +618,14 @@ hipblasStatus_t hipblasDotBatched<hipComplex>(hipblasHandle_t         handle,
 }
 
 template <>
-hipblasStatus_t hipblasDotcBatched<hipComplex>(hipblasHandle_t        handle,
-                                              int                     n,
-                                              const hipComplex* const x[],
-                                              int                     incx,
-                                              const hipComplex* const y[],
-                                              int                     incy,
-                                              int                     batch_count,
-                                              hipComplex*             result)
+hipblasStatus_t hipblasDotcBatched<hipComplex>(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipComplex* const x[],
+                                               int                     incx,
+                                               const hipComplex* const y[],
+                                               int                     incy,
+                                               int                     batch_count,
+                                               hipComplex*             result)
 {
     return hipblasCdotcBatched(handle, n, x, incx, y, incy, batch_count, result);
 }
@@ -533,7 +669,8 @@ hipblasStatus_t hipblasDotStridedBatched<float>(hipblasHandle_t handle,
                                                 int             batch_count,
                                                 float*          result)
 {
-    return hipblasSdotStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+    return hipblasSdotStridedBatched(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 template <>
@@ -548,7 +685,8 @@ hipblasStatus_t hipblasDotStridedBatched<double>(hipblasHandle_t handle,
                                                  int             batch_count,
                                                  double*         result)
 {
-    return hipblasDdotStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+    return hipblasDdotStridedBatched(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 template <>
@@ -563,22 +701,24 @@ hipblasStatus_t hipblasDotStridedBatched<hipComplex>(hipblasHandle_t   handle,
                                                      int               batch_count,
                                                      hipComplex*       result)
 {
-    return hipblasCdotuStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+    return hipblasCdotuStridedBatched(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 template <>
 hipblasStatus_t hipblasDotcStridedBatched<hipComplex>(hipblasHandle_t   handle,
-                                                     int               n,
-                                                     const hipComplex* x,
-                                                     int               incx,
-                                                     int               stridex,
-                                                     const hipComplex* y,
-                                                     int               incy,
-                                                     int               stridey,
-                                                     int               batch_count,
-                                                     hipComplex*       result)
+                                                      int               n,
+                                                      const hipComplex* x,
+                                                      int               incx,
+                                                      int               stridex,
+                                                      const hipComplex* y,
+                                                      int               incy,
+                                                      int               stridey,
+                                                      int               batch_count,
+                                                      hipComplex*       result)
 {
-    return hipblasCdotcStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+    return hipblasCdotcStridedBatched(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 template <>
@@ -593,22 +733,24 @@ hipblasStatus_t hipblasDotStridedBatched<hipDoubleComplex>(hipblasHandle_t      
                                                            int                     batch_count,
                                                            hipDoubleComplex*       result)
 {
-    return hipblasZdotuStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+    return hipblasZdotuStridedBatched(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 template <>
 hipblasStatus_t hipblasDotcStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
-                                                           int                     n,
-                                                           const hipDoubleComplex* x,
-                                                           int                     incx,
-                                                           int                     stridex,
-                                                           const hipDoubleComplex* y,
-                                                           int                     incy,
-                                                           int                     stridey,
-                                                           int                     batch_count,
-                                                           hipDoubleComplex*       result)
+                                                            int                     n,
+                                                            const hipDoubleComplex* x,
+                                                            int                     incx,
+                                                            int                     stridex,
+                                                            const hipDoubleComplex* y,
+                                                            int                     incy,
+                                                            int                     stridey,
+                                                            int                     batch_count,
+                                                            hipDoubleComplex*       result)
 {
-    return hipblasZdotcStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+    return hipblasZdotcStridedBatched(
+        handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 // asum
@@ -654,24 +796,36 @@ hipblasStatus_t hipblasAsumBatched<float, float>(
 }
 
 template <>
-hipblasStatus_t hipblasAsumBatched<double, double>(
-    hipblasHandle_t handle, int n, const double* const x[], int incx, int batch_count, double* result)
+hipblasStatus_t hipblasAsumBatched<double, double>(hipblasHandle_t     handle,
+                                                   int                 n,
+                                                   const double* const x[],
+                                                   int                 incx,
+                                                   int                 batch_count,
+                                                   double*             result)
 {
 
     return hipblasDasumBatched(handle, n, x, incx, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasAsumBatched<hipComplex, float>(
-    hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batch_count, float* result)
+hipblasStatus_t hipblasAsumBatched<hipComplex, float>(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      const hipComplex* const x[],
+                                                      int                     incx,
+                                                      int                     batch_count,
+                                                      float*                  result)
 {
 
     return hipblasScasumBatched(handle, n, x, incx, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasAsumBatched<hipDoubleComplex, double>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batch_count, double* result)
+hipblasStatus_t hipblasAsumBatched<hipDoubleComplex, double>(hipblasHandle_t               handle,
+                                                             int                           n,
+                                                             const hipDoubleComplex* const x[],
+                                                             int                           incx,
+                                                             int     batch_count,
+                                                             double* result)
 {
 
     return hipblasDzasumBatched(handle, n, x, incx, batch_count, result);
@@ -679,32 +833,52 @@ hipblasStatus_t hipblasAsumBatched<hipDoubleComplex, double>(
 
 // asum_strided_batched
 template <>
-hipblasStatus_t hipblasAsumStridedBatched<float, float>(
-    hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batch_count, float* result)
+hipblasStatus_t hipblasAsumStridedBatched<float, float>(hipblasHandle_t handle,
+                                                        int             n,
+                                                        const float*    x,
+                                                        int             incx,
+                                                        int             stridex,
+                                                        int             batch_count,
+                                                        float*          result)
 {
 
     return hipblasSasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasAsumStridedBatched<double, double>(
-    hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batch_count, double* result)
+hipblasStatus_t hipblasAsumStridedBatched<double, double>(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const double*   x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          int             batch_count,
+                                                          double*         result)
 {
 
     return hipblasDasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasAsumStridedBatched<hipComplex, float>(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batch_count, float* result)
+hipblasStatus_t hipblasAsumStridedBatched<hipComplex, float>(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             const hipComplex* x,
+                                                             int               incx,
+                                                             int               stridex,
+                                                             int               batch_count,
+                                                             float*            result)
 {
 
     return hipblasScasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasAsumStridedBatched<hipDoubleComplex, double>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batch_count, double* result)
+hipblasStatus_t hipblasAsumStridedBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
+                                                                    int                     n,
+                                                                    const hipDoubleComplex* x,
+                                                                    int                     incx,
+                                                                    int                     stridex,
+                                                                    int     batch_count,
+                                                                    double* result)
 {
 
     return hipblasDzasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
@@ -753,24 +927,36 @@ hipblasStatus_t hipblasNrm2Batched<float, float>(
 }
 
 template <>
-hipblasStatus_t hipblasNrm2Batched<double, double>(
-    hipblasHandle_t handle, int n, const double* const x[], int incx, int batch_count, double* result)
+hipblasStatus_t hipblasNrm2Batched<double, double>(hipblasHandle_t     handle,
+                                                   int                 n,
+                                                   const double* const x[],
+                                                   int                 incx,
+                                                   int                 batch_count,
+                                                   double*             result)
 {
 
     return hipblasDnrm2Batched(handle, n, x, incx, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasNrm2Batched<hipComplex, float>(
-    hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batch_count, float* result)
+hipblasStatus_t hipblasNrm2Batched<hipComplex, float>(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      const hipComplex* const x[],
+                                                      int                     incx,
+                                                      int                     batch_count,
+                                                      float*                  result)
 {
 
     return hipblasScnrm2Batched(handle, n, x, incx, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasNrm2Batched<hipDoubleComplex, double>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batch_count, double* result)
+hipblasStatus_t hipblasNrm2Batched<hipDoubleComplex, double>(hipblasHandle_t               handle,
+                                                             int                           n,
+                                                             const hipDoubleComplex* const x[],
+                                                             int                           incx,
+                                                             int     batch_count,
+                                                             double* result)
 {
 
     return hipblasDznrm2Batched(handle, n, x, incx, batch_count, result);
@@ -778,32 +964,52 @@ hipblasStatus_t hipblasNrm2Batched<hipDoubleComplex, double>(
 
 // nrm2_strided_batched
 template <>
-hipblasStatus_t hipblasNrm2StridedBatched<float, float>(
-    hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batch_count, float* result)
+hipblasStatus_t hipblasNrm2StridedBatched<float, float>(hipblasHandle_t handle,
+                                                        int             n,
+                                                        const float*    x,
+                                                        int             incx,
+                                                        int             stridex,
+                                                        int             batch_count,
+                                                        float*          result)
 {
 
     return hipblasSnrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasNrm2StridedBatched<double, double>(
-    hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batch_count, double* result)
+hipblasStatus_t hipblasNrm2StridedBatched<double, double>(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const double*   x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          int             batch_count,
+                                                          double*         result)
 {
 
     return hipblasDnrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasNrm2StridedBatched<hipComplex, float>(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batch_count, float* result)
+hipblasStatus_t hipblasNrm2StridedBatched<hipComplex, float>(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             const hipComplex* x,
+                                                             int               incx,
+                                                             int               stridex,
+                                                             int               batch_count,
+                                                             float*            result)
 {
 
     return hipblasScnrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasNrm2StridedBatched<hipDoubleComplex, double>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batch_count, double* result)
+hipblasStatus_t hipblasNrm2StridedBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
+                                                                    int                     n,
+                                                                    const hipDoubleComplex* x,
+                                                                    int                     incx,
+                                                                    int                     stridex,
+                                                                    int     batch_count,
+                                                                    double* result)
 {
 
     return hipblasDznrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -252,6 +252,64 @@ hipblasStatus_t hipblasCopy<hipDoubleComplex>(hipblasHandle_t         handle,
     return hipblasZcopy(handle, n, x, incx, y, incy);
 }
 
+// copy_batched
+template <>
+hipblasStatus_t
+    hipblasCopyBatched<float>(hipblasHandle_t handle, int n, const float* const x[], int incx, float* const y[], int incy, int batch_count)
+{
+    return hipblasScopyBatched(handle, n, x, incx, y, incy, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasCopyBatched<double>(hipblasHandle_t handle, int n, const double* const x[], int incx, double* const y[], int incy, int batch_count)
+{
+    return hipblasDcopyBatched(handle, n, x, incx, y, incy, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasCopyBatched<hipComplex>(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, hipComplex* const y[], int incy, int batch_count)
+{
+    return hipblasCcopyBatched(handle, n, x, incx, y, incy, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasCopyBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, hipDoubleComplex* const y[], int incy, int batch_count)
+{
+    return hipblasZcopyBatched(handle, n, x, incx, y, incy, batch_count);
+}
+
+// copy_strided_batched
+template <>
+hipblasStatus_t
+    hipblasCopyStridedBatched<float>(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, float* y, int incy, int stridey, int batch_count)
+{
+    return hipblasScopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasCopyStridedBatched<double>(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, double* y, int incy, int stridey, int batch_count)
+{
+    return hipblasDcopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasCopyStridedBatched<hipComplex>(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batch_count)
+{
+    return hipblasCcopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
+template <>
+hipblasStatus_t
+    hipblasCopyStridedBatched<hipDoubleComplex>(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batch_count)
+{
+    return hipblasZcopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+}
+
 // dot
 template <>
 hipblasStatus_t hipblasDot<float>(hipblasHandle_t handle,

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -9,6 +9,8 @@
 #include "testing_copy_batched.hpp"
 #include "testing_copy_strided_batched.hpp"
 #include "testing_dot.hpp"
+#include "testing_dot_batched.hpp"
+#include "testing_dot_strided_batched.hpp"
 #include "testing_iamax.hpp"
 #include "testing_iamin.hpp"
 #include "testing_nrm2.hpp"
@@ -658,6 +660,7 @@ TEST_P(blas1_gtest, swap_float_complex)
     }
 }
 
+// dot tests
 TEST_P(blas1_gtest, dot_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -740,6 +743,197 @@ TEST_P(blas1_gtest, dotc_float_complex)
     }
 }
 
+// dot_batched tests
+TEST_P(blas1_gtest, dot_batched_float)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dot_batched<float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dotu_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dot_batched<hipComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dotc_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dotc_batched<hipComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+// dot_strided_batched tests
+TEST_P(blas1_gtest, dot_strided_batched_float)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dot_strided_batched<float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dotu_strided_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dot_strided_batched<hipComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dotc_strided_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dotc_strided_batched<hipComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+// nrm2 tests
 TEST_P(blas1_gtest, nrm2_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -85,9 +85,9 @@ vector<vector<int>> incx_incy_range = {
     {-1, -1},
 };
 
-double stride_scale_range[] = { 1.0, 2.5 };
+double stride_scale_range[] = {1.0, 2.5};
 
-int batch_count_range[] = { -1, 0, 1, 2, 10 };
+int batch_count_range[] = {-1, 0, 1, 2, 10};
 
 /* ===============Google Unit Test==================================================== */
 

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -16,6 +16,8 @@
 #include "testing_iamax.hpp"
 #include "testing_iamin.hpp"
 #include "testing_nrm2.hpp"
+#include "testing_nrm2_batched.hpp"
+#include "testing_nrm2_strided_batched.hpp"
 #include "testing_scal.hpp"
 #include "testing_scal_batched.hpp"
 #include "testing_scal_strided_batched.hpp"
@@ -1096,6 +1098,128 @@ TEST_P(blas1_gtest, nrm2_float_complex)
     }
 }
 
+// nrm2_batched tests
+TEST_P(blas1_gtest, nrm2_batched_float)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_nrm2_batched<float, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(blas1_gtest, nrm2_batched_float_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_nrm2_batched<hipComplex, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+// nrm2_strided_batched tests
+TEST_P(blas1_gtest, nrm2_strided_batched_float)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_nrm2_strided_batched<float, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(blas1_gtest, nrm2_strided_batched_float_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_nrm2_strided_batched<hipComplex, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
 // asum
 TEST_P(blas1_gtest, asum_float)
 {
@@ -1273,57 +1397,57 @@ TEST_P(blas1_gtest, asum_strided_batched_float)
     }
 }
 
-// TEST_P(blas1_gtest, asum_strided_batched_float_complex)
-// {
-//     Arguments       arg    = setup_blas1_arguments(GetParam());
-//     hipblasStatus_t status = testing_asum_strided_batched<hipComplex, float>(arg);
-//     // if not success, then the input argument is problematic, so detect the error message
-//     if(status != HIPBLAS_STATUS_SUCCESS)
-//     {
-//         if(arg.N < 0)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else if(arg.incx < 0)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else if(arg.batch_count < 0)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
-//         }
-//     }
-// }
+TEST_P(blas1_gtest, asum_strided_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_asum_strided_batched<hipComplex, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
 
-// TEST_P(blas1_gtest, asum_strided_batched_double_complex)
-// {
-//     Arguments       arg    = setup_blas1_arguments(GetParam());
-//     hipblasStatus_t status = testing_asum_strided_batched<hipDoubleComplex, double>(arg);
-//     // if not success, then the input argument is problematic, so detect the error message
-//     if(status != HIPBLAS_STATUS_SUCCESS)
-//     {
-//         if(arg.N < 0)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else if(arg.incx < 0)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else if(arg.batch_count < 0)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
-//         }
-//     }
-// }
+TEST_P(blas1_gtest, asum_strided_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_asum_strided_batched<hipDoubleComplex, double>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
 
 // amax
 TEST_P(blas1_gtest, amax_float)

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -4,6 +4,8 @@
  * ************************************************************************ */
 
 #include "testing_asum.hpp"
+#include "testing_asum_batched.hpp"
+#include "testing_asum_strided_batched.hpp"
 #include "testing_axpy.hpp"
 #include "testing_copy.hpp"
 #include "testing_copy_batched.hpp"
@@ -1094,6 +1096,7 @@ TEST_P(blas1_gtest, nrm2_float_complex)
     }
 }
 
+// asum
 TEST_P(blas1_gtest, asum_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -1164,6 +1167,165 @@ TEST_P(blas1_gtest, asum_double_complex)
     }
 }
 
+// asum_batched
+TEST_P(blas1_gtest, asum_batched_float)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_asum_batched<float, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(blas1_gtest, asum_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_asum_batched<hipComplex, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(blas1_gtest, asum_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_asum_batched<hipDoubleComplex, double>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+// asum_strided_batched
+TEST_P(blas1_gtest, asum_strided_batched_float)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_asum_strided_batched<float, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+// TEST_P(blas1_gtest, asum_strided_batched_float_complex)
+// {
+//     Arguments       arg    = setup_blas1_arguments(GetParam());
+//     hipblasStatus_t status = testing_asum_strided_batched<hipComplex, float>(arg);
+//     // if not success, then the input argument is problematic, so detect the error message
+//     if(status != HIPBLAS_STATUS_SUCCESS)
+//     {
+//         if(arg.N < 0)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else if(arg.incx < 0)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else if(arg.batch_count < 0)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+//         }
+//     }
+// }
+
+// TEST_P(blas1_gtest, asum_strided_batched_double_complex)
+// {
+//     Arguments       arg    = setup_blas1_arguments(GetParam());
+//     hipblasStatus_t status = testing_asum_strided_batched<hipDoubleComplex, double>(arg);
+//     // if not success, then the input argument is problematic, so detect the error message
+//     if(status != HIPBLAS_STATUS_SUCCESS)
+//     {
+//         if(arg.N < 0)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else if(arg.incx < 0)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else if(arg.batch_count < 0)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+//         }
+//     }
+// }
+
+// amax
 TEST_P(blas1_gtest, amax_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -773,7 +773,7 @@ TEST_P(blas1_gtest, dot_batched_float)
         }
         else
         {
-            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
         }
     }
 }
@@ -803,7 +803,7 @@ TEST_P(blas1_gtest, dotu_batched_float_complex)
         }
         else
         {
-            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
         }
     }
 }
@@ -833,7 +833,7 @@ TEST_P(blas1_gtest, dotc_batched_float_complex)
         }
         else
         {
-            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
         }
     }
 }
@@ -868,7 +868,7 @@ TEST_P(blas1_gtest, dot_strided_batched_float)
         }
         else
         {
-            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
         }
     }
 }
@@ -898,7 +898,7 @@ TEST_P(blas1_gtest, dotu_strided_batched_float_complex)
         }
         else
         {
-            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
         }
     }
 }
@@ -928,7 +928,7 @@ TEST_P(blas1_gtest, dotc_strided_batched_float_complex)
         }
         else
         {
-            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
         }
     }
 }

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -18,6 +18,8 @@
 #include "testing_scal_batched.hpp"
 #include "testing_scal_strided_batched.hpp"
 #include "testing_swap.hpp"
+#include "testing_swap_batched.hpp"
+#include "testing_swap_strided_batched.hpp"
 #include "utility.h"
 #include <gtest/gtest.h>
 #include <math.h>
@@ -656,6 +658,112 @@ TEST_P(blas1_gtest, swap_float_complex)
         else
         {
             EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+// swap_batched tests
+TEST_P(blas1_gtest, swap_batched_float)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_swap_batched<float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(blas1_gtest, swap_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_swap_batched<hipComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+// swap_strided_batched tests
+TEST_P(blas1_gtest, swap_strided_batched_float)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_swap_strided_batched<float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(blas1_gtest, swap_strided_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_swap_strided_batched<hipComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
         }
     }
 }

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -6,6 +6,8 @@
 #include "testing_asum.hpp"
 #include "testing_axpy.hpp"
 #include "testing_copy.hpp"
+#include "testing_copy_batched.hpp"
+#include "testing_copy_strided_batched.hpp"
 #include "testing_dot.hpp"
 #include "testing_iamax.hpp"
 #include "testing_iamin.hpp"
@@ -192,6 +194,7 @@ TEST_P(blas1_gtest, axpy_double_complex)
     }
 }
 
+// copy tests
 TEST_P(blas1_gtest, copy_float)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
@@ -232,6 +235,112 @@ TEST_P(blas1_gtest, copy_float_complex)
         else
         {
             EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+// copy_batched tests
+TEST_P(blas1_gtest, copy_batched_float)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_copy_batched<float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(blas1_gtest, copy_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_copy_batched<hipComplex>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+// copy_strided_batched tests
+TEST_P(blas1_gtest, copy_strided_batched_float)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_copy_strided_batched<float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(blas1_gtest, copy_strided_batched_float_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_copy_strided_batched<hipComplex>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
         }
     }
 }

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -37,6 +37,12 @@ template <typename T>
 hipblasStatus_t hipblasCopy(hipblasHandle_t handle, int n, const T* x, int incx, T* y, int incy);
 
 template <typename T>
+hipblasStatus_t hipblasCopyBatched(hipblasHandle_t handle, int n, const T* const x[], int incx, T* const y[], int incy, int batch_count);
+
+template <typename T>
+hipblasStatus_t hipblasCopyStridedBatched(hipblasHandle_t handle, int n, const T* x, int incx, int stridex, T* y, int incy, int stridey, int batch_count);
+
+template <typename T>
 hipblasStatus_t hipblasSwap(hipblasHandle_t handle, int n, T* x, int incx, T* y, int incy);
 
 template <typename T>

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -79,6 +79,12 @@ template <typename T1, typename T2>
 hipblasStatus_t hipblasAsum(hipblasHandle_t handle, int n, const T1* x, int incx, T2* result);
 
 template <typename T1, typename T2>
+hipblasStatus_t hipblasAsumBatched(hipblasHandle_t handle, int n, const T1* const x[], int incx, int batch_count, T2* result);
+
+template <typename T1, typename T2>
+hipblasStatus_t hipblasAsumStridedBatched(hipblasHandle_t handle, int n, const T1* x, int incx, int stridex, int batch_count, T2* result);
+
+template <typename T1, typename T2>
 hipblasStatus_t hipblasNrm2(hipblasHandle_t handle, int n, const T1* x, int incx, T2* result);
 
 template <typename T>

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -53,6 +53,22 @@ template <typename T>
 hipblasStatus_t hipblasDotc(
     hipblasHandle_t handle, int n, const T* x, int incx, const T* y, int incy, T* result);
 
+template <typename T>
+hipblasStatus_t hipblasDotBatched(
+    hipblasHandle_t handle, int n, const T* const x[], int incx, const T* const y[], int incy, int batch_count, T* result);
+
+template <typename T>
+hipblasStatus_t hipblasDotcBatched(
+    hipblasHandle_t handle, int n, const T* const x[], int incx, const T* const y[], int incy, int batch_count, T* result);
+
+template <typename T>
+hipblasStatus_t hipblasDotStridedBatched(
+    hipblasHandle_t handle, int n, const T* x, int incx, int stridex, const T* y, int incy, int stridey, int batch_count, T* result);
+
+template <typename T>
+hipblasStatus_t hipblasDotcStridedBatched(
+    hipblasHandle_t handle, int n, const T* x, int incx, int stridex, const T* y, int incy, int stridey, int batch_count, T* result);
+
 template <typename T1, typename T2>
 hipblasStatus_t hipblasAsum(hipblasHandle_t handle, int n, const T1* x, int incx, T2* result);
 

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -46,6 +46,12 @@ template <typename T>
 hipblasStatus_t hipblasSwap(hipblasHandle_t handle, int n, T* x, int incx, T* y, int incy);
 
 template <typename T>
+hipblasStatus_t hipblasSwapBatched(hipblasHandle_t handle, int n, T* x[], int incx, T* y[], int incy, int batch_count);
+
+template <typename T>
+hipblasStatus_t hipblasSwapStridedBatched(hipblasHandle_t handle, int n, T* x, int incx, int stridex, T* y, int incy, int stridey, int batch_count);
+
+template <typename T>
 hipblasStatus_t hipblasDot(
     hipblasHandle_t handle, int n, const T* x, int incx, const T* y, int incy, T* result);
 

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -87,6 +87,12 @@ hipblasStatus_t hipblasAsumStridedBatched(hipblasHandle_t handle, int n, const T
 template <typename T1, typename T2>
 hipblasStatus_t hipblasNrm2(hipblasHandle_t handle, int n, const T1* x, int incx, T2* result);
 
+template <typename T1, typename T2>
+hipblasStatus_t hipblasNrm2Batched(hipblasHandle_t handle, int n, const T1* const x[], int incx, int batch_count, T2* result);
+
+template <typename T1, typename T2>
+hipblasStatus_t hipblasNrm2StridedBatched(hipblasHandle_t handle, int n, const T1* x, int incx, int stridex, int batch_count, T2* result);
+
 template <typename T>
 hipblasStatus_t hipblasIamax(hipblasHandle_t handle, int n, const T* x, int incx, int* result);
 

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -28,28 +28,53 @@ template <typename T, typename U = T>
 hipblasStatus_t hipblasScal(hipblasHandle_t handle, int n, const U* alpha, T* x, int incx);
 
 template <typename T, typename U = T>
-hipblasStatus_t hipblasScalBatched(hipblasHandle_t handle, int n, const U* alpha, T* const x[], int incx, int batch_count);
+hipblasStatus_t hipblasScalBatched(
+    hipblasHandle_t handle, int n, const U* alpha, T* const x[], int incx, int batch_count);
 
 template <typename T, typename U = T>
-hipblasStatus_t hipblasScalStridedBatched(hipblasHandle_t handle, int n, const U* alpha, T* x, int incx, int stridex, int batch_count);
+hipblasStatus_t hipblasScalStridedBatched(
+    hipblasHandle_t handle, int n, const U* alpha, T* x, int incx, int stridex, int batch_count);
 
 template <typename T>
 hipblasStatus_t hipblasCopy(hipblasHandle_t handle, int n, const T* x, int incx, T* y, int incy);
 
 template <typename T>
-hipblasStatus_t hipblasCopyBatched(hipblasHandle_t handle, int n, const T* const x[], int incx, T* const y[], int incy, int batch_count);
+hipblasStatus_t hipblasCopyBatched(hipblasHandle_t handle,
+                                   int             n,
+                                   const T* const  x[],
+                                   int             incx,
+                                   T* const        y[],
+                                   int             incy,
+                                   int             batch_count);
 
 template <typename T>
-hipblasStatus_t hipblasCopyStridedBatched(hipblasHandle_t handle, int n, const T* x, int incx, int stridex, T* y, int incy, int stridey, int batch_count);
+hipblasStatus_t hipblasCopyStridedBatched(hipblasHandle_t handle,
+                                          int             n,
+                                          const T*        x,
+                                          int             incx,
+                                          int             stridex,
+                                          T*              y,
+                                          int             incy,
+                                          int             stridey,
+                                          int             batch_count);
 
 template <typename T>
 hipblasStatus_t hipblasSwap(hipblasHandle_t handle, int n, T* x, int incx, T* y, int incy);
 
 template <typename T>
-hipblasStatus_t hipblasSwapBatched(hipblasHandle_t handle, int n, T* x[], int incx, T* y[], int incy, int batch_count);
+hipblasStatus_t hipblasSwapBatched(
+    hipblasHandle_t handle, int n, T* x[], int incx, T* y[], int incy, int batch_count);
 
 template <typename T>
-hipblasStatus_t hipblasSwapStridedBatched(hipblasHandle_t handle, int n, T* x, int incx, int stridex, T* y, int incy, int stridey, int batch_count);
+hipblasStatus_t hipblasSwapStridedBatched(hipblasHandle_t handle,
+                                          int             n,
+                                          T*              x,
+                                          int             incx,
+                                          int             stridex,
+                                          T*              y,
+                                          int             incy,
+                                          int             stridey,
+                                          int             batch_count);
 
 template <typename T>
 hipblasStatus_t hipblasDot(
@@ -60,38 +85,70 @@ hipblasStatus_t hipblasDotc(
     hipblasHandle_t handle, int n, const T* x, int incx, const T* y, int incy, T* result);
 
 template <typename T>
-hipblasStatus_t hipblasDotBatched(
-    hipblasHandle_t handle, int n, const T* const x[], int incx, const T* const y[], int incy, int batch_count, T* result);
+hipblasStatus_t hipblasDotBatched(hipblasHandle_t handle,
+                                  int             n,
+                                  const T* const  x[],
+                                  int             incx,
+                                  const T* const  y[],
+                                  int             incy,
+                                  int             batch_count,
+                                  T*              result);
 
 template <typename T>
-hipblasStatus_t hipblasDotcBatched(
-    hipblasHandle_t handle, int n, const T* const x[], int incx, const T* const y[], int incy, int batch_count, T* result);
+hipblasStatus_t hipblasDotcBatched(hipblasHandle_t handle,
+                                   int             n,
+                                   const T* const  x[],
+                                   int             incx,
+                                   const T* const  y[],
+                                   int             incy,
+                                   int             batch_count,
+                                   T*              result);
 
 template <typename T>
-hipblasStatus_t hipblasDotStridedBatched(
-    hipblasHandle_t handle, int n, const T* x, int incx, int stridex, const T* y, int incy, int stridey, int batch_count, T* result);
+hipblasStatus_t hipblasDotStridedBatched(hipblasHandle_t handle,
+                                         int             n,
+                                         const T*        x,
+                                         int             incx,
+                                         int             stridex,
+                                         const T*        y,
+                                         int             incy,
+                                         int             stridey,
+                                         int             batch_count,
+                                         T*              result);
 
 template <typename T>
-hipblasStatus_t hipblasDotcStridedBatched(
-    hipblasHandle_t handle, int n, const T* x, int incx, int stridex, const T* y, int incy, int stridey, int batch_count, T* result);
+hipblasStatus_t hipblasDotcStridedBatched(hipblasHandle_t handle,
+                                          int             n,
+                                          const T*        x,
+                                          int             incx,
+                                          int             stridex,
+                                          const T*        y,
+                                          int             incy,
+                                          int             stridey,
+                                          int             batch_count,
+                                          T*              result);
 
 template <typename T1, typename T2>
 hipblasStatus_t hipblasAsum(hipblasHandle_t handle, int n, const T1* x, int incx, T2* result);
 
 template <typename T1, typename T2>
-hipblasStatus_t hipblasAsumBatched(hipblasHandle_t handle, int n, const T1* const x[], int incx, int batch_count, T2* result);
+hipblasStatus_t hipblasAsumBatched(
+    hipblasHandle_t handle, int n, const T1* const x[], int incx, int batch_count, T2* result);
 
 template <typename T1, typename T2>
-hipblasStatus_t hipblasAsumStridedBatched(hipblasHandle_t handle, int n, const T1* x, int incx, int stridex, int batch_count, T2* result);
+hipblasStatus_t hipblasAsumStridedBatched(
+    hipblasHandle_t handle, int n, const T1* x, int incx, int stridex, int batch_count, T2* result);
 
 template <typename T1, typename T2>
 hipblasStatus_t hipblasNrm2(hipblasHandle_t handle, int n, const T1* x, int incx, T2* result);
 
 template <typename T1, typename T2>
-hipblasStatus_t hipblasNrm2Batched(hipblasHandle_t handle, int n, const T1* const x[], int incx, int batch_count, T2* result);
+hipblasStatus_t hipblasNrm2Batched(
+    hipblasHandle_t handle, int n, const T1* const x[], int incx, int batch_count, T2* result);
 
 template <typename T1, typename T2>
-hipblasStatus_t hipblasNrm2StridedBatched(hipblasHandle_t handle, int n, const T1* x, int incx, int stridex, int batch_count, T2* result);
+hipblasStatus_t hipblasNrm2StridedBatched(
+    hipblasHandle_t handle, int n, const T1* x, int incx, int stridex, int batch_count, T2* result);
 
 template <typename T>
 hipblasStatus_t hipblasIamax(hipblasHandle_t handle, int n, const T* x, int incx, int* result);

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -27,6 +27,12 @@
 template <typename T, typename U = T>
 hipblasStatus_t hipblasScal(hipblasHandle_t handle, int n, const U* alpha, T* x, int incx);
 
+template <typename T, typename U = T>
+hipblasStatus_t hipblasScalBatched(hipblasHandle_t handle, int n, const U* alpha, T* const x[], int incx, int batch_count);
+
+template <typename T, typename U = T>
+hipblasStatus_t hipblasScalStridedBatched(hipblasHandle_t handle, int n, const U* alpha, T* x, int incx, int stridex, int batch_count);
+
 template <typename T>
 hipblasStatus_t hipblasCopy(hipblasHandle_t handle, int n, const T* x, int incx, T* y, int incy);
 

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -59,21 +59,22 @@ hipblasStatus_t testing_asum_batched(Arguments argus)
     device_vector<T2>         d_rocblas_result(batch_count);
 
     int device_pointer = 1;
-    int host_pointer = 1;    
+    int host_pointer   = 1;
 
     // Initial Data on CPU
     srand(1);
     for(int b = 0; b < batch_count; b++)
     {
         hx_array[b] = host_vector<T1>(sizeX);
-    
+
         srand(1);
         hipblas_init<T1>(hx_array[b], 1, N, incx);
 
-        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T1) * sizeX, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(bx_array[b], hx_array[b], sizeof(T1) * sizeX, hipMemcpyHostToDevice));
     }
-    CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, sizeof(T1*) * batch_count, hipMemcpyHostToDevice));
-
+    CHECK_HIP_ERROR(
+        hipMemcpy(dx_array, bx_array, sizeof(T1*) * batch_count, hipMemcpyHostToDevice));
 
     /* =====================================================================
          ROCBLAS
@@ -82,16 +83,19 @@ hipblasStatus_t testing_asum_batched(Arguments argus)
     if(device_pointer)
     {
         status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-        status_2 = hipblasAsumBatched<T1, T2>(handle, N, dx_array, incx, batch_count, d_rocblas_result);
+        status_2
+            = hipblasAsumBatched<T1, T2>(handle, N, dx_array, incx, batch_count, d_rocblas_result);
     }
     if(host_pointer)
     {
         status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        status_4 = hipblasAsumBatched<T1, T2>(handle, N, dx_array, incx, batch_count, h_rocblas_result1);
+        status_4
+            = hipblasAsumBatched<T1, T2>(handle, N, dx_array, incx, batch_count, h_rocblas_result1);
     }
 
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS ||
-       (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS)))
+    if((status_1 != HIPBLAS_STATUS_SUCCESS)
+       || (status_2 != HIPBLAS_STATUS_SUCCESS || (status_3 != HIPBLAS_STATUS_SUCCESS)
+           || (status_4 != HIPBLAS_STATUS_SUCCESS)))
     {
         hipblasDestroy(handle);
         if(status_1 != HIPBLAS_STATUS_SUCCESS)
@@ -105,8 +109,8 @@ hipblasStatus_t testing_asum_batched(Arguments argus)
     }
 
     if(device_pointer)
-        CHECK_HIP_ERROR(
-            hipMemcpy(h_rocblas_result2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(
+            h_rocblas_result2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
 
     if(argus.unit_check)
     {

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -1,0 +1,132 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T1, typename T2>
+hipblasStatus_t testing_asum_batched(Arguments argus)
+{
+    int N           = argus.N;
+    int incx        = argus.incx;
+    int batch_count = argus.batch_count;
+
+    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
+
+    // check to prevent undefined memory allocation error
+    if(N < 0 || incx < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+    if(batch_count == 0)
+    {
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    int sizeX = N * incx;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T1> hx_array[batch_count];
+    host_vector<T2> h_rocblas_result1(batch_count);
+    host_vector<T2> h_rocblas_result2(batch_count);
+    host_vector<T2> h_cpu_result(batch_count);
+
+    device_batch_vector<T1>   bx_array(batch_count, sizeX);
+    device_vector<T1*, 0, T1> dx_array(batch_count);
+    device_vector<T2>         d_rocblas_result(batch_count);
+
+    int device_pointer = 1;
+    int host_pointer = 1;    
+
+    // Initial Data on CPU
+    srand(1);
+    for(int b = 0; b < batch_count; b++)
+    {
+        hx_array[b] = host_vector<T1>(sizeX);
+    
+        srand(1);
+        hipblas_init<T1>(hx_array[b], 1, N, incx);
+
+        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T1) * sizeX, hipMemcpyHostToDevice));
+    }
+    CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, sizeof(T1*) * batch_count, hipMemcpyHostToDevice));
+
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    // hipblasAsum accept both dev/host pointer for the scalar
+    if(device_pointer)
+    {
+        status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+        status_2 = hipblasAsumBatched<T1, T2>(handle, N, dx_array, incx, batch_count, d_rocblas_result);
+    }
+    if(host_pointer)
+    {
+        status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
+        status_4 = hipblasAsumBatched<T1, T2>(handle, N, dx_array, incx, batch_count, h_rocblas_result1);
+    }
+
+    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS ||
+       (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS)))
+    {
+        hipblasDestroy(handle);
+        if(status_1 != HIPBLAS_STATUS_SUCCESS)
+            return status_1;
+        if(status_2 != HIPBLAS_STATUS_SUCCESS)
+            return status_2;
+        if(status_3 != HIPBLAS_STATUS_SUCCESS)
+            return status_3;
+        if(status_4 != HIPBLAS_STATUS_SUCCESS)
+            return status_4;
+    }
+
+    if(device_pointer)
+        CHECK_HIP_ERROR(
+            hipMemcpy(h_rocblas_result2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_asum<T1, T2>(N, hx_array[b], incx, &(h_cpu_result[b]));
+        }
+
+        if(argus.unit_check)
+        {
+            unit_check_general<T2>(1, batch_count, 1, h_cpu_result, h_rocblas_result1);
+            unit_check_general<T2>(1, batch_count, 1, h_cpu_result, h_rocblas_result2);
+        }
+
+    } // end of if unit/norm check
+
+    //  BLAS_1_RESULT_PRINT
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -18,51 +18,21 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, bool CONJ = false>
-hipblasStatus_t testing_dot_strided_batched(Arguments argus)
+template <typename T1, typename T2>
+hipblasStatus_t testing_asum_strided_batched(Arguments argus)
 {
-    int N               = argus.N;
-    int incx            = argus.incx;
-    int incy            = argus.incy;
-    double stride_scale = argus.stride_scale;
-    int batch_count     = argus.batch_count;
+    int N            = argus.N;
+    int incx         = argus.incx;
+    int stride_scale = argus.stride_scale;
+    int batch_count  = argus.batch_count;
 
     int stridex = N * incx * stride_scale;
-    int stridey = N * incy * stride_scale;
     int sizeX   = stridex * batch_count;
-    int sizeY   = stridey * batch_count;
 
     hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
-
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_vector<T> hx(sizeX);
-    host_vector<T> hy(sizeY);
-    host_vector<T> h_rocblas_result1(batch_count);
-    host_vector<T> h_rocblas_result2(batch_count);
-    host_vector<T> h_cpu_result(batch_count);
-
-    device_vector<T> dx(sizeX);
-    device_vector<T> dy(sizeY);
-    device_vector<T> d_rocblas_result(batch_count);
-
-    int device_pointer = 1;
-
-    // TODO: Change to 1 when rocBLAS is fixed.
-    int host_pointer   = 0;
 
     double gpu_time_used, cpu_time_used;
     double rocblas_error;
@@ -70,34 +40,51 @@ hipblasStatus_t testing_dot_strided_batched(Arguments argus)
     hipblasHandle_t handle;
     hipblasCreate(&handle);
 
+    // check to prevent undefined memory allocation error
+    if(N < 0 || incx < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+    if(batch_count == 0)
+    {
+        // return early so we don't get invalid_value from rocblas because of bad result pointer
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T1> hx(sizeX);
+    host_vector<T2> cpu_result(batch_count);
+    host_vector<T2> rocblas_result1(batch_count);
+    host_vector<T2> rocblas_result2(batch_count);
+
+    device_vector<T1> dx(sizeX);
+    device_vector<T2> d_rocblas_result(batch_count);
+
+    int device_pointer = 1;
+    int host_pointer   = 1;
+
     // Initial Data on CPU
     srand(1);
-    hipblas_init<T>(hx, 1, N, incx, stridex, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stridey, batch_count);
+    hipblas_init<T1>(hx, 1, N, incx, stridex, batch_count);
 
     // copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T1) * sizeX, hipMemcpyHostToDevice));
 
     /* =====================================================================
          ROCBLAS
     =================================================================== */
-    // hipblasDot accept both dev/host pointer for the scalar
+    // hipblasAsum accept both dev/host pointer for the scalar
+
     if(device_pointer)
     {
-
         status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-
-        status_2 = (CONJ ? hipblasDotcStridedBatched<T>
-                         : hipblasDotStridedBatched<T>)(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, d_rocblas_result);
+        status_2 = hipblasAsumStridedBatched<T1, T2>(handle, N, dx, incx, stridex, batch_count, d_rocblas_result);
     }
+
     if(host_pointer)
     {
-
         status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-
-        status_4 = (CONJ ? hipblasDotcStridedBatched<T>
-                         : hipblasDotStridedBatched<T>)(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, h_rocblas_result2);
+        status_4 = hipblasAsumStridedBatched<T1, T2>(handle, N, dx, incx, stridex, batch_count, rocblas_result1);
     }
 
     if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS) ||
@@ -116,34 +103,27 @@ hipblasStatus_t testing_dot_strided_batched(Arguments argus)
 
     if(device_pointer)
         CHECK_HIP_ERROR(
-            hipMemcpy(h_rocblas_result1, d_rocblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
+            hipMemcpy(rocblas_result2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check || argus.norm_check)
+    if(argus.unit_check)
     {
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx.data() + b * stridex, incx, hy.data() + b * stridey, incy, &h_cpu_result[b]);
+            cblas_asum<T1, T2>(N, hx.data() + b * stridex, incx, &cpu_result[b]);
         }
 
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_rocblas_result1);
-            // unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_rocblas_result2);
+            unit_check_general<T2>(1, batch_count, 1, cpu_result, rocblas_result1);
+            unit_check_general<T2>(1, batch_count, 1, cpu_result, rocblas_result2);
         }
 
     } // end of if unit/norm check
 
     //  BLAS_1_RESULT_PRINT
-
     hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
-}
-
-template <typename T>
-hipblasStatus_t testing_dotc_strided_batched(Arguments argus)
-{
-    return testing_dot_strided_batched<T, true>(argus);
 }

--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -78,17 +78,19 @@ hipblasStatus_t testing_asum_strided_batched(Arguments argus)
     if(device_pointer)
     {
         status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-        status_2 = hipblasAsumStridedBatched<T1, T2>(handle, N, dx, incx, stridex, batch_count, d_rocblas_result);
+        status_2 = hipblasAsumStridedBatched<T1, T2>(
+            handle, N, dx, incx, stridex, batch_count, d_rocblas_result);
     }
 
     if(host_pointer)
     {
         status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        status_4 = hipblasAsumStridedBatched<T1, T2>(handle, N, dx, incx, stridex, batch_count, rocblas_result1);
+        status_4 = hipblasAsumStridedBatched<T1, T2>(
+            handle, N, dx, incx, stridex, batch_count, rocblas_result1);
     }
 
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS) ||
-       (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
+    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
+       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
     {
         hipblasDestroy(handle);
         if(status_1 != HIPBLAS_STATUS_SUCCESS)
@@ -102,8 +104,8 @@ hipblasStatus_t testing_asum_strided_batched(Arguments argus)
     }
 
     if(device_pointer)
-        CHECK_HIP_ERROR(
-            hipMemcpy(rocblas_result2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(
+            rocblas_result2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
 
     if(argus.unit_check)
     {

--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -41,7 +41,7 @@ hipblasStatus_t testing_copy_batched(Arguments argus)
 
     int sizeX = N * incx;
     int sizeY = N * incy;
-    
+
     double gpu_time_used, cpu_time_used;
     double rocblas_error = 0.0;
 
@@ -82,8 +82,10 @@ hipblasStatus_t testing_copy_batched(Arguments argus)
         hx_cpu_array[b] = hx_array[b];
         hy_cpu_array[b] = hy_array[b];
 
-        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
     }
     CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy_array, by_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
@@ -101,8 +103,10 @@ hipblasStatus_t testing_copy_batched(Arguments argus)
     // copy output from device to CPU
     for(int b = 0; b < batch_count; b++)
     {
-        CHECK_HIP_ERROR(hipMemcpy(hx_array[b], by_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(hy_array[b], by_array[b], sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hx_array[b], by_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hy_array[b], by_array[b], sizeof(T) * sizeY, hipMemcpyDeviceToHost));
     }
 
     if(argus.unit_check)

--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -1,0 +1,132 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_copy_batched(Arguments argus)
+{
+    int N           = argus.N;
+    int incx        = argus.incx;
+    int incy        = argus.incy;
+    int batch_count = argus.batch_count;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0 || incx < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+    else if(batch_count == 0)
+    {
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    int sizeX = N * incx;
+    int sizeY = N * incy;
+    
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error = 0.0;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T> hx_array[batch_count];
+    host_vector<T> hy_array[batch_count];
+    host_vector<T> hx_cpu_array[batch_count];
+    host_vector<T> hy_cpu_array[batch_count];
+
+    device_batch_vector<T> bx_array(batch_count, sizeX);
+    device_batch_vector<T> by_array(batch_count, sizeY);
+
+    device_vector<T*, 0, T> dx_array(batch_count);
+    device_vector<T*, 0, T> dy_array(batch_count);
+
+    int last = batch_count - 1;
+    if(!dx_array || !dy_array || (!bx_array[last] && sizeX) || (!by_array[last] && sizeY))
+    {
+        hipblasDestroy(handle);
+        return HIPBLAS_STATUS_ALLOC_FAILED;
+    }
+
+    srand(1);
+    for(int b = 0; b < batch_count; b++)
+    {
+        hx_array[b]     = host_vector<T>(sizeX);
+        hy_array[b]     = host_vector<T>(sizeY);
+        hx_cpu_array[b] = host_vector<T>(sizeX);
+        hy_cpu_array[b] = host_vector<T>(sizeY);
+
+        srand(1);
+        hipblas_init<T>(hx_array[b], 1, N, incx);
+        hipblas_init<T>(hy_array[b], 1, N, incy);
+
+        hx_cpu_array[b] = hx_array[b];
+        hy_cpu_array[b] = hy_array[b];
+
+        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
+    }
+    CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy_array, by_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    status = hipblasCopyBatched<T>(handle, N, dx_array, incx, dy_array, incy, batch_count);
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    // copy output from device to CPU
+    for(int b = 0; b < batch_count; b++)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(hx_array[b], by_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_array[b], by_array[b], sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+    }
+
+    if(argus.unit_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_copy<T>(N, hx_cpu_array[b], incx, hy_cpu_array[b], incy);
+        }
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, batch_count, incx, hx_cpu_array, hx_array);
+            unit_check_general<T>(1, N, batch_count, incx, hy_cpu_array, hy_array);
+        }
+
+    } // end of if unit check
+
+    //  BLAS_1_RESULT_PRINT
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -21,11 +21,11 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_copy_strided_batched(Arguments argus)
 {
-    int N               = argus.N;
-    int incx            = argus.incx;
-    int incy            = argus.incy;
+    int    N            = argus.N;
+    int    incx         = argus.incx;
+    int    incy         = argus.incy;
     double stride_scale = argus.stride_scale;
-    int batch_count     = argus.batch_count;
+    int    batch_count  = argus.batch_count;
 
     int stridex = N * incx * stride_scale;
     int stridey = N * incy * stride_scale;
@@ -70,7 +70,8 @@ hipblasStatus_t testing_copy_strided_batched(Arguments argus)
     /* =====================================================================
          ROCBLAS
     =================================================================== */
-    status = hipblasCopyStridedBatched<T>(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count);
+    status = hipblasCopyStridedBatched<T>(
+        handle, N, dx, incx, stridex, dy, incy, stridey, batch_count);
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
         hipblasDestroy(handle);

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -19,53 +19,47 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename T>
-hipblasStatus_t testing_copy(Arguments argus)
+hipblasStatus_t testing_copy_strided_batched(Arguments argus)
 {
-    int N    = argus.N;
-    int incx = argus.incx;
-    int incy = argus.incy;
+    int N               = argus.N;
+    int incx            = argus.incx;
+    int incy            = argus.incy;
+    double stride_scale = argus.stride_scale;
+    int batch_count     = argus.batch_count;
+
+    int stridex = N * incx * stride_scale;
+    int stridey = N * incy * stride_scale;
+    int sizeX   = stridex * batch_count;
+    int sizeY   = stridey * batch_count;
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0)
+    if(N < 0 || incx < 0 || batch_count < 0)
     {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
-    else if(incx < 0)
-    {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
-    }
-
-    int sizeX = N * incx;
-    int sizeY = N * incy;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    vector<T> hx(sizeX);
-    vector<T> hy(sizeY);
-    vector<T> hx_cpu(sizeX);
-    vector<T> hy_cpu(sizeY);
-    T*        dx;
-    T*        dy;
+    host_vector<T> hx(sizeX);
+    host_vector<T> hy(sizeY);
+    host_vector<T> hx_cpu(sizeX);
+    host_vector<T> hy_cpu(sizeY);
+
+    device_vector<T> dx(sizeX);
+    device_vector<T> dy(sizeY);
 
     double gpu_time_used, cpu_time_used;
     double rocblas_error = 0.0;
 
     hipblasHandle_t handle;
-
     hipblasCreate(&handle);
-
-    // allocate memory on device
-    CHECK_HIP_ERROR(hipMalloc(&dx, sizeX * sizeof(T)));
-    CHECK_HIP_ERROR(hipMalloc(&dy, sizeY * sizeof(T)));
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, N, incx, stridex, batch_count);
+    hipblas_init<T>(hy, 1, N, incy, stridey, batch_count);
 
     hx_cpu = hx;
     hy_cpu = hy;
@@ -76,11 +70,9 @@ hipblasStatus_t testing_copy(Arguments argus)
     /* =====================================================================
          ROCBLAS
     =================================================================== */
-    status = hipblasCopy<T>(handle, N, dx, incx, dy, incy);
+    status = hipblasCopyStridedBatched<T>(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count);
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
-        CHECK_HIP_ERROR(hipFree(dx));
-        CHECK_HIP_ERROR(hipFree(dy));
         hipblasDestroy(handle);
         return status;
     }
@@ -94,22 +86,23 @@ hipblasStatus_t testing_copy(Arguments argus)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_copy<T>(N, hx_cpu.data(), incx, hy_cpu.data(), incy);
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_copy<T>(N, hx_cpu.data() + b * stridex, incx, hy_cpu.data() + b * stridey, incy);
+        }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, incx, hx_cpu.data(), hx.data());
-            unit_check_general<T>(1, N, incy, hy_cpu.data(), hy.data());
+            unit_check_general<T>(1, N, batch_count, incx, stridex, hx_cpu.data(), hx.data());
+            unit_check_general<T>(1, N, batch_count, incy, stridey, hy_cpu.data(), hy.data());
         }
 
     } // end of if unit check
 
     //  BLAS_1_RESULT_PRINT
 
-    CHECK_HIP_ERROR(hipFree(dx));
-    CHECK_HIP_ERROR(hipFree(dy));
     hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -18,15 +18,18 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T>
-hipblasStatus_t testing_copy_batched(Arguments argus)
+template <typename T, bool CONJ = false>
+hipblasStatus_t testing_dot_batched(Arguments argus)
 {
     int N           = argus.N;
     int incx        = argus.incx;
     int incy        = argus.incy;
     int batch_count = argus.batch_count;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -41,9 +44,9 @@ hipblasStatus_t testing_copy_batched(Arguments argus)
 
     int sizeX = N * incx;
     int sizeY = N * incy;
-    
+
     double gpu_time_used, cpu_time_used;
-    double rocblas_error = 0.0;
+    double rocblas_error;
 
     hipblasHandle_t handle;
     hipblasCreate(&handle);
@@ -51,36 +54,39 @@ hipblasStatus_t testing_copy_batched(Arguments argus)
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx_array[batch_count];
     host_vector<T> hy_array[batch_count];
-    host_vector<T> hx_cpu_array[batch_count];
-    host_vector<T> hy_cpu_array[batch_count];
+    host_vector<T> h_cpu_result(batch_count);
+    host_vector<T> h_rocblas_result1(batch_count);
+    host_vector<T> h_rocblas_result2(batch_count);
 
     device_batch_vector<T> bx_array(batch_count, sizeX);
     device_batch_vector<T> by_array(batch_count, sizeY);
 
     device_vector<T*, 0, T> dx_array(batch_count);
     device_vector<T*, 0, T> dy_array(batch_count);
+    device_vector<T>        d_rocblas_result(batch_count);
+
+    int device_pointer = 1;
+
+    // TODO: change to 1 when rocBLAS is fixed.
+    int host_pointer   = 0;
 
     int last = batch_count - 1;
-    if(!dx_array || !dy_array || (!bx_array[last] && sizeX) || (!by_array[last] && sizeY))
+    if(!dx_array || !dy_array || !d_rocblas_result || (!bx_array[last] && sizeX) || (!by_array[last] && sizeY))
     {
         hipblasDestroy(handle);
         return HIPBLAS_STATUS_ALLOC_FAILED;
     }
 
+    // Initial Data on CPU
     srand(1);
     for(int b = 0; b < batch_count; b++)
     {
-        hx_array[b]     = host_vector<T>(sizeX);
-        hy_array[b]     = host_vector<T>(sizeY);
-        hx_cpu_array[b] = host_vector<T>(sizeX);
-        hy_cpu_array[b] = host_vector<T>(sizeY);
+        hx_array[b]          = host_vector<T>(sizeX);
+        hy_array[b]          = host_vector<T>(sizeY);
 
         srand(1);
         hipblas_init<T>(hx_array[b], 1, N, incx);
         hipblas_init<T>(hy_array[b], 1, N, incy);
-
-        hx_cpu_array[b] = hx_array[b];
-        hy_cpu_array[b] = hy_array[b];
 
         CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
@@ -91,42 +97,68 @@ hipblasStatus_t testing_copy_batched(Arguments argus)
     /* =====================================================================
          ROCBLAS
     =================================================================== */
-    status = hipblasCopyBatched<T>(handle, N, dx_array, incx, dy_array, incy, batch_count);
-    if(status != HIPBLAS_STATUS_SUCCESS)
+    // hipblasDot accept both dev/host pointer for the scalar
+    if(device_pointer)
+    {
+
+        status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+
+        status_2 = (CONJ ? hipblasDotcBatched<T>
+                         : hipblasDotBatched<T>)(handle, N, dx_array, incx, dy_array, incy, batch_count, d_rocblas_result);
+    }
+    if(host_pointer)
+    {
+
+        status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
+
+        status_3 = (CONJ ? hipblasDotcBatched<T>
+                         : hipblasDotBatched<T>)(handle, N, dx_array, incx, dy_array, incy, batch_count, h_rocblas_result2);
+    }
+
+    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS) ||
+       (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
     {
         hipblasDestroy(handle);
-        return status;
+        if(status_1 != HIPBLAS_STATUS_SUCCESS)
+            return status_1;
+        if(status_2 != HIPBLAS_STATUS_SUCCESS)
+            return status_2;
+        if(status_3 != HIPBLAS_STATUS_SUCCESS)
+            return status_3;
+        if(status_4 != HIPBLAS_STATUS_SUCCESS)
+            return status_4;
     }
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        CHECK_HIP_ERROR(hipMemcpy(hx_array[b], by_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(hy_array[b], by_array[b], sizeof(T) * sizeY, hipMemcpyDeviceToHost));
-    }
+    if(device_pointer)
+        CHECK_HIP_ERROR(
+            hipMemcpy(h_rocblas_result1, d_rocblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_copy<T>(N, hx_cpu_array[b], incx, hy_cpu_array[b], incy);
+            (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx_array[b], incx, hy_array[b], incy, &(h_cpu_result[b]));
         }
 
-        // enable unit check, notice unit check is not invasive, but norm check is,
-        // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incx, hx_cpu_array, hx_array);
-            unit_check_general<T>(1, N, batch_count, incx, hy_cpu_array, hy_array);
+            unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_rocblas_result1);
+            // unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_rocblas_result2);
         }
 
-    } // end of if unit check
+    } // end of if unit/norm check
 
     //  BLAS_1_RESULT_PRINT
 
     hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
+}
+
+template <typename T>
+hipblasStatus_t testing_dotc_batched(Arguments argus)
+{
+    return testing_dot_batched<T, true>(argus);
 }

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -68,10 +68,11 @@ hipblasStatus_t testing_dot_batched(Arguments argus)
     int device_pointer = 1;
 
     // TODO: change to 1 when rocBLAS is fixed.
-    int host_pointer   = 0;
+    int host_pointer = 0;
 
     int last = batch_count - 1;
-    if(!dx_array || !dy_array || !d_rocblas_result || (!bx_array[last] && sizeX) || (!by_array[last] && sizeY))
+    if(!dx_array || !dy_array || !d_rocblas_result || (!bx_array[last] && sizeX)
+       || (!by_array[last] && sizeY))
     {
         hipblasDestroy(handle);
         return HIPBLAS_STATUS_ALLOC_FAILED;
@@ -81,15 +82,17 @@ hipblasStatus_t testing_dot_batched(Arguments argus)
     srand(1);
     for(int b = 0; b < batch_count; b++)
     {
-        hx_array[b]          = host_vector<T>(sizeX);
-        hy_array[b]          = host_vector<T>(sizeY);
+        hx_array[b] = host_vector<T>(sizeX);
+        hy_array[b] = host_vector<T>(sizeY);
 
         srand(1);
         hipblas_init<T>(hx_array[b], 1, N, incx);
         hipblas_init<T>(hy_array[b], 1, N, incy);
 
-        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
     }
     CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy_array, by_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
@@ -103,20 +106,32 @@ hipblasStatus_t testing_dot_batched(Arguments argus)
 
         status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
 
-        status_2 = (CONJ ? hipblasDotcBatched<T>
-                         : hipblasDotBatched<T>)(handle, N, dx_array, incx, dy_array, incy, batch_count, d_rocblas_result);
+        status_2 = (CONJ ? hipblasDotcBatched<T> : hipblasDotBatched<T>)(handle,
+                                                                         N,
+                                                                         dx_array,
+                                                                         incx,
+                                                                         dy_array,
+                                                                         incy,
+                                                                         batch_count,
+                                                                         d_rocblas_result);
     }
     if(host_pointer)
     {
 
         status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
 
-        status_3 = (CONJ ? hipblasDotcBatched<T>
-                         : hipblasDotBatched<T>)(handle, N, dx_array, incx, dy_array, incy, batch_count, h_rocblas_result2);
+        status_3 = (CONJ ? hipblasDotcBatched<T> : hipblasDotBatched<T>)(handle,
+                                                                         N,
+                                                                         dx_array,
+                                                                         incx,
+                                                                         dy_array,
+                                                                         incy,
+                                                                         batch_count,
+                                                                         h_rocblas_result2);
     }
 
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS) ||
-       (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
+    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
+       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
     {
         hipblasDestroy(handle);
         if(status_1 != HIPBLAS_STATUS_SUCCESS)
@@ -130,8 +145,8 @@ hipblasStatus_t testing_dot_batched(Arguments argus)
     }
 
     if(device_pointer)
-        CHECK_HIP_ERROR(
-            hipMemcpy(h_rocblas_result1, d_rocblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(
+            h_rocblas_result1, d_rocblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {
@@ -140,7 +155,8 @@ hipblasStatus_t testing_dot_batched(Arguments argus)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx_array[b], incx, hy_array[b], incy, &(h_cpu_result[b]));
+            (CONJ ? cblas_dotc<T>
+                  : cblas_dot<T>)(N, hx_array[b], incx, hy_array[b], incy, &(h_cpu_result[b]));
         }
 
         if(argus.unit_check)

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -1,0 +1,145 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T, bool CONJ = false>
+hipblasStatus_t testing_dot_strided_batched(Arguments argus)
+{
+    int N               = argus.N;
+    int incx            = argus.incx;
+    int incy            = argus.incy;
+    double stride_scale = argus.stride_scale;
+    int batch_count     = argus.batch_count;
+
+    int stridex = N * incx * stride_scale;
+    int stridey = N * incy * stride_scale;
+    int sizeX   = stridex * batch_count;
+    int sizeY   = stridey * batch_count;
+
+    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T> hx(sizeX);
+    host_vector<T> hy(sizeY);
+    host_vector<T> h_rocblas_result1(batch_count);
+    host_vector<T> h_rocblas_result2(batch_count);
+    host_vector<T> h_cpu_result(batch_count);
+
+    device_vector<T> dx(sizeX);
+    device_vector<T> dy(sizeY);
+    device_vector<T> d_rocblas_result(batch_count);
+
+    int device_pointer = 1;
+
+    // TODO: Change to 1 when rocBLAS is fixed.
+    int host_pointer   = 0;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T>(hx, 1, N, incx, stridex, batch_count);
+    hipblas_init<T>(hy, 1, N, incy, stridey, batch_count);
+
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    // hipblasDot accept both dev/host pointer for the scalar
+    if(device_pointer)
+    {
+
+        status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+
+        status_2 = (CONJ ? hipblasDotcStridedBatched<T>
+                         : hipblasDotStridedBatched<T>)(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, d_rocblas_result);
+    }
+    if(host_pointer)
+    {
+
+        status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
+
+        status_4 = (CONJ ? hipblasDotcStridedBatched<T>
+                         : hipblasDotStridedBatched<T>)(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, h_rocblas_result2);
+    }
+
+    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS) ||
+       (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
+    {
+        hipblasDestroy(handle);
+        if(status_1 != HIPBLAS_STATUS_SUCCESS)
+            return status_1;
+        if(status_2 != HIPBLAS_STATUS_SUCCESS)
+            return status_2;
+        if(status_3 != HIPBLAS_STATUS_SUCCESS)
+            return status_3;
+        if(status_4 != HIPBLAS_STATUS_SUCCESS)
+            return status_4;
+    }
+
+    if(device_pointer)
+        CHECK_HIP_ERROR(
+            hipMemcpy(h_rocblas_result1, d_rocblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx.data() + b * stridex, incx, hy.data() + b * stridey, incy, &h_cpu_result[b]);
+        }
+
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_rocblas_result1);
+            // unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_rocblas_result2);
+        }
+
+    } // end of if unit/norm check
+
+    //  BLAS_1_RESULT_PRINT
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}
+
+template <typename T>
+hipblasStatus_t testing_dotc_strided_batched(Arguments argus)
+{
+    return testing_dot_strided_batched<T, true>(argus);
+}

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -21,11 +21,11 @@ using namespace std;
 template <typename T, bool CONJ = false>
 hipblasStatus_t testing_dot_strided_batched(Arguments argus)
 {
-    int N               = argus.N;
-    int incx            = argus.incx;
-    int incy            = argus.incy;
+    int    N            = argus.N;
+    int    incx         = argus.incx;
+    int    incy         = argus.incy;
     double stride_scale = argus.stride_scale;
-    int batch_count     = argus.batch_count;
+    int    batch_count  = argus.batch_count;
 
     int stridex = N * incx * stride_scale;
     int stridey = N * incy * stride_scale;
@@ -62,7 +62,7 @@ hipblasStatus_t testing_dot_strided_batched(Arguments argus)
     int device_pointer = 1;
 
     // TODO: Change to 1 when rocBLAS is fixed.
-    int host_pointer   = 0;
+    int host_pointer = 0;
 
     double gpu_time_used, cpu_time_used;
     double rocblas_error;
@@ -88,8 +88,17 @@ hipblasStatus_t testing_dot_strided_batched(Arguments argus)
 
         status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
 
-        status_2 = (CONJ ? hipblasDotcStridedBatched<T>
-                         : hipblasDotStridedBatched<T>)(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, d_rocblas_result);
+        status_2
+            = (CONJ ? hipblasDotcStridedBatched<T> : hipblasDotStridedBatched<T>)(handle,
+                                                                                  N,
+                                                                                  dx,
+                                                                                  incx,
+                                                                                  stridex,
+                                                                                  dy,
+                                                                                  incy,
+                                                                                  stridey,
+                                                                                  batch_count,
+                                                                                  d_rocblas_result);
     }
     if(host_pointer)
     {
@@ -97,11 +106,20 @@ hipblasStatus_t testing_dot_strided_batched(Arguments argus)
         status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
 
         status_4 = (CONJ ? hipblasDotcStridedBatched<T>
-                         : hipblasDotStridedBatched<T>)(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, h_rocblas_result2);
+                         : hipblasDotStridedBatched<T>)(handle,
+                                                        N,
+                                                        dx,
+                                                        incx,
+                                                        stridex,
+                                                        dy,
+                                                        incy,
+                                                        stridey,
+                                                        batch_count,
+                                                        h_rocblas_result2);
     }
 
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS) ||
-       (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
+    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
+       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
     {
         hipblasDestroy(handle);
         if(status_1 != HIPBLAS_STATUS_SUCCESS)
@@ -115,8 +133,8 @@ hipblasStatus_t testing_dot_strided_batched(Arguments argus)
     }
 
     if(device_pointer)
-        CHECK_HIP_ERROR(
-            hipMemcpy(h_rocblas_result1, d_rocblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(
+            h_rocblas_result1, d_rocblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {
@@ -125,7 +143,12 @@ hipblasStatus_t testing_dot_strided_batched(Arguments argus)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx.data() + b * stridex, incx, hy.data() + b * stridey, incy, &h_cpu_result[b]);
+            (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N,
+                                                  hx.data() + b * stridex,
+                                                  incx,
+                                                  hy.data() + b * stridey,
+                                                  incy,
+                                                  &h_cpu_result[b]);
         }
 
         if(argus.unit_check)

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -1,0 +1,141 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+// Tolerance of 100 fails for complex,
+// TODO: something better than arbitrary tolerance.
+template <typename T>
+constexpr double nrm2_batched_tolerance_multiplier = 100;
+template <>
+constexpr double nrm2_batched_tolerance_multiplier<hipComplex> = 110;
+template <>
+constexpr double nrm2_batched_tolerance_multiplier<hipDoubleComplex> = 110;
+
+template <typename T1, typename T2>
+hipblasStatus_t testing_nrm2_batched(Arguments argus)
+{
+    int N           = argus.N;
+    int incx        = argus.incx;
+    int batch_count = argus.batch_count;
+
+    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
+
+    // check to prevent undefined memory allocation error
+    if(N < 0 || incx < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+    if(batch_count == 0)
+    {
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    int sizeX = N * incx;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T1> hx_array[batch_count];
+    host_vector<T2> h_cpu_result(batch_count);
+    host_vector<T2> h_rocblas_result_1(batch_count);
+    host_vector<T2> h_rocblas_result_2(batch_count);
+
+    device_batch_vector<T1> bx_array(batch_count, sizeX);
+
+    device_vector<T1*, 0, T1> dx_array(batch_count);
+    device_vector<T2>         d_rocblas_result(batch_count);
+
+    int last = batch_count - 1;
+    if(!dx_array || ! d_rocblas_result || (!bx_array[last] && sizeX))
+    {
+        hipblasDestroy(handle);
+        return HIPBLAS_STATUS_ALLOC_FAILED;
+    }
+
+    // Initial Data on CPU
+    srand(1);
+    for(int b = 0; b < batch_count; b++)
+    {
+        hx_array[b] = host_vector<T1>(sizeX);
+    
+        srand(1);
+        hipblas_init<T1>(hx_array[b], 1, N, incx);
+
+        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T1) * sizeX, hipMemcpyHostToDevice));
+    }
+    CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, sizeof(T1*) * batch_count, hipMemcpyHostToDevice));
+
+    // hipblasNrm2 accept both dev/host pointer for the scalar
+    status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+    status_2 = hipblasNrm2Batched<T1, T2>(handle, N, dx_array, incx, batch_count, d_rocblas_result);
+
+    status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
+    status_4 = hipblasNrm2Batched<T1, T2>(handle, N, dx_array, incx, batch_count, h_rocblas_result_1);
+
+    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
+       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
+    {
+        hipblasDestroy(handle);
+        if(status_1 != HIPBLAS_STATUS_SUCCESS)
+            return status_1;
+        if(status_2 != HIPBLAS_STATUS_SUCCESS)
+            return status_2;
+        if(status_3 != HIPBLAS_STATUS_SUCCESS)
+            return status_3;
+        if(status_4 != HIPBLAS_STATUS_SUCCESS)
+            return status_4;
+    }
+
+    CHECK_HIP_ERROR(
+        hipMemcpy(h_rocblas_result_2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_nrm2<T1, T2>(N, hx_array[b], incx, &(h_cpu_result[b]));
+        }
+
+        if(argus.unit_check)
+        {
+            T2 tolerance = nrm2_tolerance_multiplier<T1>;
+            for(int b = 0; b < batch_count; b++)
+            {
+                unit_check_nrm2<T2>(h_cpu_result[b], h_rocblas_result_1[b], tolerance);
+                unit_check_nrm2<T2>(h_cpu_result[b], h_rocblas_result_2[b], tolerance);
+            }
+        }
+
+    } // end of if unit/norm check
+
+    //  BLAS_1_RESULT_PRINT
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -69,7 +69,7 @@ hipblasStatus_t testing_nrm2_batched(Arguments argus)
     device_vector<T2>         d_rocblas_result(batch_count);
 
     int last = batch_count - 1;
-    if(!dx_array || ! d_rocblas_result || (!bx_array[last] && sizeX))
+    if(!dx_array || !d_rocblas_result || (!bx_array[last] && sizeX))
     {
         hipblasDestroy(handle);
         return HIPBLAS_STATUS_ALLOC_FAILED;
@@ -80,20 +80,23 @@ hipblasStatus_t testing_nrm2_batched(Arguments argus)
     for(int b = 0; b < batch_count; b++)
     {
         hx_array[b] = host_vector<T1>(sizeX);
-    
+
         srand(1);
         hipblas_init<T1>(hx_array[b], 1, N, incx);
 
-        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T1) * sizeX, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(bx_array[b], hx_array[b], sizeof(T1) * sizeX, hipMemcpyHostToDevice));
     }
-    CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, sizeof(T1*) * batch_count, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(
+        hipMemcpy(dx_array, bx_array, sizeof(T1*) * batch_count, hipMemcpyHostToDevice));
 
     // hipblasNrm2 accept both dev/host pointer for the scalar
     status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
     status_2 = hipblasNrm2Batched<T1, T2>(handle, N, dx_array, incx, batch_count, d_rocblas_result);
 
     status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-    status_4 = hipblasNrm2Batched<T1, T2>(handle, N, dx_array, incx, batch_count, h_rocblas_result_1);
+    status_4
+        = hipblasNrm2Batched<T1, T2>(handle, N, dx_array, incx, batch_count, h_rocblas_result_1);
 
     if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
        || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
@@ -109,8 +112,8 @@ hipblasStatus_t testing_nrm2_batched(Arguments argus)
             return status_4;
     }
 
-    CHECK_HIP_ERROR(
-        hipMemcpy(h_rocblas_result_2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(
+        h_rocblas_result_2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -1,0 +1,129 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+// Tolerance of 100 fails for complex,
+// TODO: something better than arbitrary tolerance.
+template <typename T>
+constexpr double nrm2_strided_batched_tolerance_multiplier = 100;
+template <>
+constexpr double nrm2_strided_batched_tolerance_multiplier<hipComplex> = 110;
+template <>
+constexpr double nrm2_strided_batched_tolerance_multiplier<hipDoubleComplex> = 110;
+
+template <typename T1, typename T2>
+hipblasStatus_t testing_nrm2_strided_batched(Arguments argus)
+{
+    int N               = argus.N;
+    int incx            = argus.incx;
+    double stride_scale = argus.stride_scale;
+    int batch_count     = argus.batch_count;
+
+    int stridex = N * incx * stride_scale;
+    int sizeX   = stridex * batch_count;
+
+    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
+    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
+
+    // check to prevent undefined memory allocation error
+    if(N < 0 || incx < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+    if(batch_count == 0)
+    {
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T1> hx(sizeX);
+    host_vector<T2> h_rocblas_result_1(batch_count);
+    host_vector<T2> h_rocblas_result_2(batch_count);
+    host_vector<T2> h_cpu_result(batch_count);
+
+    device_vector<T1> dx(sizeX);
+    device_vector<T2> d_rocblas_result(batch_count);
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T1>(hx, 1, N, incx, stridex, batch_count);
+
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T1) * sizeX, hipMemcpyHostToDevice));
+
+    // hipblasNrm2 accept both dev/host pointer for the scalar
+
+    status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+    status_2 = hipblasNrm2StridedBatched<T1, T2>(handle, N, dx, incx, stridex, batch_count, d_rocblas_result);
+
+    status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
+    status_4 = hipblasNrm2StridedBatched<T1, T2>(handle, N, dx, incx, stridex, batch_count, h_rocblas_result_1);
+
+    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
+       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
+    {
+        hipblasDestroy(handle);
+        if(status_1 != HIPBLAS_STATUS_SUCCESS)
+            return status_1;
+        if(status_2 != HIPBLAS_STATUS_SUCCESS)
+            return status_2;
+        if(status_3 != HIPBLAS_STATUS_SUCCESS)
+            return status_3;
+        if(status_4 != HIPBLAS_STATUS_SUCCESS)
+            return status_4;
+    }
+
+    CHECK_HIP_ERROR(
+        hipMemcpy(h_rocblas_result_2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_nrm2<T1, T2>(N, hx.data() + b * stridex, incx, &(h_cpu_result[b]));
+        }
+
+        if(argus.unit_check)
+        {
+            T2 tolerance = nrm2_tolerance_multiplier<T1>;
+            for(int b = 0; b < batch_count; b++)
+            {
+                unit_check_nrm2<T2>(h_cpu_result[b], h_rocblas_result_1[b], tolerance);
+                unit_check_nrm2<T2>(h_cpu_result[b], h_rocblas_result_2[b], tolerance);
+            }
+        }
+
+    } // end of if unit/norm check
+
+    //  BLAS_1_RESULT_PRINT
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -30,10 +30,10 @@ constexpr double nrm2_strided_batched_tolerance_multiplier<hipDoubleComplex> = 1
 template <typename T1, typename T2>
 hipblasStatus_t testing_nrm2_strided_batched(Arguments argus)
 {
-    int N               = argus.N;
-    int incx            = argus.incx;
+    int    N            = argus.N;
+    int    incx         = argus.incx;
     double stride_scale = argus.stride_scale;
-    int batch_count     = argus.batch_count;
+    int    batch_count  = argus.batch_count;
 
     int stridex = N * incx * stride_scale;
     int sizeX   = stridex * batch_count;
@@ -78,10 +78,12 @@ hipblasStatus_t testing_nrm2_strided_batched(Arguments argus)
     // hipblasNrm2 accept both dev/host pointer for the scalar
 
     status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-    status_2 = hipblasNrm2StridedBatched<T1, T2>(handle, N, dx, incx, stridex, batch_count, d_rocblas_result);
+    status_2 = hipblasNrm2StridedBatched<T1, T2>(
+        handle, N, dx, incx, stridex, batch_count, d_rocblas_result);
 
     status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-    status_4 = hipblasNrm2StridedBatched<T1, T2>(handle, N, dx, incx, stridex, batch_count, h_rocblas_result_1);
+    status_4 = hipblasNrm2StridedBatched<T1, T2>(
+        handle, N, dx, incx, stridex, batch_count, h_rocblas_result_1);
 
     if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
        || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
@@ -97,8 +99,8 @@ hipblasStatus_t testing_nrm2_strided_batched(Arguments argus)
             return status_4;
     }
 
-    CHECK_HIP_ERROR(
-        hipMemcpy(h_rocblas_result_2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(
+        h_rocblas_result_2, d_rocblas_result, sizeof(T2) * batch_count, hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {

--- a/clients/include/testing_scal_batched.hpp
+++ b/clients/include/testing_scal_batched.hpp
@@ -1,0 +1,120 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T, typename U = T>
+hipblasStatus_t testing_scal_batched(Arguments argus)
+{
+    int N           = argus.N;
+    int incx        = argus.incx;
+    int batch_count = argus.batch_count;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0 || incx < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+    else if(batch_count == 0)
+    {
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    int sizeX = N * incx;
+    U   alpha = argus.alpha;
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error = 0.0;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T> hx_array[batch_count];
+    host_vector<T> hz_array[batch_count];
+
+    device_batch_vector<T> bx_array(batch_count, sizeX);
+    device_batch_vector<T> bz_array(batch_count, sizeX);
+
+    device_vector<T*, 0, T> dx_array(batch_count);
+    device_vector<T*, 0, T> dz_array(batch_count);
+
+    int last = batch_count - 1;
+    if(!dx_array || !dz_array || (!bx_array[last] && sizeX) || (!bz_array[last] && sizeX))
+    {
+        hipblasDestroy(handle);
+        return HIPBLAS_STATUS_ALLOC_FAILED;
+    }
+
+    srand(1);
+    for(int b = 0; b < batch_count; b++)
+    {
+        hx_array[b] = host_vector<T>(sizeX);
+        hz_array[b] = host_vector<T>(sizeX);
+
+        srand(1);
+        hipblas_init<T>(hx_array[b], 1, N, incx);
+        hz_array[b] = hx_array[b];
+
+        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
+    }
+
+    CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    status = hipblasScalBatched<T, U>(handle, N, &alpha, dx_array, incx, batch_count);
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    // copy output from device to CPU
+    for(int b = 0; b < batch_count; b++)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(hx_array[b], bx_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+    }
+
+    if(argus.unit_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_scal<T, U>(N, alpha, hz_array[b], incx);
+        }
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, batch_count, incx, hz_array, hx_array);
+        }
+
+    } // end of if unit check
+
+    //  BLAS_1_RESULT_PRINT
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_scal_batched.hpp
+++ b/clients/include/testing_scal_batched.hpp
@@ -38,8 +38,8 @@ hipblasStatus_t testing_scal_batched(Arguments argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int sizeX = N * incx;
-    U   alpha = argus.alpha;
+    int    sizeX = N * incx;
+    U      alpha = argus.alpha;
     double gpu_time_used, cpu_time_used;
     double rocblas_error = 0.0;
 
@@ -73,7 +73,8 @@ hipblasStatus_t testing_scal_batched(Arguments argus)
         hipblas_init<T>(hx_array[b], 1, N, incx);
         hz_array[b] = hx_array[b];
 
-        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
     }
 
     CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
@@ -91,7 +92,8 @@ hipblasStatus_t testing_scal_batched(Arguments argus)
     // copy output from device to CPU
     for(int b = 0; b < batch_count; b++)
     {
-        CHECK_HIP_ERROR(hipMemcpy(hx_array[b], bx_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hx_array[b], bx_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
     }
 
     if(argus.unit_check)

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -28,9 +28,9 @@ hipblasStatus_t testing_scal_strided_batched(Arguments argus)
     int    batch_count  = argus.batch_count;
 
     int stridex = N * incx * stride_scale;
-    int sizeX = stridex * batch_count;
+    int sizeX   = stridex * batch_count;
 
-    U   alpha = argus.alpha;
+    U alpha = argus.alpha;
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
@@ -52,7 +52,6 @@ hipblasStatus_t testing_scal_strided_batched(Arguments argus)
 
     hipblasHandle_t handle;
     hipblasCreate(&handle);
-
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -1,0 +1,104 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T, typename U = T>
+hipblasStatus_t testing_scal_strided_batched(Arguments argus)
+{
+
+    int    N            = argus.N;
+    int    incx         = argus.incx;
+    double stride_scale = argus.stride_scale;
+    int    batch_count  = argus.batch_count;
+
+    int stridex = N * incx * stride_scale;
+    int sizeX = stridex * batch_count;
+
+    U   alpha = argus.alpha;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0 || incx < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T> hx(sizeX);
+    host_vector<T> hz(sizeX);
+
+    device_vector<T> dx(sizeX);
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error = 0.0;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T>(hx, 1, N, incx, stridex, batch_count);
+
+    // copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
+    hz = hx;
+
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    status = hipblasScalStridedBatched<T, U>(handle, N, &alpha, dx, incx, stridex, batch_count);
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check)
+    {
+
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_scal<T, U>(N, alpha, hz.data() + b * stridex, incx);
+        }
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, batch_count, incx, stridex, hz, hx);
+        }
+
+    } // end of if unit check
+
+    //  BLAS_1_RESULT_PRINT
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -85,8 +85,10 @@ hipblasStatus_t testing_swap_batched(Arguments argus)
         hx_cpu_array[b] = hx_array[b];
         hy_cpu_array[b] = hy_array[b];
 
-        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(
+            hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
     }
     CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy_array, by_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
@@ -105,8 +107,10 @@ hipblasStatus_t testing_swap_batched(Arguments argus)
     for(int b = 0; b < batch_count; b++)
     {
         // copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hx_array[b], bx_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(hy_array[b], by_array[b], sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hx_array[b], bx_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hy_array[b], by_array[b], sizeof(T) * sizeY, hipMemcpyDeviceToHost));
     }
 
     if(argus.unit_check || argus.norm_check)

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -1,0 +1,134 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_swap_batched(Arguments argus)
+{
+    int N           = argus.N;
+    int incx        = argus.incx;
+    int incy        = argus.incy;
+    int batch_count = argus.batch_count;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+    else if(batch_count == 0)
+    {
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    int sizeX = N * incx;
+    int sizeY = N * incy;
+
+    int device_pointer = 1;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T> hx_array[batch_count];
+    host_vector<T> hy_array[batch_count];
+    host_vector<T> hx_cpu_array[batch_count];
+    host_vector<T> hy_cpu_array[batch_count];
+
+    device_batch_vector<T> bx_array(batch_count, sizeX);
+    device_batch_vector<T> by_array(batch_count, sizeY);
+
+    device_vector<T*, 0, T> dx_array(batch_count);
+    device_vector<T*, 0, T> dy_array(batch_count);
+
+    int last = batch_count - 1;
+    if(!dx_array || !dy_array || (!bx_array[last] && sizeX) || (!by_array[last] && sizeY))
+    {
+        hipblasDestroy(handle);
+        return HIPBLAS_STATUS_ALLOC_FAILED;
+    }
+
+    // Initial Data on CPU
+    srand(1);
+    for(int b = 0; b < batch_count; b++)
+    {
+        hx_array[b]     = host_vector<T>(sizeX);
+        hy_array[b]     = host_vector<T>(sizeY);
+        hx_cpu_array[b] = host_vector<T>(sizeX);
+        hy_cpu_array[b] = host_vector<T>(sizeY);
+
+        srand(1);
+        hipblas_init<T>(hx_array[b], 1, N, incx);
+        hipblas_init<T>(hy_array[b], 1, N, incy);
+
+        hx_cpu_array[b] = hx_array[b];
+        hy_cpu_array[b] = hy_array[b];
+
+        CHECK_HIP_ERROR(hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * sizeX, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(by_array[b], hy_array[b], sizeof(T) * sizeY, hipMemcpyHostToDevice));
+    }
+    CHECK_HIP_ERROR(hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy_array, by_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    status = hipblasSwapBatched<T>(handle, N, dx_array, incx, dy_array, incy, batch_count);
+
+    if((status != HIPBLAS_STATUS_SUCCESS))
+    {
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    for(int b = 0; b < batch_count; b++)
+    {
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx_array[b], bx_array[b], sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_array[b], by_array[b], sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+    }
+
+    if(argus.unit_check || argus.norm_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_swap<T>(N, hx_cpu_array[b], incx, hy_cpu_array[b], incy);
+        }
+
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, batch_count, incx, hx_cpu_array, hx_array);
+            unit_check_general<T>(1, N, batch_count, incy, hy_cpu_array, hy_array);
+        }
+
+    } // end of if unit/norm check
+
+    //  BLAS_1_RESULT_PRINT
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -1,0 +1,109 @@
+/* ************************************************************************
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+
+#include "cblas_interface.h"
+#include "hipblas.hpp"
+#include "norm.h"
+#include "unit.h"
+#include "utility.h"
+#include <complex.h>
+
+using namespace std;
+
+/* ============================================================================================ */
+
+template <typename T>
+hipblasStatus_t testing_swap_strided_batched(Arguments argus)
+{
+    int N               = argus.N;
+    int incx            = argus.incx;
+    int incy            = argus.incy;
+    double stride_scale = argus.stride_scale;
+    int batch_count     = argus.batch_count;
+
+    int stridex = N * incx * stride_scale;
+    int stridey = N * incy * stride_scale;
+    int sizeX   = stridex * batch_count;
+    int sizeY   = stridey * batch_count;
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+
+    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
+    host_vector<T> hx(sizeX);
+    host_vector<T> hy(sizeY);
+    host_vector<T> hx_cpu(sizeX);
+    host_vector<T> hy_cpu(sizeY);
+
+    device_vector<T> dx(sizeX);
+    device_vector<T> dy(sizeY);
+
+    int device_pointer = 1;
+
+    double gpu_time_used, cpu_time_used;
+    double rocblas_error;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Initial Data on CPU
+    srand(1);
+    hipblas_init<T>(hx, 1, N, incx, stridex, batch_count);
+    hipblas_init<T>(hy, 1, N, incy, stridey, batch_count);
+    hx_cpu = hx;
+    hy_cpu = hy;
+
+    // copy data from CPU to device, does not work for incx != 1
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
+
+    /* =====================================================================
+         ROCBLAS
+    =================================================================== */
+    status = hipblasSwapStridedBatched<T>(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count);
+
+    if((status != HIPBLAS_STATUS_SUCCESS))
+    {
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
+    {
+        /* =====================================================================
+                    CPU BLAS
+        =================================================================== */
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_swap<T>(N, hx.data() + b * stridex, incx, hy.data() + b * stridey, incy);
+        }
+
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(1, N, batch_count, incx, stridex, hx_cpu.data(), hx.data());
+            unit_check_general<T>(1, N, batch_count, incy, stridey, hy_cpu.data(), hy.data());
+        }
+
+    } // end of if unit/norm check
+
+    //  BLAS_1_RESULT_PRINT
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -21,11 +21,11 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_swap_strided_batched(Arguments argus)
 {
-    int N               = argus.N;
-    int incx            = argus.incx;
-    int incy            = argus.incy;
+    int    N            = argus.N;
+    int    incx         = argus.incx;
+    int    incy         = argus.incy;
     double stride_scale = argus.stride_scale;
-    int batch_count     = argus.batch_count;
+    int    batch_count  = argus.batch_count;
 
     int stridex = N * incx * stride_scale;
     int stridey = N * incy * stride_scale;
@@ -72,7 +72,8 @@ hipblasStatus_t testing_swap_strided_batched(Arguments argus)
     /* =====================================================================
          ROCBLAS
     =================================================================== */
-    status = hipblasSwapStridedBatched<T>(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count);
+    status = hipblasSwapStridedBatched<T>(
+        handle, N, dx, incx, stridex, dy, incy, stridey, batch_count);
 
     if((status != HIPBLAS_STATUS_SUCCESS))
     {

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -219,30 +219,62 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasum(
     hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
 
 // asum_batched
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSasumBatched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasSasumBatched(
+    hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDasumBatched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDasumBatched(hipblasHandle_t     handle,
+                                                   int                 n,
+                                                   const double* const x[],
+                                                   int                 incx,
+                                                   int                 batchCount,
+                                                   double*             result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasScasumBatched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
+                                                    int                     n,
+                                                    const hipComplex* const x[],
+                                                    int                     incx,
+                                                    int                     batchCount,
+                                                    float*                  result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDzasumBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t               handle,
+                                                    int                           n,
+                                                    const hipDoubleComplex* const x[],
+                                                    int                           incx,
+                                                    int                           batchCount,
+                                                    double*                       result);
 
 // asum_strided_batched
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSasumStridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasSasumStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const float*    x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          int             batchCount,
+                                                          float*          result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDasumStridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const double*   x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          int             batchCount,
+                                                          double*         result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasScasumStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
+                                                           int               n,
+                                                           const hipComplex* x,
+                                                           int               incx,
+                                                           int               stridex,
+                                                           int               batchCount,
+                                                           float*            result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDzasumStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
+                                                           int                     n,
+                                                           const hipDoubleComplex* x,
+                                                           int                     incx,
+                                                           int                     stridex,
+                                                           int                     batchCount,
+                                                           double*                 result);
 
 // axpy
 HIPBLAS_EXPORT hipblasStatus_t hipblasSaxpy(hipblasHandle_t handle,
@@ -299,30 +331,78 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
                                             int                     incy);
 
 // copy_batched
-HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float* const x[],
-    int incx, float* const y[], int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t    handle,
+                                                   int                n,
+                                                   const float* const x[],
+                                                   int                incx,
+                                                   float* const       y[],
+                                                   int                incy,
+                                                   int                batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double* const x[],
-    int incx, double* const y[], int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t     handle,
+                                                   int                 n,
+                                                   const double* const x[],
+                                                   int                 incx,
+                                                   double* const       y[],
+                                                   int                 incy,
+                                                   int                 batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t handle, int n, const hipComplex* const x[],
-    int incx, hipComplex* const y[], int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t         handle,
+                                                   int                     n,
+                                                   const hipComplex* const x[],
+                                                   int                     incx,
+                                                   hipComplex* const       y[],
+                                                   int                     incy,
+                                                   int                     batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[],
-    int incx, hipDoubleComplex* const y[], int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t               handle,
+                                                   int                           n,
+                                                   const hipDoubleComplex* const x[],
+                                                   int                           incx,
+                                                   hipDoubleComplex* const       y[],
+                                                   int                           incy,
+                                                   int                           batchCount);
 
 // copy_strided_batched
-HIPBLAS_EXPORT hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle, int n, const float* x,
-    int incx, int stridex, float* y, int incy, int stridey, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const float*    x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          float*          y,
+                                                          int             incy,
+                                                          int             stridey,
+                                                          int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle, int n, const double* x,
-    int incx, int stridex, double* y, int incy, int stridey, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const double*   x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          double*         y,
+                                                          int             incy,
+                                                          int             stridey,
+                                                          int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x,
-    int incx, int stridex, hipComplex* y, int incy, int stridey, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t   handle,
+                                                          int               n,
+                                                          const hipComplex* x,
+                                                          int               incx,
+                                                          int               stridex,
+                                                          hipComplex*       y,
+                                                          int               incy,
+                                                          int               stridey,
+                                                          int               batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x,
-    int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t         handle,
+                                                          int                     n,
+                                                          const hipDoubleComplex* x,
+                                                          int                     incx,
+                                                          int                     stridex,
+                                                          hipDoubleComplex*       y,
+                                                          int                     incy,
+                                                          int                     stridey,
+                                                          int                     batchCount);
 
 // dot
 HIPBLAS_EXPORT hipblasStatus_t hipblasSdot(hipblasHandle_t handle,
@@ -392,41 +472,41 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
                                                   int                 batch_count,
                                                   double*             result);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t        handle,
-                                                  int                     n,
-                                                  const hipComplex* const x[],
-                                                  int                     incx,
-                                                  const hipComplex* const y[],
-                                                  int                     incy,
-                                                  int                     batch_count,
-                                                  hipComplex*             result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t         handle,
+                                                   int                     n,
+                                                   const hipComplex* const x[],
+                                                   int                     incx,
+                                                   const hipComplex* const y[],
+                                                   int                     incy,
+                                                   int                     batch_count,
+                                                   hipComplex*             result);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t        handle,
-                                                  int                     n,
-                                                  const hipComplex* const x[],
-                                                  int                     incx,
-                                                  const hipComplex* const y[],
-                                                  int                     incy,
-                                                  int                     batch_count,
-                                                  hipComplex*             result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t         handle,
+                                                   int                     n,
+                                                   const hipComplex* const x[],
+                                                   int                     incx,
+                                                   const hipComplex* const y[],
+                                                   int                     incy,
+                                                   int                     batch_count,
+                                                   hipComplex*             result);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t              handle,
-                                                  int                           n,
-                                                  const hipDoubleComplex* const x[],
-                                                  int                           incx,
-                                                  const hipDoubleComplex* const y[],
-                                                  int                           incy,
-                                                  int                           batch_count,
-                                                  hipDoubleComplex*             result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t               handle,
+                                                   int                           n,
+                                                   const hipDoubleComplex* const x[],
+                                                   int                           incx,
+                                                   const hipDoubleComplex* const y[],
+                                                   int                           incy,
+                                                   int                           batch_count,
+                                                   hipDoubleComplex*             result);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t              handle,
-                                                  int                           n,
-                                                  const hipDoubleComplex* const x[],
-                                                  int                           incx,
-                                                  const hipDoubleComplex* const y[],
-                                                  int                           incy,
-                                                  int                           batch_count,
-                                                  hipDoubleComplex*             result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t               handle,
+                                                   int                           n,
+                                                   const hipDoubleComplex* const x[],
+                                                   int                           incx,
+                                                   const hipDoubleComplex* const y[],
+                                                   int                           incy,
+                                                   int                           batch_count,
+                                                   hipDoubleComplex*             result);
 
 // dot_strided_batched
 HIPBLAS_EXPORT hipblasStatus_t hipblasSdotStridedBatched(hipblasHandle_t handle,
@@ -452,48 +532,48 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
                                                          double*         result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t   handle,
-                                                         int               n,
-                                                         const hipComplex* x,
-                                                         int               incx,
-                                                         int               stridex,
-                                                         const hipComplex* y,
-                                                         int               incy,
-                                                         int               stridey,
-                                                         int               batch_count,
-                                                         hipComplex*       result);
+                                                          int               n,
+                                                          const hipComplex* x,
+                                                          int               incx,
+                                                          int               stridex,
+                                                          const hipComplex* y,
+                                                          int               incy,
+                                                          int               stridey,
+                                                          int               batch_count,
+                                                          hipComplex*       result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t   handle,
-                                                         int               n,
-                                                         const hipComplex* x,
-                                                         int               incx,
-                                                         int               stridex,
-                                                         const hipComplex* y,
-                                                         int               incy,
-                                                         int               stridey,
-                                                         int               batch_count,
-                                                         hipComplex*       result);
+                                                          int               n,
+                                                          const hipComplex* x,
+                                                          int               incx,
+                                                          int               stridex,
+                                                          const hipComplex* y,
+                                                          int               incy,
+                                                          int               stridey,
+                                                          int               batch_count,
+                                                          hipComplex*       result);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t        handle,
-                                                         int                     n,
-                                                         const hipDoubleComplex* x,
-                                                         int                     incx,
-                                                         int                     stridex,
-                                                         const hipDoubleComplex* y,
-                                                         int                     incy,
-                                                         int                     stridey,
-                                                         int                     batch_count,
-                                                         hipDoubleComplex*       result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t         handle,
+                                                          int                     n,
+                                                          const hipDoubleComplex* x,
+                                                          int                     incx,
+                                                          int                     stridex,
+                                                          const hipDoubleComplex* y,
+                                                          int                     incy,
+                                                          int                     stridey,
+                                                          int                     batch_count,
+                                                          hipDoubleComplex*       result);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t        handle,
-                                                         int                     n,
-                                                         const hipDoubleComplex* x,
-                                                         int                     incx,
-                                                         int                     stridex,
-                                                         const hipDoubleComplex* y,
-                                                         int                     incy,
-                                                         int                     stridey,
-                                                         int                     batch_count,
-                                                         hipDoubleComplex*       result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t         handle,
+                                                          int                     n,
+                                                          const hipDoubleComplex* x,
+                                                          int                     incx,
+                                                          int                     stridex,
+                                                          const hipDoubleComplex* y,
+                                                          int                     incy,
+                                                          int                     stridey,
+                                                          int                     batch_count,
+                                                          hipDoubleComplex*       result);
 
 // snrm2
 HIPBLAS_EXPORT hipblasStatus_t
@@ -509,30 +589,62 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2(
     hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
 
 // nrm2_batched
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSnrm2Batched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasSnrm2Batched(
+    hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDnrm2Batched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t     handle,
+                                                   int                 n,
+                                                   const double* const x[],
+                                                   int                 incx,
+                                                   int                 batchCount,
+                                                   double*             result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasScnrm2Batched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t         handle,
+                                                    int                     n,
+                                                    const hipComplex* const x[],
+                                                    int                     incx,
+                                                    int                     batchCount,
+                                                    float*                  result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDznrm2Batched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t               handle,
+                                                    int                           n,
+                                                    const hipDoubleComplex* const x[],
+                                                    int                           incx,
+                                                    int                           batchCount,
+                                                    double*                       result);
 
 // nrm2_strided_batched
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSnrm2StridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const float*    x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          int             batchCount,
+                                                          float*          result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const double*   x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          int             batchCount,
+                                                          double*         result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasScnrm2StridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   handle,
+                                                           int               n,
+                                                           const hipComplex* x,
+                                                           int               incx,
+                                                           int               stridex,
+                                                           int               batchCount,
+                                                           float*            result);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDznrm2StridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t         handle,
+                                                           int                     n,
+                                                           const hipDoubleComplex* x,
+                                                           int                     incx,
+                                                           int                     stridex,
+                                                           int                     batchCount,
+                                                           double*                 result);
 
 // HIPBLAS_EXPORT hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
 //                                            int             n,
@@ -590,43 +702,92 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscal(
     hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx);
 
 // scal_batched
-HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float
-    *alpha, float* const x[], int incx, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasSscalBatched(
+    hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double
-    *alpha,  double* const x[], int incx, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDscalBatched(hipblasHandle_t handle,
+                                                   int             n,
+                                                   const double*   alpha,
+                                                   double* const   x[],
+                                                   int             incx,
+                                                   int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasCscalBatched(hipblasHandle_t handle, int n, const hipComplex
-    *alpha, hipComplex* const x[], int incx, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCscalBatched(hipblasHandle_t   handle,
+                                                   int               n,
+                                                   const hipComplex* alpha,
+                                                   hipComplex* const x[],
+                                                   int               incx,
+                                                   int               batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasZscalBatched(hipblasHandle_t handle, int n, const hipDoubleComplex
-    *alpha,  hipDoubleComplex* const x[], int incx, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZscalBatched(hipblasHandle_t         handle,
+                                                   int                     n,
+                                                   const hipDoubleComplex* alpha,
+                                                   hipDoubleComplex* const x[],
+                                                   int                     incx,
+                                                   int                     batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasCsscalBatched(hipblasHandle_t handle, int n, const float
-    *alpha, hipComplex* const x[], int incx, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCsscalBatched(hipblasHandle_t   handle,
+                                                    int               n,
+                                                    const float*      alpha,
+                                                    hipComplex* const x[],
+                                                    int               incx,
+                                                    int               batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasZdscalBatched(hipblasHandle_t handle, int n, const double
-    *alpha,  hipDoubleComplex* const x[], int incx, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t         handle,
+                                                    int                     n,
+                                                    const double*           alpha,
+                                                    hipDoubleComplex* const x[],
+                                                    int                     incx,
+                                                    int                     batchCount);
 
 // scal_strided_batched
-HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalStridedBatched(hipblasHandle_t handle, int n, const float
-    *alpha, float* x, int incx, int stridex, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const float*    alpha,
+                                                          float*          x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const double
-    *alpha, double* x, int incx, int stridex, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          const double*   alpha,
+                                                          double*         x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const hipComplex
-    *alpha, hipComplex* x, int incx, int stridex, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t   handle,
+                                                          int               n,
+                                                          const hipComplex* alpha,
+                                                          hipComplex*       x,
+                                                          int               incx,
+                                                          int               stridex,
+                                                          int               batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex
-    *alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t         handle,
+                                                          int                     n,
+                                                          const hipDoubleComplex* alpha,
+                                                          hipDoubleComplex*       x,
+                                                          int                     incx,
+                                                          int                     stridex,
+                                                          int                     batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasCsscalStridedBatched(hipblasHandle_t handle, int n, const float
-    *alpha, hipComplex* x, int incx, int stridex, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle,
+                                                           int             n,
+                                                           const float*    alpha,
+                                                           hipComplex*     x,
+                                                           int             incx,
+                                                           int             stridex,
+                                                           int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t  hipblasZdscalStridedBatched(hipblasHandle_t handle, int n, const double
-    *alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount);
-
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t   handle,
+                                                           int               n,
+                                                           const double*     alpha,
+                                                           hipDoubleComplex* x,
+                                                           int               incx,
+                                                           int               stridex,
+                                                           int               batchCount);
 
 // swap
 HIPBLAS_EXPORT hipblasStatus_t
@@ -642,30 +803,68 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswap(
     hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy);
 
 // swap_batched
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSswapBatched(hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasSswapBatched(
+    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDswapBatched(hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDswapBatched(
+    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasCswapBatched(hipblasHandle_t handle, int n, hipComplex* x[], int incx, hipComplex* y[], int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
+                                                   int             n,
+                                                   hipComplex*     x[],
+                                                   int             incx,
+                                                   hipComplex*     y[],
+                                                   int             incy,
+                                                   int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasZswapBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x[], int incx, hipDoubleComplex* y[], int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZswapBatched(hipblasHandle_t   handle,
+                                                   int               n,
+                                                   hipDoubleComplex* x[],
+                                                   int               incx,
+                                                   hipDoubleComplex* y[],
+                                                   int               incy,
+                                                   int               batchCount);
 
 // swap_strided_batched
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasSswapStridedBatched(hipblasHandle_t handle, int n, float* x, int incx, int stridex, float* y, int incy, int stridey, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasSswapStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          float*          x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          float*          y,
+                                                          int             incy,
+                                                          int             stridey,
+                                                          int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasDswapStridedBatched(hipblasHandle_t handle, int n, double* x, int incx, int stridex, double* y, int incy, int stridey, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          double*         x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          double*         y,
+                                                          int             incy,
+                                                          int             stridey,
+                                                          int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasCswapStridedBatched(hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle,
+                                                          int             n,
+                                                          hipComplex*     x,
+                                                          int             incx,
+                                                          int             stridex,
+                                                          hipComplex*     y,
+                                                          int             incy,
+                                                          int             stridey,
+                                                          int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t
-    hipblasZswapStridedBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t   handle,
+                                                          int               n,
+                                                          hipDoubleComplex* x,
+                                                          int               incx,
+                                                          int               stridex,
+                                                          hipDoubleComplex* y,
+                                                          int               incy,
+                                                          int               stridey,
+                                                          int               batchCount);
 
 // gemv
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgemv(hipblasHandle_t    handle,

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -595,6 +595,32 @@ HIPBLAS_EXPORT hipblasStatus_t
 HIPBLAS_EXPORT hipblasStatus_t hipblasZswap(
     hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy);
 
+// swap_batched
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasSswapBatched(hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDswapBatched(hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasCswapBatched(hipblasHandle_t handle, int n, hipComplex* x[], int incx, hipComplex* y[], int incy, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasZswapBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x[], int incx, hipDoubleComplex* y[], int incy, int batchCount);
+
+// swap_strided_batched
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasSswapStridedBatched(hipblasHandle_t handle, int n, float* x, int incx, int stridex, float* y, int incy, int stridey, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDswapStridedBatched(hipblasHandle_t handle, int n, double* x, int incx, int stridex, double* y, int incy, int stridey, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasCswapStridedBatched(hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasZswapStridedBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batchCount);
+
 // gemv
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgemv(hipblasHandle_t    handle,
                                             hipblasOperation_t trans,

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -218,13 +218,33 @@ HIPBLAS_EXPORT hipblasStatus_t
 HIPBLAS_EXPORT hipblasStatus_t hipblasDzasum(
     hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
 
-// not implemented
-// HIPBLAS_EXPORT hipblasStatus_t  hipblasSasumBatched(hipblasHandle_t handle, int n, float *x, int
-// incx, float  *result, int batchCount);
+// asum_batched
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasSasumBatched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result);
 
-// HIPBLAS_EXPORT hipblasStatus_t  hipblasDasumBatched(hipblasHandle_t handle, int n, double *x, int
-// incx, double *result, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDasumBatched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result);
 
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasScasumBatched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDzasumBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result);
+
+// asum_strided_batched
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasSasumStridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDasumStridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasScasumStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDzasumStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result);
+
+// axpy
 HIPBLAS_EXPORT hipblasStatus_t hipblasSaxpy(hipblasHandle_t handle,
                                             int             n,
                                             const float*    alpha,

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -408,12 +408,44 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZscal(
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdscal(
     hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx);
 
-// not implemented
-// HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float
-// *alpha,  float *x, int incx, int batchCount);
+// scal_batched
+HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float
+    *alpha, float* const x[], int incx, int batchCount);
 
-// HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double
-// *alpha,  double *x, int incx, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double
+    *alpha,  double* const x[], int incx, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasCscalBatched(hipblasHandle_t handle, int n, const hipComplex
+    *alpha, hipComplex* const x[], int incx, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasZscalBatched(hipblasHandle_t handle, int n, const hipDoubleComplex
+    *alpha,  hipDoubleComplex* const x[], int incx, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasCsscalBatched(hipblasHandle_t handle, int n, const float
+    *alpha, hipComplex* const x[], int incx, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasZdscalBatched(hipblasHandle_t handle, int n, const double
+    *alpha,  hipDoubleComplex* const x[], int incx, int batchCount);
+
+// scal_strided_batched
+HIPBLAS_EXPORT hipblasStatus_t  hipblasSscalStridedBatched(hipblasHandle_t handle, int n, const float
+    *alpha, float* x, int incx, int stridex, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const double
+    *alpha, double* x, int incx, int stridex, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const hipComplex
+    *alpha, hipComplex* x, int incx, int stridex, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex
+    *alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasCsscalStridedBatched(hipblasHandle_t handle, int n, const float
+    *alpha, hipComplex* x, int incx, int stridex, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t  hipblasZdscalStridedBatched(hipblasHandle_t handle, int n, const double
+    *alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount);
+
 
 // swap
 HIPBLAS_EXPORT hipblasStatus_t

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -508,6 +508,32 @@ HIPBLAS_EXPORT hipblasStatus_t
 HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2(
     hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
 
+// nrm2_batched
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasSnrm2Batched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDnrm2Batched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasScnrm2Batched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDznrm2Batched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result);
+
+// nrm2_strided_batched
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasSnrm2StridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasScnrm2StridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasDznrm2StridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result);
+
 // HIPBLAS_EXPORT hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
 //                                            int             n,
 //                                            float*          x,

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -353,11 +353,127 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotu(hipblasHandle_t         handle,
                                             int                     incy,
                                             hipDoubleComplex*       result);
 
-// HIPBLAS_EXPORT hipblasStatus_t hipblasSdotBatched (hipblasHandle_t handle, int n, const float *x,
-// int incx, const float *y, int incy, float *result, int batchCount);
+// dot_batched
+HIPBLAS_EXPORT hipblasStatus_t hipblasSdotBatched(hipblasHandle_t    handle,
+                                                  int                n,
+                                                  const float* const x[],
+                                                  int                incx,
+                                                  const float* const y[],
+                                                  int                incy,
+                                                  int                batch_count,
+                                                  float*             result);
 
-// HIPBLAS_EXPORT hipblasStatus_t hipblasDdotBatched (hipblasHandle_t handle, int n, const double *x,
-// int incx, const double *y, int incy, double *result, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
+                                                  int                 n,
+                                                  const double* const x[],
+                                                  int                 incx,
+                                                  const double* const y[],
+                                                  int                 incy,
+                                                  int                 batch_count,
+                                                  double*             result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t        handle,
+                                                  int                     n,
+                                                  const hipComplex* const x[],
+                                                  int                     incx,
+                                                  const hipComplex* const y[],
+                                                  int                     incy,
+                                                  int                     batch_count,
+                                                  hipComplex*             result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t        handle,
+                                                  int                     n,
+                                                  const hipComplex* const x[],
+                                                  int                     incx,
+                                                  const hipComplex* const y[],
+                                                  int                     incy,
+                                                  int                     batch_count,
+                                                  hipComplex*             result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t              handle,
+                                                  int                           n,
+                                                  const hipDoubleComplex* const x[],
+                                                  int                           incx,
+                                                  const hipDoubleComplex* const y[],
+                                                  int                           incy,
+                                                  int                           batch_count,
+                                                  hipDoubleComplex*             result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t              handle,
+                                                  int                           n,
+                                                  const hipDoubleComplex* const x[],
+                                                  int                           incx,
+                                                  const hipDoubleComplex* const y[],
+                                                  int                           incy,
+                                                  int                           batch_count,
+                                                  hipDoubleComplex*             result);
+
+// dot_strided_batched
+HIPBLAS_EXPORT hipblasStatus_t hipblasSdotStridedBatched(hipblasHandle_t handle,
+                                                         int             n,
+                                                         const float*    x,
+                                                         int             incx,
+                                                         int             stridex,
+                                                         const float*    y,
+                                                         int             incy,
+                                                         int             stridey,
+                                                         int             batch_count,
+                                                         float*          result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
+                                                         int             n,
+                                                         const double*   x,
+                                                         int             incx,
+                                                         int             stridex,
+                                                         const double*   y,
+                                                         int             incy,
+                                                         int             stridey,
+                                                         int             batch_count,
+                                                         double*         result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t   handle,
+                                                         int               n,
+                                                         const hipComplex* x,
+                                                         int               incx,
+                                                         int               stridex,
+                                                         const hipComplex* y,
+                                                         int               incy,
+                                                         int               stridey,
+                                                         int               batch_count,
+                                                         hipComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t   handle,
+                                                         int               n,
+                                                         const hipComplex* x,
+                                                         int               incx,
+                                                         int               stridex,
+                                                         const hipComplex* y,
+                                                         int               incy,
+                                                         int               stridey,
+                                                         int               batch_count,
+                                                         hipComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t        handle,
+                                                         int                     n,
+                                                         const hipDoubleComplex* x,
+                                                         int                     incx,
+                                                         int                     stridex,
+                                                         const hipDoubleComplex* y,
+                                                         int                     incy,
+                                                         int                     stridey,
+                                                         int                     batch_count,
+                                                         hipDoubleComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t        handle,
+                                                         int                     n,
+                                                         const hipDoubleComplex* x,
+                                                         int                     incx,
+                                                         int                     stridex,
+                                                         const hipDoubleComplex* y,
+                                                         int                     incy,
+                                                         int                     stridey,
+                                                         int                     batch_count,
+                                                         hipDoubleComplex*       result);
 
 // snrm2
 HIPBLAS_EXPORT hipblasStatus_t

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -278,12 +278,31 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
                                             hipDoubleComplex*       y,
                                             int                     incy);
 
-// not implemented
-// HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float *x,
-// int incx, float *y, int incy, int batchCount);
+// copy_batched
+HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float* const x[],
+    int incx, float* const y[], int incy, int batchCount);
 
-// HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double *x,
-// int incx, double *y, int incy, int batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double* const x[],
+    int incx, double* const y[], int incy, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t handle, int n, const hipComplex* const x[],
+    int incx, hipComplex* const y[], int incy, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[],
+    int incx, hipDoubleComplex* const y[], int incy, int batchCount);
+
+// copy_strided_batched
+HIPBLAS_EXPORT hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle, int n, const float* x,
+    int incx, int stridex, float* y, int incy, int stridey, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle, int n, const double* x,
+    int incx, int stridex, double* y, int incy, int stridey, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x,
+    int incx, int stridex, hipComplex* y, int incy, int stridey, int batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x,
+    int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batchCount);
 
 // dot
 HIPBLAS_EXPORT hipblasStatus_t hipblasSdot(hipblasHandle_t handle,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -801,13 +801,133 @@ hipblasStatus_t
         rocblas_zdscal((rocblas_handle)handle, n, alpha, (rocblas_double_complex*)x, incx));
 }
 
-/* not implemented
-hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float *alpha,  float *x,
-int incx, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+// scal_batched
+hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float *alpha, float* const x[], int incx, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_sscal_batched((rocblas_handle)handle,
+                                                          n,
+                                                          alpha,
+                                                          x,
+                                                          incx,
+                                                          batchCount));
+}
 
-hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double *alpha,  double *x,
-int incx, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
-*/
+hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double *alpha, double* const x[], int incx, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dscal_batched((rocblas_handle)handle,
+                                                          n,
+                                                          alpha,
+                                                          x,
+                                                          incx,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasCscalBatched(hipblasHandle_t handle, int n, const hipComplex *alpha, hipComplex* const x[], int incx, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_cscal_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex*)alpha,
+                                                          (rocblas_float_complex*const*)x,
+                                                          incx,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasZscalBatched(hipblasHandle_t handle, int n, const hipDoubleComplex *alpha, hipDoubleComplex* const x[], int incx, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zscal_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex*)alpha,
+                                                          (rocblas_double_complex*const*)x,
+                                                          incx,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasCsscalBatched(hipblasHandle_t handle, int n, const float *alpha, hipComplex* const x[], int incx, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_csscal_batched((rocblas_handle)handle,
+                                                          n,
+                                                          alpha,
+                                                          (rocblas_float_complex*const*)x,
+                                                          incx,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasZdscalBatched(hipblasHandle_t handle, int n, const double *alpha, hipDoubleComplex* const x[], int incx, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdscal_batched((rocblas_handle)handle,
+                                                          n,
+                                                          alpha,
+                                                          (rocblas_double_complex*const*)x,
+                                                          incx,
+                                                          batchCount));
+}
+
+// scal_strided_batched
+hipblasStatus_t  hipblasSscalStridedBatched(hipblasHandle_t handle, int n, const float *alpha, float* x, int incx, int stridex, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_sscal_strided_batched((rocblas_handle)handle,
+                                                          n,
+                                                          alpha,
+                                                          x,
+                                                          incx,
+                                                          stridex,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const double *alpha, double* x, int incx, int stridex, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dscal_strided_batched((rocblas_handle)handle,
+                                                          n,
+                                                          alpha,
+                                                          x,
+                                                          incx,
+                                                          stridex,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const hipComplex *alpha, hipComplex* x, int incx, int stridex, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_cscal_strided_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex*)alpha,
+                                                          (rocblas_float_complex*)x,
+                                                          incx,
+                                                          stridex,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex *alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zscal_strided_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex*)alpha,
+                                                          (rocblas_double_complex*)x,
+                                                          incx,
+                                                          stridex,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasCsscalStridedBatched(hipblasHandle_t handle, int n, const float *alpha, hipComplex* x, int incx, int stridex, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_csscal_strided_batched((rocblas_handle)handle,
+                                                          n,
+                                                          alpha,
+                                                          (rocblas_float_complex*)x,
+                                                          incx,
+                                                          stridex,
+                                                          batchCount));
+}
+
+hipblasStatus_t  hipblasZdscalStridedBatched(hipblasHandle_t handle, int n, const double *alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdscal_strided_batched((rocblas_handle)handle,
+                                                          n,
+                                                          alpha,
+                                                          (rocblas_double_complex*)x,
+                                                          incx,
+                                                          stridex,
+                                                          batchCount));
+}
 
 // swap
 hipblasStatus_t hipblasSswap(hipblasHandle_t handle, int n, float* x, int incx, float* y, int incy)

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -469,45 +469,93 @@ hipblasStatus_t hipblasDzasum(
 }
 
 // asum_batched
-hipblasStatus_t hipblasSasumBatched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batch_count, float* result)
+hipblasStatus_t hipblasSasumBatched(
+    hipblasHandle_t handle, int n, const float* const x[], int incx, int batch_count, float* result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_sasum_batched((rocblas_handle)handle, n, x, incx, batch_count, result));
+    return rocBLASStatusToHIPStatus(
+        rocblas_sasum_batched((rocblas_handle)handle, n, x, incx, batch_count, result));
 }
 
-hipblasStatus_t hipblasDasumBatched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batch_count, double* result)
+hipblasStatus_t hipblasDasumBatched(hipblasHandle_t     handle,
+                                    int                 n,
+                                    const double* const x[],
+                                    int                 incx,
+                                    int                 batch_count,
+                                    double*             result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dasum_batched((rocblas_handle)handle, n, x, incx, batch_count, result));
+    return rocBLASStatusToHIPStatus(
+        rocblas_dasum_batched((rocblas_handle)handle, n, x, incx, batch_count, result));
 }
 
-hipblasStatus_t hipblasScasumBatched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batch_count, float* result)
+hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
+                                     int                     n,
+                                     const hipComplex* const x[],
+                                     int                     incx,
+                                     int                     batch_count,
+                                     float*                  result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_scasum_batched((rocblas_handle)handle, n, (rocblas_float_complex*const*)x, incx, batch_count, result));
+    return rocBLASStatusToHIPStatus(rocblas_scasum_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex* const*)x, incx, batch_count, result));
 }
 
-hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batch_count, double* result)
+hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t               handle,
+                                     int                           n,
+                                     const hipDoubleComplex* const x[],
+                                     int                           incx,
+                                     int                           batch_count,
+                                     double*                       result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dzasum_batched((rocblas_handle)handle, n, (rocblas_double_complex*const*)x, incx, batch_count, result));
+    return rocBLASStatusToHIPStatus(rocblas_dzasum_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex* const*)x, incx, batch_count, result));
 }
 
 // asum_strided_batched
-hipblasStatus_t hipblasSasumStridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batch_count, float* result)
+hipblasStatus_t hipblasSasumStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const float*    x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batch_count,
+                                           float*          result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_sasum_strided_batched((rocblas_handle)handle, n, x, incx, stridex, batch_count, result));
+    return rocBLASStatusToHIPStatus(rocblas_sasum_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, batch_count, result));
 }
 
-hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batch_count, double* result)
+hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batch_count,
+                                           double*         result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dasum_strided_batched((rocblas_handle)handle, n, x, incx, stridex, batch_count, result));
+    return rocBLASStatusToHIPStatus(rocblas_dasum_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, batch_count, result));
 }
 
-hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batch_count, float* result)
+hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
+                                            int               n,
+                                            const hipComplex* x,
+                                            int               incx,
+                                            int               stridex,
+                                            int               batch_count,
+                                            float*            result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_scasum_strided_batched((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batch_count, result));
+    return rocBLASStatusToHIPStatus(rocblas_scasum_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batch_count, result));
 }
 
-hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batch_count, double* result)
+hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const hipDoubleComplex* x,
+                                            int                     incx,
+                                            int                     stridex,
+                                            int                     batch_count,
+                                            double*                 result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dzasum_strided_batched((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batch_count, result));
+    return rocBLASStatusToHIPStatus(rocblas_dzasum_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batch_count, result));
 }
 
 // axpy
@@ -609,109 +657,133 @@ hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
 }
 
 // copy_batched
-hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float* const x[], int incx, float* const y[],
-    int incy, int batchCount)
+hipblasStatus_t hipblasScopyBatched(hipblasHandle_t    handle,
+                                    int                n,
+                                    const float* const x[],
+                                    int                incx,
+                                    float* const       y[],
+                                    int                incy,
+                                    int                batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_scopy_batched((rocblas_handle)handle,
-                                                           n,
-                                                           x,
-                                                           incx,
-                                                           y,
-                                                           incy,
-                                                           batchCount));
+    return rocBLASStatusToHIPStatus(
+        rocblas_scopy_batched((rocblas_handle)handle, n, x, incx, y, incy, batchCount));
 }
 
-hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double* const x[], int incx, double* const y[],
-    int incy, int batchCount)
+hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t     handle,
+                                    int                 n,
+                                    const double* const x[],
+                                    int                 incx,
+                                    double* const       y[],
+                                    int                 incy,
+                                    int                 batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dcopy_batched((rocblas_handle)handle,
-                                                           n,
-                                                           x,
-                                                           incx,
-                                                           y,
-                                                           incy,
-                                                           batchCount));
+    return rocBLASStatusToHIPStatus(
+        rocblas_dcopy_batched((rocblas_handle)handle, n, x, incx, y, incy, batchCount));
 }
 
-hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, hipComplex* const y[],
-    int incy, int batchCount)
+hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipComplex* const x[],
+                                    int                     incx,
+                                    hipComplex* const       y[],
+                                    int                     incy,
+                                    int                     batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_ccopy_batched((rocblas_handle)handle,
-                                                           n,
-                                                           (rocblas_float_complex**)x,
-                                                           incx,
-                                                           (rocblas_float_complex**)y,
-                                                           incy,
-                                                           batchCount));
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          batchCount));
 }
 
-hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, hipDoubleComplex* const y[],
-    int incy, int batchCount)
+hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t               handle,
+                                    int                           n,
+                                    const hipDoubleComplex* const x[],
+                                    int                           incx,
+                                    hipDoubleComplex* const       y[],
+                                    int                           incy,
+                                    int                           batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zcopy_batched((rocblas_handle)handle,
-                                                           n,
-                                                           (rocblas_double_complex**)x,
-                                                           incx,
-                                                           (rocblas_double_complex**)y,
-                                                           incy,
-                                                           batchCount));
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          batchCount));
 }
 
 // copy_strided_batched
-hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, float* y,
-    int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const float*    x,
+                                           int             incx,
+                                           int             stridex,
+                                           float*          y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_scopy_strided_batched((rocblas_handle)handle,
-                                                                   n,
-                                                                   x,
-                                                                   incx,
-                                                                   stridex,
-                                                                   y,
-                                                                   incy,
-                                                                   stridey,
-                                                                   batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_scopy_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batchCount));
 }
 
-hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, double* y,
-    int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   x,
+                                           int             incx,
+                                           int             stridex,
+                                           double*         y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dcopy_strided_batched((rocblas_handle)handle,
-                                                                   n,
-                                                                   x,
-                                                                   incx,
-                                                                   stridex,
-                                                                   y,
-                                                                   incy,
-                                                                   stridey,
-                                                                   batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_dcopy_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batchCount));
 }
 
-hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, hipComplex* y,
-    int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* x,
+                                           int               incx,
+                                           int               stridex,
+                                           hipComplex*       y,
+                                           int               incy,
+                                           int               stridey,
+                                           int               batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_ccopy_strided_batched((rocblas_handle)handle,
-                                                                   n,
-                                                                   (rocblas_float_complex*)x,
-                                                                   incx,
-                                                                   stridex,
-                                                                   (rocblas_float_complex*)y,
-                                                                   incy,
-                                                                   stridey,
-                                                                   batchCount));
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
 }
 
-hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y,
-    int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* x,
+                                           int                     incx,
+                                           int                     stridex,
+                                           hipDoubleComplex*       y,
+                                           int                     incy,
+                                           int                     stridey,
+                                           int                     batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zcopy_strided_batched((rocblas_handle)handle,
-                                                                   n,
-                                                                   (rocblas_double_complex*)x,
-                                                                   incx,
-                                                                   stridex,
-                                                                   (rocblas_double_complex*)y,
-                                                                   incy,
-                                                                   stridey,
-                                                                   batchCount));
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
 }
 
 // dot
@@ -834,56 +906,80 @@ hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
         rocblas_ddot_batched((rocblas_handle)handle, n, x, incx, y, incy, batch_count, result));
 }
 
-hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t        handle,
-                                   int                     n,
-                                   const hipComplex* const x[],
-                                   int                     incx,
-                                   const hipComplex* const y[],
-                                   int                     incy,
-                                   int                     batch_count,
-                                   hipComplex*             result)
+hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipComplex* const x[],
+                                    int                     incx,
+                                    const hipComplex* const y[],
+                                    int                     incy,
+                                    int                     batch_count,
+                                    hipComplex*             result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_cdotc_batched((rocblas_handle)handle, n, (rocblas_float_complex**)x, incx, (rocblas_float_complex**)y, incy, batch_count, (rocblas_float_complex*)result));
+    return rocBLASStatusToHIPStatus(rocblas_cdotc_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          batch_count,
+                                                          (rocblas_float_complex*)result));
 }
 
-hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t        handle,
-                                   int                     n,
-                                   const hipComplex* const x[],
-                                   int                     incx,
-                                   const hipComplex* const y[],
-                                   int                     incy,
-                                   int                     batch_count,
-                                   hipComplex*             result)
+hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipComplex* const x[],
+                                    int                     incx,
+                                    const hipComplex* const y[],
+                                    int                     incy,
+                                    int                     batch_count,
+                                    hipComplex*             result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_cdotu_batched((rocblas_handle)handle, n, (rocblas_float_complex**)x, incx, (rocblas_float_complex**)y, incy, batch_count, (rocblas_float_complex*)result));
+    return rocBLASStatusToHIPStatus(rocblas_cdotu_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          batch_count,
+                                                          (rocblas_float_complex*)result));
 }
 
-hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t              handle,
-                                   int                           n,
-                                   const hipDoubleComplex* const x[],
-                                   int                           incx,
-                                   const hipDoubleComplex* const y[],
-                                   int                           incy,
-                                   int                           batch_count,
-                                   hipDoubleComplex*             result)
+hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t               handle,
+                                    int                           n,
+                                    const hipDoubleComplex* const x[],
+                                    int                           incx,
+                                    const hipDoubleComplex* const y[],
+                                    int                           incy,
+                                    int                           batch_count,
+                                    hipDoubleComplex*             result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_zdotc_batched((rocblas_handle)handle, n, (rocblas_double_complex**)x, incx, (rocblas_double_complex**)y, incy, batch_count, (rocblas_double_complex*)result));
+    return rocBLASStatusToHIPStatus(rocblas_zdotc_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          batch_count,
+                                                          (rocblas_double_complex*)result));
 }
 
-hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t              handle,
-                                   int                           n,
-                                   const hipDoubleComplex* const x[],
-                                   int                           incx,
-                                   const hipDoubleComplex* const y[],
-                                   int                           incy,
-                                   int                           batch_count,
-                                   hipDoubleComplex*             result)
+hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t               handle,
+                                    int                           n,
+                                    const hipDoubleComplex* const x[],
+                                    int                           incx,
+                                    const hipDoubleComplex* const y[],
+                                    int                           incy,
+                                    int                           batch_count,
+                                    hipDoubleComplex*             result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_zdotu_batched((rocblas_handle)handle, n, (rocblas_double_complex**)x, incx, (rocblas_double_complex**)y, incy, batch_count, (rocblas_double_complex*)result));
+    return rocBLASStatusToHIPStatus(rocblas_zdotu_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          batch_count,
+                                                          (rocblas_double_complex*)result));
 }
 
 // dot_strided_batched
@@ -898,8 +994,8 @@ hipblasStatus_t hipblasSdotStridedBatched(hipblasHandle_t handle,
                                           int             batch_count,
                                           float*          result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_sdot_strided_batched((rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batch_count, result));
+    return rocBLASStatusToHIPStatus(rocblas_sdot_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batch_count, result));
 }
 
 hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
@@ -913,68 +1009,100 @@ hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
                                           int             batch_count,
                                           double*         result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_ddot_strided_batched((rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batch_count, result));
+    return rocBLASStatusToHIPStatus(rocblas_ddot_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batch_count, result));
 }
 
-hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t  handle,
-                                          int               n,
-                                          const hipComplex* x,
-                                          int               incx,
-                                          int               stridex,
-                                          const hipComplex* y,
-                                          int               incy,
-                                          int               stridey,
-                                          int               batch_count,
-                                          hipComplex*       result)
+hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* x,
+                                           int               incx,
+                                           int               stridex,
+                                           const hipComplex* y,
+                                           int               incy,
+                                           int               stridey,
+                                           int               batch_count,
+                                           hipComplex*       result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_cdotc_strided_batched((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, (rocblas_float_complex*)y, incy, stridey, batch_count, (rocblas_float_complex*)result));
+    return rocBLASStatusToHIPStatus(rocblas_cdotc_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batch_count,
+                                                                  (rocblas_float_complex*)result));
 }
 
-hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t  handle,
-                                          int               n,
-                                          const hipComplex* x,
-                                          int               incx,
-                                          int               stridex,
-                                          const hipComplex* y,
-                                          int               incy,
-                                          int               stridey,
-                                          int               batch_count,
-                                          hipComplex*       result)
+hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* x,
+                                           int               incx,
+                                           int               stridex,
+                                           const hipComplex* y,
+                                           int               incy,
+                                           int               stridey,
+                                           int               batch_count,
+                                           hipComplex*       result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_cdotu_strided_batched((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, (rocblas_float_complex*)y, incy, stridey, batch_count, (rocblas_float_complex*)result));
+    return rocBLASStatusToHIPStatus(rocblas_cdotu_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batch_count,
+                                                                  (rocblas_float_complex*)result));
 }
 
-hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t        handle,
-                                          int                     n,
-                                          const hipDoubleComplex* x,
-                                          int                     incx,
-                                          int                     stridex,
-                                          const hipDoubleComplex* y,
-                                          int                     incy,
-                                          int                     stridey,
-                                          int                     batch_count,
-                                          hipDoubleComplex*       result)
+hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* x,
+                                           int                     incx,
+                                           int                     stridex,
+                                           const hipDoubleComplex* y,
+                                           int                     incy,
+                                           int                     stridey,
+                                           int                     batch_count,
+                                           hipDoubleComplex*       result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_zdotc_strided_batched((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, (rocblas_double_complex*)y, incy, stridey, batch_count, (rocblas_double_complex*)result));
+    return rocBLASStatusToHIPStatus(rocblas_zdotc_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batch_count,
+                                                                  (rocblas_double_complex*)result));
 }
 
-hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t        handle,
-                                          int                     n,
-                                          const hipDoubleComplex* x,
-                                          int                     incx,
-                                          int                     stridex,
-                                          const hipDoubleComplex* y,
-                                          int                     incy,
-                                          int                     stridey,
-                                          int                     batch_count,
-                                          hipDoubleComplex*       result)
+hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* x,
+                                           int                     incx,
+                                           int                     stridex,
+                                           const hipDoubleComplex* y,
+                                           int                     incy,
+                                           int                     stridey,
+                                           int                     batch_count,
+                                           hipDoubleComplex*       result)
 {
-    return rocBLASStatusToHIPStatus(
-        rocblas_zdotu_strided_batched((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, (rocblas_double_complex*)y, incy, stridey, batch_count, (rocblas_double_complex*)result));
+    return rocBLASStatusToHIPStatus(rocblas_zdotu_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batch_count,
+                                                                  (rocblas_double_complex*)result));
 }
 
 // nrm2
@@ -1004,45 +1132,93 @@ hipblasStatus_t hipblasDznrm2(
 }
 
 // nrm2_batched
-hipblasStatus_t hipblasSnrm2Batched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
+hipblasStatus_t hipblasSnrm2Batched(
+    hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_snrm2_batched((rocblas_handle)handle, n, x, incx, batchCount, result));
+    return rocBLASStatusToHIPStatus(
+        rocblas_snrm2_batched((rocblas_handle)handle, n, x, incx, batchCount, result));
 }
 
-hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result)
+hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t     handle,
+                                    int                 n,
+                                    const double* const x[],
+                                    int                 incx,
+                                    int                 batchCount,
+                                    double*             result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dnrm2_batched((rocblas_handle)handle, n, x, incx, batchCount, result));
+    return rocBLASStatusToHIPStatus(
+        rocblas_dnrm2_batched((rocblas_handle)handle, n, x, incx, batchCount, result));
 }
 
-hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result)
+hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t         handle,
+                                     int                     n,
+                                     const hipComplex* const x[],
+                                     int                     incx,
+                                     int                     batchCount,
+                                     float*                  result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_scnrm2_batched((rocblas_handle)handle, n, (rocblas_float_complex*const*)x, incx, batchCount, result));
+    return rocBLASStatusToHIPStatus(rocblas_scnrm2_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex* const*)x, incx, batchCount, result));
 }
 
-hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result)
+hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t               handle,
+                                     int                           n,
+                                     const hipDoubleComplex* const x[],
+                                     int                           incx,
+                                     int                           batchCount,
+                                     double*                       result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dznrm2_batched((rocblas_handle)handle, n, (rocblas_double_complex*const*)x, incx, batchCount, result));
+    return rocBLASStatusToHIPStatus(rocblas_dznrm2_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex* const*)x, incx, batchCount, result));
 }
 
 // nrm2_strided_batched
-hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result)
+hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const float*    x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount,
+                                           float*          result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_snrm2_strided_batched((rocblas_handle)handle, n, x, incx, stridex, batchCount, result));
+    return rocBLASStatusToHIPStatus(rocblas_snrm2_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, batchCount, result));
 }
 
-hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result)
+hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount,
+                                           double*         result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dnrm2_strided_batched((rocblas_handle)handle, n, x, incx, stridex, batchCount, result));
+    return rocBLASStatusToHIPStatus(rocblas_dnrm2_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, batchCount, result));
 }
 
-hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result)
+hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   handle,
+                                            int               n,
+                                            const hipComplex* x,
+                                            int               incx,
+                                            int               stridex,
+                                            int               batchCount,
+                                            float*            result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_scnrm2_strided_batched((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batchCount, result));
+    return rocBLASStatusToHIPStatus(rocblas_scnrm2_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batchCount, result));
 }
 
-hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result)
+hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const hipDoubleComplex* x,
+                                            int                     incx,
+                                            int                     stridex,
+                                            int                     batchCount,
+                                            double*                 result)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dznrm2_strided_batched((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batchCount, result));
+    return rocBLASStatusToHIPStatus(rocblas_dznrm2_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batchCount, result));
 }
 
 // rot
@@ -1138,131 +1314,153 @@ hipblasStatus_t
 }
 
 // scal_batched
-hipblasStatus_t  hipblasSscalBatched(hipblasHandle_t handle, int n, const float *alpha, float* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasSscalBatched(
+    hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_sscal_batched((rocblas_handle)handle,
-                                                          n,
-                                                          alpha,
-                                                          x,
-                                                          incx,
-                                                          batchCount));
+    return rocBLASStatusToHIPStatus(
+        rocblas_sscal_batched((rocblas_handle)handle, n, alpha, x, incx, batchCount));
 }
 
-hipblasStatus_t  hipblasDscalBatched(hipblasHandle_t handle, int n, const double *alpha, double* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasDscalBatched(
+    hipblasHandle_t handle, int n, const double* alpha, double* const x[], int incx, int batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dscal_batched((rocblas_handle)handle,
-                                                          n,
-                                                          alpha,
-                                                          x,
-                                                          incx,
-                                                          batchCount));
+    return rocBLASStatusToHIPStatus(
+        rocblas_dscal_batched((rocblas_handle)handle, n, alpha, x, incx, batchCount));
 }
 
-hipblasStatus_t  hipblasCscalBatched(hipblasHandle_t handle, int n, const hipComplex *alpha, hipComplex* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasCscalBatched(hipblasHandle_t   handle,
+                                    int               n,
+                                    const hipComplex* alpha,
+                                    hipComplex* const x[],
+                                    int               incx,
+                                    int               batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_cscal_batched((rocblas_handle)handle,
                                                           n,
                                                           (rocblas_float_complex*)alpha,
-                                                          (rocblas_float_complex*const*)x,
+                                                          (rocblas_float_complex* const*)x,
                                                           incx,
                                                           batchCount));
 }
 
-hipblasStatus_t  hipblasZscalBatched(hipblasHandle_t handle, int n, const hipDoubleComplex *alpha, hipDoubleComplex* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasZscalBatched(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipDoubleComplex* alpha,
+                                    hipDoubleComplex* const x[],
+                                    int                     incx,
+                                    int                     batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zscal_batched((rocblas_handle)handle,
                                                           n,
                                                           (rocblas_double_complex*)alpha,
-                                                          (rocblas_double_complex*const*)x,
+                                                          (rocblas_double_complex* const*)x,
                                                           incx,
                                                           batchCount));
 }
 
-hipblasStatus_t  hipblasCsscalBatched(hipblasHandle_t handle, int n, const float *alpha, hipComplex* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasCsscalBatched(hipblasHandle_t   handle,
+                                     int               n,
+                                     const float*      alpha,
+                                     hipComplex* const x[],
+                                     int               incx,
+                                     int               batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_csscal_batched((rocblas_handle)handle,
-                                                          n,
-                                                          alpha,
-                                                          (rocblas_float_complex*const*)x,
-                                                          incx,
-                                                          batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_csscal_batched(
+        (rocblas_handle)handle, n, alpha, (rocblas_float_complex* const*)x, incx, batchCount));
 }
 
-hipblasStatus_t  hipblasZdscalBatched(hipblasHandle_t handle, int n, const double *alpha, hipDoubleComplex* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t         handle,
+                                     int                     n,
+                                     const double*           alpha,
+                                     hipDoubleComplex* const x[],
+                                     int                     incx,
+                                     int                     batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_zdscal_batched((rocblas_handle)handle,
-                                                          n,
-                                                          alpha,
-                                                          (rocblas_double_complex*const*)x,
-                                                          incx,
-                                                          batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_zdscal_batched(
+        (rocblas_handle)handle, n, alpha, (rocblas_double_complex* const*)x, incx, batchCount));
 }
 
 // scal_strided_batched
-hipblasStatus_t  hipblasSscalStridedBatched(hipblasHandle_t handle, int n, const float *alpha, float* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const float*    alpha,
+                                           float*          x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_sscal_strided_batched((rocblas_handle)handle,
-                                                          n,
-                                                          alpha,
-                                                          x,
-                                                          incx,
-                                                          stridex,
-                                                          batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_sscal_strided_batched(
+        (rocblas_handle)handle, n, alpha, x, incx, stridex, batchCount));
 }
 
-hipblasStatus_t  hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const double *alpha, double* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   alpha,
+                                           double*         x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dscal_strided_batched((rocblas_handle)handle,
-                                                          n,
-                                                          alpha,
-                                                          x,
-                                                          incx,
-                                                          stridex,
-                                                          batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_dscal_strided_batched(
+        (rocblas_handle)handle, n, alpha, x, incx, stridex, batchCount));
 }
 
-hipblasStatus_t  hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const hipComplex *alpha, hipComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* alpha,
+                                           hipComplex*       x,
+                                           int               incx,
+                                           int               stridex,
+                                           int               batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_cscal_strided_batched((rocblas_handle)handle,
-                                                          n,
-                                                          (rocblas_float_complex*)alpha,
-                                                          (rocblas_float_complex*)x,
-                                                          incx,
-                                                          stridex,
-                                                          batchCount));
+                                                                  n,
+                                                                  (rocblas_float_complex*)alpha,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  batchCount));
 }
 
-hipblasStatus_t  hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex *alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* alpha,
+                                           hipDoubleComplex*       x,
+                                           int                     incx,
+                                           int                     stridex,
+                                           int                     batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zscal_strided_batched((rocblas_handle)handle,
-                                                          n,
-                                                          (rocblas_double_complex*)alpha,
-                                                          (rocblas_double_complex*)x,
-                                                          incx,
-                                                          stridex,
-                                                          batchCount));
+                                                                  n,
+                                                                  (rocblas_double_complex*)alpha,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  batchCount));
 }
 
-hipblasStatus_t  hipblasCsscalStridedBatched(hipblasHandle_t handle, int n, const float *alpha, hipComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle,
+                                            int             n,
+                                            const float*    alpha,
+                                            hipComplex*     x,
+                                            int             incx,
+                                            int             stridex,
+                                            int             batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_csscal_strided_batched((rocblas_handle)handle,
-                                                          n,
-                                                          alpha,
-                                                          (rocblas_float_complex*)x,
-                                                          incx,
-                                                          stridex,
-                                                          batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_csscal_strided_batched(
+        (rocblas_handle)handle, n, alpha, (rocblas_float_complex*)x, incx, stridex, batchCount));
 }
 
-hipblasStatus_t  hipblasZdscalStridedBatched(hipblasHandle_t handle, int n, const double *alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t   handle,
+                                            int               n,
+                                            const double*     alpha,
+                                            hipDoubleComplex* x,
+                                            int               incx,
+                                            int               stridex,
+                                            int               batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_zdscal_strided_batched((rocblas_handle)handle,
-                                                          n,
-                                                          alpha,
-                                                          (rocblas_double_complex*)x,
-                                                          incx,
-                                                          stridex,
-                                                          batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_zdscal_strided_batched(
+        (rocblas_handle)handle, n, alpha, (rocblas_double_complex*)x, incx, stridex, batchCount));
 }
 
 // swap
@@ -1300,50 +1498,92 @@ hipblasStatus_t hipblasZswap(
 }
 
 // swap_batched
-hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount)
+hipblasStatus_t hipblasSswapBatched(
+    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_sswap_batched((rocblas_handle)handle, n, x, incx, y, incy, batchCount));
+    return rocBLASStatusToHIPStatus(
+        rocblas_sswap_batched((rocblas_handle)handle, n, x, incx, y, incy, batchCount));
 }
 
-hipblasStatus_t hipblasDswapBatched(hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount)
+hipblasStatus_t hipblasDswapBatched(
+    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dswap_batched((rocblas_handle)handle, n, x, incx, y, incy, batchCount));
+    return rocBLASStatusToHIPStatus(
+        rocblas_dswap_batched((rocblas_handle)handle, n, x, incx, y, incy, batchCount));
 }
 
-hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle, int n, hipComplex* x[], int incx, hipComplex* y[], int incy, int batchCount)
+hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
+                                    int             n,
+                                    hipComplex*     x[],
+                                    int             incx,
+                                    hipComplex*     y[],
+                                    int             incy,
+                                    int             batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_cswap_batched((rocblas_handle)handle,
-                                                           n,
-                                                           (rocblas_float_complex**)x,
-                                                           incx,
-                                                           (rocblas_float_complex**)y,
-                                                           incy,
-                                                           batchCount));
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          batchCount));
 }
 
-hipblasStatus_t hipblasZswapBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x[], int incx, hipDoubleComplex* y[], int incy, int batchCount)
+hipblasStatus_t hipblasZswapBatched(hipblasHandle_t   handle,
+                                    int               n,
+                                    hipDoubleComplex* x[],
+                                    int               incx,
+                                    hipDoubleComplex* y[],
+                                    int               incy,
+                                    int               batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zswap_batched((rocblas_handle)handle,
-                                                           n,
-                                                           (rocblas_double_complex**)x,
-                                                           incx,
-                                                           (rocblas_double_complex**)y,
-                                                           incy,
-                                                           batchCount));
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          batchCount));
 }
 
 // swap_strided_batched
-hipblasStatus_t hipblasSswapStridedBatched(hipblasHandle_t handle, int n, float* x, int incx, int stridex, float* y, int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasSswapStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           float*          x,
+                                           int             incx,
+                                           int             stridex,
+                                           float*          y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_sswap_strided_batched((rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_sswap_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batchCount));
 }
 
-hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle, int n, double* x, int incx, int stridex, double* y, int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           double*         x,
+                                           int             incx,
+                                           int             stridex,
+                                           double*         y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
-    return rocBLASStatusToHIPStatus(rocblas_dswap_strided_batched((rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batchCount));
+    return rocBLASStatusToHIPStatus(rocblas_dswap_strided_batched(
+        (rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batchCount));
 }
 
-hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           hipComplex*     x,
+                                           int             incx,
+                                           int             stridex,
+                                           hipComplex*     y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_cswap_strided_batched((rocblas_handle)handle,
                                                                   n,
@@ -1356,7 +1596,15 @@ hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle, int n, hipCom
                                                                   batchCount));
 }
 
-hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           hipDoubleComplex* x,
+                                           int               incx,
+                                           int               stridex,
+                                           hipDoubleComplex* y,
+                                           int               incy,
+                                           int               stridey,
+                                           int               batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zswap_strided_batched((rocblas_handle)handle,
                                                                   n,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -1003,6 +1003,48 @@ hipblasStatus_t hipblasDznrm2(
         rocblas_dznrm2((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
 }
 
+// nrm2_batched
+hipblasStatus_t hipblasSnrm2Batched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_snrm2_batched((rocblas_handle)handle, n, x, incx, batchCount, result));
+}
+
+hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dnrm2_batched((rocblas_handle)handle, n, x, incx, batchCount, result));
+}
+
+hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_scnrm2_batched((rocblas_handle)handle, n, (rocblas_float_complex*const*)x, incx, batchCount, result));
+}
+
+hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dznrm2_batched((rocblas_handle)handle, n, (rocblas_double_complex*const*)x, incx, batchCount, result));
+}
+
+// nrm2_strided_batched
+hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_snrm2_strided_batched((rocblas_handle)handle, n, x, incx, stridex, batchCount, result));
+}
+
+hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dnrm2_strided_batched((rocblas_handle)handle, n, x, incx, stridex, batchCount, result));
+}
+
+hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_scnrm2_strided_batched((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batchCount, result));
+}
+
+hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dznrm2_strided_batched((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batchCount, result));
+}
+
 // rot
 // hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
 //                             int             n,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -773,13 +773,175 @@ hipblasStatus_t hipblasZdotu(hipblasHandle_t         handle,
                                                   (rocblas_double_complex*)result));
 }
 
-/* not implemented
-hipblasStatus_t hipblasSdotBatched (hipblasHandle_t handle, int n, const float *x, int incx, const
-float *y, int incy, float *result, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+// dot_batched
+hipblasStatus_t hipblasSdotBatched(hipblasHandle_t    handle,
+                                   int                n,
+                                   const float* const x[],
+                                   int                incx,
+                                   const float* const y[],
+                                   int                incy,
+                                   int                batch_count,
+                                   float*             result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_sdot_batched((rocblas_handle)handle, n, x, incx, y, incy, batch_count, result));
+}
 
-hipblasStatus_t hipblasDdotBatched (hipblasHandle_t handle, int n, const double *x, int incx, const
-double *y, int incy, double *result, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
-*/
+hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
+                                   int                 n,
+                                   const double* const x[],
+                                   int                 incx,
+                                   const double* const y[],
+                                   int                 incy,
+                                   int                 batch_count,
+                                   double*             result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_ddot_batched((rocblas_handle)handle, n, x, incx, y, incy, batch_count, result));
+}
+
+hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t        handle,
+                                   int                     n,
+                                   const hipComplex* const x[],
+                                   int                     incx,
+                                   const hipComplex* const y[],
+                                   int                     incy,
+                                   int                     batch_count,
+                                   hipComplex*             result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_cdotc_batched((rocblas_handle)handle, n, (rocblas_float_complex**)x, incx, (rocblas_float_complex**)y, incy, batch_count, (rocblas_float_complex*)result));
+}
+
+hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t        handle,
+                                   int                     n,
+                                   const hipComplex* const x[],
+                                   int                     incx,
+                                   const hipComplex* const y[],
+                                   int                     incy,
+                                   int                     batch_count,
+                                   hipComplex*             result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_cdotu_batched((rocblas_handle)handle, n, (rocblas_float_complex**)x, incx, (rocblas_float_complex**)y, incy, batch_count, (rocblas_float_complex*)result));
+}
+
+hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t              handle,
+                                   int                           n,
+                                   const hipDoubleComplex* const x[],
+                                   int                           incx,
+                                   const hipDoubleComplex* const y[],
+                                   int                           incy,
+                                   int                           batch_count,
+                                   hipDoubleComplex*             result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_zdotc_batched((rocblas_handle)handle, n, (rocblas_double_complex**)x, incx, (rocblas_double_complex**)y, incy, batch_count, (rocblas_double_complex*)result));
+}
+
+hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t              handle,
+                                   int                           n,
+                                   const hipDoubleComplex* const x[],
+                                   int                           incx,
+                                   const hipDoubleComplex* const y[],
+                                   int                           incy,
+                                   int                           batch_count,
+                                   hipDoubleComplex*             result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_zdotu_batched((rocblas_handle)handle, n, (rocblas_double_complex**)x, incx, (rocblas_double_complex**)y, incy, batch_count, (rocblas_double_complex*)result));
+}
+
+// dot_strided_batched
+hipblasStatus_t hipblasSdotStridedBatched(hipblasHandle_t handle,
+                                          int             n,
+                                          const float*    x,
+                                          int             incx,
+                                          int             stridex,
+                                          const float*    y,
+                                          int             incy,
+                                          int             stridey,
+                                          int             batch_count,
+                                          float*          result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_sdot_strided_batched((rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batch_count, result));
+}
+
+hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
+                                          int             n,
+                                          const double*   x,
+                                          int             incx,
+                                          int             stridex,
+                                          const double*   y,
+                                          int             incy,
+                                          int             stridey,
+                                          int             batch_count,
+                                          double*         result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_ddot_strided_batched((rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batch_count, result));
+}
+
+hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t  handle,
+                                          int               n,
+                                          const hipComplex* x,
+                                          int               incx,
+                                          int               stridex,
+                                          const hipComplex* y,
+                                          int               incy,
+                                          int               stridey,
+                                          int               batch_count,
+                                          hipComplex*       result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_cdotc_strided_batched((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, (rocblas_float_complex*)y, incy, stridey, batch_count, (rocblas_float_complex*)result));
+}
+
+hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t  handle,
+                                          int               n,
+                                          const hipComplex* x,
+                                          int               incx,
+                                          int               stridex,
+                                          const hipComplex* y,
+                                          int               incy,
+                                          int               stridey,
+                                          int               batch_count,
+                                          hipComplex*       result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_cdotu_strided_batched((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, (rocblas_float_complex*)y, incy, stridey, batch_count, (rocblas_float_complex*)result));
+}
+
+hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t        handle,
+                                          int                     n,
+                                          const hipDoubleComplex* x,
+                                          int                     incx,
+                                          int                     stridex,
+                                          const hipDoubleComplex* y,
+                                          int                     incy,
+                                          int                     stridey,
+                                          int                     batch_count,
+                                          hipDoubleComplex*       result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_zdotc_strided_batched((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, (rocblas_double_complex*)y, incy, stridey, batch_count, (rocblas_double_complex*)result));
+}
+
+hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t        handle,
+                                          int                     n,
+                                          const hipDoubleComplex* x,
+                                          int                     incx,
+                                          int                     stridex,
+                                          const hipDoubleComplex* y,
+                                          int                     incy,
+                                          int                     stridey,
+                                          int                     batch_count,
+                                          hipDoubleComplex*       result)
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_zdotu_strided_batched((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, (rocblas_double_complex*)y, incy, stridey, batch_count, (rocblas_double_complex*)result));
+}
 
 // nrm2
 hipblasStatus_t hipblasSnrm2(hipblasHandle_t handle, int n, const float* x, int incx, float* result)

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -574,13 +574,111 @@ hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
                                                   incy));
 }
 
-/* not implemented
-hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float *x, int incx, float
-*y, int incy, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+// copy_batched
+hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float* const x[], int incx, float* const y[],
+    int incy, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_scopy_batched((rocblas_handle)handle,
+                                                           n,
+                                                           x,
+                                                           incx,
+                                                           y,
+                                                           incy,
+                                                           batchCount));
+}
 
-hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double *x, int incx, double
-*y, int incy, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
-*/
+hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double* const x[], int incx, double* const y[],
+    int incy, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dcopy_batched((rocblas_handle)handle,
+                                                           n,
+                                                           x,
+                                                           incx,
+                                                           y,
+                                                           incy,
+                                                           batchCount));
+}
+
+hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, hipComplex* const y[],
+    int incy, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_ccopy_batched((rocblas_handle)handle,
+                                                           n,
+                                                           (rocblas_float_complex**)x,
+                                                           incx,
+                                                           (rocblas_float_complex**)y,
+                                                           incy,
+                                                           batchCount));
+}
+
+hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, hipDoubleComplex* const y[],
+    int incy, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zcopy_batched((rocblas_handle)handle,
+                                                           n,
+                                                           (rocblas_double_complex**)x,
+                                                           incx,
+                                                           (rocblas_double_complex**)y,
+                                                           incy,
+                                                           batchCount));
+}
+
+// copy_strided_batched
+hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, float* y,
+    int incy, int stridey, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_scopy_strided_batched((rocblas_handle)handle,
+                                                                   n,
+                                                                   x,
+                                                                   incx,
+                                                                   stridex,
+                                                                   y,
+                                                                   incy,
+                                                                   stridey,
+                                                                   batchCount));
+}
+
+hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, double* y,
+    int incy, int stridey, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dcopy_strided_batched((rocblas_handle)handle,
+                                                                   n,
+                                                                   x,
+                                                                   incx,
+                                                                   stridex,
+                                                                   y,
+                                                                   incy,
+                                                                   stridey,
+                                                                   batchCount));
+}
+
+hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, hipComplex* y,
+    int incy, int stridey, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_ccopy_strided_batched((rocblas_handle)handle,
+                                                                   n,
+                                                                   (rocblas_float_complex*)x,
+                                                                   incx,
+                                                                   stridex,
+                                                                   (rocblas_float_complex*)y,
+                                                                   incy,
+                                                                   stridey,
+                                                                   batchCount));
+}
+
+hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y,
+    int incy, int stridey, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zcopy_strided_batched((rocblas_handle)handle,
+                                                                   n,
+                                                                   (rocblas_double_complex*)x,
+                                                                   incx,
+                                                                   stridex,
+                                                                   (rocblas_double_complex*)y,
+                                                                   incy,
+                                                                   stridey,
+                                                                   batchCount));
+}
 
 // dot
 hipblasStatus_t hipblasSdot(hipblasHandle_t handle,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -1223,6 +1223,76 @@ hipblasStatus_t hipblasZswap(
                                                   incy));
 }
 
+// swap_batched
+hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_sswap_batched((rocblas_handle)handle, n, x, incx, y, incy, batchCount));
+}
+
+hipblasStatus_t hipblasDswapBatched(hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dswap_batched((rocblas_handle)handle, n, x, incx, y, incy, batchCount));
+}
+
+hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle, int n, hipComplex* x[], int incx, hipComplex* y[], int incy, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_cswap_batched((rocblas_handle)handle,
+                                                           n,
+                                                           (rocblas_float_complex**)x,
+                                                           incx,
+                                                           (rocblas_float_complex**)y,
+                                                           incy,
+                                                           batchCount));
+}
+
+hipblasStatus_t hipblasZswapBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x[], int incx, hipDoubleComplex* y[], int incy, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zswap_batched((rocblas_handle)handle,
+                                                           n,
+                                                           (rocblas_double_complex**)x,
+                                                           incx,
+                                                           (rocblas_double_complex**)y,
+                                                           incy,
+                                                           batchCount));
+}
+
+// swap_strided_batched
+hipblasStatus_t hipblasSswapStridedBatched(hipblasHandle_t handle, int n, float* x, int incx, int stridex, float* y, int incy, int stridey, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_sswap_strided_batched((rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batchCount));
+}
+
+hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle, int n, double* x, int incx, int stridex, double* y, int incy, int stridey, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dswap_strided_batched((rocblas_handle)handle, n, x, incx, stridex, y, incy, stridey, batchCount));
+}
+
+hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_cswap_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
+}
+
+hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batchCount)
+{
+    return rocBLASStatusToHIPStatus(rocblas_zswap_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
+}
+
 // gemv
 hipblasStatus_t hipblasSgemv(hipblasHandle_t    handle,
                              hipblasOperation_t trans,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -442,7 +442,7 @@ hipblasStatus_t
         rocblas_izamin((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
 }
 
-// ASUM
+// asum
 hipblasStatus_t hipblasSasum(hipblasHandle_t handle, int n, const float* x, int incx, float* result)
 {
     return rocBLASStatusToHIPStatus(rocblas_sasum((rocblas_handle)handle, n, x, incx, result));
@@ -468,13 +468,47 @@ hipblasStatus_t hipblasDzasum(
         rocblas_dzasum((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
 }
 
-/* not implemented
-hipblasStatus_t  hipblasSasumBatched(hipblasHandle_t handle, int n, float *x, int incx, float
-*result, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
+// asum_batched
+hipblasStatus_t hipblasSasumBatched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batch_count, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_sasum_batched((rocblas_handle)handle, n, x, incx, batch_count, result));
+}
 
-hipblasStatus_t  hipblasDasumBatched(hipblasHandle_t handle, int n, double *x, int incx, double
-*result, int batchCount){return HIPBLAS_STATUS_NOT_SUPPORTED;}
-*/
+hipblasStatus_t hipblasDasumBatched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batch_count, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dasum_batched((rocblas_handle)handle, n, x, incx, batch_count, result));
+}
+
+hipblasStatus_t hipblasScasumBatched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batch_count, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_scasum_batched((rocblas_handle)handle, n, (rocblas_float_complex*const*)x, incx, batch_count, result));
+}
+
+hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batch_count, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dzasum_batched((rocblas_handle)handle, n, (rocblas_double_complex*const*)x, incx, batch_count, result));
+}
+
+// asum_strided_batched
+hipblasStatus_t hipblasSasumStridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batch_count, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_sasum_strided_batched((rocblas_handle)handle, n, x, incx, stridex, batch_count, result));
+}
+
+hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batch_count, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dasum_strided_batched((rocblas_handle)handle, n, x, incx, stridex, batch_count, result));
+}
+
+hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batch_count, float* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_scasum_strided_batched((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batch_count, result));
+}
+
+hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batch_count, double* result)
+{
+    return rocBLASStatusToHIPStatus(rocblas_dzasum_strided_batched((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batch_count, result));
+}
 
 // axpy
 hipblasStatus_t hipblasSaxpy(

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -382,7 +382,7 @@ hipblasStatus_t hipblasDzasum(
 
 // asum_batched
 hipblasStatus_t hipblasSasumBatched(
-    hipblasHandle_t handle, int n, float* const x[], int incx, int batchCount, float* result)
+    hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
     // // TODO warn user that function was demoted to ignore batch
@@ -390,44 +390,44 @@ hipblasStatus_t hipblasSasumBatched(
 }
 
 hipblasStatus_t hipblasDasumBatched(
-    hipblasHandle_t handle, int n, double* const x[], int incx, int batchCount, double* result)
+    hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasScasumBatched(
-    hipblasHandle_t handle, int n, hipComplex* const x[], int incx, int batchCount, float* result)
+    hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasDzasumBatched(
-    hipblasHandle_t handle, int n, hipDoubleComplex* const x[], int incx, int batchCount, double* result)
+    hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // asum_strided_batched
 hipblasStatus_t hipblasSasumStridedBatched(
-    hipblasHandle_t handle, int n, float* x, int incx, int stridex, int batchCount, float* result)
+    hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasDasumStridedBatched(
-    hipblasHandle_t handle, int n, double* x, int incx, int stridex, int batchCount, double* result)
+    hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasScasumStridedBatched(
-    hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, int batchCount, float* result)
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasDzasumStridedBatched(
-    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result)
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -717,17 +717,73 @@ hipblasStatus_t
         cublasZdscal((cublasHandle_t)handle, n, alpha, (cuDoubleComplex*)x, incx));
 }
 
+// scal_batched
 hipblasStatus_t hipblasSscalBatched(
-    hipblasHandle_t handle, int n, const float* alpha, float* x, int incx, int batchCount)
+    hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batchCount)
 {
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
     // TODO warn user that function was demoted to ignore batch
-    return hipCUBLASStatusToHIPStatus(cublasSscal((cublasHandle_t)handle, n, alpha, x, incx));
+    // return hipCUBLASStatusToHIPStatus(cublasSscal((cublasHandle_t)handle, n, alpha, x, incx));
 }
 hipblasStatus_t hipblasDscalBatched(
-    hipblasHandle_t handle, int n, const double* alpha, double* x, int incx, int batchCount)
+    hipblasHandle_t handle, int n, const double* alpha, double* const x[], int incx, int batchCount)
 {
-    // TODO warn user that function was demoted to ignore batch
-    return hipCUBLASStatusToHIPStatus(cublasDscal((cublasHandle_t)handle, n, alpha, x, incx));
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCscalBatched(
+    hipblasHandle_t handle, int n, const cuComplex* alpha, cuComplex* const x[], int incx, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZscalBatched(
+    hipblasHandle_t handle, int n, const cuDoubleComplex* alpha, cuDoubleComplex* const x[], int incx, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCsscalBatched(
+    hipblasHandle_t handle, int n, const float* alpha, cuComplex* const x[], int incx, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdscalBatched(
+    hipblasHandle_t handle, int n, const double* alpha, cuDoubleComplex* const x[], int incx, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+// scal_strided_batched
+hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx, int stridex, int batchCount);
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx, int stridex, int batchCount);
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const cuComplex* alpha, cuComplex* x, int incx, int stridex, int batchCount);
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const cuDoubleComplex* alpha, cuDoubleComplex* x, int incx, int stridex, int batchCount);
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, cuComplex* x, int incx, int stridex, int batchCount);
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, cuDoubleComplex* x, int incx, int stridex, int batchCount);
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // swap

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -635,32 +635,165 @@ hipblasStatus_t hipblasZdotu(hipblasHandle_t         handle,
                                                   (cuDoubleComplex*)result));
 }
 
-hipblasStatus_t hipblasSdotBatched(hipblasHandle_t handle,
-                                   int             n,
-                                   const float*    x,
-                                   int             incx,
-                                   const float*    y,
-                                   int             incy,
-                                   float*          result,
-                                   int             batchCount)
+// dot_batched
+hipblasStatus_t hipblasSdotBatched(hipblasHandle_t    handle,
+                                   int                n,
+                                   const float* const x[],
+                                   int                incx,
+                                   const float* const y[],
+                                   int                incy,
+                                   int                batchCount,
+                                   float*             result)
 {
-    // TODO warn user that function was demoted to ignore batch
-    return hipCUBLASStatusToHIPStatus(
-        cublasSdot((cublasHandle_t)handle, n, x, incx, y, incy, result));
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    // // TODO warn user that function was demoted to ignore batch
+    // return hipCUBLASStatusToHIPStatus(
+    //     cublasSdot((cublasHandle_t)handle, n, x, incx, y, incy, result));
 }
 
-hipblasStatus_t hipblasDdotBatched(hipblasHandle_t handle,
-                                   int             n,
-                                   const double*   x,
-                                   int             incx,
-                                   const double*   y,
-                                   int             incy,
-                                   double*         result,
-                                   int             batchCount)
+hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
+                                   int                 n,
+                                   const double* const x[],
+                                   int                 incx,
+                                   const double* const y[],
+                                   int                 incy,
+                                   int                 batchCount,
+                                   double*             result)
 {
-    // TODO warn user that function was demoted to ignore batch
-    return hipCUBLASStatusToHIPStatus(
-        cublasDdot((cublasHandle_t)handle, n, x, incx, y, incy, result));
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t        handle,
+                                   int                     n,
+                                   const hipComplex* const x[],
+                                   int                     incx,
+                                   const hipComplex* const y[],
+                                   int                     incy,
+                                   int                     batchCount,
+                                   hipComplex*             result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t        handle,
+                                   int                     n,
+                                   const hipComplex* const x[],
+                                   int                     incx,
+                                   const hipComplex* const y[],
+                                   int                     incy,
+                                   int                     batchCount,
+                                   hipComplex*             result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t              handle,
+                                   int                           n,
+                                   const hipDoubleComplex* const x[],
+                                   int                           incx,
+                                   const hipDoubleComplex* const y[],
+                                   int                           incy,
+                                   int                           batchCount,
+                                   hipDoubleComplex*             result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t              handle,
+                                   int                           n,
+                                   const hipDoubleComplex* const x[],
+                                   int                           incx,
+                                   const hipDoubleComplex* const y[],
+                                   int                           incy,
+                                   int                           batchCount,
+                                   hipDoubleComplex*             result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+// dot_strided_batched
+hipblasStatus_t hipblasSdotStridedBatched(hipblasHandle_t handle,
+                                          int             n,
+                                          const float*    x,
+                                          int             incx,
+                                          int             stridex,
+                                          const float*    y,
+                                          int             incy,
+                                          int             stridey,
+                                          int             batchCount,
+                                          float*          result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
+                                          int             n,
+                                          const double*   x,
+                                          int             incx,
+                                          int             stridex,
+                                          const double*   y,
+                                          int             incy,
+                                          int             stridey,
+                                          int             batchCount,
+                                          double*         result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* x,
+                                           int               incx,
+                                           int               stridex,
+                                           const hipComplex* y,
+                                           int               incy,
+                                           int               stridey,
+                                           int               batchCount,
+                                           hipComplex*       result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* x,
+                                           int               incx,
+                                           int               stridex,
+                                           const hipComplex* y,
+                                           int               incy,
+                                           int               stridey,
+                                           int               batchCount,
+                                           hipComplex*       result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* x,
+                                           int                     incx,
+                                           int                     stridex,
+                                           const hipDoubleComplex* y,
+                                           int                     incy,
+                                           int                     stridey,
+                                           int                     batchCount,
+                                           hipDoubleComplex*       result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* x,
+                                           int                     incx,
+                                           int                     stridex,
+                                           const hipDoubleComplex* y,
+                                           int                     incy,
+                                           int                     stridey,
+                                           int                     batchCount,
+                                           hipDoubleComplex*       result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // nrm2

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -882,22 +882,22 @@ hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t handle, int n, const hipDou
 }
 
 // nrm2_strided_batched
-hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount float* result)
+hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount double* result)
+hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount float* result)
+hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount double* result)
+hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -732,25 +732,25 @@ hipblasStatus_t hipblasDscalBatched(
 }
 
 hipblasStatus_t hipblasCscalBatched(
-    hipblasHandle_t handle, int n, const cuComplex* alpha, cuComplex* const x[], int incx, int batchCount)
+    hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* const x[], int incx, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasZscalBatched(
-    hipblasHandle_t handle, int n, const cuDoubleComplex* alpha, cuDoubleComplex* const x[], int incx, int batchCount)
+    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* const x[], int incx, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasCsscalBatched(
-    hipblasHandle_t handle, int n, const float* alpha, cuComplex* const x[], int incx, int batchCount)
+    hipblasHandle_t handle, int n, const float* alpha, hipComplex* const x[], int incx, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasZdscalBatched(
-    hipblasHandle_t handle, int n, const double* alpha, cuDoubleComplex* const x[], int incx, int batchCount)
+    hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* const x[], int incx, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -766,22 +766,22 @@ hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const 
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const cuComplex* alpha, cuComplex* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx, int stridex, int batchCount);
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const cuDoubleComplex* alpha, cuDoubleComplex* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount);
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, cuComplex* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx, int stridex, int batchCount);
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, cuDoubleComplex* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount);
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -389,45 +389,77 @@ hipblasStatus_t hipblasSasumBatched(
     // return hipCUBLASStatusToHIPStatus(cublasSasum((cublasHandle_t)handle, n, x, incx, result));
 }
 
-hipblasStatus_t hipblasDasumBatched(
-    hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result)
+hipblasStatus_t hipblasDasumBatched(hipblasHandle_t     handle,
+                                    int                 n,
+                                    const double* const x[],
+                                    int                 incx,
+                                    int                 batchCount,
+                                    double*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasScasumBatched(
-    hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result)
+hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
+                                     int                     n,
+                                     const hipComplex* const x[],
+                                     int                     incx,
+                                     int                     batchCount,
+                                     float*                  result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDzasumBatched(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result)
+hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t               handle,
+                                     int                           n,
+                                     const hipDoubleComplex* const x[],
+                                     int                           incx,
+                                     int                           batchCount,
+                                     double*                       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // asum_strided_batched
-hipblasStatus_t hipblasSasumStridedBatched(
-    hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result)
+hipblasStatus_t hipblasSasumStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const float*    x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount,
+                                           float*          result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDasumStridedBatched(
-    hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result)
+hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount,
+                                           double*         result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasScasumStridedBatched(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result)
+hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
+                                            int               n,
+                                            const hipComplex* x,
+                                            int               incx,
+                                            int               stridex,
+                                            int               batchCount,
+                                            float*            result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDzasumStridedBatched(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result)
+hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const hipDoubleComplex* x,
+                                            int                     incx,
+                                            int                     stridex,
+                                            int                     batchCount,
+                                            double*                 result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -541,51 +573,99 @@ hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
 }
 
 // copy_batched
-hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float* const x[], int incx, float* const y[],
-    int incy, int batchCount)
+hipblasStatus_t hipblasScopyBatched(hipblasHandle_t    handle,
+                                    int                n,
+                                    const float* const x[],
+                                    int                incx,
+                                    float* const       y[],
+                                    int                incy,
+                                    int                batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double* const x[], int incx, double* const y[],
-    int incy, int batchCount)
+hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t     handle,
+                                    int                 n,
+                                    const double* const x[],
+                                    int                 incx,
+                                    double* const       y[],
+                                    int                 incy,
+                                    int                 batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, hipComplex* const y[],
-    int incy, int batchCount)
+hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipComplex* const x[],
+                                    int                     incx,
+                                    hipComplex* const       y[],
+                                    int                     incy,
+                                    int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, hipDoubleComplex* const y[],
-    int incy, int batchCount)
+hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t               handle,
+                                    int                           n,
+                                    const hipDoubleComplex* const x[],
+                                    int                           incx,
+                                    hipDoubleComplex* const       y[],
+                                    int                           incy,
+                                    int                           batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // copy_strided_batched
-hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, float* y,
-    int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const float*    x,
+                                           int             incx,
+                                           int             stridex,
+                                           float*          y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, double* y,
-    int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   x,
+                                           int             incx,
+                                           int             stridex,
+                                           double*         y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, hipComplex* y,
-    int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* x,
+                                           int               incx,
+                                           int               stridex,
+                                           hipComplex*       y,
+                                           int               incy,
+                                           int               stridey,
+                                           int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y,
-    int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* x,
+                                           int                     incx,
+                                           int                     stridex,
+                                           hipDoubleComplex*       y,
+                                           int                     incy,
+                                           int                     stridey,
+                                           int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -701,50 +781,50 @@ hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t        handle,
-                                   int                     n,
-                                   const hipComplex* const x[],
-                                   int                     incx,
-                                   const hipComplex* const y[],
-                                   int                     incy,
-                                   int                     batchCount,
-                                   hipComplex*             result)
+hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipComplex* const x[],
+                                    int                     incx,
+                                    const hipComplex* const y[],
+                                    int                     incy,
+                                    int                     batchCount,
+                                    hipComplex*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t        handle,
-                                   int                     n,
-                                   const hipComplex* const x[],
-                                   int                     incx,
-                                   const hipComplex* const y[],
-                                   int                     incy,
-                                   int                     batchCount,
-                                   hipComplex*             result)
+hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipComplex* const x[],
+                                    int                     incx,
+                                    const hipComplex* const y[],
+                                    int                     incy,
+                                    int                     batchCount,
+                                    hipComplex*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t              handle,
-                                   int                           n,
-                                   const hipDoubleComplex* const x[],
-                                   int                           incx,
-                                   const hipDoubleComplex* const y[],
-                                   int                           incy,
-                                   int                           batchCount,
-                                   hipDoubleComplex*             result)
+hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t               handle,
+                                    int                           n,
+                                    const hipDoubleComplex* const x[],
+                                    int                           incx,
+                                    const hipDoubleComplex* const y[],
+                                    int                           incy,
+                                    int                           batchCount,
+                                    hipDoubleComplex*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t              handle,
-                                   int                           n,
-                                   const hipDoubleComplex* const x[],
-                                   int                           incx,
-                                   const hipDoubleComplex* const y[],
-                                   int                           incy,
-                                   int                           batchCount,
-                                   hipDoubleComplex*             result)
+hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t               handle,
+                                    int                           n,
+                                    const hipDoubleComplex* const x[],
+                                    int                           incx,
+                                    const hipDoubleComplex* const y[],
+                                    int                           incy,
+                                    int                           batchCount,
+                                    hipDoubleComplex*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -861,43 +941,83 @@ hipblasStatus_t hipblasDznrm2(
 }
 
 // nrm2_batched
-hipblasStatus_t hipblasSnrm2Batched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
+hipblasStatus_t hipblasSnrm2Batched(
+    hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result)
+hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t     handle,
+                                    int                 n,
+                                    const double* const x[],
+                                    int                 incx,
+                                    int                 batchCount,
+                                    double*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result)
+hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t         handle,
+                                     int                     n,
+                                     const hipComplex* const x[],
+                                     int                     incx,
+                                     int                     batchCount,
+                                     float*                  result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result)
+hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t               handle,
+                                     int                           n,
+                                     const hipDoubleComplex* const x[],
+                                     int                           incx,
+                                     int                           batchCount,
+                                     double*                       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // nrm2_strided_batched
-hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount, float* result)
+hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const float*    x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount,
+                                           float*          result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount, double* result)
+hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount,
+                                           double*         result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount, float* result)
+hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   handle,
+                                            int               n,
+                                            const hipComplex* x,
+                                            int               incx,
+                                            int               stridex,
+                                            int               batchCount,
+                                            float*            result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result)
+hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const hipDoubleComplex* x,
+                                            int                     incx,
+                                            int                     stridex,
+                                            int                     batchCount,
+                                            double*                 result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -981,57 +1101,109 @@ hipblasStatus_t hipblasDscalBatched(
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCscalBatched(
-    hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasCscalBatched(hipblasHandle_t   handle,
+                                    int               n,
+                                    const hipComplex* alpha,
+                                    hipComplex* const x[],
+                                    int               incx,
+                                    int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZscalBatched(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasZscalBatched(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipDoubleComplex* alpha,
+                                    hipDoubleComplex* const x[],
+                                    int                     incx,
+                                    int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCsscalBatched(
-    hipblasHandle_t handle, int n, const float* alpha, hipComplex* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasCsscalBatched(hipblasHandle_t   handle,
+                                     int               n,
+                                     const float*      alpha,
+                                     hipComplex* const x[],
+                                     int               incx,
+                                     int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZdscalBatched(
-    hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* const x[], int incx, int batchCount)
+hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t         handle,
+                                     int                     n,
+                                     const double*           alpha,
+                                     hipDoubleComplex* const x[],
+                                     int                     incx,
+                                     int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // scal_strided_batched
-hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const float*    alpha,
+                                           float*          x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           const double*   alpha,
+                                           double*         x,
+                                           int             incx,
+                                           int             stridex,
+                                           int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* alpha,
+                                           hipComplex*       x,
+                                           int               incx,
+                                           int               stridex,
+                                           int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* alpha,
+                                           hipDoubleComplex*       x,
+                                           int                     incx,
+                                           int                     stridex,
+                                           int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle,
+                                            int             n,
+                                            const float*    alpha,
+                                            hipComplex*     x,
+                                            int             incx,
+                                            int             stridex,
+                                            int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t   handle,
+                                            int               n,
+                                            const double*     alpha,
+                                            hipDoubleComplex* x,
+                                            int               incx,
+                                            int               stridex,
+                                            int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -1063,43 +1235,89 @@ hipblasStatus_t hipblasZswap(
 }
 
 // swap_batched
-hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount)
+hipblasStatus_t hipblasSswapBatched(
+    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDswapBatched(hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount)
+hipblasStatus_t hipblasDswapBatched(
+    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle, int n, hipComplex* x[], int incx, hipComplex* y[], int incy, int batchCount)
+hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
+                                    int             n,
+                                    hipComplex*     x[],
+                                    int             incx,
+                                    hipComplex*     y[],
+                                    int             incy,
+                                    int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZswapBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x[], int incx, hipDoubleComplex* y[], int incy, int batchCount)
+hipblasStatus_t hipblasZswapBatched(hipblasHandle_t   handle,
+                                    int               n,
+                                    hipDoubleComplex* x[],
+                                    int               incx,
+                                    hipDoubleComplex* y[],
+                                    int               incy,
+                                    int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // swap_strided_batched
-hipblasStatus_t hipblasSswapStridedBatched(hipblasHandle_t handle, int n, float* x, int incx, int stridex, float* y, int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasSswapStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           float*          x,
+                                           int             incx,
+                                           int             stridex,
+                                           float*          y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle, int n, double* x, int incx, int stridex, double* y, int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           double*         x,
+                                           int             incx,
+                                           int             stridex,
+                                           double*         y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle,
+                                           int             n,
+                                           hipComplex*     x,
+                                           int             incx,
+                                           int             stridex,
+                                           hipComplex*     y,
+                                           int             incy,
+                                           int             stridey,
+                                           int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batchCount)
+hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t   handle,
+                                           int               n,
+                                           hipDoubleComplex* x,
+                                           int               incx,
+                                           int               stridex,
+                                           hipDoubleComplex* y,
+                                           int               incy,
+                                           int               stridey,
+                                           int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -776,12 +776,12 @@ hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const 
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx, int stridex, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
+hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -502,18 +502,54 @@ hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
         (cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, (cuDoubleComplex*)y, incy));
 }
 
-hipblasStatus_t hipblasScopyBatched(
-    hipblasHandle_t handle, int n, const float* x, int incx, float* y, int incy, int batchCount)
+// copy_batched
+hipblasStatus_t hipblasScopyBatched(hipblasHandle_t handle, int n, const float* const x[], int incx, float* const y[],
+    int incy, int batchCount)
 {
-    // TODO warn user that function was demoted to ignore batch
-    return hipCUBLASStatusToHIPStatus(cublasScopy((cublasHandle_t)handle, n, x, incx, y, incy));
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDcopyBatched(
-    hipblasHandle_t handle, int n, const double* x, int incx, double* y, int incy, int batchCount)
+hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t handle, int n, const double* const x[], int incx, double* const y[],
+    int incy, int batchCount)
 {
-    // TODO warn user that function was demoted to ignore batch
-    return hipCUBLASStatusToHIPStatus(cublasDcopy((cublasHandle_t)handle, n, x, incx, y, incy));
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, hipComplex* const y[],
+    int incy, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, hipDoubleComplex* const y[],
+    int incy, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+// copy_strided_batched
+hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, float* y,
+    int incy, int stridey, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, double* y,
+    int incy, int stridey, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, hipComplex* y,
+    int incy, int stridey, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y,
+    int incy, int stridey, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 // dot

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -382,19 +382,57 @@ hipblasStatus_t hipblasDzasum(
 
 // asum_batched
 hipblasStatus_t hipblasSasumBatched(
-    hipblasHandle_t handle, int n, float* x, int incx, float* result, int batchCount)
+    hipblasHandle_t handle, int n, float* const x[], int incx, int batchCount, float* result)
 {
-    // TODO warn user that function was demoted to ignore batch
-    return hipCUBLASStatusToHIPStatus(cublasSasum((cublasHandle_t)handle, n, x, incx, result));
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    // // TODO warn user that function was demoted to ignore batch
+    // return hipCUBLASStatusToHIPStatus(cublasSasum((cublasHandle_t)handle, n, x, incx, result));
 }
 
 hipblasStatus_t hipblasDasumBatched(
-    hipblasHandle_t handle, int n, double* x, int incx, double* result, int batchCount)
+    hipblasHandle_t handle, int n, double* const x[], int incx, int batchCount, double* result)
 {
-    // TODO warn user that function was demoted to ignore batch
-    return hipCUBLASStatusToHIPStatus(cublasDasum((cublasHandle_t)handle, n, x, incx, result));
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
+hipblasStatus_t hipblasScasumBatched(
+    hipblasHandle_t handle, int n, hipComplex* const x[], int incx, int batchCount, float* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDzasumBatched(
+    hipblasHandle_t handle, int n, hipDoubleComplex* const x[], int incx, int batchCount, double* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+// asum_strided_batched
+hipblasStatus_t hipblasSasumStridedBatched(
+    hipblasHandle_t handle, int n, float* x, int incx, int stridex, int batchCount, float* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDasumStridedBatched(
+    hipblasHandle_t handle, int n, double* x, int incx, int stridex, int batchCount, double* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasScasumStridedBatched(
+    hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, int batchCount, float* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDzasumStridedBatched(
+    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, int batchCount, double* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+// axpy
 hipblasStatus_t hipblasSaxpy(
     hipblasHandle_t handle, int n, const float* alpha, const float* x, int incx, float* y, int incy)
 {

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -981,6 +981,48 @@ hipblasStatus_t hipblasZswap(
         (cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, (cuDoubleComplex*)y, incy));
 }
 
+// swap_batched
+hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDswapBatched(hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle, int n, hipComplex* x[], int incx, hipComplex* y[], int incy, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZswapBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x[], int incx, hipDoubleComplex* y[], int incy, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+// swap_strided_batched
+hipblasStatus_t hipblasSswapStridedBatched(hipblasHandle_t handle, int n, float* x, int incx, int stridex, float* y, int incy, int stridey, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle, int n, double* x, int incx, int stridex, double* y, int incy, int stridey, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle, int n, hipComplex* x, int incx, int stridex, hipComplex* y, int incy, int stridey, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, int stridex, hipDoubleComplex* y, int incy, int stridey, int batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
 // gemv
 hipblasStatus_t hipblasSgemv(hipblasHandle_t    handle,
                              hipblasOperation_t trans,

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -860,6 +860,49 @@ hipblasStatus_t hipblasDznrm2(
         cublasDznrm2((cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, result));
 }
 
+// nrm2_batched
+hipblasStatus_t hipblasSnrm2Batched(hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t handle, int n, const double* const x[], int incx, int batchCount, double* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t handle, int n, const hipComplex* const x[], int incx, int batchCount, float* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t handle, int n, const hipDoubleComplex* const x[], int incx, int batchCount, double* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+// nrm2_strided_batched
+hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle, int n, const float* x, int incx, int stridex, int batchCount float* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const double* x, int incx, int stridex, int batchCount double* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int stridex, int batchCount float* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int stridex, int batchCount double* result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+// rot
 // hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
 //                             int             n,
 //                             float*          x,

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -756,32 +756,32 @@ hipblasStatus_t hipblasZdscalBatched(
 }
 
 // scal_strided_batched
-hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx, int stridex, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx, int stridex, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx, int stridex, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx, int stridex, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount);
+hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx, int stridex, int batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }


### PR DESCRIPTION
Sorry for the big PR.

First step to match rocblas 2.10 functionality. Adds:
- scal_batched and scal_strided_batched
- copy_batched and copy_strided_batched
- dot(c)_batched and dot(c)_strided_batched
- swap_batched and swap_strided_batched
- asum_batched and asum_strided_batched
- nrm2_batched and nrm2_strided_batched
Along with corresponding unit tests.

All cuda implementations of L1 batched have been changed to return NOT_SUPPORTED rather than demoting them to non-batched versions.

Most of the changes are testing code changes except for library/src/*/hipblas.cpp and library/include/hipblas.h

A future PR (tomorrow) will include:
- ger_batched and ger_strided_batched
- syr_batched and syr_strided_batched
- gemm_batched and gemm_strided_batched
- complex gemm
- hdot and haxpy, maybe bfdot.

This would match rocblas 2.10 I believe.