### PR TITLE
hipBLAS changes to support multiple ROCM installation

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -82,7 +82,7 @@ target_include_directories( hipblas-test
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-    /opt/rocm/hsa/include
+    ${ROCM_PATH}/hsa/include
 )
 
 target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack ${GTEST_LIBRARIES} ${Boost_LIBRARIES} )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
   target_include_directories( ${exe}
     SYSTEM PRIVATE
       $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-      /opt/rocm/hsa/include
+      ${ROCM_PATH}/hsa/include
   )
 
   # Try to test for specific compiler features if cmake version is recent enough

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@ function display_help()
   echo "    [-d|--dependencies] install build dependencies"
   echo "    [-c|--clients] build library clients too (combines with -i & -d)"
   echo "    [-g|--debug] -DCMAKE_BUILD_TYPE=Debug (default is =Release)"
+  echo "    [-r]--relocatable] create a package to support relocatable ROCm"
   echo "    [--cuda] build library for cuda backend"
   echo "    [-p|--cmakepp] addition to CMAKE_PREFIX_PATH"
 }
@@ -215,7 +216,9 @@ install_prefix=hipblas-install
 build_clients=false
 build_cuda=false
 build_release=true
+build_relocatable=false
 cmake_prefix_path=/opt/rocm
+rocm_path=/opt/rocm
 
 # #################################################
 # Parameter parsing
@@ -224,7 +227,7 @@ cmake_prefix_path=/opt/rocm
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,cuda,cmakepp: --options hicdgp: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,cuda,cmakepp,relocatable: --options rhicdgp: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -249,6 +252,9 @@ while true; do
     -d|--dependencies)
         install_dependencies=true
         shift ;;
+    -r|--relocatable)
+        build_relocatable=true
+        shift ;;
     -c|--clients)
         build_clients=true
         shift ;;
@@ -270,6 +276,17 @@ while true; do
         ;;
   esac
 done
+
+if [[ "${build_relocatable}" == true ]]; then
+    if ! [ -z ${ROCM_PATH+x} ]; then
+        rocm_path=${ROCM_PATH}
+    fi
+
+    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
+    if ! [ -z ${ROCM_RPATH+x} ]; then
+        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
+    fi
+fi
 
 build_dir=./build
 printf "\033[32mCreating project build directory in: \033[33m${build_dir}\033[0m\n"
@@ -336,7 +353,15 @@ pushd .
   fi
 
   # Build library
-  CXX=g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" ../..
+  if [[ "${build_relocatable}" == true ]]; then
+    CXX=g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${rocm_path} \
+    -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hcc;${rocm_path}/hip;$(pwd)/../deps/deps-install;${cmake_prefix_path}" \
+    -DCMAKE_SHARED_LINKER_FLAGS=${rocm_rpath} \
+    -DROCM_DISABLE_LDCONFIG=ON \
+    -DROCM_PATH=${rocm_path} ../..
+  else
+    CXX=g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..
+  fi
   make -j$(nproc)
 
   # #################################################


### PR DESCRIPTION
- New mode of building is added "-r,--relocatable" which is used
   for ROCm stack installed in /opt/rocm-ver.
- Below CMAKE parameters are set/overwritten in above mode
   CMAKE_INSTALL_PREFIX
   CMAKE_PREFIX_PATH
   CMAKE_SHARED_LINKER_FLAGS
   ROCM_DISABLE_LDCONFIG
   ROCM_PATH


Signed-off-by: Pruthvi Madugundu <pruthvigithub@gmail.com>
