### PR TITLE
Fixed hipBLAS build failure due to missing gtest include directory

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -35,6 +35,7 @@ if( NOT TARGET hipblas )
 endif( )
 
 find_package( GTest REQUIRED )
+include_directories(${GTEST_INCLUDE_DIRS})
 
 set(hipblas_test_source
   hipblas_gtest_main.cpp


### PR DESCRIPTION
resolves #SWDEV-198086

Summary of proposed changes:
-  add gtest include directory in gtest/CMakeLists.txt
