### PR TITLE
Changing package dependency to rocm-dev

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -59,7 +59,7 @@ add_subdirectory( src )
 
 # Package specific CPACK vars
 set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-dev (>= 2.5.27), rocblas (>= 0.10.3)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "rocm-dev (>= 2.5.27), rocblas >= 0.10.3" )
+set( CPACK_RPM_PACKAGE_REQUIRES "rocm-dev >= 2.5.27, rocblas >= 0.10.3" )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -58,8 +58,8 @@ add_subdirectory( src )
 # endif( )
 
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "hip_hcc (>= 1.3), rocblas (>= 0.10.3)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "hip_hcc >= 1.3, rocblas >= 0.10.3" )
+set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-dev (>= 2.5.27), rocblas (>= 0.10.3)" )
+set( CPACK_RPM_PACKAGE_REQUIRES "rocm-dev (>= 2.5.27), rocblas >= 0.10.3" )
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
 if( NOT CPACK_PACKAGING_INSTALL_PREFIX )


### PR DESCRIPTION
ROCm3.0 is changing the name of hip_hcc to hip-hcc. Changing the dependency to rocm-dev will allow us to support current and future package names.