### PR TITLE
hipComplex -> hipblasComplex, hipDoubleComplex -> hipblasDoubleComplex

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -22,13 +22,13 @@ extern "C" {
 
 void strtri_(char* uplo, char* diag, int* n, float* A, int* lda, int* info);
 void dtrtri_(char* uplo, char* diag, int* n, double* A, int* lda, int* info);
-//  void    ctrtri_(char* uplo, char* diag, int* n, hipComplex* A,  int* lda, int *info);
-//  void    ztrtri_(char* uplo, char* diag, int* n, hipDoubleComplex* A, int* lda, int *info);
+//  void    ctrtri_(char* uplo, char* diag, int* n, hipblasComplex* A,  int* lda, int *info);
+//  void    ztrtri_(char* uplo, char* diag, int* n, hipblasDoubleComplex* A, int* lda, int *info);
 
 void sgetrf_(int* m, int* n, float* A, int* lda, int* ipiv, int* info);
 void dgetrf_(int* m, int* n, double* A, int* lda, int* ipiv, int* info);
-//  void    cgetrf_(int* m, int* n, hipComplex* A, int* lda, int* ipiv, int *info);
-//  void    zgetrf_(int* m, int* n, hipDoubleComplex* A, int* lda, int* ipiv, int *info);
+//  void    cgetrf_(int* m, int* n, hipblasComplex* A, int* lda, int* ipiv, int *info);
+//  void    zgetrf_(int* m, int* n, hipblasDoubleComplex* A, int* lda, int* ipiv, int *info);
 
 void spotrf_(char* uplo, int* m, float* A, int* lda, int* info);
 void dpotrf_(char* uplo, int* m, double* A, int* lda, int* info);
@@ -80,18 +80,18 @@ void cblas_axpy<double>(int n, const double alpha, const double* x, int incx, do
 }
 
 template <>
-void cblas_axpy<hipComplex>(
-    int n, const hipComplex alpha, const hipComplex* x, int incx, hipComplex* y, int incy)
+void cblas_axpy<hipblasComplex>(
+    int n, const hipblasComplex alpha, const hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     cblas_caxpy(n, &alpha, x, incx, y, incy);
 }
 
 template <>
-void cblas_axpy<hipDoubleComplex>(int                     n,
-                                  const hipDoubleComplex  alpha,
-                                  const hipDoubleComplex* x,
+void cblas_axpy<hipblasDoubleComplex>(int                     n,
+                                  const hipblasDoubleComplex  alpha,
+                                  const hipblasDoubleComplex* x,
                                   int                     incx,
-                                  hipDoubleComplex*       y,
+                                  hipblasDoubleComplex*       y,
                                   int                     incy)
 {
     cblas_zaxpy(n, &alpha, x, incx, y, incy);
@@ -111,28 +111,28 @@ void cblas_scal<double>(int n, const double alpha, double* x, int incx)
 }
 
 template <>
-void cblas_scal<hipComplex>(int n, const hipComplex alpha, hipComplex* x, int incx)
+void cblas_scal<hipblasComplex>(int n, const hipblasComplex alpha, hipblasComplex* x, int incx)
 {
     cblas_cscal(n, &alpha, x, incx);
 }
 
 template <>
-void cblas_scal<hipComplex, float>(int n, const float alpha, hipComplex* x, int incx)
+void cblas_scal<hipblasComplex, float>(int n, const float alpha, hipblasComplex* x, int incx)
 {
     cblas_csscal(n, alpha, x, incx);
 }
 
 template <>
-void cblas_scal<hipDoubleComplex>(int                    n,
-                                  const hipDoubleComplex alpha,
-                                  hipDoubleComplex*      x,
+void cblas_scal<hipblasDoubleComplex>(int                    n,
+                                  const hipblasDoubleComplex alpha,
+                                  hipblasDoubleComplex*      x,
                                   int                    incx)
 {
     cblas_zscal(n, &alpha, x, incx);
 }
 
 template <>
-void cblas_scal<hipDoubleComplex, double>(int n, const double alpha, hipDoubleComplex* x, int incx)
+void cblas_scal<hipblasDoubleComplex, double>(int n, const double alpha, hipblasDoubleComplex* x, int incx)
 {
     cblas_zdscal(n, alpha, x, incx);
 }
@@ -151,14 +151,14 @@ void cblas_copy<double>(int n, double* x, int incx, double* y, int incy)
 }
 
 template <>
-void cblas_copy<hipComplex>(int n, hipComplex* x, int incx, hipComplex* y, int incy)
+void cblas_copy<hipblasComplex>(int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     cblas_ccopy(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_copy<hipDoubleComplex>(
-    int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy)
+void cblas_copy<hipblasDoubleComplex>(
+    int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy)
 {
     cblas_zcopy(n, x, incx, y, incy);
 }
@@ -177,14 +177,14 @@ void cblas_swap<double>(int n, double* x, int incx, double* y, int incy)
 }
 
 template <>
-void cblas_swap<hipComplex>(int n, hipComplex* x, int incx, hipComplex* y, int incy)
+void cblas_swap<hipblasComplex>(int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     cblas_cswap(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_swap<hipDoubleComplex>(
-    int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy)
+void cblas_swap<hipblasDoubleComplex>(
+    int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy)
 {
     cblas_zswap(n, x, incx, y, incy);
 }
@@ -241,37 +241,37 @@ void cblas_dot<double>(int n, const double* x, int incx, const double* y, int in
 }
 
 template <>
-void cblas_dot<hipComplex>(
-    int n, const hipComplex* x, int incx, const hipComplex* y, int incy, hipComplex* result)
+void cblas_dot<hipblasComplex>(
+    int n, const hipblasComplex* x, int incx, const hipblasComplex* y, int incy, hipblasComplex* result)
 {
     cblas_cdotu_sub(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dot<hipDoubleComplex>(int                     n,
-                                 const hipDoubleComplex* x,
+void cblas_dot<hipblasDoubleComplex>(int                     n,
+                                 const hipblasDoubleComplex* x,
                                  int                     incx,
-                                 const hipDoubleComplex* y,
+                                 const hipblasDoubleComplex* y,
                                  int                     incy,
-                                 hipDoubleComplex*       result)
+                                 hipblasDoubleComplex*       result)
 {
     cblas_zdotu_sub(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dotc<hipComplex>(
-    int n, const hipComplex* x, int incx, const hipComplex* y, int incy, hipComplex* result)
+void cblas_dotc<hipblasComplex>(
+    int n, const hipblasComplex* x, int incx, const hipblasComplex* y, int incy, hipblasComplex* result)
 {
     cblas_cdotc_sub(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dotc<hipDoubleComplex>(int                     n,
-                                  const hipDoubleComplex* x,
+void cblas_dotc<hipblasDoubleComplex>(int                     n,
+                                  const hipblasDoubleComplex* x,
                                   int                     incx,
-                                  const hipDoubleComplex* y,
+                                  const hipblasDoubleComplex* y,
                                   int                     incy,
-                                  hipDoubleComplex*       result)
+                                  hipblasDoubleComplex*       result)
 {
     cblas_zdotc_sub(n, x, incx, y, incy, result);
 }
@@ -290,14 +290,14 @@ void cblas_nrm2<double, double>(int n, const double* x, int incx, double* result
 }
 
 template <>
-void cblas_nrm2<hipComplex, float>(int n, const hipComplex* x, int incx, float* result)
+void cblas_nrm2<hipblasComplex, float>(int n, const hipblasComplex* x, int incx, float* result)
 {
     *result = cblas_scnrm2(n, x, incx);
 }
 
 template <>
-void cblas_nrm2<hipDoubleComplex, double>(int                     n,
-                                          const hipDoubleComplex* x,
+void cblas_nrm2<hipblasDoubleComplex, double>(int                     n,
+                                          const hipblasDoubleComplex* x,
                                           int                     incx,
                                           double*                 result)
 {
@@ -310,21 +310,21 @@ void cblas_nrm2<hipDoubleComplex, double>(int                     n,
 // LAPACK fortran library functionality
 extern "C" {
 void crot_(const int*        n,
-           hipComplex*       cx,
+           hipblasComplex*       cx,
            const int*        incx,
-           hipComplex*       cy,
+           hipblasComplex*       cy,
            const int*        incy,
            const float*      c,
-           const hipComplex* s);
+           const hipblasComplex* s);
 void csrot_(const int*   n,
-            hipComplex*  cx,
+            hipblasComplex*  cx,
             const int*   incx,
-            hipComplex*  cy,
+            hipblasComplex*  cy,
             const int*   incy,
             const float* c,
             const float* s);
 
-void crotg_(hipComplex* a, hipComplex* b, float* c, hipComplex* s);
+void crotg_(hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s);
 }
 
 // rot
@@ -341,15 +341,15 @@ void cblas_rot<double>(int n, double* x, int incx, double* y, int incy, double c
 }
 
 template <>
-void cblas_rot<hipComplex, float>(
-    int n, hipComplex* x, int incx, hipComplex* y, int incy, float c, hipComplex s)
+void cblas_rot<hipblasComplex, float>(
+    int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy, float c, hipblasComplex s)
 {
     crot_(&n, x, &incx, y, &incx, &c, &s);
 }
 
 template <>
-void cblas_rot<hipComplex, float, float>(
-    int n, hipComplex* x, int incx, hipComplex* y, int incy, float c, float s)
+void cblas_rot<hipblasComplex, float, float>(
+    int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy, float c, float s)
 {
     csrot_(&n, x, &incx, y, &incx, &c, &s);
 }
@@ -368,7 +368,7 @@ void cblas_rotg<double>(double* a, double* b, double* c, double* s)
 }
 
 template <>
-void cblas_rotg<hipComplex, float>(hipComplex* a, hipComplex* b, float* c, hipComplex* s)
+void cblas_rotg<hipblasComplex, float>(hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s)
 {
     crotg_(a, b, c, s);
 }
@@ -413,14 +413,14 @@ void cblas_asum<double, double>(int n, const double* x, int incx, double* result
 }
 
 template <>
-void cblas_asum<hipComplex, float>(int n, const hipComplex* x, int incx, float* result)
+void cblas_asum<hipblasComplex, float>(int n, const hipblasComplex* x, int incx, float* result)
 {
     *result = cblas_scasum(n, x, incx);
 }
 
 template <>
-void cblas_asum<hipDoubleComplex, double>(int                     n,
-                                          const hipDoubleComplex* x,
+void cblas_asum<hipblasDoubleComplex, double>(int                     n,
+                                          const hipblasDoubleComplex* x,
                                           int                     incx,
                                           double*                 result)
 {
@@ -441,13 +441,13 @@ void cblas_iamax<double>(int n, const double* x, int incx, int* result)
 }
 
 template <>
-void cblas_iamax<hipComplex>(int n, const hipComplex* x, int incx, int* result)
+void cblas_iamax<hipblasComplex>(int n, const hipblasComplex* x, int incx, int* result)
 {
     *result = (int)cblas_icamax(n, x, incx);
 }
 
 template <>
-void cblas_iamax<hipDoubleComplex>(int n, const hipDoubleComplex* x, int incx, int* result)
+void cblas_iamax<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     *result = (int)cblas_izamax(n, x, incx);
 }
@@ -461,13 +461,13 @@ double abs_helper(T val)
 }
 
 template <>
-double abs_helper(hipComplex val)
+double abs_helper(hipblasComplex val)
 {
     return std::abs(val.x) + std::abs(val.y);
 }
 
 template <>
-double abs_helper(hipDoubleComplex val)
+double abs_helper(hipblasDoubleComplex val)
 {
     return std::abs(val.x) + std::abs(val.y);
 }
@@ -506,13 +506,13 @@ void cblas_iamin<double>(int n, const double* x, int incx, int* result)
 }
 
 template <>
-void cblas_iamin<hipComplex>(int n, const hipComplex* x, int incx, int* result)
+void cblas_iamin<hipblasComplex>(int n, const hipblasComplex* x, int incx, int* result)
 {
     *result = (int)cblas_iamin_helper(n, x, incx);
 }
 
 template <>
-void cblas_iamin<hipDoubleComplex>(int n, const hipDoubleComplex* x, int incx, int* result)
+void cblas_iamin<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     *result = (int)cblas_iamin_helper(n, x, incx);
 }
@@ -559,16 +559,16 @@ void cblas_gemv<double>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemv<hipComplex>(hipblasOperation_t transA,
+void cblas_gemv<hipblasComplex>(hipblasOperation_t transA,
                             int                m,
                             int                n,
-                            hipComplex         alpha,
-                            hipComplex*        A,
+                            hipblasComplex         alpha,
+                            hipblasComplex*        A,
                             int                lda,
-                            hipComplex*        x,
+                            hipblasComplex*        x,
                             int                incx,
-                            hipComplex         beta,
-                            hipComplex*        y,
+                            hipblasComplex         beta,
+                            hipblasComplex*        y,
                             int                incy)
 {
     cblas_cgemv(
@@ -576,16 +576,16 @@ void cblas_gemv<hipComplex>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemv<hipDoubleComplex>(hipblasOperation_t transA,
+void cblas_gemv<hipblasDoubleComplex>(hipblasOperation_t transA,
                                   int                m,
                                   int                n,
-                                  hipDoubleComplex   alpha,
-                                  hipDoubleComplex*  A,
+                                  hipblasDoubleComplex   alpha,
+                                  hipblasDoubleComplex*  A,
                                   int                lda,
-                                  hipDoubleComplex*  x,
+                                  hipblasDoubleComplex*  x,
                                   int                incx,
-                                  hipDoubleComplex   beta,
-                                  hipDoubleComplex*  y,
+                                  hipblasDoubleComplex   beta,
+                                  hipblasDoubleComplex*  y,
                                   int                incy)
 {
     cblas_zgemv(
@@ -624,21 +624,21 @@ void cblas_symv<double>(hipblasFillMode_t uplo,
 }
 
 //  template<>
-//  void cblas_hemv<hipComplex>(hipblasFillMode_t uplo, int n,
-//                          hipComplex alpha,
-//                          hipComplex *A, int lda,
-//                          hipComplex *x, int incx,
-//                          hipComplex beta, hipComplex *y, int incy)
+//  void cblas_hemv<hipblasComplex>(hipblasFillMode_t uplo, int n,
+//                          hipblasComplex alpha,
+//                          hipblasComplex *A, int lda,
+//                          hipblasComplex *x, int incx,
+//                          hipblasComplex beta, hipblasComplex *y, int incy)
 //  {
 //      cblas_chemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
 //  }
 
 //  template<>
-//  void cblas_hemv<hipDoubleComplex>(hipblasFillMode_t uplo, int n,
-//                          hipDoubleComplex alpha,
-//                          hipDoubleComplex *A, int lda,
-//                          hipDoubleComplex *x, int incx,
-//                          hipDoubleComplex beta, hipDoubleComplex *y, int incy)
+//  void cblas_hemv<hipblasDoubleComplex>(hipblasFillMode_t uplo, int n,
+//                          hipblasDoubleComplex alpha,
+//                          hipblasDoubleComplex *A, int lda,
+//                          hipblasDoubleComplex *x, int incx,
+//                          hipblasDoubleComplex beta, hipblasDoubleComplex *y, int incy)
 //  {
 //      cblas_zhemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
 //  }
@@ -914,18 +914,18 @@ void cblas_gemm<double>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<hipComplex>(hipblasOperation_t transA,
+void cblas_gemm<hipblasComplex>(hipblasOperation_t transA,
                             hipblasOperation_t transB,
                             int                m,
                             int                n,
                             int                k,
-                            hipComplex         alpha,
-                            hipComplex*        A,
+                            hipblasComplex         alpha,
+                            hipblasComplex*        A,
                             int                lda,
-                            hipComplex*        B,
+                            hipblasComplex*        B,
                             int                ldb,
-                            hipComplex         beta,
-                            hipComplex*        C,
+                            hipblasComplex         beta,
+                            hipblasComplex*        C,
                             int                ldc)
 {
     //just directly cast, since transA, transB are integers in the enum
@@ -946,18 +946,18 @@ void cblas_gemm<hipComplex>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<hipDoubleComplex>(hipblasOperation_t transA,
+void cblas_gemm<hipblasDoubleComplex>(hipblasOperation_t transA,
                                   hipblasOperation_t transB,
                                   int                m,
                                   int                n,
                                   int                k,
-                                  hipDoubleComplex   alpha,
-                                  hipDoubleComplex*  A,
+                                  hipblasDoubleComplex   alpha,
+                                  hipblasDoubleComplex*  A,
                                   int                lda,
-                                  hipDoubleComplex*  B,
+                                  hipblasDoubleComplex*  B,
                                   int                ldb,
-                                  hipDoubleComplex   beta,
-                                  hipDoubleComplex*  C,
+                                  hipblasDoubleComplex   beta,
+                                  hipblasDoubleComplex*  C,
                                   int                ldc)
 {
     cblas_zgemm(CblasColMajor,
@@ -1034,12 +1034,12 @@ void cblas_trsm<double>(hipblasSideMode_t  side,
 }
 
 //  template<>
-//  void cblas_trsm<hipComplex>( hipblasSideMode_t side, hipblasFillMode_t uplo,
+//  void cblas_trsm<hipblasComplex>( hipblasSideMode_t side, hipblasFillMode_t uplo,
 //                          hipblasOperation_t transA, hipblasDiagType_t diag,
 //                          int m, int n,
-//                          hipComplex alpha,
-//                          const hipComplex *A, int lda,
-//                          hipComplex *B, int ldb)
+//                          hipblasComplex alpha,
+//                          const hipblasComplex *A, int lda,
+//                          hipblasComplex *B, int ldb)
 //  {
 //      //just directly cast, since transA, transB are integers in the enum
 //      cblas_ctrsm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA,
@@ -1047,12 +1047,12 @@ void cblas_trsm<double>(hipblasSideMode_t  side,
 //  }
 
 //  template<>
-//  void cblas_trsm<hipDoubleComplex>( hipblasSideMode_t side, hipblasFillMode_t uplo,
+//  void cblas_trsm<hipblasDoubleComplex>( hipblasSideMode_t side, hipblasFillMode_t uplo,
 //                          hipblasOperation_t transA, hipblasDiagType_t diag,
 //                          int m, int n,
-//                          hipDoubleComplex alpha,
-//                          const hipDoubleComplex *A, int lda,
-//                          hipDoubleComplex *B, int ldb)
+//                          hipblasDoubleComplex alpha,
+//                          const hipblasDoubleComplex *A, int lda,
+//                          hipblasDoubleComplex *B, int ldb)
 //  {
 //      //just directly cast, since transA, transB are integers in the enum
 //      cblas_ztrsm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA,
@@ -1138,12 +1138,12 @@ void cblas_trmm<double>(hipblasSideMode_t  side,
 }
 
 //  template<>
-//  void cblas_trmm<hipComplex>( hipblasSideMode_t side, hipblasFillMode_t uplo,
+//  void cblas_trmm<hipblasComplex>( hipblasSideMode_t side, hipblasFillMode_t uplo,
 //                          hipblasOperation_t transA, hipblasDiagType_t diag,
 //                          int m, int n,
-//                          hipComplex alpha,
-//                          const hipComplex *A, int lda,
-//                          hipComplex *B, int ldb)
+//                          hipblasComplex alpha,
+//                          const hipblasComplex *A, int lda,
+//                          hipblasComplex *B, int ldb)
 //  {
 //      //just directly cast, since transA, transB are integers in the enum
 //      cblas_ctrmm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA,
@@ -1151,12 +1151,12 @@ void cblas_trmm<double>(hipblasSideMode_t  side,
 //  }
 
 //  template<>
-//  void cblas_trmm<hipDoubleComplex>( hipblasSideMode_t side, hipblasFillMode_t uplo,
+//  void cblas_trmm<hipblasDoubleComplex>( hipblasSideMode_t side, hipblasFillMode_t uplo,
 //                          hipblasOperation_t transA, hipblasDiagType_t diag,
 //                          int m, int n,
-//                          hipDoubleComplex alpha,
-//                          const hipDoubleComplex *A, int lda,
-//                          hipDoubleComplex *B, int ldb)
+//                          hipblasDoubleComplex alpha,
+//                          const hipblasDoubleComplex *A, int lda,
+//                          hipblasDoubleComplex *B, int ldb)
 //  {
 //      //just directly cast, since transA, transB are integers in the enum
 //      cblas_ztrmm(CblasColMajor, (CBLAS_SIDE)side, (CBLAS_UPLO)uplo, (CBLAS_TRANSPOSE)transA,
@@ -1181,9 +1181,9 @@ int cblas_getrf<double>(int m, int n, double* A, int lda, int* ipiv)
 }
 
 // template<>
-// int cblas_getrf<hipComplex>(int m,
+// int cblas_getrf<hipblasComplex>(int m,
 //                         int n,
-//                         hipComplex *A, int lda,
+//                         hipblasComplex *A, int lda,
 //                         int *ipiv)
 // {
 //     int info;
@@ -1192,9 +1192,9 @@ int cblas_getrf<double>(int m, int n, double* A, int lda, int* ipiv)
 // }
 
 // template<>
-// int cblas_getrf<hipDoubleComplex>(int m,
+// int cblas_getrf<hipblasDoubleComplex>(int m,
 //                         int n,
-//                         hipDoubleComplex *A, int lda,
+//                         hipblasDoubleComplex *A, int lda,
 //                         int *ipiv)
 // {
 //     int info;

--- a/clients/common/flops.cpp
+++ b/clients/common/flops.cpp
@@ -19,12 +19,12 @@
 
 /* \brief floating point counts of GEMV */
 //  template<>
-//  double  gemv_gflop_count<hipComplex>(int m, int n){
+//  double  gemv_gflop_count<hipblasComplex>(int m, int n){
 //      return (double)(8.0 * m * n)/1e9;
 //  }
 
 //  template<>
-//  double  gemv_gflop_count<hipDoubleComplex>(int m, int n){
+//  double  gemv_gflop_count<hipblasDoubleComplex>(int m, int n){
 //      return (double)(8.0 * m * n)/1e9;
 //  }
 
@@ -38,33 +38,33 @@
 
 /* \brief floating point counts of GEMM */
 //  template<>
-//  double  gemm_gflop_count<hipComplex>(int m, int n, int k){
+//  double  gemm_gflop_count<hipblasComplex>(int m, int n, int k){
 //      return (double)(8.0 * m * n * k)/1e9;
 //  }
 
 //  template<>
-//  double  gemm_gflop_count<hipDoubleComplex>(int m, int n, int k){
+//  double  gemm_gflop_count<hipblasDoubleComplex>(int m, int n, int k){
 //      return (double)(8.0 * m * n * k)/1e9;
 //  }
 
 /* \brief floating point counts of TRMM */
 //  template<>
-//  double  trsm_gflop_count<hipComplex>(int m, int n, int k){
+//  double  trsm_gflop_count<hipblasComplex>(int m, int n, int k){
 //      return (double)(4.0 * m * n * (k+1))/1e9;
 //  }
 
 //  template<>
-//  double  trsm_gflop_count<hipDoubleComplex>(int m, int n, int k){
+//  double  trsm_gflop_count<hipblasDoubleComplex>(int m, int n, int k){
 //      return (double)(4.0 * m * n * (k+1))/1e9;
 //  }
 
 /* \brief floating point counts of TRTRI */
 //  template<>
-//  double  trtri_gflop_count<hipComplex>(int n){
+//  double  trtri_gflop_count<hipblasComplex>(int n){
 //      return (double)(8.0 * n * n * n)/3.0/1e9;
 //  }
 
 //  template<>
-//  double  trtri_gflop_count<hipDoubleComplex>(int n){
+//  double  trtri_gflop_count<hipblasDoubleComplex>(int n){
 //      return (double)(8.0 * n * n * n)/3.0/1e9;
 //  }

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -50,24 +50,24 @@ hipblasStatus_t hipblasAxpy<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasAxpy<hipComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasAxpy<hipblasComplex>(hipblasHandle_t   handle,
                                         int               n,
-                                        const hipComplex* alpha,
-                                        const hipComplex* x,
+                                        const hipblasComplex* alpha,
+                                        const hipblasComplex* x,
                                         int               incx,
-                                        hipComplex*       y,
+                                        hipblasComplex*       y,
                                         int               incy)
 {
     return hipblasCaxpy(handle, n, alpha, x, incx, y, incy);
 }
 
 template <>
-hipblasStatus_t hipblasAxpy<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasAxpy<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                               int                     n,
-                                              const hipDoubleComplex* alpha,
-                                              const hipDoubleComplex* x,
+                                              const hipblasDoubleComplex* alpha,
+                                              const hipblasDoubleComplex* x,
                                               int                     incx,
-                                              hipDoubleComplex*       y,
+                                              hipblasDoubleComplex*       y,
                                               int                     incy)
 {
     return hipblasZaxpy(handle, n, alpha, x, incx, y, incy);
@@ -89,29 +89,29 @@ hipblasStatus_t
 }
 
 template <>
-hipblasStatus_t hipblasScal<hipComplex>(
-    hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx)
+hipblasStatus_t hipblasScal<hipblasComplex>(
+    hipblasHandle_t handle, int n, const hipblasComplex* alpha, hipblasComplex* x, int incx)
 {
     return hipblasCscal(handle, n, alpha, x, incx);
 }
 
 template <>
-hipblasStatus_t hipblasScal<hipComplex, float>(
-    hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx)
+hipblasStatus_t hipblasScal<hipblasComplex, float>(
+    hipblasHandle_t handle, int n, const float* alpha, hipblasComplex* x, int incx)
 {
     return hipblasCsscal(handle, n, alpha, x, incx);
 }
 
 template <>
-hipblasStatus_t hipblasScal<hipDoubleComplex>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx)
+hipblasStatus_t hipblasScal<hipblasDoubleComplex>(
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* alpha, hipblasDoubleComplex* x, int incx)
 {
     return hipblasZscal(handle, n, alpha, x, incx);
 }
 
 template <>
-hipblasStatus_t hipblasScal<hipDoubleComplex, double>(
-    hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx)
+hipblasStatus_t hipblasScal<hipblasDoubleComplex, double>(
+    hipblasHandle_t handle, int n, const double* alpha, hipblasDoubleComplex* x, int incx)
 {
     return hipblasZdscal(handle, n, alpha, x, incx);
 }
@@ -136,10 +136,10 @@ hipblasStatus_t hipblasScalBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasScalBatched<hipComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasScalBatched<hipblasComplex>(hipblasHandle_t   handle,
                                                int               n,
-                                               const hipComplex* alpha,
-                                               hipComplex* const x[],
+                                               const hipblasComplex* alpha,
+                                               hipblasComplex* const x[],
                                                int               incx,
                                                int               batch_count)
 {
@@ -147,10 +147,10 @@ hipblasStatus_t hipblasScalBatched<hipComplex>(hipblasHandle_t   handle,
 }
 
 template <>
-hipblasStatus_t hipblasScalBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasScalBatched<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                                      int                     n,
-                                                     const hipDoubleComplex* alpha,
-                                                     hipDoubleComplex* const x[],
+                                                     const hipblasDoubleComplex* alpha,
+                                                     hipblasDoubleComplex* const x[],
                                                      int                     incx,
                                                      int                     batch_count)
 {
@@ -158,10 +158,10 @@ hipblasStatus_t hipblasScalBatched<hipDoubleComplex>(hipblasHandle_t         han
 }
 
 template <>
-hipblasStatus_t hipblasScalBatched<hipComplex, float>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasScalBatched<hipblasComplex, float>(hipblasHandle_t   handle,
                                                       int               n,
                                                       const float*      alpha,
-                                                      hipComplex* const x[],
+                                                      hipblasComplex* const x[],
                                                       int               incx,
                                                       int               batch_count)
 {
@@ -169,10 +169,10 @@ hipblasStatus_t hipblasScalBatched<hipComplex, float>(hipblasHandle_t   handle,
 }
 
 template <>
-hipblasStatus_t hipblasScalBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasScalBatched<hipblasDoubleComplex, double>(hipblasHandle_t         handle,
                                                              int                     n,
                                                              const double*           alpha,
-                                                             hipDoubleComplex* const x[],
+                                                             hipblasDoubleComplex* const x[],
                                                              int                     incx,
                                                              int                     batch_count)
 {
@@ -205,10 +205,10 @@ hipblasStatus_t hipblasScalStridedBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasScalStridedBatched<hipComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasScalStridedBatched<hipblasComplex>(hipblasHandle_t   handle,
                                                       int               n,
-                                                      const hipComplex* alpha,
-                                                      hipComplex*       x,
+                                                      const hipblasComplex* alpha,
+                                                      hipblasComplex*       x,
                                                       int               incx,
                                                       int               stridex,
                                                       int               batch_count)
@@ -217,10 +217,10 @@ hipblasStatus_t hipblasScalStridedBatched<hipComplex>(hipblasHandle_t   handle,
 }
 
 template <>
-hipblasStatus_t hipblasScalStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasScalStridedBatched<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                                             int                     n,
-                                                            const hipDoubleComplex* alpha,
-                                                            hipDoubleComplex*       x,
+                                                            const hipblasDoubleComplex* alpha,
+                                                            hipblasDoubleComplex*       x,
                                                             int                     incx,
                                                             int                     stridex,
                                                             int                     batch_count)
@@ -229,10 +229,10 @@ hipblasStatus_t hipblasScalStridedBatched<hipDoubleComplex>(hipblasHandle_t     
 }
 
 template <>
-hipblasStatus_t hipblasScalStridedBatched<hipComplex, float>(hipblasHandle_t handle,
+hipblasStatus_t hipblasScalStridedBatched<hipblasComplex, float>(hipblasHandle_t handle,
                                                              int             n,
                                                              const float*    alpha,
-                                                             hipComplex*     x,
+                                                             hipblasComplex*     x,
                                                              int             incx,
                                                              int             stridex,
                                                              int             batch_count)
@@ -241,10 +241,10 @@ hipblasStatus_t hipblasScalStridedBatched<hipComplex, float>(hipblasHandle_t han
 }
 
 template <>
-hipblasStatus_t hipblasScalStridedBatched<hipDoubleComplex, double>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasScalStridedBatched<hipblasDoubleComplex, double>(hipblasHandle_t   handle,
                                                                     int               n,
                                                                     const double*     alpha,
-                                                                    hipDoubleComplex* x,
+                                                                    hipblasDoubleComplex* x,
                                                                     int               incx,
                                                                     int               stridex,
                                                                     int               batch_count)
@@ -268,15 +268,15 @@ hipblasStatus_t
 }
 
 template <>
-hipblasStatus_t hipblasSwap<hipComplex>(
-    hipblasHandle_t handle, int n, hipComplex* x, int incx, hipComplex* y, int incy)
+hipblasStatus_t hipblasSwap<hipblasComplex>(
+    hipblasHandle_t handle, int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     return hipblasCswap(handle, n, x, incx, y, incy);
 }
 
 template <>
-hipblasStatus_t hipblasSwap<hipDoubleComplex>(
-    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy)
+hipblasStatus_t hipblasSwap<hipblasDoubleComplex>(
+    hipblasHandle_t handle, int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy)
 {
     return hipblasZswap(handle, n, x, incx, y, incy);
 }
@@ -297,11 +297,11 @@ hipblasStatus_t hipblasSwapBatched<double>(
 }
 
 template <>
-hipblasStatus_t hipblasSwapBatched<hipComplex>(hipblasHandle_t handle,
+hipblasStatus_t hipblasSwapBatched<hipblasComplex>(hipblasHandle_t handle,
                                                int             n,
-                                               hipComplex*     x[],
+                                               hipblasComplex*     x[],
                                                int             incx,
-                                               hipComplex*     y[],
+                                               hipblasComplex*     y[],
                                                int             incy,
                                                int             batch_count)
 {
@@ -309,11 +309,11 @@ hipblasStatus_t hipblasSwapBatched<hipComplex>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasSwapBatched<hipDoubleComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasSwapBatched<hipblasDoubleComplex>(hipblasHandle_t   handle,
                                                      int               n,
-                                                     hipDoubleComplex* x[],
+                                                     hipblasDoubleComplex* x[],
                                                      int               incx,
-                                                     hipDoubleComplex* y[],
+                                                     hipblasDoubleComplex* y[],
                                                      int               incy,
                                                      int               batch_count)
 {
@@ -350,12 +350,12 @@ hipblasStatus_t hipblasSwapStridedBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasSwapStridedBatched<hipComplex>(hipblasHandle_t handle,
+hipblasStatus_t hipblasSwapStridedBatched<hipblasComplex>(hipblasHandle_t handle,
                                                       int             n,
-                                                      hipComplex*     x,
+                                                      hipblasComplex*     x,
                                                       int             incx,
                                                       int             stridex,
-                                                      hipComplex*     y,
+                                                      hipblasComplex*     y,
                                                       int             incy,
                                                       int             stridey,
                                                       int             batch_count)
@@ -364,12 +364,12 @@ hipblasStatus_t hipblasSwapStridedBatched<hipComplex>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasSwapStridedBatched<hipDoubleComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasSwapStridedBatched<hipblasDoubleComplex>(hipblasHandle_t   handle,
                                                             int               n,
-                                                            hipDoubleComplex* x,
+                                                            hipblasDoubleComplex* x,
                                                             int               incx,
                                                             int               stridex,
-                                                            hipDoubleComplex* y,
+                                                            hipblasDoubleComplex* y,
                                                             int               incy,
                                                             int               stridey,
                                                             int               batch_count)
@@ -393,18 +393,18 @@ hipblasStatus_t hipblasCopy<double>(
 }
 
 template <>
-hipblasStatus_t hipblasCopy<hipComplex>(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, hipComplex* y, int incy)
+hipblasStatus_t hipblasCopy<hipblasComplex>(
+    hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     return hipblasCcopy(handle, n, x, incx, y, incy);
 }
 
 template <>
-hipblasStatus_t hipblasCopy<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasCopy<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                               int                     n,
-                                              const hipDoubleComplex* x,
+                                              const hipblasDoubleComplex* x,
                                               int                     incx,
-                                              hipDoubleComplex*       y,
+                                              hipblasDoubleComplex*       y,
                                               int                     incy)
 {
     return hipblasZcopy(handle, n, x, incx, y, incy);
@@ -436,11 +436,11 @@ hipblasStatus_t hipblasCopyBatched<double>(hipblasHandle_t     handle,
 }
 
 template <>
-hipblasStatus_t hipblasCopyBatched<hipComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasCopyBatched<hipblasComplex>(hipblasHandle_t         handle,
                                                int                     n,
-                                               const hipComplex* const x[],
+                                               const hipblasComplex* const x[],
                                                int                     incx,
-                                               hipComplex* const       y[],
+                                               hipblasComplex* const       y[],
                                                int                     incy,
                                                int                     batch_count)
 {
@@ -448,11 +448,11 @@ hipblasStatus_t hipblasCopyBatched<hipComplex>(hipblasHandle_t         handle,
 }
 
 template <>
-hipblasStatus_t hipblasCopyBatched<hipDoubleComplex>(hipblasHandle_t               handle,
+hipblasStatus_t hipblasCopyBatched<hipblasDoubleComplex>(hipblasHandle_t               handle,
                                                      int                           n,
-                                                     const hipDoubleComplex* const x[],
+                                                     const hipblasDoubleComplex* const x[],
                                                      int                           incx,
-                                                     hipDoubleComplex* const       y[],
+                                                     hipblasDoubleComplex* const       y[],
                                                      int                           incy,
                                                      int                           batch_count)
 {
@@ -489,12 +489,12 @@ hipblasStatus_t hipblasCopyStridedBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasCopyStridedBatched<hipComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasCopyStridedBatched<hipblasComplex>(hipblasHandle_t   handle,
                                                       int               n,
-                                                      const hipComplex* x,
+                                                      const hipblasComplex* x,
                                                       int               incx,
                                                       int               stridex,
-                                                      hipComplex*       y,
+                                                      hipblasComplex*       y,
                                                       int               incy,
                                                       int               stridey,
                                                       int               batch_count)
@@ -503,12 +503,12 @@ hipblasStatus_t hipblasCopyStridedBatched<hipComplex>(hipblasHandle_t   handle,
 }
 
 template <>
-hipblasStatus_t hipblasCopyStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasCopyStridedBatched<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                                             int                     n,
-                                                            const hipDoubleComplex* x,
+                                                            const hipblasDoubleComplex* x,
                                                             int                     incx,
                                                             int                     stridex,
-                                                            hipDoubleComplex*       y,
+                                                            hipblasDoubleComplex*       y,
                                                             int                     incy,
                                                             int                     stridey,
                                                             int                     batch_count)
@@ -566,49 +566,49 @@ hipblasStatus_t hipblasDot<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasDot<hipComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasDot<hipblasComplex>(hipblasHandle_t   handle,
                                        int               n,
-                                       const hipComplex* x,
+                                       const hipblasComplex* x,
                                        int               incx,
-                                       const hipComplex* y,
+                                       const hipblasComplex* y,
                                        int               incy,
-                                       hipComplex*       result)
+                                       hipblasComplex*       result)
 {
     return hipblasCdotu(handle, n, x, incx, y, incy, result);
 }
 
 template <>
-hipblasStatus_t hipblasDot<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasDot<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                              int                     n,
-                                             const hipDoubleComplex* x,
+                                             const hipblasDoubleComplex* x,
                                              int                     incx,
-                                             const hipDoubleComplex* y,
+                                             const hipblasDoubleComplex* y,
                                              int                     incy,
-                                             hipDoubleComplex*       result)
+                                             hipblasDoubleComplex*       result)
 {
     return hipblasZdotu(handle, n, x, incx, y, incy, result);
 }
 
 template <>
-hipblasStatus_t hipblasDotc<hipComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasDotc<hipblasComplex>(hipblasHandle_t   handle,
                                         int               n,
-                                        const hipComplex* x,
+                                        const hipblasComplex* x,
                                         int               incx,
-                                        const hipComplex* y,
+                                        const hipblasComplex* y,
                                         int               incy,
-                                        hipComplex*       result)
+                                        hipblasComplex*       result)
 {
     return hipblasCdotc(handle, n, x, incx, y, incy, result);
 }
 
 template <>
-hipblasStatus_t hipblasDotc<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasDotc<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                               int                     n,
-                                              const hipDoubleComplex* x,
+                                              const hipblasDoubleComplex* x,
                                               int                     incx,
-                                              const hipDoubleComplex* y,
+                                              const hipblasDoubleComplex* y,
                                               int                     incy,
-                                              hipDoubleComplex*       result)
+                                              hipblasDoubleComplex*       result)
 {
     return hipblasZdotc(handle, n, x, incx, y, incy, result);
 }
@@ -667,53 +667,53 @@ hipblasStatus_t hipblasDotBatched<double>(hipblasHandle_t     handle,
 }
 
 template <>
-hipblasStatus_t hipblasDotBatched<hipComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasDotBatched<hipblasComplex>(hipblasHandle_t         handle,
                                               int                     n,
-                                              const hipComplex* const x[],
+                                              const hipblasComplex* const x[],
                                               int                     incx,
-                                              const hipComplex* const y[],
+                                              const hipblasComplex* const y[],
                                               int                     incy,
                                               int                     batch_count,
-                                              hipComplex*             result)
+                                              hipblasComplex*             result)
 {
     return hipblasCdotuBatched(handle, n, x, incx, y, incy, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasDotcBatched<hipComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasDotcBatched<hipblasComplex>(hipblasHandle_t         handle,
                                                int                     n,
-                                               const hipComplex* const x[],
+                                               const hipblasComplex* const x[],
                                                int                     incx,
-                                               const hipComplex* const y[],
+                                               const hipblasComplex* const y[],
                                                int                     incy,
                                                int                     batch_count,
-                                               hipComplex*             result)
+                                               hipblasComplex*             result)
 {
     return hipblasCdotcBatched(handle, n, x, incx, y, incy, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasDotBatched<hipDoubleComplex>(hipblasHandle_t               handle,
+hipblasStatus_t hipblasDotBatched<hipblasDoubleComplex>(hipblasHandle_t               handle,
                                                     int                           n,
-                                                    const hipDoubleComplex* const x[],
+                                                    const hipblasDoubleComplex* const x[],
                                                     int                           incx,
-                                                    const hipDoubleComplex* const y[],
+                                                    const hipblasDoubleComplex* const y[],
                                                     int                           incy,
                                                     int                           batch_count,
-                                                    hipDoubleComplex*             result)
+                                                    hipblasDoubleComplex*             result)
 {
     return hipblasZdotuBatched(handle, n, x, incx, y, incy, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasDotcBatched<hipDoubleComplex>(hipblasHandle_t               handle,
+hipblasStatus_t hipblasDotcBatched<hipblasDoubleComplex>(hipblasHandle_t               handle,
                                                      int                           n,
-                                                     const hipDoubleComplex* const x[],
+                                                     const hipblasDoubleComplex* const x[],
                                                      int                           incx,
-                                                     const hipDoubleComplex* const y[],
+                                                     const hipblasDoubleComplex* const y[],
                                                      int                           incy,
                                                      int                           batch_count,
-                                                     hipDoubleComplex*             result)
+                                                     hipblasDoubleComplex*             result)
 {
     return hipblasZdotcBatched(handle, n, x, incx, y, incy, batch_count, result);
 }
@@ -784,64 +784,64 @@ hipblasStatus_t hipblasDotStridedBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasDotStridedBatched<hipComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasDotStridedBatched<hipblasComplex>(hipblasHandle_t   handle,
                                                      int               n,
-                                                     const hipComplex* x,
+                                                     const hipblasComplex* x,
                                                      int               incx,
                                                      int               stridex,
-                                                     const hipComplex* y,
+                                                     const hipblasComplex* y,
                                                      int               incy,
                                                      int               stridey,
                                                      int               batch_count,
-                                                     hipComplex*       result)
+                                                     hipblasComplex*       result)
 {
     return hipblasCdotuStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasDotcStridedBatched<hipComplex>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasDotcStridedBatched<hipblasComplex>(hipblasHandle_t   handle,
                                                       int               n,
-                                                      const hipComplex* x,
+                                                      const hipblasComplex* x,
                                                       int               incx,
                                                       int               stridex,
-                                                      const hipComplex* y,
+                                                      const hipblasComplex* y,
                                                       int               incy,
                                                       int               stridey,
                                                       int               batch_count,
-                                                      hipComplex*       result)
+                                                      hipblasComplex*       result)
 {
     return hipblasCdotcStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasDotStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasDotStridedBatched<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                                            int                     n,
-                                                           const hipDoubleComplex* x,
+                                                           const hipblasDoubleComplex* x,
                                                            int                     incx,
                                                            int                     stridex,
-                                                           const hipDoubleComplex* y,
+                                                           const hipblasDoubleComplex* y,
                                                            int                     incy,
                                                            int                     stridey,
                                                            int                     batch_count,
-                                                           hipDoubleComplex*       result)
+                                                           hipblasDoubleComplex*       result)
 {
     return hipblasZdotuStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
 }
 
 template <>
-hipblasStatus_t hipblasDotcStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasDotcStridedBatched<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                                             int                     n,
-                                                            const hipDoubleComplex* x,
+                                                            const hipblasDoubleComplex* x,
                                                             int                     incx,
                                                             int                     stridex,
-                                                            const hipDoubleComplex* y,
+                                                            const hipblasDoubleComplex* y,
                                                             int                     incy,
                                                             int                     stridey,
                                                             int                     batch_count,
-                                                            hipDoubleComplex*       result)
+                                                            hipblasDoubleComplex*       result)
 {
     return hipblasZdotcStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
@@ -865,16 +865,16 @@ hipblasStatus_t hipblasAsum<double, double>(
 }
 
 template <>
-hipblasStatus_t hipblasAsum<hipComplex, float>(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+hipblasStatus_t hipblasAsum<hipblasComplex, float>(
+    hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
 
     return hipblasScasum(handle, n, x, incx, result);
 }
 
 template <>
-hipblasStatus_t hipblasAsum<hipDoubleComplex, double>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+hipblasStatus_t hipblasAsum<hipblasDoubleComplex, double>(
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
 
     return hipblasDzasum(handle, n, x, incx, result);
@@ -902,9 +902,9 @@ hipblasStatus_t hipblasAsumBatched<double, double>(hipblasHandle_t     handle,
 }
 
 template <>
-hipblasStatus_t hipblasAsumBatched<hipComplex, float>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasAsumBatched<hipblasComplex, float>(hipblasHandle_t         handle,
                                                       int                     n,
-                                                      const hipComplex* const x[],
+                                                      const hipblasComplex* const x[],
                                                       int                     incx,
                                                       int                     batch_count,
                                                       float*                  result)
@@ -914,9 +914,9 @@ hipblasStatus_t hipblasAsumBatched<hipComplex, float>(hipblasHandle_t         ha
 }
 
 template <>
-hipblasStatus_t hipblasAsumBatched<hipDoubleComplex, double>(hipblasHandle_t               handle,
+hipblasStatus_t hipblasAsumBatched<hipblasDoubleComplex, double>(hipblasHandle_t               handle,
                                                              int                           n,
-                                                             const hipDoubleComplex* const x[],
+                                                             const hipblasDoubleComplex* const x[],
                                                              int                           incx,
                                                              int     batch_count,
                                                              double* result)
@@ -953,9 +953,9 @@ hipblasStatus_t hipblasAsumStridedBatched<double, double>(hipblasHandle_t handle
 }
 
 template <>
-hipblasStatus_t hipblasAsumStridedBatched<hipComplex, float>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasAsumStridedBatched<hipblasComplex, float>(hipblasHandle_t   handle,
                                                              int               n,
-                                                             const hipComplex* x,
+                                                             const hipblasComplex* x,
                                                              int               incx,
                                                              int               stridex,
                                                              int               batch_count,
@@ -966,9 +966,9 @@ hipblasStatus_t hipblasAsumStridedBatched<hipComplex, float>(hipblasHandle_t   h
 }
 
 template <>
-hipblasStatus_t hipblasAsumStridedBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasAsumStridedBatched<hipblasDoubleComplex, double>(hipblasHandle_t         handle,
                                                                     int                     n,
-                                                                    const hipDoubleComplex* x,
+                                                                    const hipblasDoubleComplex* x,
                                                                     int                     incx,
                                                                     int                     stridex,
                                                                     int     batch_count,
@@ -996,16 +996,16 @@ hipblasStatus_t hipblasNrm2<double, double>(
 }
 
 template <>
-hipblasStatus_t hipblasNrm2<hipComplex, float>(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+hipblasStatus_t hipblasNrm2<hipblasComplex, float>(
+    hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
 
     return hipblasScnrm2(handle, n, x, incx, result);
 }
 
 template <>
-hipblasStatus_t hipblasNrm2<hipDoubleComplex, double>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+hipblasStatus_t hipblasNrm2<hipblasDoubleComplex, double>(
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
 
     return hipblasDznrm2(handle, n, x, incx, result);
@@ -1033,9 +1033,9 @@ hipblasStatus_t hipblasNrm2Batched<double, double>(hipblasHandle_t     handle,
 }
 
 template <>
-hipblasStatus_t hipblasNrm2Batched<hipComplex, float>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasNrm2Batched<hipblasComplex, float>(hipblasHandle_t         handle,
                                                       int                     n,
-                                                      const hipComplex* const x[],
+                                                      const hipblasComplex* const x[],
                                                       int                     incx,
                                                       int                     batch_count,
                                                       float*                  result)
@@ -1045,9 +1045,9 @@ hipblasStatus_t hipblasNrm2Batched<hipComplex, float>(hipblasHandle_t         ha
 }
 
 template <>
-hipblasStatus_t hipblasNrm2Batched<hipDoubleComplex, double>(hipblasHandle_t               handle,
+hipblasStatus_t hipblasNrm2Batched<hipblasDoubleComplex, double>(hipblasHandle_t               handle,
                                                              int                           n,
-                                                             const hipDoubleComplex* const x[],
+                                                             const hipblasDoubleComplex* const x[],
                                                              int                           incx,
                                                              int     batch_count,
                                                              double* result)
@@ -1084,9 +1084,9 @@ hipblasStatus_t hipblasNrm2StridedBatched<double, double>(hipblasHandle_t handle
 }
 
 template <>
-hipblasStatus_t hipblasNrm2StridedBatched<hipComplex, float>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasNrm2StridedBatched<hipblasComplex, float>(hipblasHandle_t   handle,
                                                              int               n,
-                                                             const hipComplex* x,
+                                                             const hipblasComplex* x,
                                                              int               incx,
                                                              int               stridex,
                                                              int               batch_count,
@@ -1097,9 +1097,9 @@ hipblasStatus_t hipblasNrm2StridedBatched<hipComplex, float>(hipblasHandle_t   h
 }
 
 template <>
-hipblasStatus_t hipblasNrm2StridedBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasNrm2StridedBatched<hipblasDoubleComplex, double>(hipblasHandle_t         handle,
                                                                     int                     n,
-                                                                    const hipDoubleComplex* x,
+                                                                    const hipblasDoubleComplex* x,
                                                                     int                     incx,
                                                                     int                     stridex,
                                                                     int     batch_count,
@@ -1137,24 +1137,24 @@ hipblasStatus_t hipblasRot<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasRot<hipComplex, float>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasRot<hipblasComplex, float>(hipblasHandle_t   handle,
                                               int               n,
-                                              hipComplex*       x,
+                                              hipblasComplex*       x,
                                               int               incx,
-                                              hipComplex*       y,
+                                              hipblasComplex*       y,
                                               int               incy,
                                               const float*      c,
-                                              const hipComplex* s)
+                                              const hipblasComplex* s)
 {
     return hipblasCrot(handle, n, x, incx, y, incy, c, s);
 }
 
 template <>
-hipblasStatus_t hipblasRot<hipComplex, float, float>(hipblasHandle_t handle,
+hipblasStatus_t hipblasRot<hipblasComplex, float, float>(hipblasHandle_t handle,
                                                      int             n,
-                                                     hipComplex*     x,
+                                                     hipblasComplex*     x,
                                                      int             incx,
-                                                     hipComplex*     y,
+                                                     hipblasComplex*     y,
                                                      int             incy,
                                                      const float*    c,
                                                      const float*    s)
@@ -1163,24 +1163,24 @@ hipblasStatus_t hipblasRot<hipComplex, float, float>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasRot<hipDoubleComplex, double>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasRot<hipblasDoubleComplex, double>(hipblasHandle_t         handle,
                                                      int                     n,
-                                                     hipDoubleComplex*       x,
+                                                     hipblasDoubleComplex*       x,
                                                      int                     incx,
-                                                     hipDoubleComplex*       y,
+                                                     hipblasDoubleComplex*       y,
                                                      int                     incy,
                                                      const double*           c,
-                                                     const hipDoubleComplex* s)
+                                                     const hipblasDoubleComplex* s)
 {
     return hipblasZrot(handle, n, x, incx, y, incy, c, s);
 }
 
 template <>
-hipblasStatus_t hipblasRot<hipDoubleComplex, double, double>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasRot<hipblasDoubleComplex, double, double>(hipblasHandle_t   handle,
                                                              int               n,
-                                                             hipDoubleComplex* x,
+                                                             hipblasDoubleComplex* x,
                                                              int               incx,
-                                                             hipDoubleComplex* y,
+                                                             hipblasDoubleComplex* y,
                                                              int               incy,
                                                              const double*     c,
                                                              const double*     s)
@@ -1218,25 +1218,25 @@ hipblasStatus_t hipblasRotBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasRotBatched<hipComplex, float>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasRotBatched<hipblasComplex, float>(hipblasHandle_t   handle,
                                                      int               n,
-                                                     hipComplex* const x[],
+                                                     hipblasComplex* const x[],
                                                      int               incx,
-                                                     hipComplex* const y[],
+                                                     hipblasComplex* const y[],
                                                      int               incy,
                                                      const float*      c,
-                                                     const hipComplex* s,
+                                                     const hipblasComplex* s,
                                                      int               batch_count)
 {
     return hipblasCrotBatched(handle, n, x, incx, y, incy, c, s, batch_count);
 }
 
 template <>
-hipblasStatus_t hipblasRotBatched<hipComplex, float, float>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasRotBatched<hipblasComplex, float, float>(hipblasHandle_t   handle,
                                                             int               n,
-                                                            hipComplex* const x[],
+                                                            hipblasComplex* const x[],
                                                             int               incx,
-                                                            hipComplex* const y[],
+                                                            hipblasComplex* const y[],
                                                             int               incy,
                                                             const float*      c,
                                                             const float*      s,
@@ -1246,25 +1246,25 @@ hipblasStatus_t hipblasRotBatched<hipComplex, float, float>(hipblasHandle_t   ha
 }
 
 template <>
-hipblasStatus_t hipblasRotBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasRotBatched<hipblasDoubleComplex, double>(hipblasHandle_t         handle,
                                                             int                     n,
-                                                            hipDoubleComplex* const x[],
+                                                            hipblasDoubleComplex* const x[],
                                                             int                     incx,
-                                                            hipDoubleComplex* const y[],
+                                                            hipblasDoubleComplex* const y[],
                                                             int                     incy,
                                                             const double*           c,
-                                                            const hipDoubleComplex* s,
+                                                            const hipblasDoubleComplex* s,
                                                             int                     batch_count)
 {
     return hipblasZrotBatched(handle, n, x, incx, y, incy, c, s, batch_count);
 }
 
 template <>
-hipblasStatus_t hipblasRotBatched<hipDoubleComplex, double, double>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasRotBatched<hipblasDoubleComplex, double, double>(hipblasHandle_t         handle,
                                                                     int                     n,
-                                                                    hipDoubleComplex* const x[],
+                                                                    hipblasDoubleComplex* const x[],
                                                                     int                     incx,
-                                                                    hipDoubleComplex* const y[],
+                                                                    hipblasDoubleComplex* const y[],
                                                                     int                     incy,
                                                                     const double*           c,
                                                                     const double*           s,
@@ -1309,16 +1309,16 @@ hipblasStatus_t hipblasRotStridedBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasRotStridedBatched<hipComplex, float>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasRotStridedBatched<hipblasComplex, float>(hipblasHandle_t   handle,
                                                             int               n,
-                                                            hipComplex*       x,
+                                                            hipblasComplex*       x,
                                                             int               incx,
                                                             int               stridex,
-                                                            hipComplex*       y,
+                                                            hipblasComplex*       y,
                                                             int               incy,
                                                             int               stridey,
                                                             const float*      c,
-                                                            const hipComplex* s,
+                                                            const hipblasComplex* s,
                                                             int               batch_count)
 {
     return hipblasCrotStridedBatched(
@@ -1326,12 +1326,12 @@ hipblasStatus_t hipblasRotStridedBatched<hipComplex, float>(hipblasHandle_t   ha
 }
 
 template <>
-hipblasStatus_t hipblasRotStridedBatched<hipComplex, float, float>(hipblasHandle_t handle,
+hipblasStatus_t hipblasRotStridedBatched<hipblasComplex, float, float>(hipblasHandle_t handle,
                                                                    int             n,
-                                                                   hipComplex*     x,
+                                                                   hipblasComplex*     x,
                                                                    int             incx,
                                                                    int             stridex,
-                                                                   hipComplex*     y,
+                                                                   hipblasComplex*     y,
                                                                    int             incy,
                                                                    int             stridey,
                                                                    const float*    c,
@@ -1343,16 +1343,16 @@ hipblasStatus_t hipblasRotStridedBatched<hipComplex, float, float>(hipblasHandle
 }
 
 template <>
-hipblasStatus_t hipblasRotStridedBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasRotStridedBatched<hipblasDoubleComplex, double>(hipblasHandle_t         handle,
                                                                    int                     n,
-                                                                   hipDoubleComplex*       x,
+                                                                   hipblasDoubleComplex*       x,
                                                                    int                     incx,
                                                                    int                     stridex,
-                                                                   hipDoubleComplex*       y,
+                                                                   hipblasDoubleComplex*       y,
                                                                    int                     incy,
                                                                    int                     stridey,
                                                                    const double*           c,
-                                                                   const hipDoubleComplex* s,
+                                                                   const hipblasDoubleComplex* s,
                                                                    int batch_count)
 {
     return hipblasZrotStridedBatched(
@@ -1360,12 +1360,12 @@ hipblasStatus_t hipblasRotStridedBatched<hipDoubleComplex, double>(hipblasHandle
 }
 
 template <>
-hipblasStatus_t hipblasRotStridedBatched<hipDoubleComplex, double, double>(hipblasHandle_t   handle,
+hipblasStatus_t hipblasRotStridedBatched<hipblasDoubleComplex, double, double>(hipblasHandle_t   handle,
                                                                            int               n,
-                                                                           hipDoubleComplex* x,
+                                                                           hipblasDoubleComplex* x,
                                                                            int               incx,
                                                                            int stridex,
-                                                                           hipDoubleComplex* y,
+                                                                           hipblasDoubleComplex* y,
                                                                            int               incy,
                                                                            int           stridey,
                                                                            const double* c,
@@ -1391,18 +1391,18 @@ hipblasStatus_t
 }
 
 template <>
-hipblasStatus_t hipblasRotg<hipComplex, float>(
-    hipblasHandle_t handle, hipComplex* a, hipComplex* b, float* c, hipComplex* s)
+hipblasStatus_t hipblasRotg<hipblasComplex, float>(
+    hipblasHandle_t handle, hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s)
 {
     return hipblasCrotg(handle, a, b, c, s);
 }
 
 template <>
-hipblasStatus_t hipblasRotg<hipDoubleComplex, double>(hipblasHandle_t   handle,
-                                                      hipDoubleComplex* a,
-                                                      hipDoubleComplex* b,
+hipblasStatus_t hipblasRotg<hipblasDoubleComplex, double>(hipblasHandle_t   handle,
+                                                      hipblasDoubleComplex* a,
+                                                      hipblasDoubleComplex* b,
                                                       double*           c,
-                                                      hipDoubleComplex* s)
+                                                      hipblasDoubleComplex* s)
 {
     return hipblasZrotg(handle, a, b, c, s);
 }
@@ -1431,22 +1431,22 @@ hipblasStatus_t hipblasRotgBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasRotgBatched<hipComplex, float>(hipblasHandle_t   handle,
-                                                      hipComplex* const a[],
-                                                      hipComplex* const b[],
+hipblasStatus_t hipblasRotgBatched<hipblasComplex, float>(hipblasHandle_t   handle,
+                                                      hipblasComplex* const a[],
+                                                      hipblasComplex* const b[],
                                                       float* const      c[],
-                                                      hipComplex* const s[],
+                                                      hipblasComplex* const s[],
                                                       int               batch_count)
 {
     return hipblasCrotgBatched(handle, a, b, c, s, batch_count);
 }
 
 template <>
-hipblasStatus_t hipblasRotgBatched<hipDoubleComplex, double>(hipblasHandle_t         handle,
-                                                             hipDoubleComplex* const a[],
-                                                             hipDoubleComplex* const b[],
+hipblasStatus_t hipblasRotgBatched<hipblasDoubleComplex, double>(hipblasHandle_t         handle,
+                                                             hipblasDoubleComplex* const a[],
+                                                             hipblasDoubleComplex* const b[],
                                                              double* const           c[],
-                                                             hipDoubleComplex* const s[],
+                                                             hipblasDoubleComplex* const s[],
                                                              int                     batch_count)
 {
     return hipblasZrotgBatched(handle, a, b, c, s, batch_count);
@@ -1486,14 +1486,14 @@ hipblasStatus_t hipblasRotgStridedBatched<double>(hipblasHandle_t handle,
 }
 
 template <>
-hipblasStatus_t hipblasRotgStridedBatched<hipComplex, float>(hipblasHandle_t handle,
-                                                             hipComplex*     a,
+hipblasStatus_t hipblasRotgStridedBatched<hipblasComplex, float>(hipblasHandle_t handle,
+                                                             hipblasComplex*     a,
                                                              int             stridea,
-                                                             hipComplex*     b,
+                                                             hipblasComplex*     b,
                                                              int             strideb,
                                                              float*          c,
                                                              int             stridec,
-                                                             hipComplex*     s,
+                                                             hipblasComplex*     s,
                                                              int             strides,
                                                              int             batch_count)
 {
@@ -1502,14 +1502,14 @@ hipblasStatus_t hipblasRotgStridedBatched<hipComplex, float>(hipblasHandle_t han
 }
 
 template <>
-hipblasStatus_t hipblasRotgStridedBatched<hipDoubleComplex, double>(hipblasHandle_t   handle,
-                                                                    hipDoubleComplex* a,
+hipblasStatus_t hipblasRotgStridedBatched<hipblasDoubleComplex, double>(hipblasHandle_t   handle,
+                                                                    hipblasDoubleComplex* a,
                                                                     int               stridea,
-                                                                    hipDoubleComplex* b,
+                                                                    hipblasDoubleComplex* b,
                                                                     int               strideb,
                                                                     double*           c,
                                                                     int               stridec,
-                                                                    hipDoubleComplex* s,
+                                                                    hipblasDoubleComplex* s,
                                                                     int               strides,
                                                                     int               batch_count)
 {
@@ -1707,15 +1707,15 @@ hipblasStatus_t
 }
 
 template <>
-hipblasStatus_t hipblasIamax<hipComplex>(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result)
+hipblasStatus_t hipblasIamax<hipblasComplex>(
+    hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result)
 {
     return hipblasIcamax(handle, n, x, incx, result);
 }
 
 template <>
-hipblasStatus_t hipblasIamax<hipDoubleComplex>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result)
+hipblasStatus_t hipblasIamax<hipblasDoubleComplex>(
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     return hipblasIzamax(handle, n, x, incx, result);
 }
@@ -1736,15 +1736,15 @@ hipblasStatus_t
 }
 
 template <>
-hipblasStatus_t hipblasIamin<hipComplex>(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result)
+hipblasStatus_t hipblasIamin<hipblasComplex>(
+    hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result)
 {
     return hipblasIcamin(handle, n, x, incx, result);
 }
 
 template <>
-hipblasStatus_t hipblasIamin<hipDoubleComplex>(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result)
+hipblasStatus_t hipblasIamin<hipblasDoubleComplex>(
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     return hipblasIzamin(handle, n, x, incx, result);
 }
@@ -1791,34 +1791,34 @@ hipblasStatus_t hipblasGemv<double>(hipblasHandle_t    handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemv<hipComplex>(hipblasHandle_t    handle,
+hipblasStatus_t hipblasGemv<hipblasComplex>(hipblasHandle_t    handle,
                                         hipblasOperation_t transA,
                                         int                m,
                                         int                n,
-                                        const hipComplex*  alpha,
-                                        const hipComplex*  A,
+                                        const hipblasComplex*  alpha,
+                                        const hipblasComplex*  A,
                                         int                lda,
-                                        const hipComplex*  x,
+                                        const hipblasComplex*  x,
                                         int                incx,
-                                        const hipComplex*  beta,
-                                        hipComplex*        y,
+                                        const hipblasComplex*  beta,
+                                        hipblasComplex*        y,
                                         int                incy)
 {
     return hipblasCgemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
-hipblasStatus_t hipblasGemv<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasGemv<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                               hipblasOperation_t      transA,
                                               int                     m,
                                               int                     n,
-                                              const hipDoubleComplex* alpha,
-                                              const hipDoubleComplex* A,
+                                              const hipblasDoubleComplex* alpha,
+                                              const hipblasDoubleComplex* A,
                                               int                     lda,
-                                              const hipDoubleComplex* x,
+                                              const hipblasDoubleComplex* x,
                                               int                     incx,
-                                              const hipDoubleComplex* beta,
-                                              hipDoubleComplex*       y,
+                                              const hipblasDoubleComplex* beta,
+                                              hipblasDoubleComplex*       y,
                                               int                     incy)
 {
     return hipblasZgemv(handle, transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
@@ -1864,17 +1864,17 @@ hipblasStatus_t hipblasGemvBatched<double>(hipblasHandle_t     handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemvBatched<hipComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasGemvBatched<hipblasComplex>(hipblasHandle_t         handle,
                                                hipblasOperation_t      transA,
                                                int                     m,
                                                int                     n,
-                                               const hipComplex*       alpha,
-                                               const hipComplex* const A[],
+                                               const hipblasComplex*       alpha,
+                                               const hipblasComplex* const A[],
                                                int                     lda,
-                                               const hipComplex* const x[],
+                                               const hipblasComplex* const x[],
                                                int                     incx,
-                                               const hipComplex*       beta,
-                                               hipComplex* const       y[],
+                                               const hipblasComplex*       beta,
+                                               hipblasComplex* const       y[],
                                                int                     incy,
                                                int                     batch_count)
 {
@@ -1883,17 +1883,17 @@ hipblasStatus_t hipblasGemvBatched<hipComplex>(hipblasHandle_t         handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemvBatched<hipDoubleComplex>(hipblasHandle_t               handle,
+hipblasStatus_t hipblasGemvBatched<hipblasDoubleComplex>(hipblasHandle_t               handle,
                                                      hipblasOperation_t            transA,
                                                      int                           m,
                                                      int                           n,
-                                                     const hipDoubleComplex*       alpha,
-                                                     const hipDoubleComplex* const A[],
+                                                     const hipblasDoubleComplex*       alpha,
+                                                     const hipblasDoubleComplex* const A[],
                                                      int                           lda,
-                                                     const hipDoubleComplex* const x[],
+                                                     const hipblasDoubleComplex* const x[],
                                                      int                           incx,
-                                                     const hipDoubleComplex*       beta,
-                                                     hipDoubleComplex* const       y[],
+                                                     const hipblasDoubleComplex*       beta,
+                                                     hipblasDoubleComplex* const       y[],
                                                      int                           incy,
                                                      int                           batch_count)
 {
@@ -1975,19 +1975,19 @@ hipblasStatus_t hipblasGemvStridedBatched<double>(hipblasHandle_t    handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemvStridedBatched<hipComplex>(hipblasHandle_t    handle,
+hipblasStatus_t hipblasGemvStridedBatched<hipblasComplex>(hipblasHandle_t    handle,
                                                       hipblasOperation_t transA,
                                                       int                m,
                                                       int                n,
-                                                      const hipComplex*  alpha,
-                                                      const hipComplex*  A,
+                                                      const hipblasComplex*  alpha,
+                                                      const hipblasComplex*  A,
                                                       int                lda,
                                                       int                strideA,
-                                                      const hipComplex*  x,
+                                                      const hipblasComplex*  x,
                                                       int                incx,
                                                       int                stridex,
-                                                      const hipComplex*  beta,
-                                                      hipComplex*        y,
+                                                      const hipblasComplex*  beta,
+                                                      hipblasComplex*        y,
                                                       int                incy,
                                                       int                stridey,
                                                       int                batch_count)
@@ -2011,19 +2011,19 @@ hipblasStatus_t hipblasGemvStridedBatched<hipComplex>(hipblasHandle_t    handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemvStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasGemvStridedBatched<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                                             hipblasOperation_t      transA,
                                                             int                     m,
                                                             int                     n,
-                                                            const hipDoubleComplex* alpha,
-                                                            const hipDoubleComplex* A,
+                                                            const hipblasDoubleComplex* alpha,
+                                                            const hipblasDoubleComplex* A,
                                                             int                     lda,
                                                             int                     strideA,
-                                                            const hipDoubleComplex* x,
+                                                            const hipblasDoubleComplex* x,
                                                             int                     incx,
                                                             int                     stridex,
-                                                            const hipDoubleComplex* beta,
-                                                            hipDoubleComplex*       y,
+                                                            const hipblasDoubleComplex* beta,
+                                                            hipblasDoubleComplex*       y,
                                                             int                     incy,
                                                             int                     stridey,
                                                             int                     batch_count)
@@ -2394,38 +2394,38 @@ hipblasStatus_t hipblasGemm<double>(hipblasHandle_t    handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemm<hipComplex>(hipblasHandle_t    handle,
+hipblasStatus_t hipblasGemm<hipblasComplex>(hipblasHandle_t    handle,
                                         hipblasOperation_t transA,
                                         hipblasOperation_t transB,
                                         int                m,
                                         int                n,
                                         int                k,
-                                        const hipComplex*  alpha,
-                                        const hipComplex*  A,
+                                        const hipblasComplex*  alpha,
+                                        const hipblasComplex*  A,
                                         int                lda,
-                                        const hipComplex*  B,
+                                        const hipblasComplex*  B,
                                         int                ldb,
-                                        const hipComplex*  beta,
-                                        hipComplex*        C,
+                                        const hipblasComplex*  beta,
+                                        hipblasComplex*        C,
                                         int                ldc)
 {
     return hipblasCgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 template <>
-hipblasStatus_t hipblasGemm<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasGemm<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                               hipblasOperation_t      transA,
                                               hipblasOperation_t      transB,
                                               int                     m,
                                               int                     n,
                                               int                     k,
-                                              const hipDoubleComplex* alpha,
-                                              const hipDoubleComplex* A,
+                                              const hipblasDoubleComplex* alpha,
+                                              const hipblasDoubleComplex* A,
                                               int                     lda,
-                                              const hipDoubleComplex* B,
+                                              const hipblasDoubleComplex* B,
                                               int                     ldb,
-                                              const hipDoubleComplex* beta,
-                                              hipDoubleComplex*       C,
+                                              const hipblasDoubleComplex* beta,
+                                              hipblasDoubleComplex*       C,
                                               int                     ldc)
 {
     return hipblasZgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
@@ -2496,19 +2496,19 @@ hipblasStatus_t hipblasGemmBatched<double>(hipblasHandle_t     handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemmBatched<hipComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasGemmBatched<hipblasComplex>(hipblasHandle_t         handle,
                                                hipblasOperation_t      transA,
                                                hipblasOperation_t      transB,
                                                int                     m,
                                                int                     n,
                                                int                     k,
-                                               const hipComplex*       alpha,
-                                               const hipComplex* const A[],
+                                               const hipblasComplex*       alpha,
+                                               const hipblasComplex* const A[],
                                                int                     lda,
-                                               const hipComplex* const B[],
+                                               const hipblasComplex* const B[],
                                                int                     ldb,
-                                               const hipComplex*       beta,
-                                               hipComplex* const       C[],
+                                               const hipblasComplex*       beta,
+                                               hipblasComplex* const       C[],
                                                int                     ldc,
                                                int                     batch_count)
 {
@@ -2517,19 +2517,19 @@ hipblasStatus_t hipblasGemmBatched<hipComplex>(hipblasHandle_t         handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemmBatched<hipDoubleComplex>(hipblasHandle_t               handle,
+hipblasStatus_t hipblasGemmBatched<hipblasDoubleComplex>(hipblasHandle_t               handle,
                                                      hipblasOperation_t            transA,
                                                      hipblasOperation_t            transB,
                                                      int                           m,
                                                      int                           n,
                                                      int                           k,
-                                                     const hipDoubleComplex*       alpha,
-                                                     const hipDoubleComplex* const A[],
+                                                     const hipblasDoubleComplex*       alpha,
+                                                     const hipblasDoubleComplex* const A[],
                                                      int                           lda,
-                                                     const hipDoubleComplex* const B[],
+                                                     const hipblasDoubleComplex* const B[],
                                                      int                           ldb,
-                                                     const hipDoubleComplex*       beta,
-                                                     hipDoubleComplex* const       C[],
+                                                     const hipblasDoubleComplex*       beta,
+                                                     hipblasDoubleComplex* const       C[],
                                                      int                           ldc,
                                                      int                           batch_count)
 {
@@ -2662,21 +2662,21 @@ hipblasStatus_t hipblasGemmStridedBatched<double>(hipblasHandle_t    handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemmStridedBatched<hipComplex>(hipblasHandle_t    handle,
+hipblasStatus_t hipblasGemmStridedBatched<hipblasComplex>(hipblasHandle_t    handle,
                                                       hipblasOperation_t transA,
                                                       hipblasOperation_t transB,
                                                       int                m,
                                                       int                n,
                                                       int                k,
-                                                      const hipComplex*  alpha,
-                                                      const hipComplex*  A,
+                                                      const hipblasComplex*  alpha,
+                                                      const hipblasComplex*  A,
                                                       int                lda,
                                                       int                bsa,
-                                                      const hipComplex*  B,
+                                                      const hipblasComplex*  B,
                                                       int                ldb,
                                                       int                bsb,
-                                                      const hipComplex*  beta,
-                                                      hipComplex*        C,
+                                                      const hipblasComplex*  beta,
+                                                      hipblasComplex*        C,
                                                       int                ldc,
                                                       int                bsc,
                                                       int                batch_count)
@@ -2703,21 +2703,21 @@ hipblasStatus_t hipblasGemmStridedBatched<hipComplex>(hipblasHandle_t    handle,
 }
 
 template <>
-hipblasStatus_t hipblasGemmStridedBatched<hipDoubleComplex>(hipblasHandle_t         handle,
+hipblasStatus_t hipblasGemmStridedBatched<hipblasDoubleComplex>(hipblasHandle_t         handle,
                                                             hipblasOperation_t      transA,
                                                             hipblasOperation_t      transB,
                                                             int                     m,
                                                             int                     n,
                                                             int                     k,
-                                                            const hipDoubleComplex* alpha,
-                                                            const hipDoubleComplex* A,
+                                                            const hipblasDoubleComplex* alpha,
+                                                            const hipblasDoubleComplex* A,
                                                             int                     lda,
                                                             int                     bsa,
-                                                            const hipDoubleComplex* B,
+                                                            const hipblasDoubleComplex* B,
                                                             int                     ldb,
                                                             int                     bsb,
-                                                            const hipDoubleComplex* beta,
-                                                            hipDoubleComplex*       C,
+                                                            const hipblasDoubleComplex* beta,
+                                                            hipblasDoubleComplex*       C,
                                                             int                     ldc,
                                                             int                     bsc,
                                                             int                     batch_count)

--- a/clients/common/near.cpp
+++ b/clients/common/near.cpp
@@ -79,7 +79,7 @@ void near_check_general(
 }
 
 template <>
-void near_check_general(int M, int N, int lda, hipComplex* hCPU, hipComplex* hGPU, double abs_error)
+void near_check_general(int M, int N, int lda, hipblasComplex* hCPU, hipblasComplex* hGPU, double abs_error)
 {
     abs_error *= sqrthalf;
     NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
@@ -87,7 +87,7 @@ void near_check_general(int M, int N, int lda, hipComplex* hCPU, hipComplex* hGP
 
 template <>
 void near_check_general(
-    int M, int N, int lda, hipDoubleComplex* hCPU, hipDoubleComplex* hGPU, double abs_error)
+    int M, int N, int lda, hipblasDoubleComplex* hCPU, hipblasDoubleComplex* hGPU, double abs_error)
 {
     abs_error *= sqrthalf;
     NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
@@ -132,8 +132,8 @@ void near_check_general(int         M,
                         int         batch_count,
                         int         lda,
                         int         strideA,
-                        hipComplex* hCPU,
-                        hipComplex* hGPU,
+                        hipblasComplex* hCPU,
+                        hipblasComplex* hGPU,
                         double      abs_error)
 {
     abs_error *= sqrthalf;
@@ -146,8 +146,8 @@ void near_check_general(int               M,
                         int               batch_count,
                         int               lda,
                         int               strideA,
-                        hipDoubleComplex* hCPU,
-                        hipDoubleComplex* hGPU,
+                        hipblasDoubleComplex* hCPU,
+                        hipblasDoubleComplex* hGPU,
                         double            abs_error)
 {
     abs_error *= sqrthalf;
@@ -195,8 +195,8 @@ void near_check_general(int                     M,
                         int                     N,
                         int                     batch_count,
                         int                     lda,
-                        host_vector<hipComplex> hCPU[],
-                        host_vector<hipComplex> hGPU[],
+                        host_vector<hipblasComplex> hCPU[],
+                        host_vector<hipblasComplex> hGPU[],
                         double                  abs_error)
 {
     abs_error *= sqrthalf;
@@ -208,8 +208,8 @@ void near_check_general(int                           M,
                         int                           N,
                         int                           batch_count,
                         int                           lda,
-                        host_vector<hipDoubleComplex> hCPU[],
-                        host_vector<hipDoubleComplex> hGPU[],
+                        host_vector<hipblasDoubleComplex> hCPU[],
+                        host_vector<hipblasDoubleComplex> hGPU[],
                         double                        abs_error)
 {
     abs_error *= sqrthalf;

--- a/clients/common/norm.cpp
+++ b/clients/common/norm.cpp
@@ -27,19 +27,19 @@ extern "C" {
 
 float  slange_(char* norm_type, int* m, int* n, float* A, int* lda, float* work);
 double dlange_(char* norm_type, int* m, int* n, double* A, int* lda, double* work);
-//  float  clange_(char* norm_type, int* m, int* n, hipComplex* A, int* lda, float* work);
-//  double zlange_(char* norm_type, int* m, int* n, hipDoubleComplex* A, int* lda, double* work);
+//  float  clange_(char* norm_type, int* m, int* n, hipblasComplex* A, int* lda, float* work);
+//  double zlange_(char* norm_type, int* m, int* n, hipblasDoubleComplex* A, int* lda, double* work);
 
 float  slansy_(char* norm_type, char* uplo, int* n, float* A, int* lda, float* work);
 double dlansy_(char* norm_type, char* uplo, int* n, double* A, int* lda, double* work);
-//  float  clanhe_(char* norm_type, char* uplo, int* n, hipComplex* A, int* lda, float* work);
-//  double zlanhe_(char* norm_type, char* uplo, int* n, hipDoubleComplex* A, int* lda, double*
+//  float  clanhe_(char* norm_type, char* uplo, int* n, hipblasComplex* A, int* lda, float* work);
+//  double zlanhe_(char* norm_type, char* uplo, int* n, hipblasDoubleComplex* A, int* lda, double*
 //  work);
 
 void saxpy_(int* n, float* alpha, float* x, int* incx, float* y, int* incy);
 void daxpy_(int* n, double* alpha, double* x, int* incx, double* y, int* incy);
-//  void   caxpy_(int* n, float* alpha, hipComplex* x, int* incx, hipComplex* y, int* incy);
-//  void   zaxpy_(int* n, double* alpha, hipDoubleComplex* x, int* incx, hipDoubleComplex* y, int*
+//  void   caxpy_(int* n, float* alpha, hipblasComplex* x, int* incx, hipblasComplex* y, int* incy);
+//  void   zaxpy_(int* n, double* alpha, hipblasDoubleComplex* x, int* incx, hipblasDoubleComplex* y, int*
 //  incy);
 
 #ifdef __cplusplus
@@ -87,8 +87,8 @@ double norm_check_general<double>(char norm_type, int M, int N, int lda, double*
 }
 
 // template<>
-// double norm_check_general<hipComplex>(char norm_type, int M, int N, int lda, hipComplex *hCPU,
-// hipComplex *hGPU)
+// double norm_check_general<hipblasComplex>(char norm_type, int M, int N, int lda, hipblasComplex *hCPU,
+// hipblasComplex *hGPU)
 //{
 ////norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 //
@@ -107,9 +107,9 @@ double norm_check_general<double>(char norm_type, int M, int N, int lda, double*
 //
 //
 // template<>
-// double norm_check_general<hipDoubleComplex>(char norm_type, int M, int N, int lda,
-// hipDoubleComplex *hCPU,
-// hipDoubleComplex *hGPU)
+// double norm_check_general<hipblasDoubleComplex>(char norm_type, int M, int N, int lda,
+// hipblasDoubleComplex *hCPU,
+// hipblasDoubleComplex *hGPU)
 //{
 ////norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 //
@@ -170,8 +170,8 @@ double norm_check_symmetric<double>(
 }
 
 // template<>
-// double norm_check_symmetric<hipComplex>(char norm_type, char uplo, int N, int lda, hipComplex
-// *hCPU, hipComplex *hGPU)
+// double norm_check_symmetric<hipblasComplex>(char norm_type, char uplo, int N, int lda, hipblasComplex
+// *hCPU, hipblasComplex *hGPU)
 //{
 ////norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 //
@@ -189,8 +189,8 @@ double norm_check_symmetric<double>(
 //}
 //
 // template<>
-// double norm_check_symmetric<hipDoubleComplex>(char norm_type, char uplo, int N, int lda,
-// hipDoubleComplex *hCPU, hipDoubleComplex *hGPU)
+// double norm_check_symmetric<hipblasDoubleComplex>(char norm_type, char uplo, int N, int lda,
+// hipblasDoubleComplex *hCPU, hipblasDoubleComplex *hGPU)
 //{
 ////norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 //

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -95,7 +95,7 @@ void unit_check_general(int M, int N, int lda, double* hCPU, double* hGPU)
 }
 
 template <>
-void unit_check_general(int M, int N, int lda, hipComplex* hCPU, hipComplex* hGPU)
+void unit_check_general(int M, int N, int lda, hipblasComplex* hCPU, hipblasComplex* hGPU)
 {
 #pragma unroll
     for(int j = 0; j < N; j++)
@@ -112,7 +112,7 @@ void unit_check_general(int M, int N, int lda, hipComplex* hCPU, hipComplex* hGP
 }
 
 template <>
-void unit_check_general(int M, int N, int lda, hipDoubleComplex* hCPU, hipDoubleComplex* hGPU)
+void unit_check_general(int M, int N, int lda, hipblasDoubleComplex* hCPU, hipblasDoubleComplex* hGPU)
 {
 #pragma unroll
     for(int j = 0; j < N; j++)
@@ -169,14 +169,14 @@ void unit_check_general(int M, int N, int batch_count, int lda, int** hCPU, int*
 
 template <>
 void unit_check_general(
-    int M, int N, int batch_count, int lda, hipComplex** hCPU, hipComplex** hGPU)
+    int M, int N, int batch_count, int lda, hipblasComplex** hCPU, hipblasComplex** hGPU)
 {
     UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, ASSERT_FLOAT_COMPLEX_EQ);
 }
 
 template <>
 void unit_check_general(
-    int M, int N, int batch_count, int lda, hipDoubleComplex** hCPU, hipDoubleComplex** hGPU)
+    int M, int N, int batch_count, int lda, hipblasDoubleComplex** hCPU, hipblasDoubleComplex** hGPU)
 {
     UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, ASSERT_DOUBLE_COMPLEX_EQ);
 }
@@ -230,8 +230,8 @@ void unit_check_general(int                     M,
                         int                     N,
                         int                     batch_count,
                         int                     lda,
-                        host_vector<hipComplex> hCPU[],
-                        host_vector<hipComplex> hGPU[])
+                        host_vector<hipblasComplex> hCPU[],
+                        host_vector<hipblasComplex> hGPU[])
 {
     UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, ASSERT_FLOAT_COMPLEX_EQ);
 }
@@ -241,8 +241,8 @@ void unit_check_general(int                           M,
                         int                           N,
                         int                           batch_count,
                         int                           lda,
-                        host_vector<hipDoubleComplex> hCPU[],
-                        host_vector<hipDoubleComplex> hGPU[])
+                        host_vector<hipblasDoubleComplex> hCPU[],
+                        host_vector<hipblasDoubleComplex> hGPU[])
 {
     UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, ASSERT_DOUBLE_COMPLEX_EQ);
 }
@@ -283,7 +283,7 @@ void unit_check_general(
 
 template <>
 void unit_check_general(
-    int M, int N, int batch_count, int lda, int strideA, hipComplex* hCPU, hipComplex* hGPU)
+    int M, int N, int batch_count, int lda, int strideA, hipblasComplex* hCPU, hipblasComplex* hGPU)
 {
     UNIT_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, ASSERT_FLOAT_COMPLEX_EQ);
 }
@@ -294,8 +294,8 @@ void unit_check_general(int               M,
                         int               batch_count,
                         int               lda,
                         int               strideA,
-                        hipDoubleComplex* hCPU,
-                        hipDoubleComplex* hGPU)
+                        hipblasDoubleComplex* hCPU,
+                        hipblasDoubleComplex* hGPU)
 {
     UNIT_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, ASSERT_DOUBLE_COMPLEX_EQ);
 }

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -23,12 +23,12 @@ char type2char<double>()
 }
 
 //  template<>
-//  char type2char<hipComplex>(){
+//  char type2char<hipblasComplex>(){
 //      return 'c';
 //  }
 
 //  template<>
-//  char type2char<hipDoubleComplex>(){
+//  char type2char<hipblasDoubleComplex>(){
 //      return 'z';
 //  }
 

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -195,7 +195,7 @@ TEST_P(blas1_gtest, axpy_float)
 TEST_P(blas1_gtest, axpy_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_axpy<hipComplex>(arg);
+    hipblasStatus_t status = testing_axpy<hipblasComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -217,7 +217,7 @@ TEST_P(blas1_gtest, axpy_float_complex)
 TEST_P(blas1_gtest, axpy_double_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_axpy<hipDoubleComplex>(arg);
+    hipblasStatus_t status = testing_axpy<hipblasDoubleComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -262,7 +262,7 @@ TEST_P(blas1_gtest, copy_float)
 TEST_P(blas1_gtest, copy_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_copy<hipComplex>(arg);
+    hipblasStatus_t status = testing_copy<hipblasComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -311,7 +311,7 @@ TEST_P(blas1_gtest, copy_batched_float)
 TEST_P(blas1_gtest, copy_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_copy_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_copy_batched<hipblasComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -364,7 +364,7 @@ TEST_P(blas1_gtest, copy_strided_batched_float)
 TEST_P(blas1_gtest, copy_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_copy_strided_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_copy_strided_batched<hipblasComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -421,7 +421,7 @@ TEST_P(blas1_gtest, scal_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_scal<hipComplex>(arg);
+    hipblasStatus_t status = testing_scal<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -447,7 +447,7 @@ TEST_P(blas1_gtest, scal_float_complex_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_scal<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_scal<hipblasComplex, float>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -506,7 +506,7 @@ TEST_P(blas1_gtest, scal_batched_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_scal_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_scal_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -537,7 +537,7 @@ TEST_P(blas1_gtest, scal_batched_float_complex_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_scal_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_scal_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -600,7 +600,7 @@ TEST_P(blas1_gtest, scal_strided_batched_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_scal_strided_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_scal_strided_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -631,7 +631,7 @@ TEST_P(blas1_gtest, scal_strided_batched_float_complex_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_scal_strided_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_scal_strided_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -681,7 +681,7 @@ TEST_P(blas1_gtest, swap_float)
 TEST_P(blas1_gtest, swap_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_swap<hipComplex>(arg);
+    hipblasStatus_t status = testing_swap<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -730,7 +730,7 @@ TEST_P(blas1_gtest, swap_batched_float)
 TEST_P(blas1_gtest, swap_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_swap_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_swap_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -783,7 +783,7 @@ TEST_P(blas1_gtest, swap_strided_batched_float)
 TEST_P(blas1_gtest, swap_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_swap_strided_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_swap_strided_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -902,7 +902,7 @@ TEST_P(blas1_gtest, dot_float)
 TEST_P(blas1_gtest, dotu_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_dot<hipComplex>(arg);
+    hipblasStatus_t status = testing_dot<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -928,7 +928,7 @@ TEST_P(blas1_gtest, dotu_float_complex)
 TEST_P(blas1_gtest, dotc_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_dotc<hipComplex>(arg);
+    hipblasStatus_t status = testing_dotc<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1059,7 +1059,7 @@ TEST_P(blas1_gtest, dot_batched_float)
 TEST_P(blas1_gtest, dotu_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_dot_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_dot_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1089,7 +1089,7 @@ TEST_P(blas1_gtest, dotu_batched_float_complex)
 TEST_P(blas1_gtest, dotc_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_dotc_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_dotc_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1224,7 +1224,7 @@ TEST_P(blas1_gtest, dot_strided_batched_float)
 TEST_P(blas1_gtest, dotu_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_dot_strided_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_dot_strided_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1254,7 +1254,7 @@ TEST_P(blas1_gtest, dotu_strided_batched_float_complex)
 TEST_P(blas1_gtest, dotc_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_dotc_strided_batched<hipComplex>(arg);
+    hipblasStatus_t status = testing_dotc_strided_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1315,7 +1315,7 @@ TEST_P(blas1_gtest, nrm2_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_nrm2<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_nrm2<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1372,7 +1372,7 @@ TEST_P(blas1_gtest, nrm2_batched_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_nrm2_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_nrm2_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1433,7 +1433,7 @@ TEST_P(blas1_gtest, nrm2_strided_batched_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_nrm2_strided_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_nrm2_strided_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1479,7 +1479,7 @@ TEST_P(blas1_gtest, rot_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rot<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_rot<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1494,7 +1494,7 @@ TEST_P(blas1_gtest, rot_float_complex_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rot<hipComplex, float, float>(arg);
+    hipblasStatus_t status = testing_rot<hipblasComplex, float, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1532,7 +1532,7 @@ TEST_P(blas1_gtest, rot_batched_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rot_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_rot_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1554,7 +1554,7 @@ TEST_P(blas1_gtest, rot_batched_float_complex_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rot_batched<hipComplex, float, float>(arg);
+    hipblasStatus_t status = testing_rot_batched<hipblasComplex, float, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1599,7 +1599,7 @@ TEST_P(blas1_gtest, rot_strided_batched_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rot_strided_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_rot_strided_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1621,7 +1621,7 @@ TEST_P(blas1_gtest, rot_strided_batched_float_complex_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rot_strided_batched<hipComplex, float, float>(arg);
+    hipblasStatus_t status = testing_rot_strided_batched<hipblasComplex, float, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1651,7 +1651,7 @@ TEST_P(blas1_gtest, rotg_float)
 TEST_P(blas1_gtest, rotg_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_rotg<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1681,7 +1681,7 @@ TEST_P(blas1_gtest, rotg_batched_float)
 TEST_P(blas1_gtest, rotg_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_rotg_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1718,7 +1718,7 @@ TEST_P(blas1_gtest, rotg_strided_batched_float)
 TEST_P(blas1_gtest, rotg_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg_strided_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_rotg_strided_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1863,7 +1863,7 @@ TEST_P(blas1_gtest, asum_float)
 TEST_P(blas1_gtest, asum_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_asum<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_asum<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1885,7 +1885,7 @@ TEST_P(blas1_gtest, asum_float_complex)
 TEST_P(blas1_gtest, asum_double_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_asum<hipDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_asum<hipblasDoubleComplex, double>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1934,7 +1934,7 @@ TEST_P(blas1_gtest, asum_batched_float)
 TEST_P(blas1_gtest, asum_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_asum_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_asum_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1960,7 +1960,7 @@ TEST_P(blas1_gtest, asum_batched_float_complex)
 TEST_P(blas1_gtest, asum_batched_double_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_asum_batched<hipDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_asum_batched<hipblasDoubleComplex, double>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -2013,7 +2013,7 @@ TEST_P(blas1_gtest, asum_strided_batched_float)
 TEST_P(blas1_gtest, asum_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_asum_strided_batched<hipComplex, float>(arg);
+    hipblasStatus_t status = testing_asum_strided_batched<hipblasComplex, float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -2039,7 +2039,7 @@ TEST_P(blas1_gtest, asum_strided_batched_float_complex)
 TEST_P(blas1_gtest, asum_strided_batched_double_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_asum_strided_batched<hipDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_asum_strided_batched<hipblasDoubleComplex, double>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -2100,7 +2100,7 @@ TEST_P(blas1_gtest, amax_float_complex)
 
     Arguments arg = setup_blas1_arguments(GetParam());
 
-    hipblasStatus_t status = testing_amax<hipComplex>(arg);
+    hipblasStatus_t status = testing_amax<hipblasComplex>(arg);
 
     EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
 }
@@ -2109,7 +2109,7 @@ TEST_P(blas1_gtest, amax_double_complex)
 {
     Arguments arg = setup_blas1_arguments(GetParam());
 
-    hipblasStatus_t status = testing_amax<hipDoubleComplex>(arg);
+    hipblasStatus_t status = testing_amax<hipblasDoubleComplex>(arg);
 
     EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
 }
@@ -2139,7 +2139,7 @@ TEST_P(blas1_gtest, amin_float_complex)
     // TODO: min is broken in rocblas currently (fixed in 2.10?)
     // Arguments arg = setup_blas1_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_amin<hipComplex>(arg);
+    // hipblasStatus_t status = testing_amin<hipblasComplex>(arg);
 
     // EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
 }
@@ -2149,7 +2149,7 @@ TEST_P(blas1_gtest, amin_double_complex)
     // TODO: min is broken in rocblas currently (fixed in 2.10?)
     // Arguments arg = setup_blas1_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_amin<hipDoubleComplex>(arg);
+    // hipblasStatus_t status = testing_amin<hipblasDoubleComplex>(arg);
 
     // EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
 }

--- a/clients/gtest/gemm_batched_gtest.cpp
+++ b/clients/gtest/gemm_batched_gtest.cpp
@@ -212,7 +212,7 @@ TEST_P(gemm_batched_gtest, double)
     }
 }
 
-TEST_P(gemm_batched_gtest, hipComplex)
+TEST_P(gemm_batched_gtest, hipblasComplex)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
@@ -221,7 +221,7 @@ TEST_P(gemm_batched_gtest, hipComplex)
 
     Arguments arg = setup_gemm_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_GemmBatched<hipComplex>(arg);
+    hipblasStatus_t status = testing_GemmBatched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -253,7 +253,7 @@ TEST_P(gemm_batched_gtest, hipComplex)
     }
 }
 
-TEST_P(gemm_batched_gtest, hipDoubleComplex)
+TEST_P(gemm_batched_gtest, hipblasDoubleComplex)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
@@ -262,7 +262,7 @@ TEST_P(gemm_batched_gtest, hipDoubleComplex)
 
     Arguments arg = setup_gemm_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_GemmBatched<hipDoubleComplex>(arg);
+    hipblasStatus_t status = testing_GemmBatched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/gemm_gtest.cpp
+++ b/clients/gtest/gemm_gtest.cpp
@@ -188,7 +188,7 @@ TEST_P(gemm_gtest, gemm_gtest_float_complex)
 
     Arguments arg = setup_gemm_arguments(GetParam());
 
-    hipblasStatus_t status = testing_gemm<hipComplex>(arg);
+    hipblasStatus_t status = testing_gemm<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -226,7 +226,7 @@ TEST_P(gemm_gtest, gemm_gtest_double_complex)
 
     Arguments arg = setup_gemm_arguments(GetParam());
 
-    hipblasStatus_t status = testing_gemm<hipDoubleComplex>(arg);
+    hipblasStatus_t status = testing_gemm<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/gemm_strided_batched_gtest.cpp
+++ b/clients/gtest/gemm_strided_batched_gtest.cpp
@@ -205,7 +205,7 @@ TEST_P(gemm_strided_batched_gtest, double)
     }
 }
 
-TEST_P(gemm_strided_batched_gtest, hipComplex)
+TEST_P(gemm_strided_batched_gtest, hipblasComplex)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
@@ -214,7 +214,7 @@ TEST_P(gemm_strided_batched_gtest, hipComplex)
 
     Arguments arg = setup_gemm_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_GemmStridedBatched<hipComplex>(arg);
+    hipblasStatus_t status = testing_GemmStridedBatched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -246,7 +246,7 @@ TEST_P(gemm_strided_batched_gtest, hipComplex)
     }
 }
 
-TEST_P(gemm_strided_batched_gtest, hipDoubleComplex)
+TEST_P(gemm_strided_batched_gtest, hipblasDoubleComplex)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
     // and initializes arg(Arguments) which will be passed to testing routine
@@ -255,7 +255,7 @@ TEST_P(gemm_strided_batched_gtest, hipDoubleComplex)
 
     Arguments arg = setup_gemm_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_GemmStridedBatched<hipDoubleComplex>(arg);
+    hipblasStatus_t status = testing_GemmStridedBatched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/gemv_batched_gtest.cpp
+++ b/clients/gtest/gemv_batched_gtest.cpp
@@ -173,7 +173,7 @@ TEST_P(gemv_gtest_batched, gemv_gtest_float_complex)
 {
     Arguments arg = setup_gemv_arguments(GetParam());
 
-    hipblasStatus_t status = testing_gemvBatched<hipComplex>(arg);
+    hipblasStatus_t status = testing_gemvBatched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -176,7 +176,7 @@ TEST_P(gemv_gtest, gemv_gtest_float_complex)
 
     Arguments arg = setup_gemv_arguments(GetParam());
 
-    hipblasStatus_t status = testing_gemv<hipComplex>(arg);
+    hipblasStatus_t status = testing_gemv<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/gemv_strided_batched_gtest.cpp
+++ b/clients/gtest/gemv_strided_batched_gtest.cpp
@@ -190,7 +190,7 @@ TEST_P(gemv_gtest_strided_batched, gemv_gtest_float_complex)
 {
     Arguments arg = setup_gemv_arguments(GetParam());
 
-    hipblasStatus_t status = testing_gemvStridedBatched<hipComplex>(arg);
+    hipblasStatus_t status = testing_gemvStridedBatched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -23,9 +23,9 @@ using namespace std;
 template <typename T>
 constexpr double nrm2_tolerance_multiplier = 100;
 template <>
-constexpr double nrm2_tolerance_multiplier<hipComplex> = 110;
+constexpr double nrm2_tolerance_multiplier<hipblasComplex> = 110;
 template <>
-constexpr double nrm2_tolerance_multiplier<hipDoubleComplex> = 110;
+constexpr double nrm2_tolerance_multiplier<hipblasDoubleComplex> = 110;
 
 template <typename T1, typename T2>
 hipblasStatus_t testing_nrm2(Arguments argus)

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -23,9 +23,9 @@ using namespace std;
 template <typename T>
 constexpr double nrm2_batched_tolerance_multiplier = 100;
 template <>
-constexpr double nrm2_batched_tolerance_multiplier<hipComplex> = 110;
+constexpr double nrm2_batched_tolerance_multiplier<hipblasComplex> = 110;
 template <>
-constexpr double nrm2_batched_tolerance_multiplier<hipDoubleComplex> = 110;
+constexpr double nrm2_batched_tolerance_multiplier<hipblasDoubleComplex> = 110;
 
 template <typename T1, typename T2>
 hipblasStatus_t testing_nrm2_batched(Arguments argus)

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -23,9 +23,9 @@ using namespace std;
 template <typename T>
 constexpr double nrm2_strided_batched_tolerance_multiplier = 100;
 template <>
-constexpr double nrm2_strided_batched_tolerance_multiplier<hipComplex> = 110;
+constexpr double nrm2_strided_batched_tolerance_multiplier<hipblasComplex> = 110;
 template <>
-constexpr double nrm2_strided_batched_tolerance_multiplier<hipDoubleComplex> = 110;
+constexpr double nrm2_strided_batched_tolerance_multiplier<hipblasDoubleComplex> = 110;
 
 template <typename T1, typename T2>
 hipblasStatus_t testing_nrm2_strided_batched(Arguments argus)

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -70,11 +70,11 @@ inline bool hipblas_isnan(hipblasHalf arg)
 {
     return (~arg & 0x7c00) == 0 && (arg & 0x3ff) != 0;
 }
-inline bool hipblas_isnan(hipComplex arg)
+inline bool hipblas_isnan(hipblasComplex arg)
 {
     return std::isnan(arg.x) || std::isnan(arg.y);
 }
-inline bool hipblas_isnan(hipDoubleComplex arg)
+inline bool hipblas_isnan(hipblasDoubleComplex arg)
 {
     return std::isnan(arg.x) || std::isnan(arg.y);
 }
@@ -222,20 +222,20 @@ inline hipblasBfloat16 random_generator<hipblasBfloat16>()
         static_cast<float>((rand() % 3 + 1))); // generate an integer number in range [1,2,3]
 }
 
-// for hipComplex, generate 2 floats
+// for hipblasComplex, generate 2 floats
 /*! \brief  generate two random numbers in range [1,2,3,4,5,6,7,8,9,10] */
 template <>
-inline hipComplex random_generator<hipComplex>()
+inline hipblasComplex random_generator<hipblasComplex>()
 {
-    return hipComplex(rand() % 10 + 1, rand() % 10 + 1);
+    return hipblasComplex(rand() % 10 + 1, rand() % 10 + 1);
 }
 
-// for hipDoubleComplex, generate 2 doubles
+// for hipblasDoubleComplex, generate 2 doubles
 /*! \brief  generate two random numbers in range [1,2,3,4,5,6,7,8,9,10] */
 template <>
-inline hipDoubleComplex random_generator<hipDoubleComplex>()
+inline hipblasDoubleComplex random_generator<hipblasDoubleComplex>()
 {
-    return hipDoubleComplex(rand() % 10 + 1, rand() % 10 + 1);
+    return hipblasDoubleComplex(rand() % 10 + 1, rand() % 10 + 1);
 }
 
 /*! \brief  generate a random number in range [-1,-2,-3,-4,-5,-6,-7,-8,-9,-10] */
@@ -267,15 +267,15 @@ inline hipblasBfloat16 random_generator_negative<hipblasBfloat16>()
 *           imaginary value in range [-1, -10]
 */
 template <>
-inline hipComplex random_generator_negative<hipComplex>()
+inline hipblasComplex random_generator_negative<hipblasComplex>()
 {
-    hipComplex(-(rand() % 10 + 1), -(rand() % 10 + 1));
+    hipblasComplex(-(rand() % 10 + 1), -(rand() % 10 + 1));
 }
 
 template <>
-inline hipDoubleComplex random_generator_negative<hipDoubleComplex>()
+inline hipblasDoubleComplex random_generator_negative<hipblasDoubleComplex>()
 {
-    hipDoubleComplex(-(rand() % 10 + 1), -(rand() % 10 + 1));
+    hipblasDoubleComplex(-(rand() % 10 + 1), -(rand() % 10 + 1));
 }
 
 /* ============================================================================================ */

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -50,8 +50,8 @@ struct hip_complex_number
     }
 };
 
-typedef hip_complex_number<float>  hipComplex;
-typedef hip_complex_number<double> hipDoubleComplex;
+typedef hip_complex_number<float>  hipblasComplex;
+typedef hip_complex_number<double> hipblasDoubleComplex;
 
 enum hipblasStatus_t
 {
@@ -192,10 +192,10 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasIdamax(hipblasHandle_t handle, int n, const double* x, int incx, int* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasIcamax(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result);
+    hipblasIcamax(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasIzamax(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result);
+    hipblasIzamax(hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result);
 
 // amin
 HIPBLAS_EXPORT hipblasStatus_t
@@ -205,10 +205,10 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasIdamin(hipblasHandle_t handle, int n, const double* x, int incx, int* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasIcamin(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result);
+    hipblasIcamin(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasIzamin(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result);
+    hipblasIzamin(hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result);
 
 // asum
 HIPBLAS_EXPORT hipblasStatus_t
@@ -218,10 +218,10 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasDasum(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasScasum(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
+    hipblasScasum(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDzasum(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result);
 
 // asum_batched
 HIPBLAS_EXPORT hipblasStatus_t hipblasSasumBatched(
@@ -236,14 +236,14 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDasumBatched(hipblasHandle_t     handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
                                                     int                     n,
-                                                    const hipComplex* const x[],
+                                                    const hipblasComplex* const x[],
                                                     int                     incx,
                                                     int                     batchCount,
                                                     float*                  result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t               handle,
                                                     int                           n,
-                                                    const hipDoubleComplex* const x[],
+                                                    const hipblasDoubleComplex* const x[],
                                                     int                           incx,
                                                     int                           batchCount,
                                                     double*                       result);
@@ -267,7 +267,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
                                                            int               n,
-                                                           const hipComplex* x,
+                                                           const hipblasComplex* x,
                                                            int               incx,
                                                            int               stridex,
                                                            int               batchCount,
@@ -275,7 +275,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   han
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
                                                            int                     n,
-                                                           const hipDoubleComplex* x,
+                                                           const hipblasDoubleComplex* x,
                                                            int                     incx,
                                                            int                     stridex,
                                                            int                     batchCount,
@@ -299,14 +299,14 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDasumBatched(hipblasHandle_t     handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
                                                     int                     n,
-                                                    const hipComplex* const x[],
+                                                    const hipblasComplex* const x[],
                                                     int                     incx,
                                                     int                     batchCount,
                                                     float*                  result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t               handle,
                                                     int                           n,
-                                                    const hipDoubleComplex* const x[],
+                                                    const hipblasDoubleComplex* const x[],
                                                     int                           incx,
                                                     int                           batchCount,
                                                     double*                       result);
@@ -330,7 +330,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
                                                            int               n,
-                                                           const hipComplex* x,
+                                                           const hipblasComplex* x,
                                                            int               incx,
                                                            int               stridex,
                                                            int               batchCount,
@@ -338,7 +338,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   han
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
                                                            int                     n,
-                                                           const hipDoubleComplex* x,
+                                                           const hipblasDoubleComplex* x,
                                                            int                     incx,
                                                            int                     stridex,
                                                            int                     batchCount,
@@ -363,18 +363,18 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDaxpy(hipblasHandle_t handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCaxpy(hipblasHandle_t   handle,
                                             int               n,
-                                            const hipComplex* alpha,
-                                            const hipComplex* x,
+                                            const hipblasComplex* alpha,
+                                            const hipblasComplex* x,
                                             int               incx,
-                                            hipComplex*       y,
+                                            hipblasComplex*       y,
                                             int               incy);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpy(hipblasHandle_t         handle,
                                             int                     n,
-                                            const hipDoubleComplex* alpha,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* alpha,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
-                                            hipDoubleComplex*       y,
+                                            hipblasDoubleComplex*       y,
                                             int                     incy);
 
 // not implemented
@@ -389,13 +389,13 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasDcopy(hipblasHandle_t handle, int n, const double* x, int incx, double* y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCcopy(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, hipComplex* y, int incy);
+    hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, hipblasComplex* y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
                                             int                     n,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
-                                            hipDoubleComplex*       y,
+                                            hipblasDoubleComplex*       y,
                                             int                     incy);
 
 // copy_batched
@@ -417,17 +417,17 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t     handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t         handle,
                                                    int                     n,
-                                                   const hipComplex* const x[],
+                                                   const hipblasComplex* const x[],
                                                    int                     incx,
-                                                   hipComplex* const       y[],
+                                                   hipblasComplex* const       y[],
                                                    int                     incy,
                                                    int                     batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t               handle,
                                                    int                           n,
-                                                   const hipDoubleComplex* const x[],
+                                                   const hipblasDoubleComplex* const x[],
                                                    int                           incx,
-                                                   hipDoubleComplex* const       y[],
+                                                   hipblasDoubleComplex* const       y[],
                                                    int                           incy,
                                                    int                           batchCount);
 
@@ -454,20 +454,20 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t   handle,
                                                           int               n,
-                                                          const hipComplex* x,
+                                                          const hipblasComplex* x,
                                                           int               incx,
                                                           int               stridex,
-                                                          hipComplex*       y,
+                                                          hipblasComplex*       y,
                                                           int               incy,
                                                           int               stridey,
                                                           int               batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t         handle,
                                                           int                     n,
-                                                          const hipDoubleComplex* x,
+                                                          const hipblasDoubleComplex* x,
                                                           int                     incx,
                                                           int                     stridex,
-                                                          hipDoubleComplex*       y,
+                                                          hipblasDoubleComplex*       y,
                                                           int                     incy,
                                                           int                     stridey,
                                                           int                     batchCount);
@@ -507,35 +507,35 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDdot(hipblasHandle_t handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCdotc(hipblasHandle_t   handle,
                                             int               n,
-                                            const hipComplex* x,
+                                            const hipblasComplex* x,
                                             int               incx,
-                                            const hipComplex* y,
+                                            const hipblasComplex* y,
                                             int               incy,
-                                            hipComplex*       result);
+                                            hipblasComplex*       result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCdotu(hipblasHandle_t   handle,
                                             int               n,
-                                            const hipComplex* x,
+                                            const hipblasComplex* x,
                                             int               incx,
-                                            const hipComplex* y,
+                                            const hipblasComplex* y,
                                             int               incy,
-                                            hipComplex*       result);
+                                            hipblasComplex*       result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdotc(hipblasHandle_t         handle,
                                             int                     n,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
-                                            const hipDoubleComplex* y,
+                                            const hipblasDoubleComplex* y,
                                             int                     incy,
-                                            hipDoubleComplex*       result);
+                                            hipblasDoubleComplex*       result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdotu(hipblasHandle_t         handle,
                                             int                     n,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
-                                            const hipDoubleComplex* y,
+                                            const hipblasDoubleComplex* y,
                                             int                     incy,
-                                            hipDoubleComplex*       result);
+                                            hipblasDoubleComplex*       result);
 
 // dot_batched
 HIPBLAS_EXPORT hipblasStatus_t hipblasHdotBatched(hipblasHandle_t          handle,
@@ -576,39 +576,39 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t         handle,
                                                    int                     n,
-                                                   const hipComplex* const x[],
+                                                   const hipblasComplex* const x[],
                                                    int                     incx,
-                                                   const hipComplex* const y[],
+                                                   const hipblasComplex* const y[],
                                                    int                     incy,
                                                    int                     batch_count,
-                                                   hipComplex*             result);
+                                                   hipblasComplex*             result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t         handle,
                                                    int                     n,
-                                                   const hipComplex* const x[],
+                                                   const hipblasComplex* const x[],
                                                    int                     incx,
-                                                   const hipComplex* const y[],
+                                                   const hipblasComplex* const y[],
                                                    int                     incy,
                                                    int                     batch_count,
-                                                   hipComplex*             result);
+                                                   hipblasComplex*             result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t               handle,
                                                    int                           n,
-                                                   const hipDoubleComplex* const x[],
+                                                   const hipblasDoubleComplex* const x[],
                                                    int                           incx,
-                                                   const hipDoubleComplex* const y[],
+                                                   const hipblasDoubleComplex* const y[],
                                                    int                           incy,
                                                    int                           batch_count,
-                                                   hipDoubleComplex*             result);
+                                                   hipblasDoubleComplex*             result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t               handle,
                                                    int                           n,
-                                                   const hipDoubleComplex* const x[],
+                                                   const hipblasDoubleComplex* const x[],
                                                    int                           incx,
-                                                   const hipDoubleComplex* const y[],
+                                                   const hipblasDoubleComplex* const y[],
                                                    int                           incy,
                                                    int                           batch_count,
-                                                   hipDoubleComplex*             result);
+                                                   hipblasDoubleComplex*             result);
 
 // dot_strided_batched
 HIPBLAS_EXPORT hipblasStatus_t hipblasHdotStridedBatched(hipblasHandle_t    handle,
@@ -657,47 +657,47 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t   handle,
                                                           int               n,
-                                                          const hipComplex* x,
+                                                          const hipblasComplex* x,
                                                           int               incx,
                                                           int               stridex,
-                                                          const hipComplex* y,
+                                                          const hipblasComplex* y,
                                                           int               incy,
                                                           int               stridey,
                                                           int               batch_count,
-                                                          hipComplex*       result);
+                                                          hipblasComplex*       result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t   handle,
                                                           int               n,
-                                                          const hipComplex* x,
+                                                          const hipblasComplex* x,
                                                           int               incx,
                                                           int               stridex,
-                                                          const hipComplex* y,
+                                                          const hipblasComplex* y,
                                                           int               incy,
                                                           int               stridey,
                                                           int               batch_count,
-                                                          hipComplex*       result);
+                                                          hipblasComplex*       result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t         handle,
                                                           int                     n,
-                                                          const hipDoubleComplex* x,
+                                                          const hipblasDoubleComplex* x,
                                                           int                     incx,
                                                           int                     stridex,
-                                                          const hipDoubleComplex* y,
+                                                          const hipblasDoubleComplex* y,
                                                           int                     incy,
                                                           int                     stridey,
                                                           int                     batch_count,
-                                                          hipDoubleComplex*       result);
+                                                          hipblasDoubleComplex*       result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t         handle,
                                                           int                     n,
-                                                          const hipDoubleComplex* x,
+                                                          const hipblasDoubleComplex* x,
                                                           int                     incx,
                                                           int                     stridex,
-                                                          const hipDoubleComplex* y,
+                                                          const hipblasDoubleComplex* y,
                                                           int                     incy,
                                                           int                     stridey,
                                                           int                     batch_count,
-                                                          hipDoubleComplex*       result);
+                                                          hipblasDoubleComplex*       result);
 
 // snrm2
 HIPBLAS_EXPORT hipblasStatus_t
@@ -707,10 +707,10 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasDnrm2(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasScnrm2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
+    hipblasScnrm2(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result);
 
 // nrm2_batched
 HIPBLAS_EXPORT hipblasStatus_t hipblasSnrm2Batched(
@@ -725,14 +725,14 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t     handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t         handle,
                                                     int                     n,
-                                                    const hipComplex* const x[],
+                                                    const hipblasComplex* const x[],
                                                     int                     incx,
                                                     int                     batchCount,
                                                     float*                  result);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t               handle,
                                                     int                           n,
-                                                    const hipDoubleComplex* const x[],
+                                                    const hipblasDoubleComplex* const x[],
                                                     int                           incx,
                                                     int                           batchCount,
                                                     double*                       result);
@@ -756,7 +756,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   handle,
                                                            int               n,
-                                                           const hipComplex* x,
+                                                           const hipblasComplex* x,
                                                            int               incx,
                                                            int               stridex,
                                                            int               batchCount,
@@ -764,7 +764,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   han
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t         handle,
                                                            int                     n,
-                                                           const hipDoubleComplex* x,
+                                                           const hipblasDoubleComplex* x,
                                                            int                     incx,
                                                            int                     stridex,
                                                            int                     batchCount,
@@ -791,36 +791,36 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrot(hipblasHandle_t handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCrot(hipblasHandle_t   handle,
                                            int               n,
-                                           hipComplex*       x,
+                                           hipblasComplex*       x,
                                            int               incx,
-                                           hipComplex*       y,
+                                           hipblasComplex*       y,
                                            int               incy,
                                            const float*      c,
-                                           const hipComplex* s);
+                                           const hipblasComplex* s);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCsrot(hipblasHandle_t handle,
                                             int             n,
-                                            hipComplex*     x,
+                                            hipblasComplex*     x,
                                             int             incx,
-                                            hipComplex*     y,
+                                            hipblasComplex*     y,
                                             int             incy,
                                             const float*    c,
                                             const float*    s);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
                                            int                     n,
-                                           hipDoubleComplex*       x,
+                                           hipblasDoubleComplex*       x,
                                            int                     incx,
-                                           hipDoubleComplex*       y,
+                                           hipblasDoubleComplex*       y,
                                            int                     incy,
                                            const double*           c,
-                                           const hipDoubleComplex* s);
+                                           const hipblasDoubleComplex* s);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdrot(hipblasHandle_t   handle,
                                             int               n,
-                                            hipDoubleComplex* x,
+                                            hipblasDoubleComplex* x,
                                             int               incx,
-                                            hipDoubleComplex* y,
+                                            hipblasDoubleComplex* y,
                                             int               incy,
                                             const double*     c,
                                             const double*     s);
@@ -848,19 +848,19 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotBatched(hipblasHandle_t handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCrotBatched(hipblasHandle_t   handle,
                                                   int               n,
-                                                  hipComplex* const x[],
+                                                  hipblasComplex* const x[],
                                                   int               incx,
-                                                  hipComplex* const y[],
+                                                  hipblasComplex* const y[],
                                                   int               incy,
                                                   const float*      c,
-                                                  const hipComplex* s,
+                                                  const hipblasComplex* s,
                                                   int               batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCsrotBatched(hipblasHandle_t   handle,
                                                    int               n,
-                                                   hipComplex* const x[],
+                                                   hipblasComplex* const x[],
                                                    int               incx,
-                                                   hipComplex* const y[],
+                                                   hipblasComplex* const y[],
                                                    int               incy,
                                                    const float*      c,
                                                    const float*      s,
@@ -868,19 +868,19 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCsrotBatched(hipblasHandle_t   handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZrotBatched(hipblasHandle_t         handle,
                                                   int                     n,
-                                                  hipDoubleComplex* const x[],
+                                                  hipblasDoubleComplex* const x[],
                                                   int                     incx,
-                                                  hipDoubleComplex* const y[],
+                                                  hipblasDoubleComplex* const y[],
                                                   int                     incy,
                                                   const double*           c,
-                                                  const hipDoubleComplex* s,
+                                                  const hipblasDoubleComplex* s,
                                                   int                     batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotBatched(hipblasHandle_t         handle,
                                                    int                     n,
-                                                   hipDoubleComplex* const x[],
+                                                   hipblasDoubleComplex* const x[],
                                                    int                     incx,
-                                                   hipDoubleComplex* const y[],
+                                                   hipblasDoubleComplex* const y[],
                                                    int                     incy,
                                                    const double*           c,
                                                    const double*           s,
@@ -913,22 +913,22 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotStridedBatched(hipblasHandle_t handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCrotStridedBatched(hipblasHandle_t   handle,
                                                          int               n,
-                                                         hipComplex*       x,
+                                                         hipblasComplex*       x,
                                                          int               incx,
                                                          int               stridex,
-                                                         hipComplex*       y,
+                                                         hipblasComplex*       y,
                                                          int               incy,
                                                          int               stridey,
                                                          const float*      c,
-                                                         const hipComplex* s,
+                                                         const hipblasComplex* s,
                                                          int               batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCsrotStridedBatched(hipblasHandle_t handle,
                                                           int             n,
-                                                          hipComplex*     x,
+                                                          hipblasComplex*     x,
                                                           int             incx,
                                                           int             stridex,
-                                                          hipComplex*     y,
+                                                          hipblasComplex*     y,
                                                           int             incy,
                                                           int             stridey,
                                                           const float*    c,
@@ -937,22 +937,22 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCsrotStridedBatched(hipblasHandle_t handle
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZrotStridedBatched(hipblasHandle_t         handle,
                                                          int                     n,
-                                                         hipDoubleComplex*       x,
+                                                         hipblasDoubleComplex*       x,
                                                          int                     incx,
                                                          int                     stridex,
-                                                         hipDoubleComplex*       y,
+                                                         hipblasDoubleComplex*       y,
                                                          int                     incy,
                                                          int                     stridey,
                                                          const double*           c,
-                                                         const hipDoubleComplex* s,
+                                                         const hipblasDoubleComplex* s,
                                                          int                     batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotStridedBatched(hipblasHandle_t   handle,
                                                           int               n,
-                                                          hipDoubleComplex* x,
+                                                          hipblasDoubleComplex* x,
                                                           int               incx,
                                                           int               stridex,
-                                                          hipDoubleComplex* y,
+                                                          hipblasDoubleComplex* y,
                                                           int               incy,
                                                           int               stridey,
                                                           const double*     c,
@@ -967,13 +967,13 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasDrotg(hipblasHandle_t handle, double* a, double* b, double* c, double* s);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasCrotg(hipblasHandle_t handle, hipComplex* a, hipComplex* b, float* c, hipComplex* s);
+    hipblasCrotg(hipblasHandle_t handle, hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZrotg(hipblasHandle_t   handle,
-                                            hipDoubleComplex* a,
-                                            hipDoubleComplex* b,
+                                            hipblasDoubleComplex* a,
+                                            hipblasDoubleComplex* b,
                                             double*           c,
-                                            hipDoubleComplex* s);
+                                            hipblasDoubleComplex* s);
 
 // rotg_batched
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotgBatched(hipblasHandle_t handle,
@@ -991,17 +991,17 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotgBatched(hipblasHandle_t handle,
                                                    int             batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCrotgBatched(hipblasHandle_t   handle,
-                                                   hipComplex* const a[],
-                                                   hipComplex* const b[],
+                                                   hipblasComplex* const a[],
+                                                   hipblasComplex* const b[],
                                                    float* const      c[],
-                                                   hipComplex* const s[],
+                                                   hipblasComplex* const s[],
                                                    int               batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgBatched(hipblasHandle_t         handle,
-                                                   hipDoubleComplex* const a[],
-                                                   hipDoubleComplex* const b[],
+                                                   hipblasDoubleComplex* const a[],
+                                                   hipblasDoubleComplex* const b[],
                                                    double* const           c[],
-                                                   hipDoubleComplex* const s[],
+                                                   hipblasDoubleComplex* const s[],
                                                    int                     batchCount);
 
 // rotg_strided_batched
@@ -1028,24 +1028,24 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotgStridedBatched(hipblasHandle_t handle
                                                           int             batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCrotgStridedBatched(hipblasHandle_t handle,
-                                                          hipComplex*     a,
+                                                          hipblasComplex*     a,
                                                           int             stride_a,
-                                                          hipComplex*     b,
+                                                          hipblasComplex*     b,
                                                           int             stride_b,
                                                           float*          c,
                                                           int             stride_c,
-                                                          hipComplex*     s,
+                                                          hipblasComplex*     s,
                                                           int             stride_s,
                                                           int             batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgStridedBatched(hipblasHandle_t   handle,
-                                                          hipDoubleComplex* a,
+                                                          hipblasDoubleComplex* a,
                                                           int               stride_a,
-                                                          hipDoubleComplex* b,
+                                                          hipblasDoubleComplex* b,
                                                           int               stride_b,
                                                           double*           c,
                                                           int               stride_c,
-                                                          hipDoubleComplex* s,
+                                                          hipblasDoubleComplex* s,
                                                           int               stride_s,
                                                           int               batchCount);
 
@@ -1159,16 +1159,16 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasDscal(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasCscal(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx);
+    hipblasCscal(hipblasHandle_t handle, int n, const hipblasComplex* alpha, hipblasComplex* x, int incx);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasCsscal(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx);
+    hipblasCsscal(hipblasHandle_t handle, int n, const float* alpha, hipblasComplex* x, int incx);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZscal(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx);
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* alpha, hipblasDoubleComplex* x, int incx);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdscal(
-    hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx);
+    hipblasHandle_t handle, int n, const double* alpha, hipblasDoubleComplex* x, int incx);
 
 // scal_batched
 HIPBLAS_EXPORT hipblasStatus_t hipblasSscalBatched(
@@ -1183,29 +1183,29 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDscalBatched(hipblasHandle_t handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCscalBatched(hipblasHandle_t   handle,
                                                    int               n,
-                                                   const hipComplex* alpha,
-                                                   hipComplex* const x[],
+                                                   const hipblasComplex* alpha,
+                                                   hipblasComplex* const x[],
                                                    int               incx,
                                                    int               batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZscalBatched(hipblasHandle_t         handle,
                                                    int                     n,
-                                                   const hipDoubleComplex* alpha,
-                                                   hipDoubleComplex* const x[],
+                                                   const hipblasDoubleComplex* alpha,
+                                                   hipblasDoubleComplex* const x[],
                                                    int                     incx,
                                                    int                     batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCsscalBatched(hipblasHandle_t   handle,
                                                     int               n,
                                                     const float*      alpha,
-                                                    hipComplex* const x[],
+                                                    hipblasComplex* const x[],
                                                     int               incx,
                                                     int               batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t         handle,
                                                     int                     n,
                                                     const double*           alpha,
-                                                    hipDoubleComplex* const x[],
+                                                    hipblasDoubleComplex* const x[],
                                                     int                     incx,
                                                     int                     batchCount);
 
@@ -1228,16 +1228,16 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t   handle,
                                                           int               n,
-                                                          const hipComplex* alpha,
-                                                          hipComplex*       x,
+                                                          const hipblasComplex* alpha,
+                                                          hipblasComplex*       x,
                                                           int               incx,
                                                           int               stridex,
                                                           int               batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t         handle,
                                                           int                     n,
-                                                          const hipDoubleComplex* alpha,
-                                                          hipDoubleComplex*       x,
+                                                          const hipblasDoubleComplex* alpha,
+                                                          hipblasDoubleComplex*       x,
                                                           int                     incx,
                                                           int                     stridex,
                                                           int                     batchCount);
@@ -1245,7 +1245,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t       
 HIPBLAS_EXPORT hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle,
                                                            int             n,
                                                            const float*    alpha,
-                                                           hipComplex*     x,
+                                                           hipblasComplex*     x,
                                                            int             incx,
                                                            int             stridex,
                                                            int             batchCount);
@@ -1253,7 +1253,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handl
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t   handle,
                                                            int               n,
                                                            const double*     alpha,
-                                                           hipDoubleComplex* x,
+                                                           hipblasDoubleComplex* x,
                                                            int               incx,
                                                            int               stridex,
                                                            int               batchCount);
@@ -1266,10 +1266,10 @@ HIPBLAS_EXPORT hipblasStatus_t
     hipblasDswap(hipblasHandle_t handle, int n, double* x, int incx, double* y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t
-    hipblasCswap(hipblasHandle_t handle, int n, hipComplex* x, int incx, hipComplex* y, int incy);
+    hipblasCswap(hipblasHandle_t handle, int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZswap(
-    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy);
+    hipblasHandle_t handle, int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy);
 
 // swap_batched
 HIPBLAS_EXPORT hipblasStatus_t hipblasSswapBatched(
@@ -1280,17 +1280,17 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDswapBatched(
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
                                                    int             n,
-                                                   hipComplex*     x[],
+                                                   hipblasComplex*     x[],
                                                    int             incx,
-                                                   hipComplex*     y[],
+                                                   hipblasComplex*     y[],
                                                    int             incy,
                                                    int             batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZswapBatched(hipblasHandle_t   handle,
                                                    int               n,
-                                                   hipDoubleComplex* x[],
+                                                   hipblasDoubleComplex* x[],
                                                    int               incx,
-                                                   hipDoubleComplex* y[],
+                                                   hipblasDoubleComplex* y[],
                                                    int               incy,
                                                    int               batchCount);
 
@@ -1317,20 +1317,20 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle,
                                                           int             n,
-                                                          hipComplex*     x,
+                                                          hipblasComplex*     x,
                                                           int             incx,
                                                           int             stridex,
-                                                          hipComplex*     y,
+                                                          hipblasComplex*     y,
                                                           int             incy,
                                                           int             stridey,
                                                           int             batchCount);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t   handle,
                                                           int               n,
-                                                          hipDoubleComplex* x,
+                                                          hipblasDoubleComplex* x,
                                                           int               incx,
                                                           int               stridex,
-                                                          hipDoubleComplex* y,
+                                                          hipblasDoubleComplex* y,
                                                           int               incy,
                                                           int               stridey,
                                                           int               batchCount);
@@ -1366,26 +1366,26 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCgemv(hipblasHandle_t    handle,
                                             hipblasOperation_t trans,
                                             int                m,
                                             int                n,
-                                            const hipComplex*  alpha,
-                                            const hipComplex*  A,
+                                            const hipblasComplex*  alpha,
+                                            const hipblasComplex*  A,
                                             int                lda,
-                                            const hipComplex*  x,
+                                            const hipblasComplex*  x,
                                             int                incx,
-                                            const hipComplex*  beta,
-                                            hipComplex*        y,
+                                            const hipblasComplex*  beta,
+                                            hipblasComplex*        y,
                                             int                incy);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZgemv(hipblasHandle_t         handle,
                                             hipblasOperation_t      trans,
                                             int                     m,
                                             int                     n,
-                                            const hipDoubleComplex* alpha,
-                                            const hipDoubleComplex* A,
+                                            const hipblasDoubleComplex* alpha,
+                                            const hipblasDoubleComplex* A,
                                             int                     lda,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
-                                            const hipDoubleComplex* beta,
-                                            hipDoubleComplex*       y,
+                                            const hipblasDoubleComplex* beta,
+                                            hipblasDoubleComplex*       y,
                                             int                     incy);
 
 // gemv_batched
@@ -1421,13 +1421,13 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCgemvBatched(hipblasHandle_t         handl
                                                    hipblasOperation_t      trans,
                                                    int                     m,
                                                    int                     n,
-                                                   const hipComplex*       alpha,
-                                                   const hipComplex* const A[],
+                                                   const hipblasComplex*       alpha,
+                                                   const hipblasComplex* const A[],
                                                    int                     lda,
-                                                   const hipComplex* const x[],
+                                                   const hipblasComplex* const x[],
                                                    int                     incx,
-                                                   const hipComplex*       beta,
-                                                   hipComplex* const       y[],
+                                                   const hipblasComplex*       beta,
+                                                   hipblasComplex* const       y[],
                                                    int                     incy,
                                                    int                     batchCount);
 
@@ -1435,13 +1435,13 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgemvBatched(hipblasHandle_t              
                                                    hipblasOperation_t            trans,
                                                    int                           m,
                                                    int                           n,
-                                                   const hipDoubleComplex*       alpha,
-                                                   const hipDoubleComplex* const A[],
+                                                   const hipblasDoubleComplex*       alpha,
+                                                   const hipblasDoubleComplex* const A[],
                                                    int                           lda,
-                                                   const hipDoubleComplex* const x[],
+                                                   const hipblasDoubleComplex* const x[],
                                                    int                           incx,
-                                                   const hipDoubleComplex*       beta,
-                                                   hipDoubleComplex* const       y[],
+                                                   const hipblasDoubleComplex*       beta,
+                                                   hipblasDoubleComplex* const       y[],
                                                    int                           incy,
                                                    int                           batchCount);
 
@@ -1484,15 +1484,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCgemvStridedBatched(hipblasHandle_t    han
                                                           hipblasOperation_t trans,
                                                           int                m,
                                                           int                n,
-                                                          const hipComplex*  alpha,
-                                                          const hipComplex*  A,
+                                                          const hipblasComplex*  alpha,
+                                                          const hipblasComplex*  A,
                                                           int                lda,
                                                           int                strideA,
-                                                          const hipComplex*  x,
+                                                          const hipblasComplex*  x,
                                                           int                incx,
                                                           int                stridex,
-                                                          const hipComplex*  beta,
-                                                          hipComplex*        y,
+                                                          const hipblasComplex*  beta,
+                                                          hipblasComplex*        y,
                                                           int                incy,
                                                           int                stridey,
                                                           int                batchCount);
@@ -1501,15 +1501,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgemvStridedBatched(hipblasHandle_t       
                                                           hipblasOperation_t      trans,
                                                           int                     m,
                                                           int                     n,
-                                                          const hipDoubleComplex* alpha,
-                                                          const hipDoubleComplex* A,
+                                                          const hipblasDoubleComplex* alpha,
+                                                          const hipblasDoubleComplex* A,
                                                           int                     lda,
                                                           int                     strideA,
-                                                          const hipDoubleComplex* x,
+                                                          const hipblasDoubleComplex* x,
                                                           int                     incx,
                                                           int                     stridex,
-                                                          const hipDoubleComplex* beta,
-                                                          hipDoubleComplex*       y,
+                                                          const hipblasDoubleComplex* beta,
+                                                          hipblasDoubleComplex*       y,
                                                           int                     stridey,
                                                           int                     incy,
                                                           int                     batchCount);
@@ -1758,13 +1758,13 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCgemm(hipblasHandle_t    handle,
                                             int                m,
                                             int                n,
                                             int                k,
-                                            const hipComplex*  alpha,
-                                            const hipComplex*  A,
+                                            const hipblasComplex*  alpha,
+                                            const hipblasComplex*  A,
                                             int                lda,
-                                            const hipComplex*  B,
+                                            const hipblasComplex*  B,
                                             int                ldb,
-                                            const hipComplex*  beta,
-                                            hipComplex*        C,
+                                            const hipblasComplex*  beta,
+                                            hipblasComplex*        C,
                                             int                ldc);
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZgemm(hipblasHandle_t         handle,
@@ -1773,13 +1773,13 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgemm(hipblasHandle_t         handle,
                                             int                     m,
                                             int                     n,
                                             int                     k,
-                                            const hipDoubleComplex* alpha,
-                                            const hipDoubleComplex* A,
+                                            const hipblasDoubleComplex* alpha,
+                                            const hipblasDoubleComplex* A,
                                             int                     lda,
-                                            const hipDoubleComplex* B,
+                                            const hipblasDoubleComplex* B,
                                             int                     ldb,
-                                            const hipDoubleComplex* beta,
-                                            hipDoubleComplex*       C,
+                                            const hipblasDoubleComplex* beta,
+                                            hipblasDoubleComplex*       C,
                                             int                     ldc);
 
 // gemm batched
@@ -1837,13 +1837,13 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCgemmBatched(hipblasHandle_t         handl
                                                    int                     m,
                                                    int                     n,
                                                    int                     k,
-                                                   const hipComplex*       alpha,
-                                                   const hipComplex* const A[],
+                                                   const hipblasComplex*       alpha,
+                                                   const hipblasComplex* const A[],
                                                    int                     lda,
-                                                   const hipComplex* const B[],
+                                                   const hipblasComplex* const B[],
                                                    int                     ldb,
-                                                   const hipComplex*       beta,
-                                                   hipComplex* const       C[],
+                                                   const hipblasComplex*       beta,
+                                                   hipblasComplex* const       C[],
                                                    int                     ldc,
                                                    int                     batchCount);
 
@@ -1853,13 +1853,13 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgemmBatched(hipblasHandle_t              
                                                    int                           m,
                                                    int                           n,
                                                    int                           k,
-                                                   const hipDoubleComplex*       alpha,
-                                                   const hipDoubleComplex* const A[],
+                                                   const hipblasDoubleComplex*       alpha,
+                                                   const hipblasDoubleComplex* const A[],
                                                    int                           lda,
-                                                   const hipDoubleComplex* const B[],
+                                                   const hipblasDoubleComplex* const B[],
                                                    int                           ldb,
-                                                   const hipDoubleComplex*       beta,
-                                                   hipDoubleComplex* const       C[],
+                                                   const hipblasDoubleComplex*       beta,
+                                                   hipblasDoubleComplex* const       C[],
                                                    int                           ldc,
                                                    int                           batchCount);
 
@@ -1927,15 +1927,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCgemmStridedBatched(hipblasHandle_t    han
                                                           int                m,
                                                           int                n,
                                                           int                k,
-                                                          const hipComplex*  alpha,
-                                                          const hipComplex*  A,
+                                                          const hipblasComplex*  alpha,
+                                                          const hipblasComplex*  A,
                                                           int                lda,
                                                           long long          bsa,
-                                                          const hipComplex*  B,
+                                                          const hipblasComplex*  B,
                                                           int                ldb,
                                                           long long          bsb,
-                                                          const hipComplex*  beta,
-                                                          hipComplex*        C,
+                                                          const hipblasComplex*  beta,
+                                                          hipblasComplex*        C,
                                                           int                ldc,
                                                           long long          bsc,
                                                           int                batchCount);
@@ -1946,15 +1946,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgemmStridedBatched(hipblasHandle_t       
                                                           int                     m,
                                                           int                     n,
                                                           int                     k,
-                                                          const hipDoubleComplex* alpha,
-                                                          const hipDoubleComplex* A,
+                                                          const hipblasDoubleComplex* alpha,
+                                                          const hipblasDoubleComplex* A,
                                                           int                     lda,
                                                           long long               bsa,
-                                                          const hipDoubleComplex* B,
+                                                          const hipblasDoubleComplex* B,
                                                           int                     ldb,
                                                           long long               bsb,
-                                                          const hipDoubleComplex* beta,
-                                                          hipDoubleComplex*       C,
+                                                          const hipblasDoubleComplex* beta,
+                                                          hipblasDoubleComplex*       C,
                                                           int                     ldc,
                                                           long long               bsc,
                                                           int                     batchCount);

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -404,14 +404,14 @@ hipblasStatus_t hipblasIdamax(hipblasHandle_t handle, int n, const double* x, in
 }
 
 hipblasStatus_t
-    hipblasIcamax(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result)
+    hipblasIcamax(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_icamax((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, result));
 }
 
 hipblasStatus_t
-    hipblasIzamax(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result)
+    hipblasIzamax(hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_izamax((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
@@ -429,14 +429,14 @@ hipblasStatus_t hipblasIdamin(hipblasHandle_t handle, int n, const double* x, in
 }
 
 hipblasStatus_t
-    hipblasIcamin(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result)
+    hipblasIcamin(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_icamin((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, result));
 }
 
 hipblasStatus_t
-    hipblasIzamin(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result)
+    hipblasIzamin(hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_izamin((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
@@ -455,14 +455,14 @@ hipblasStatus_t
 }
 
 hipblasStatus_t
-    hipblasScasum(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+    hipblasScasum(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_scasum((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, result));
 }
 
 hipblasStatus_t hipblasDzasum(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_dzasum((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
@@ -489,7 +489,7 @@ hipblasStatus_t hipblasDasumBatched(hipblasHandle_t     handle,
 
 hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
                                      int                     n,
-                                     const hipComplex* const x[],
+                                     const hipblasComplex* const x[],
                                      int                     incx,
                                      int                     batch_count,
                                      float*                  result)
@@ -500,7 +500,7 @@ hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t               handle,
                                      int                           n,
-                                     const hipDoubleComplex* const x[],
+                                     const hipblasDoubleComplex* const x[],
                                      int                           incx,
                                      int                           batch_count,
                                      double*                       result)
@@ -536,7 +536,7 @@ hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
                                             int               n,
-                                            const hipComplex* x,
+                                            const hipblasComplex* x,
                                             int               incx,
                                             int               stridex,
                                             int               batch_count,
@@ -548,7 +548,7 @@ hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
                                             int                     n,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
                                             int                     stridex,
                                             int                     batch_count,
@@ -597,10 +597,10 @@ hipblasStatus_t hipblasDaxpy(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCaxpy(hipblasHandle_t   handle,
                              int               n,
-                             const hipComplex* alpha,
-                             const hipComplex* x,
+                             const hipblasComplex* alpha,
+                             const hipblasComplex* x,
                              int               incx,
-                             hipComplex*       y,
+                             hipblasComplex*       y,
                              int               incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_caxpy((rocblas_handle)handle,
@@ -614,10 +614,10 @@ hipblasStatus_t hipblasCaxpy(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZaxpy(hipblasHandle_t         handle,
                              int                     n,
-                             const hipDoubleComplex* alpha,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* alpha,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             hipDoubleComplex*       y,
+                             hipblasDoubleComplex*       y,
                              int                     incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_zaxpy((rocblas_handle)handle,
@@ -648,7 +648,7 @@ hipblasStatus_t
 }
 
 hipblasStatus_t hipblasCcopy(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, hipComplex* y, int incy)
+    hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_ccopy((rocblas_handle)handle,
                                                   n,
@@ -660,9 +660,9 @@ hipblasStatus_t hipblasCcopy(
 
 hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
                              int                     n,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             hipDoubleComplex*       y,
+                             hipblasDoubleComplex*       y,
                              int                     incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_zcopy((rocblas_handle)handle,
@@ -700,9 +700,9 @@ hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t     handle,
 
 hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    const hipComplex* const x[],
+                                    const hipblasComplex* const x[],
                                     int                     incx,
-                                    hipComplex* const       y[],
+                                    hipblasComplex* const       y[],
                                     int                     incy,
                                     int                     batchCount)
 {
@@ -717,9 +717,9 @@ hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t               handle,
                                     int                           n,
-                                    const hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* const x[],
                                     int                           incx,
-                                    hipDoubleComplex* const       y[],
+                                    hipblasDoubleComplex* const       y[],
                                     int                           incy,
                                     int                           batchCount)
 {
@@ -763,10 +763,10 @@ hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           const hipComplex* x,
+                                           const hipblasComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           hipComplex*       y,
+                                           hipblasComplex*       y,
                                            int               incy,
                                            int               stridey,
                                            int               batchCount)
@@ -784,10 +784,10 @@ hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t         handle,
                                            int                     n,
-                                           const hipDoubleComplex* x,
+                                           const hipblasDoubleComplex* x,
                                            int                     incx,
                                            int                     stridex,
-                                           hipDoubleComplex*       y,
+                                           hipblasDoubleComplex*       y,
                                            int                     incy,
                                            int                     stridey,
                                            int                     batchCount)
@@ -864,11 +864,11 @@ hipblasStatus_t hipblasDdot(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCdotc(hipblasHandle_t   handle,
                              int               n,
-                             const hipComplex* x,
+                             const hipblasComplex* x,
                              int               incx,
-                             const hipComplex* y,
+                             const hipblasComplex* y,
                              int               incy,
-                             hipComplex*       result)
+                             hipblasComplex*       result)
 {
     return rocBLASStatusToHIPStatus(rocblas_cdotc((rocblas_handle)handle,
                                                   n,
@@ -881,11 +881,11 @@ hipblasStatus_t hipblasCdotc(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCdotu(hipblasHandle_t   handle,
                              int               n,
-                             const hipComplex* x,
+                             const hipblasComplex* x,
                              int               incx,
-                             const hipComplex* y,
+                             const hipblasComplex* y,
                              int               incy,
-                             hipComplex*       result)
+                             hipblasComplex*       result)
 {
     return rocBLASStatusToHIPStatus(rocblas_cdotu((rocblas_handle)handle,
                                                   n,
@@ -898,11 +898,11 @@ hipblasStatus_t hipblasCdotu(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZdotc(hipblasHandle_t         handle,
                              int                     n,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             const hipDoubleComplex* y,
+                             const hipblasDoubleComplex* y,
                              int                     incy,
-                             hipDoubleComplex*       result)
+                             hipblasDoubleComplex*       result)
 {
     return rocBLASStatusToHIPStatus(rocblas_zdotc((rocblas_handle)handle,
                                                   n,
@@ -915,11 +915,11 @@ hipblasStatus_t hipblasZdotc(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdotu(hipblasHandle_t         handle,
                              int                     n,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             const hipDoubleComplex* y,
+                             const hipblasDoubleComplex* y,
                              int                     incy,
-                             hipDoubleComplex*       result)
+                             hipblasDoubleComplex*       result)
 {
     return rocBLASStatusToHIPStatus(rocblas_zdotu((rocblas_handle)handle,
                                                   n,
@@ -997,12 +997,12 @@ hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
 
 hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    const hipComplex* const x[],
+                                    const hipblasComplex* const x[],
                                     int                     incx,
-                                    const hipComplex* const y[],
+                                    const hipblasComplex* const y[],
                                     int                     incy,
                                     int                     batch_count,
-                                    hipComplex*             result)
+                                    hipblasComplex*             result)
 {
     return rocBLASStatusToHIPStatus(rocblas_cdotc_batched((rocblas_handle)handle,
                                                           n,
@@ -1016,12 +1016,12 @@ hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    const hipComplex* const x[],
+                                    const hipblasComplex* const x[],
                                     int                     incx,
-                                    const hipComplex* const y[],
+                                    const hipblasComplex* const y[],
                                     int                     incy,
                                     int                     batch_count,
-                                    hipComplex*             result)
+                                    hipblasComplex*             result)
 {
     return rocBLASStatusToHIPStatus(rocblas_cdotu_batched((rocblas_handle)handle,
                                                           n,
@@ -1035,12 +1035,12 @@ hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t               handle,
                                     int                           n,
-                                    const hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* const x[],
                                     int                           incx,
-                                    const hipDoubleComplex* const y[],
+                                    const hipblasDoubleComplex* const y[],
                                     int                           incy,
                                     int                           batch_count,
-                                    hipDoubleComplex*             result)
+                                    hipblasDoubleComplex*             result)
 {
     return rocBLASStatusToHIPStatus(rocblas_zdotc_batched((rocblas_handle)handle,
                                                           n,
@@ -1054,12 +1054,12 @@ hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t               handle,
 
 hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t               handle,
                                     int                           n,
-                                    const hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* const x[],
                                     int                           incx,
-                                    const hipDoubleComplex* const y[],
+                                    const hipblasDoubleComplex* const y[],
                                     int                           incy,
                                     int                           batch_count,
-                                    hipDoubleComplex*             result)
+                                    hipblasDoubleComplex*             result)
 {
     return rocBLASStatusToHIPStatus(rocblas_zdotu_batched((rocblas_handle)handle,
                                                           n,
@@ -1150,14 +1150,14 @@ hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           const hipComplex* x,
+                                           const hipblasComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           const hipComplex* y,
+                                           const hipblasComplex* y,
                                            int               incy,
                                            int               stridey,
                                            int               batch_count,
-                                           hipComplex*       result)
+                                           hipblasComplex*       result)
 {
     return rocBLASStatusToHIPStatus(rocblas_cdotc_strided_batched((rocblas_handle)handle,
                                                                   n,
@@ -1173,14 +1173,14 @@ hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           const hipComplex* x,
+                                           const hipblasComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           const hipComplex* y,
+                                           const hipblasComplex* y,
                                            int               incy,
                                            int               stridey,
                                            int               batch_count,
-                                           hipComplex*       result)
+                                           hipblasComplex*       result)
 {
     return rocBLASStatusToHIPStatus(rocblas_cdotu_strided_batched((rocblas_handle)handle,
                                                                   n,
@@ -1196,14 +1196,14 @@ hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t         handle,
                                            int                     n,
-                                           const hipDoubleComplex* x,
+                                           const hipblasDoubleComplex* x,
                                            int                     incx,
                                            int                     stridex,
-                                           const hipDoubleComplex* y,
+                                           const hipblasDoubleComplex* y,
                                            int                     incy,
                                            int                     stridey,
                                            int                     batch_count,
-                                           hipDoubleComplex*       result)
+                                           hipblasDoubleComplex*       result)
 {
     return rocBLASStatusToHIPStatus(rocblas_zdotc_strided_batched((rocblas_handle)handle,
                                                                   n,
@@ -1219,14 +1219,14 @@ hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t         handle,
                                            int                     n,
-                                           const hipDoubleComplex* x,
+                                           const hipblasDoubleComplex* x,
                                            int                     incx,
                                            int                     stridex,
-                                           const hipDoubleComplex* y,
+                                           const hipblasDoubleComplex* y,
                                            int                     incy,
                                            int                     stridey,
                                            int                     batch_count,
-                                           hipDoubleComplex*       result)
+                                           hipblasDoubleComplex*       result)
 {
     return rocBLASStatusToHIPStatus(rocblas_zdotu_strided_batched((rocblas_handle)handle,
                                                                   n,
@@ -1253,14 +1253,14 @@ hipblasStatus_t
 }
 
 hipblasStatus_t
-    hipblasScnrm2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+    hipblasScnrm2(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_scnrm2((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, result));
 }
 
 hipblasStatus_t hipblasDznrm2(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_dznrm2((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
@@ -1287,7 +1287,7 @@ hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t     handle,
 
 hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t         handle,
                                      int                     n,
-                                     const hipComplex* const x[],
+                                     const hipblasComplex* const x[],
                                      int                     incx,
                                      int                     batchCount,
                                      float*                  result)
@@ -1298,7 +1298,7 @@ hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t               handle,
                                      int                           n,
-                                     const hipDoubleComplex* const x[],
+                                     const hipblasDoubleComplex* const x[],
                                      int                           incx,
                                      int                           batchCount,
                                      double*                       result)
@@ -1334,7 +1334,7 @@ hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   handle,
                                             int               n,
-                                            const hipComplex* x,
+                                            const hipblasComplex* x,
                                             int               incx,
                                             int               stridex,
                                             int               batchCount,
@@ -1346,7 +1346,7 @@ hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t         handle,
                                             int                     n,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
                                             int                     stridex,
                                             int                     batchCount,
@@ -1385,12 +1385,12 @@ hipblasStatus_t hipblasDrot(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCrot(hipblasHandle_t   handle,
                             int               n,
-                            hipComplex*       x,
+                            hipblasComplex*       x,
                             int               incx,
-                            hipComplex*       y,
+                            hipblasComplex*       y,
                             int               incy,
                             const float*      c,
-                            const hipComplex* s)
+                            const hipblasComplex* s)
 {
     return rocBLASStatusToHIPStatus(rocblas_crot((rocblas_handle)handle,
                                                  n,
@@ -1404,9 +1404,9 @@ hipblasStatus_t hipblasCrot(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCsrot(hipblasHandle_t handle,
                              int             n,
-                             hipComplex*     x,
+                             hipblasComplex*     x,
                              int             incx,
-                             hipComplex*     y,
+                             hipblasComplex*     y,
                              int             incy,
                              const float*    c,
                              const float*    s)
@@ -1423,12 +1423,12 @@ hipblasStatus_t hipblasCsrot(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
                             int                     n,
-                            hipDoubleComplex*       x,
+                            hipblasDoubleComplex*       x,
                             int                     incx,
-                            hipDoubleComplex*       y,
+                            hipblasDoubleComplex*       y,
                             int                     incy,
                             const double*           c,
-                            const hipDoubleComplex* s)
+                            const hipblasDoubleComplex* s)
 {
     return rocBLASStatusToHIPStatus(rocblas_zrot((rocblas_handle)handle,
                                                  n,
@@ -1442,9 +1442,9 @@ hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdrot(hipblasHandle_t   handle,
                              int               n,
-                             hipDoubleComplex* x,
+                             hipblasDoubleComplex* x,
                              int               incx,
-                             hipDoubleComplex* y,
+                             hipblasDoubleComplex* y,
                              int               incy,
                              const double*     c,
                              const double*     s)
@@ -1490,12 +1490,12 @@ hipblasStatus_t hipblasDrotBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCrotBatched(hipblasHandle_t   handle,
                                    int               n,
-                                   hipComplex* const x[],
+                                   hipblasComplex* const x[],
                                    int               incx,
-                                   hipComplex* const y[],
+                                   hipblasComplex* const y[],
                                    int               incy,
                                    const float*      c,
-                                   const hipComplex* s,
+                                   const hipblasComplex* s,
                                    int               batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_crot_batched((rocblas_handle)handle,
@@ -1511,9 +1511,9 @@ hipblasStatus_t hipblasCrotBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCsrotBatched(hipblasHandle_t   handle,
                                     int               n,
-                                    hipComplex* const x[],
+                                    hipblasComplex* const x[],
                                     int               incx,
-                                    hipComplex* const y[],
+                                    hipblasComplex* const y[],
                                     int               incy,
                                     const float*      c,
                                     const float*      s,
@@ -1532,12 +1532,12 @@ hipblasStatus_t hipblasCsrotBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZrotBatched(hipblasHandle_t         handle,
                                    int                     n,
-                                   hipDoubleComplex* const x[],
+                                   hipblasDoubleComplex* const x[],
                                    int                     incx,
-                                   hipDoubleComplex* const y[],
+                                   hipblasDoubleComplex* const y[],
                                    int                     incy,
                                    const double*           c,
-                                   const hipDoubleComplex* s,
+                                   const hipblasDoubleComplex* s,
                                    int                     batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zrot_batched((rocblas_handle)handle,
@@ -1553,9 +1553,9 @@ hipblasStatus_t hipblasZrotBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdrotBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    hipDoubleComplex* const x[],
+                                    hipblasDoubleComplex* const x[],
                                     int                     incx,
-                                    hipDoubleComplex* const y[],
+                                    hipblasDoubleComplex* const y[],
                                     int                     incy,
                                     const double*           c,
                                     const double*           s,
@@ -1607,14 +1607,14 @@ hipblasStatus_t hipblasDrotStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCrotStridedBatched(hipblasHandle_t   handle,
                                           int               n,
-                                          hipComplex*       x,
+                                          hipblasComplex*       x,
                                           int               incx,
                                           int               stridex,
-                                          hipComplex*       y,
+                                          hipblasComplex*       y,
                                           int               incy,
                                           int               stridey,
                                           const float*      c,
-                                          const hipComplex* s,
+                                          const hipblasComplex* s,
                                           int               batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_crot_strided_batched((rocblas_handle)handle,
@@ -1632,10 +1632,10 @@ hipblasStatus_t hipblasCrotStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCsrotStridedBatched(hipblasHandle_t handle,
                                            int             n,
-                                           hipComplex*     x,
+                                           hipblasComplex*     x,
                                            int             incx,
                                            int             stridex,
-                                           hipComplex*     y,
+                                           hipblasComplex*     y,
                                            int             incy,
                                            int             stridey,
                                            const float*    c,
@@ -1657,14 +1657,14 @@ hipblasStatus_t hipblasCsrotStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasZrotStridedBatched(hipblasHandle_t         handle,
                                           int                     n,
-                                          hipDoubleComplex*       x,
+                                          hipblasDoubleComplex*       x,
                                           int                     incx,
                                           int                     stridex,
-                                          hipDoubleComplex*       y,
+                                          hipblasDoubleComplex*       y,
                                           int                     incy,
                                           int                     stridey,
                                           const double*           c,
-                                          const hipDoubleComplex* s,
+                                          const hipblasDoubleComplex* s,
                                           int                     batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zrot_strided_batched((rocblas_handle)handle,
@@ -1682,10 +1682,10 @@ hipblasStatus_t hipblasZrotStridedBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdrotStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           hipDoubleComplex* x,
+                                           hipblasDoubleComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           hipDoubleComplex* y,
+                                           hipblasDoubleComplex* y,
                                            int               incy,
                                            int               stridey,
                                            const double*     c,
@@ -1717,7 +1717,7 @@ hipblasStatus_t hipblasDrotg(hipblasHandle_t handle, double* a, double* b, doubl
 }
 
 hipblasStatus_t
-    hipblasCrotg(hipblasHandle_t handle, hipComplex* a, hipComplex* b, float* c, hipComplex* s)
+    hipblasCrotg(hipblasHandle_t handle, hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s)
 {
     return rocBLASStatusToHIPStatus(rocblas_crotg((rocblas_handle)handle,
                                                   (rocblas_float_complex*)a,
@@ -1727,10 +1727,10 @@ hipblasStatus_t
 }
 
 hipblasStatus_t hipblasZrotg(hipblasHandle_t   handle,
-                             hipDoubleComplex* a,
-                             hipDoubleComplex* b,
+                             hipblasDoubleComplex* a,
+                             hipblasDoubleComplex* b,
                              double*           c,
-                             hipDoubleComplex* s)
+                             hipblasDoubleComplex* s)
 {
     return rocBLASStatusToHIPStatus(rocblas_zrotg((rocblas_handle)handle,
                                                   (rocblas_double_complex*)a,
@@ -1763,10 +1763,10 @@ hipblasStatus_t hipblasDrotgBatched(hipblasHandle_t handle,
 }
 
 hipblasStatus_t hipblasCrotgBatched(hipblasHandle_t   handle,
-                                    hipComplex* const a[],
-                                    hipComplex* const b[],
+                                    hipblasComplex* const a[],
+                                    hipblasComplex* const b[],
                                     float* const      c[],
-                                    hipComplex* const s[],
+                                    hipblasComplex* const s[],
                                     int               batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_crotg_batched((rocblas_handle)handle,
@@ -1778,10 +1778,10 @@ hipblasStatus_t hipblasCrotgBatched(hipblasHandle_t   handle,
 }
 
 hipblasStatus_t hipblasZrotgBatched(hipblasHandle_t         handle,
-                                    hipDoubleComplex* const a[],
-                                    hipDoubleComplex* const b[],
+                                    hipblasDoubleComplex* const a[],
+                                    hipblasDoubleComplex* const b[],
                                     double* const           c[],
-                                    hipDoubleComplex* const s[],
+                                    hipblasDoubleComplex* const s[],
                                     int                     batchCount)
 {
     return rocBLASStatusToHIPStatus(rocblas_zrotg_batched((rocblas_handle)handle,
@@ -1824,13 +1824,13 @@ hipblasStatus_t hipblasDrotgStridedBatched(hipblasHandle_t handle,
 }
 
 hipblasStatus_t hipblasCrotgStridedBatched(hipblasHandle_t handle,
-                                           hipComplex*     a,
+                                           hipblasComplex*     a,
                                            int             stride_a,
-                                           hipComplex*     b,
+                                           hipblasComplex*     b,
                                            int             stride_b,
                                            float*          c,
                                            int             stride_c,
-                                           hipComplex*     s,
+                                           hipblasComplex*     s,
                                            int             stride_s,
                                            int             batchCount)
 {
@@ -1847,13 +1847,13 @@ hipblasStatus_t hipblasCrotgStridedBatched(hipblasHandle_t handle,
 }
 
 hipblasStatus_t hipblasZrotgStridedBatched(hipblasHandle_t   handle,
-                                           hipDoubleComplex* a,
+                                           hipblasDoubleComplex* a,
                                            int               stride_a,
-                                           hipDoubleComplex* b,
+                                           hipblasDoubleComplex* b,
                                            int               stride_b,
                                            double*           c,
                                            int               stride_c,
-                                           hipDoubleComplex* s,
+                                           hipblasDoubleComplex* s,
                                            int               stride_s,
                                            int               batchCount)
 {
@@ -2068,21 +2068,21 @@ hipblasStatus_t
 }
 
 hipblasStatus_t
-    hipblasCscal(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx)
+    hipblasCscal(hipblasHandle_t handle, int n, const hipblasComplex* alpha, hipblasComplex* x, int incx)
 {
     return rocBLASStatusToHIPStatus(rocblas_cscal(
         (rocblas_handle)handle, n, (rocblas_float_complex*)alpha, (rocblas_float_complex*)x, incx));
 }
 
 hipblasStatus_t
-    hipblasCsscal(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx)
+    hipblasCsscal(hipblasHandle_t handle, int n, const float* alpha, hipblasComplex* x, int incx)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_csscal((rocblas_handle)handle, n, alpha, (rocblas_float_complex*)x, incx));
 }
 
 hipblasStatus_t hipblasZscal(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx)
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* alpha, hipblasDoubleComplex* x, int incx)
 {
     return rocBLASStatusToHIPStatus(rocblas_zscal((rocblas_handle)handle,
                                                   n,
@@ -2092,7 +2092,7 @@ hipblasStatus_t hipblasZscal(
 }
 
 hipblasStatus_t
-    hipblasZdscal(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx)
+    hipblasZdscal(hipblasHandle_t handle, int n, const double* alpha, hipblasDoubleComplex* x, int incx)
 {
     return rocBLASStatusToHIPStatus(
         rocblas_zdscal((rocblas_handle)handle, n, alpha, (rocblas_double_complex*)x, incx));
@@ -2115,8 +2115,8 @@ hipblasStatus_t hipblasDscalBatched(
 
 hipblasStatus_t hipblasCscalBatched(hipblasHandle_t   handle,
                                     int               n,
-                                    const hipComplex* alpha,
-                                    hipComplex* const x[],
+                                    const hipblasComplex* alpha,
+                                    hipblasComplex* const x[],
                                     int               incx,
                                     int               batchCount)
 {
@@ -2130,8 +2130,8 @@ hipblasStatus_t hipblasCscalBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZscalBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    const hipDoubleComplex* alpha,
-                                    hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* alpha,
+                                    hipblasDoubleComplex* const x[],
                                     int                     incx,
                                     int                     batchCount)
 {
@@ -2146,7 +2146,7 @@ hipblasStatus_t hipblasZscalBatched(hipblasHandle_t         handle,
 hipblasStatus_t hipblasCsscalBatched(hipblasHandle_t   handle,
                                      int               n,
                                      const float*      alpha,
-                                     hipComplex* const x[],
+                                     hipblasComplex* const x[],
                                      int               incx,
                                      int               batchCount)
 {
@@ -2157,7 +2157,7 @@ hipblasStatus_t hipblasCsscalBatched(hipblasHandle_t   handle,
 hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t         handle,
                                      int                     n,
                                      const double*           alpha,
-                                     hipDoubleComplex* const x[],
+                                     hipblasDoubleComplex* const x[],
                                      int                     incx,
                                      int                     batchCount)
 {
@@ -2192,8 +2192,8 @@ hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           const hipComplex* alpha,
-                                           hipComplex*       x,
+                                           const hipblasComplex* alpha,
+                                           hipblasComplex*       x,
                                            int               incx,
                                            int               stridex,
                                            int               batchCount)
@@ -2209,8 +2209,8 @@ hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t         handle,
                                            int                     n,
-                                           const hipDoubleComplex* alpha,
-                                           hipDoubleComplex*       x,
+                                           const hipblasDoubleComplex* alpha,
+                                           hipblasDoubleComplex*       x,
                                            int                     incx,
                                            int                     stridex,
                                            int                     batchCount)
@@ -2227,7 +2227,7 @@ hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t         handle,
 hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle,
                                             int             n,
                                             const float*    alpha,
-                                            hipComplex*     x,
+                                            hipblasComplex*     x,
                                             int             incx,
                                             int             stridex,
                                             int             batchCount)
@@ -2239,7 +2239,7 @@ hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle,
 hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t   handle,
                                             int               n,
                                             const double*     alpha,
-                                            hipDoubleComplex* x,
+                                            hipblasDoubleComplex* x,
                                             int               incx,
                                             int               stridex,
                                             int               batchCount)
@@ -2261,7 +2261,7 @@ hipblasStatus_t
 }
 
 hipblasStatus_t
-    hipblasCswap(hipblasHandle_t handle, int n, hipComplex* x, int incx, hipComplex* y, int incy)
+    hipblasCswap(hipblasHandle_t handle, int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_cswap((rocblas_handle)handle,
                                                   n,
@@ -2272,7 +2272,7 @@ hipblasStatus_t
 }
 
 hipblasStatus_t hipblasZswap(
-    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy)
+    hipblasHandle_t handle, int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_zswap((rocblas_handle)handle,
                                                   n,
@@ -2299,9 +2299,9 @@ hipblasStatus_t hipblasDswapBatched(
 
 hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
                                     int             n,
-                                    hipComplex*     x[],
+                                    hipblasComplex*     x[],
                                     int             incx,
-                                    hipComplex*     y[],
+                                    hipblasComplex*     y[],
                                     int             incy,
                                     int             batchCount)
 {
@@ -2316,9 +2316,9 @@ hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasZswapBatched(hipblasHandle_t   handle,
                                     int               n,
-                                    hipDoubleComplex* x[],
+                                    hipblasDoubleComplex* x[],
                                     int               incx,
-                                    hipDoubleComplex* y[],
+                                    hipblasDoubleComplex* y[],
                                     int               incy,
                                     int               batchCount)
 {
@@ -2362,10 +2362,10 @@ hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle,
                                            int             n,
-                                           hipComplex*     x,
+                                           hipblasComplex*     x,
                                            int             incx,
                                            int             stridex,
-                                           hipComplex*     y,
+                                           hipblasComplex*     y,
                                            int             incy,
                                            int             stridey,
                                            int             batchCount)
@@ -2383,10 +2383,10 @@ hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           hipDoubleComplex* x,
+                                           hipblasDoubleComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           hipDoubleComplex* y,
+                                           hipblasDoubleComplex* y,
                                            int               incy,
                                            int               stridey,
                                            int               batchCount)
@@ -2461,13 +2461,13 @@ hipblasStatus_t hipblasCgemv(hipblasHandle_t    handle,
                              hipblasOperation_t trans,
                              int                m,
                              int                n,
-                             const hipComplex*  alpha,
-                             const hipComplex*  A,
+                             const hipblasComplex*  alpha,
+                             const hipblasComplex*  A,
                              int                lda,
-                             const hipComplex*  x,
+                             const hipblasComplex*  x,
                              int                incx,
-                             const hipComplex*  beta,
-                             hipComplex*        y,
+                             const hipblasComplex*  beta,
+                             hipblasComplex*        y,
                              int                incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_cgemv((rocblas_handle)handle,
@@ -2488,13 +2488,13 @@ hipblasStatus_t hipblasZgemv(hipblasHandle_t         handle,
                              hipblasOperation_t      trans,
                              int                     m,
                              int                     n,
-                             const hipDoubleComplex* alpha,
-                             const hipDoubleComplex* A,
+                             const hipblasDoubleComplex* alpha,
+                             const hipblasDoubleComplex* A,
                              int                     lda,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             const hipDoubleComplex* beta,
-                             hipDoubleComplex*       y,
+                             const hipblasDoubleComplex* beta,
+                             hipblasDoubleComplex*       y,
                              int                     incy)
 {
     return rocBLASStatusToHIPStatus(rocblas_zgemv((rocblas_handle)handle,
@@ -2574,13 +2574,13 @@ hipblasStatus_t hipblasCgemvBatched(hipblasHandle_t         handle,
                                     hipblasOperation_t      trans,
                                     int                     m,
                                     int                     n,
-                                    const hipComplex*       alpha,
-                                    const hipComplex* const A[],
+                                    const hipblasComplex*       alpha,
+                                    const hipblasComplex* const A[],
                                     int                     lda,
-                                    const hipComplex* const x[],
+                                    const hipblasComplex* const x[],
                                     int                     incx,
-                                    const hipComplex*       beta,
-                                    hipComplex* const       y[],
+                                    const hipblasComplex*       beta,
+                                    hipblasComplex* const       y[],
                                     int                     incy,
                                     int                     batchCount)
 {
@@ -2603,13 +2603,13 @@ hipblasStatus_t hipblasZgemvBatched(hipblasHandle_t               handle,
                                     hipblasOperation_t            trans,
                                     int                           m,
                                     int                           n,
-                                    const hipDoubleComplex*       alpha,
-                                    const hipDoubleComplex* const A[],
+                                    const hipblasDoubleComplex*       alpha,
+                                    const hipblasDoubleComplex* const A[],
                                     int                           lda,
-                                    const hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* const x[],
                                     int                           incx,
-                                    const hipDoubleComplex*       beta,
-                                    hipDoubleComplex* const       y[],
+                                    const hipblasDoubleComplex*       beta,
+                                    hipblasDoubleComplex* const       y[],
                                     int                           incy,
                                     int                           batchCount)
 {
@@ -2703,15 +2703,15 @@ hipblasStatus_t hipblasCgemvStridedBatched(hipblasHandle_t    handle,
                                            hipblasOperation_t trans,
                                            int                m,
                                            int                n,
-                                           const hipComplex*  alpha,
-                                           const hipComplex*  A,
+                                           const hipblasComplex*  alpha,
+                                           const hipblasComplex*  A,
                                            int                lda,
                                            int                strideA,
-                                           const hipComplex*  x,
+                                           const hipblasComplex*  x,
                                            int                incx,
                                            int                stridex,
-                                           const hipComplex*  beta,
-                                           hipComplex*        y,
+                                           const hipblasComplex*  beta,
+                                           hipblasComplex*        y,
                                            int                incy,
                                            int                stridey,
                                            int                batchCount)
@@ -2738,15 +2738,15 @@ hipblasStatus_t hipblasZgemvStridedBatched(hipblasHandle_t         handle,
                                            hipblasOperation_t      trans,
                                            int                     m,
                                            int                     n,
-                                           const hipDoubleComplex* alpha,
-                                           const hipDoubleComplex* A,
+                                           const hipblasDoubleComplex* alpha,
+                                           const hipblasDoubleComplex* A,
                                            int                     lda,
                                            int                     strideA,
-                                           const hipDoubleComplex* x,
+                                           const hipblasDoubleComplex* x,
                                            int                     incx,
                                            int                     stridex,
-                                           const hipDoubleComplex* beta,
-                                           hipDoubleComplex*       y,
+                                           const hipblasDoubleComplex* beta,
+                                           hipblasDoubleComplex*       y,
                                            int                     incy,
                                            int                     stridey,
                                            int                     batchCount)
@@ -3203,13 +3203,13 @@ hipblasStatus_t hipblasCgemm(hipblasHandle_t    handle,
                              int                m,
                              int                n,
                              int                k,
-                             const hipComplex*  alpha,
-                             const hipComplex*  A,
+                             const hipblasComplex*  alpha,
+                             const hipblasComplex*  A,
                              int                lda,
-                             const hipComplex*  B,
+                             const hipblasComplex*  B,
                              int                ldb,
-                             const hipComplex*  beta,
-                             hipComplex*        C,
+                             const hipblasComplex*  beta,
+                             hipblasComplex*        C,
                              int                ldc)
 {
     return rocBLASStatusToHIPStatus(rocblas_cgemm((rocblas_handle)handle,
@@ -3234,13 +3234,13 @@ hipblasStatus_t hipblasZgemm(hipblasHandle_t         handle,
                              int                     m,
                              int                     n,
                              int                     k,
-                             const hipDoubleComplex* alpha,
-                             const hipDoubleComplex* A,
+                             const hipblasDoubleComplex* alpha,
+                             const hipblasDoubleComplex* A,
                              int                     lda,
-                             const hipDoubleComplex* B,
+                             const hipblasDoubleComplex* B,
                              int                     ldb,
-                             const hipDoubleComplex* beta,
-                             hipDoubleComplex*       C,
+                             const hipblasDoubleComplex* beta,
+                             hipblasDoubleComplex*       C,
                              int                     ldc)
 {
     return rocBLASStatusToHIPStatus(rocblas_zgemm((rocblas_handle)handle,
@@ -3365,13 +3365,13 @@ hipblasStatus_t hipblasCgemmBatched(hipblasHandle_t         handle,
                                     int                     m,
                                     int                     n,
                                     int                     k,
-                                    const hipComplex*       alpha,
-                                    const hipComplex* const A[],
+                                    const hipblasComplex*       alpha,
+                                    const hipblasComplex* const A[],
                                     int                     lda,
-                                    const hipComplex* const B[],
+                                    const hipblasComplex* const B[],
                                     int                     ldb,
-                                    const hipComplex*       beta,
-                                    hipComplex* const       C[],
+                                    const hipblasComplex*       beta,
+                                    hipblasComplex* const       C[],
                                     int                     ldc,
                                     int                     batchCount)
 {
@@ -3398,13 +3398,13 @@ hipblasStatus_t hipblasZgemmBatched(hipblasHandle_t               handle,
                                     int                           m,
                                     int                           n,
                                     int                           k,
-                                    const hipDoubleComplex*       alpha,
-                                    const hipDoubleComplex* const A[],
+                                    const hipblasDoubleComplex*       alpha,
+                                    const hipblasDoubleComplex* const A[],
                                     int                           lda,
-                                    const hipDoubleComplex* const B[],
+                                    const hipblasDoubleComplex* const B[],
                                     int                           ldb,
-                                    const hipDoubleComplex*       beta,
-                                    hipDoubleComplex* const       C[],
+                                    const hipblasDoubleComplex*       beta,
+                                    hipblasDoubleComplex* const       C[],
                                     int                           ldc,
                                     int                           batchCount)
 {
@@ -3588,15 +3588,15 @@ hipblasStatus_t hipblasCgemmStridedBatched(hipblasHandle_t    handle,
                                            int                m,
                                            int                n,
                                            int                k,
-                                           const hipComplex*  alpha,
-                                           const hipComplex*  A,
+                                           const hipblasComplex*  alpha,
+                                           const hipblasComplex*  A,
                                            int                lda,
                                            long long          bsa,
-                                           const hipComplex*  B,
+                                           const hipblasComplex*  B,
                                            int                ldb,
                                            long long          bsb,
-                                           const hipComplex*  beta,
-                                           hipComplex*        C,
+                                           const hipblasComplex*  beta,
+                                           hipblasComplex*        C,
                                            int                ldc,
                                            long long          bsc,
                                            int                batchCount)
@@ -3640,15 +3640,15 @@ hipblasStatus_t hipblasZgemmStridedBatched(hipblasHandle_t         handle,
                                            int                     m,
                                            int                     n,
                                            int                     k,
-                                           const hipDoubleComplex* alpha,
-                                           const hipDoubleComplex* A,
+                                           const hipblasDoubleComplex* alpha,
+                                           const hipblasDoubleComplex* A,
                                            int                     lda,
                                            long long               bsa,
-                                           const hipDoubleComplex* B,
+                                           const hipblasDoubleComplex* B,
                                            int                     ldb,
                                            long long               bsb,
-                                           const hipDoubleComplex* beta,
-                                           hipDoubleComplex*       C,
+                                           const hipblasDoubleComplex* beta,
+                                           hipblasDoubleComplex*       C,
                                            int                     ldc,
                                            long long               bsc,
                                            int                     batchCount)

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -316,14 +316,14 @@ hipblasStatus_t hipblasIdamax(hipblasHandle_t handle, int n, const double* x, in
 }
 
 hipblasStatus_t
-    hipblasIcamax(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result)
+    hipblasIcamax(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasIcamax((cublasHandle_t)handle, n, (cuComplex*)x, incx, result));
 }
 
 hipblasStatus_t
-    hipblasIzamax(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result)
+    hipblasIzamax(hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasIzamax((cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, result));
@@ -341,14 +341,14 @@ hipblasStatus_t hipblasIdamin(hipblasHandle_t handle, int n, const double* x, in
 }
 
 hipblasStatus_t
-    hipblasIcamin(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result)
+    hipblasIcamin(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasIcamin((cublasHandle_t)handle, n, (cuComplex*)x, incx, result));
 }
 
 hipblasStatus_t
-    hipblasIzamin(hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result)
+    hipblasIzamin(hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasIzamin((cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, result));
@@ -367,14 +367,14 @@ hipblasStatus_t
 }
 
 hipblasStatus_t
-    hipblasScasum(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+    hipblasScasum(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasScasum((cublasHandle_t)handle, n, (cuComplex*)x, incx, result));
 }
 
 hipblasStatus_t hipblasDzasum(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasDzasum((cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, result));
@@ -401,7 +401,7 @@ hipblasStatus_t hipblasDasumBatched(hipblasHandle_t     handle,
 
 hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
                                      int                     n,
-                                     const hipComplex* const x[],
+                                     const hipblasComplex* const x[],
                                      int                     incx,
                                      int                     batchCount,
                                      float*                  result)
@@ -411,7 +411,7 @@ hipblasStatus_t hipblasScasumBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t               handle,
                                      int                           n,
-                                     const hipDoubleComplex* const x[],
+                                     const hipblasDoubleComplex* const x[],
                                      int                           incx,
                                      int                           batchCount,
                                      double*                       result)
@@ -444,7 +444,7 @@ hipblasStatus_t hipblasDasumStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
                                             int               n,
-                                            const hipComplex* x,
+                                            const hipblasComplex* x,
                                             int               incx,
                                             int               stridex,
                                             int               batchCount,
@@ -455,7 +455,7 @@ hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
                                             int                     n,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
                                             int                     stridex,
                                             int                     batchCount,
@@ -498,10 +498,10 @@ hipblasStatus_t hipblasDaxpy(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCaxpy(hipblasHandle_t   handle,
                              int               n,
-                             const hipComplex* alpha,
-                             const hipComplex* x,
+                             const hipblasComplex* alpha,
+                             const hipblasComplex* x,
                              int               incx,
-                             hipComplex*       y,
+                             hipblasComplex*       y,
                              int               incy)
 {
     return hipCUBLASStatusToHIPStatus(cublasCaxpy(
@@ -510,10 +510,10 @@ hipblasStatus_t hipblasCaxpy(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZaxpy(hipblasHandle_t         handle,
                              int                     n,
-                             const hipDoubleComplex* alpha,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* alpha,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             hipDoubleComplex*       y,
+                             hipblasDoubleComplex*       y,
                              int                     incy)
 {
     return hipCUBLASStatusToHIPStatus(cublasZaxpy((cublasHandle_t)handle,
@@ -567,7 +567,7 @@ hipblasStatus_t
 }
 
 hipblasStatus_t hipblasCcopy(
-    hipblasHandle_t handle, int n, const hipComplex* x, int incx, hipComplex* y, int incy)
+    hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasCcopy((cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy));
@@ -575,9 +575,9 @@ hipblasStatus_t hipblasCcopy(
 
 hipblasStatus_t hipblasZcopy(hipblasHandle_t         handle,
                              int                     n,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             hipDoubleComplex*       y,
+                             hipblasDoubleComplex*       y,
                              int                     incy)
 {
     return hipCUBLASStatusToHIPStatus(cublasZcopy(
@@ -609,9 +609,9 @@ hipblasStatus_t hipblasDcopyBatched(hipblasHandle_t     handle,
 
 hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    const hipComplex* const x[],
+                                    const hipblasComplex* const x[],
                                     int                     incx,
-                                    hipComplex* const       y[],
+                                    hipblasComplex* const       y[],
                                     int                     incy,
                                     int                     batchCount)
 {
@@ -620,9 +620,9 @@ hipblasStatus_t hipblasCcopyBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t               handle,
                                     int                           n,
-                                    const hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* const x[],
                                     int                           incx,
-                                    hipDoubleComplex* const       y[],
+                                    hipblasDoubleComplex* const       y[],
                                     int                           incy,
                                     int                           batchCount)
 {
@@ -658,10 +658,10 @@ hipblasStatus_t hipblasDcopyStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           const hipComplex* x,
+                                           const hipblasComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           hipComplex*       y,
+                                           hipblasComplex*       y,
                                            int               incy,
                                            int               stridey,
                                            int               batchCount)
@@ -671,10 +671,10 @@ hipblasStatus_t hipblasCcopyStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t         handle,
                                            int                     n,
-                                           const hipDoubleComplex* x,
+                                           const hipblasDoubleComplex* x,
                                            int                     incx,
                                            int                     stridex,
-                                           hipDoubleComplex*       y,
+                                           hipblasDoubleComplex*       y,
                                            int                     incy,
                                            int                     stridey,
                                            int                     batchCount)
@@ -731,11 +731,11 @@ hipblasStatus_t hipblasDdot(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCdotc(hipblasHandle_t   handle,
                              int               n,
-                             const hipComplex* x,
+                             const hipblasComplex* x,
                              int               incx,
-                             const hipComplex* y,
+                             const hipblasComplex* y,
                              int               incy,
-                             hipComplex*       result)
+                             hipblasComplex*       result)
 {
     return hipCUBLASStatusToHIPStatus(cublasCdotc(
         (cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy, (cuComplex*)result));
@@ -743,11 +743,11 @@ hipblasStatus_t hipblasCdotc(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCdotu(hipblasHandle_t   handle,
                              int               n,
-                             const hipComplex* x,
+                             const hipblasComplex* x,
                              int               incx,
-                             const hipComplex* y,
+                             const hipblasComplex* y,
                              int               incy,
-                             hipComplex*       result)
+                             hipblasComplex*       result)
 {
     return hipCUBLASStatusToHIPStatus(cublasCdotu(
         (cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy, (cuComplex*)result));
@@ -755,11 +755,11 @@ hipblasStatus_t hipblasCdotu(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZdotc(hipblasHandle_t         handle,
                              int                     n,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             const hipDoubleComplex* y,
+                             const hipblasDoubleComplex* y,
                              int                     incy,
-                             hipDoubleComplex*       result)
+                             hipblasDoubleComplex*       result)
 {
     return hipCUBLASStatusToHIPStatus(cublasZdotc((cublasHandle_t)handle,
                                                   n,
@@ -772,11 +772,11 @@ hipblasStatus_t hipblasZdotc(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdotu(hipblasHandle_t         handle,
                              int                     n,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             const hipDoubleComplex* y,
+                             const hipblasDoubleComplex* y,
                              int                     incy,
-                             hipDoubleComplex*       result)
+                             hipblasDoubleComplex*       result)
 {
     return hipCUBLASStatusToHIPStatus(cublasZdotu((cublasHandle_t)handle,
                                                   n,
@@ -844,48 +844,48 @@ hipblasStatus_t hipblasDdotBatched(hipblasHandle_t     handle,
 
 hipblasStatus_t hipblasCdotcBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    const hipComplex* const x[],
+                                    const hipblasComplex* const x[],
                                     int                     incx,
-                                    const hipComplex* const y[],
+                                    const hipblasComplex* const y[],
                                     int                     incy,
                                     int                     batchCount,
-                                    hipComplex*             result)
+                                    hipblasComplex*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasCdotuBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    const hipComplex* const x[],
+                                    const hipblasComplex* const x[],
                                     int                     incx,
-                                    const hipComplex* const y[],
+                                    const hipblasComplex* const y[],
                                     int                     incy,
                                     int                     batchCount,
-                                    hipComplex*             result)
+                                    hipblasComplex*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasZdotcBatched(hipblasHandle_t               handle,
                                     int                           n,
-                                    const hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* const x[],
                                     int                           incx,
-                                    const hipDoubleComplex* const y[],
+                                    const hipblasDoubleComplex* const y[],
                                     int                           incy,
                                     int                           batchCount,
-                                    hipDoubleComplex*             result)
+                                    hipblasDoubleComplex*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t               handle,
                                     int                           n,
-                                    const hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* const x[],
                                     int                           incx,
-                                    const hipDoubleComplex* const y[],
+                                    const hipblasDoubleComplex* const y[],
                                     int                           incy,
                                     int                           batchCount,
-                                    hipDoubleComplex*             result)
+                                    hipblasDoubleComplex*             result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -949,56 +949,56 @@ hipblasStatus_t hipblasDdotStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCdotcStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           const hipComplex* x,
+                                           const hipblasComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           const hipComplex* y,
+                                           const hipblasComplex* y,
                                            int               incy,
                                            int               stridey,
                                            int               batchCount,
-                                           hipComplex*       result)
+                                           hipblasComplex*       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasCdotuStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           const hipComplex* x,
+                                           const hipblasComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           const hipComplex* y,
+                                           const hipblasComplex* y,
                                            int               incy,
                                            int               stridey,
                                            int               batchCount,
-                                           hipComplex*       result)
+                                           hipblasComplex*       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasZdotcStridedBatched(hipblasHandle_t         handle,
                                            int                     n,
-                                           const hipDoubleComplex* x,
+                                           const hipblasDoubleComplex* x,
                                            int                     incx,
                                            int                     stridex,
-                                           const hipDoubleComplex* y,
+                                           const hipblasDoubleComplex* y,
                                            int                     incy,
                                            int                     stridey,
                                            int                     batchCount,
-                                           hipDoubleComplex*       result)
+                                           hipblasDoubleComplex*       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t         handle,
                                            int                     n,
-                                           const hipDoubleComplex* x,
+                                           const hipblasDoubleComplex* x,
                                            int                     incx,
                                            int                     stridex,
-                                           const hipDoubleComplex* y,
+                                           const hipblasDoubleComplex* y,
                                            int                     incy,
                                            int                     stridey,
                                            int                     batchCount,
-                                           hipDoubleComplex*       result)
+                                           hipblasDoubleComplex*       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -1016,14 +1016,14 @@ hipblasStatus_t
 }
 
 hipblasStatus_t
-    hipblasScnrm2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+    hipblasScnrm2(hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasScnrm2((cublasHandle_t)handle, n, (cuComplex*)x, incx, result));
 }
 
 hipblasStatus_t hipblasDznrm2(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasDznrm2((cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, result));
@@ -1048,7 +1048,7 @@ hipblasStatus_t hipblasDnrm2Batched(hipblasHandle_t     handle,
 
 hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t         handle,
                                      int                     n,
-                                     const hipComplex* const x[],
+                                     const hipblasComplex* const x[],
                                      int                     incx,
                                      int                     batchCount,
                                      float*                  result)
@@ -1058,7 +1058,7 @@ hipblasStatus_t hipblasScnrm2Batched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t               handle,
                                      int                           n,
-                                     const hipDoubleComplex* const x[],
+                                     const hipblasDoubleComplex* const x[],
                                      int                           incx,
                                      int                           batchCount,
                                      double*                       result)
@@ -1091,7 +1091,7 @@ hipblasStatus_t hipblasDnrm2StridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   handle,
                                             int               n,
-                                            const hipComplex* x,
+                                            const hipblasComplex* x,
                                             int               incx,
                                             int               stridex,
                                             int               batchCount,
@@ -1102,7 +1102,7 @@ hipblasStatus_t hipblasScnrm2StridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t         handle,
                                             int                     n,
-                                            const hipDoubleComplex* x,
+                                            const hipblasDoubleComplex* x,
                                             int                     incx,
                                             int                     stridex,
                                             int                     batchCount,
@@ -1140,12 +1140,12 @@ hipblasStatus_t hipblasDrot(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCrot(hipblasHandle_t   handle,
                             int               n,
-                            hipComplex*       x,
+                            hipblasComplex*       x,
                             int               incx,
-                            hipComplex*       y,
+                            hipblasComplex*       y,
                             int               incy,
                             const float*      c,
-                            const hipComplex* s)
+                            const hipblasComplex* s)
 {
     return hipCUBLASStatusToHIPStatus(cublasCrot(
         (cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy, c, (cuComplex*)s));
@@ -1153,9 +1153,9 @@ hipblasStatus_t hipblasCrot(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCsrot(hipblasHandle_t handle,
                              int             n,
-                             hipComplex*     x,
+                             hipblasComplex*     x,
                              int             incx,
-                             hipComplex*     y,
+                             hipblasComplex*     y,
                              int             incy,
                              const float*    c,
                              const float*    s)
@@ -1166,12 +1166,12 @@ hipblasStatus_t hipblasCsrot(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
                             int                     n,
-                            hipDoubleComplex*       x,
+                            hipblasDoubleComplex*       x,
                             int                     incx,
-                            hipDoubleComplex*       y,
+                            hipblasDoubleComplex*       y,
                             int                     incy,
                             const double*           c,
-                            const hipDoubleComplex* s)
+                            const hipblasDoubleComplex* s)
 {
     return hipCUBLASStatusToHIPStatus(cublasZrot((cublasHandle_t)handle,
                                                  n,
@@ -1185,9 +1185,9 @@ hipblasStatus_t hipblasZrot(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdrot(hipblasHandle_t   handle,
                              int               n,
-                             hipDoubleComplex* x,
+                             hipblasDoubleComplex* x,
                              int               incx,
-                             hipDoubleComplex* y,
+                             hipblasDoubleComplex* y,
                              int               incy,
                              const double*     c,
                              const double*     s)
@@ -1225,12 +1225,12 @@ hipblasStatus_t hipblasDrotBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCrotBatched(hipblasHandle_t   handle,
                                    int               n,
-                                   hipComplex* const x[],
+                                   hipblasComplex* const x[],
                                    int               incx,
-                                   hipComplex* const y[],
+                                   hipblasComplex* const y[],
                                    int               incy,
                                    const float*      c,
-                                   const hipComplex* s,
+                                   const hipblasComplex* s,
                                    int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
@@ -1238,9 +1238,9 @@ hipblasStatus_t hipblasCrotBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCsrotBatched(hipblasHandle_t   handle,
                                     int               n,
-                                    hipComplex* const x[],
+                                    hipblasComplex* const x[],
                                     int               incx,
-                                    hipComplex* const y[],
+                                    hipblasComplex* const y[],
                                     int               incy,
                                     const float*      c,
                                     const float*      s,
@@ -1251,12 +1251,12 @@ hipblasStatus_t hipblasCsrotBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZrotBatched(hipblasHandle_t         handle,
                                    int                     n,
-                                   hipDoubleComplex* const x[],
+                                   hipblasDoubleComplex* const x[],
                                    int                     incx,
-                                   hipDoubleComplex* const y[],
+                                   hipblasDoubleComplex* const y[],
                                    int                     incy,
                                    const double*           c,
-                                   const hipDoubleComplex* s,
+                                   const hipblasDoubleComplex* s,
                                    int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
@@ -1264,9 +1264,9 @@ hipblasStatus_t hipblasZrotBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdrotBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    hipDoubleComplex* const x[],
+                                    hipblasDoubleComplex* const x[],
                                     int                     incx,
-                                    hipDoubleComplex* const y[],
+                                    hipblasDoubleComplex* const y[],
                                     int                     incy,
                                     const double*           c,
                                     const double*           s,
@@ -1308,14 +1308,14 @@ hipblasStatus_t hipblasDrotStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCrotStridedBatched(hipblasHandle_t   handle,
                                           int               n,
-                                          hipComplex*       x,
+                                          hipblasComplex*       x,
                                           int               incx,
                                           int               stridex,
-                                          hipComplex*       y,
+                                          hipblasComplex*       y,
                                           int               incy,
                                           int               stridey,
                                           const float*      c,
-                                          const hipComplex* s,
+                                          const hipblasComplex* s,
                                           int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
@@ -1323,10 +1323,10 @@ hipblasStatus_t hipblasCrotStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasCsrotStridedBatched(hipblasHandle_t handle,
                                            int             n,
-                                           hipComplex*     x,
+                                           hipblasComplex*     x,
                                            int             incx,
                                            int             stridex,
-                                           hipComplex*     y,
+                                           hipblasComplex*     y,
                                            int             incy,
                                            int             stridey,
                                            const float*    c,
@@ -1338,14 +1338,14 @@ hipblasStatus_t hipblasCsrotStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasZrotStridedBatched(hipblasHandle_t         handle,
                                           int                     n,
-                                          hipDoubleComplex*       x,
+                                          hipblasDoubleComplex*       x,
                                           int                     incx,
                                           int                     stridex,
-                                          hipDoubleComplex*       y,
+                                          hipblasDoubleComplex*       y,
                                           int                     incy,
                                           int                     stridey,
                                           const double*           c,
-                                          const hipDoubleComplex* s,
+                                          const hipblasDoubleComplex* s,
                                           int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
@@ -1353,10 +1353,10 @@ hipblasStatus_t hipblasZrotStridedBatched(hipblasHandle_t         handle,
 
 hipblasStatus_t hipblasZdrotStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           hipDoubleComplex* x,
+                                           hipblasDoubleComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           hipDoubleComplex* y,
+                                           hipblasDoubleComplex* y,
                                            int               incy,
                                            int               stridey,
                                            const double*     c,
@@ -1378,17 +1378,17 @@ hipblasStatus_t hipblasDrotg(hipblasHandle_t handle, double* a, double* b, doubl
 }
 
 hipblasStatus_t
-    hipblasCrotg(hipblasHandle_t handle, hipComplex* a, hipComplex* b, float* c, hipComplex* s)
+    hipblasCrotg(hipblasHandle_t handle, hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasCrotg((cublasHandle_t)handle, (cuComplex*)a, (cuComplex*)b, c, (cuComplex*)s));
 }
 
 hipblasStatus_t hipblasZrotg(hipblasHandle_t   handle,
-                             hipDoubleComplex* a,
-                             hipDoubleComplex* b,
+                             hipblasDoubleComplex* a,
+                             hipblasDoubleComplex* b,
                              double*           c,
-                             hipDoubleComplex* s)
+                             hipblasDoubleComplex* s)
 {
     return hipCUBLASStatusToHIPStatus(cublasZrotg(
         (cublasHandle_t)handle, (cuDoubleComplex*)a, (cuDoubleComplex*)b, c, (cuDoubleComplex*)s));
@@ -1416,20 +1416,20 @@ hipblasStatus_t hipblasDrotgBatched(hipblasHandle_t handle,
 }
 
 hipblasStatus_t hipblasCrotgBatched(hipblasHandle_t   handle,
-                                    hipComplex* const a[],
-                                    hipComplex* const b[],
+                                    hipblasComplex* const a[],
+                                    hipblasComplex* const b[],
                                     float* const      c[],
-                                    hipComplex* const s[],
+                                    hipblasComplex* const s[],
                                     int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
 hipblasStatus_t hipblasZrotgBatched(hipblasHandle_t         handle,
-                                    hipDoubleComplex* const a[],
-                                    hipDoubleComplex* const b[],
+                                    hipblasDoubleComplex* const a[],
+                                    hipblasDoubleComplex* const b[],
                                     double* const           c[],
-                                    hipDoubleComplex* const s[],
+                                    hipblasDoubleComplex* const s[],
                                     int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
@@ -1465,13 +1465,13 @@ hipblasStatus_t hipblasDrotgStridedBatched(hipblasHandle_t handle,
 }
 
 hipblasStatus_t hipblasCrotgStridedBatched(hipblasHandle_t handle,
-                                           hipComplex*     a,
+                                           hipblasComplex*     a,
                                            int             stride_a,
-                                           hipComplex*     b,
+                                           hipblasComplex*     b,
                                            int             stride_b,
                                            float*          c,
                                            int             stride_c,
-                                           hipComplex*     s,
+                                           hipblasComplex*     s,
                                            int             stride_s,
                                            int             batchCount)
 {
@@ -1479,13 +1479,13 @@ hipblasStatus_t hipblasCrotgStridedBatched(hipblasHandle_t handle,
 }
 
 hipblasStatus_t hipblasZrotgStridedBatched(hipblasHandle_t   handle,
-                                           hipDoubleComplex* a,
+                                           hipblasDoubleComplex* a,
                                            int               stride_a,
-                                           hipDoubleComplex* b,
+                                           hipblasDoubleComplex* b,
                                            int               stride_b,
                                            double*           c,
                                            int               stride_c,
-                                           hipDoubleComplex* s,
+                                           hipblasDoubleComplex* s,
                                            int               stride_s,
                                            int               batchCount)
 {
@@ -1645,28 +1645,28 @@ hipblasStatus_t
 }
 
 hipblasStatus_t
-    hipblasCscal(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx)
+    hipblasCscal(hipblasHandle_t handle, int n, const hipblasComplex* alpha, hipblasComplex* x, int incx)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasCscal((cublasHandle_t)handle, n, (cuComplex*)alpha, (cuComplex*)x, incx));
 }
 
 hipblasStatus_t
-    hipblasCsscal(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx)
+    hipblasCsscal(hipblasHandle_t handle, int n, const float* alpha, hipblasComplex* x, int incx)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasCsscal((cublasHandle_t)handle, n, alpha, (cuComplex*)x, incx));
 }
 
 hipblasStatus_t hipblasZscal(
-    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx)
+    hipblasHandle_t handle, int n, const hipblasDoubleComplex* alpha, hipblasDoubleComplex* x, int incx)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasZscal((cublasHandle_t)handle, n, (cuDoubleComplex*)alpha, (cuDoubleComplex*)x, incx));
 }
 
 hipblasStatus_t
-    hipblasZdscal(hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx)
+    hipblasZdscal(hipblasHandle_t handle, int n, const double* alpha, hipblasDoubleComplex* x, int incx)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasZdscal((cublasHandle_t)handle, n, alpha, (cuDoubleComplex*)x, incx));
@@ -1688,8 +1688,8 @@ hipblasStatus_t hipblasDscalBatched(
 
 hipblasStatus_t hipblasCscalBatched(hipblasHandle_t   handle,
                                     int               n,
-                                    const hipComplex* alpha,
-                                    hipComplex* const x[],
+                                    const hipblasComplex* alpha,
+                                    hipblasComplex* const x[],
                                     int               incx,
                                     int               batchCount)
 {
@@ -1698,8 +1698,8 @@ hipblasStatus_t hipblasCscalBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZscalBatched(hipblasHandle_t         handle,
                                     int                     n,
-                                    const hipDoubleComplex* alpha,
-                                    hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* alpha,
+                                    hipblasDoubleComplex* const x[],
                                     int                     incx,
                                     int                     batchCount)
 {
@@ -1709,7 +1709,7 @@ hipblasStatus_t hipblasZscalBatched(hipblasHandle_t         handle,
 hipblasStatus_t hipblasCsscalBatched(hipblasHandle_t   handle,
                                      int               n,
                                      const float*      alpha,
-                                     hipComplex* const x[],
+                                     hipblasComplex* const x[],
                                      int               incx,
                                      int               batchCount)
 {
@@ -1719,7 +1719,7 @@ hipblasStatus_t hipblasCsscalBatched(hipblasHandle_t   handle,
 hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t         handle,
                                      int                     n,
                                      const double*           alpha,
-                                     hipDoubleComplex* const x[],
+                                     hipblasDoubleComplex* const x[],
                                      int                     incx,
                                      int                     batchCount)
 {
@@ -1751,8 +1751,8 @@ hipblasStatus_t hipblasDscalStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           const hipComplex* alpha,
-                                           hipComplex*       x,
+                                           const hipblasComplex* alpha,
+                                           hipblasComplex*       x,
                                            int               incx,
                                            int               stridex,
                                            int               batchCount)
@@ -1762,8 +1762,8 @@ hipblasStatus_t hipblasCscalStridedBatched(hipblasHandle_t   handle,
 
 hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t         handle,
                                            int                     n,
-                                           const hipDoubleComplex* alpha,
-                                           hipDoubleComplex*       x,
+                                           const hipblasDoubleComplex* alpha,
+                                           hipblasDoubleComplex*       x,
                                            int                     incx,
                                            int                     stridex,
                                            int                     batchCount)
@@ -1774,7 +1774,7 @@ hipblasStatus_t hipblasZscalStridedBatched(hipblasHandle_t         handle,
 hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle,
                                             int             n,
                                             const float*    alpha,
-                                            hipComplex*     x,
+                                            hipblasComplex*     x,
                                             int             incx,
                                             int             stridex,
                                             int             batchCount)
@@ -1785,7 +1785,7 @@ hipblasStatus_t hipblasCsscalStridedBatched(hipblasHandle_t handle,
 hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t   handle,
                                             int               n,
                                             const double*     alpha,
-                                            hipDoubleComplex* x,
+                                            hipblasDoubleComplex* x,
                                             int               incx,
                                             int               stridex,
                                             int               batchCount)
@@ -1806,14 +1806,14 @@ hipblasStatus_t
 }
 
 hipblasStatus_t
-    hipblasCswap(hipblasHandle_t handle, int n, hipComplex* x, int incx, hipComplex* y, int incy)
+    hipblasCswap(hipblasHandle_t handle, int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     return hipCUBLASStatusToHIPStatus(
         cublasCswap((cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy));
 }
 
 hipblasStatus_t hipblasZswap(
-    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy)
+    hipblasHandle_t handle, int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy)
 {
     return hipCUBLASStatusToHIPStatus(cublasZswap(
         (cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, (cuDoubleComplex*)y, incy));
@@ -1834,9 +1834,9 @@ hipblasStatus_t hipblasDswapBatched(
 
 hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
                                     int             n,
-                                    hipComplex*     x[],
+                                    hipblasComplex*     x[],
                                     int             incx,
-                                    hipComplex*     y[],
+                                    hipblasComplex*     y[],
                                     int             incy,
                                     int             batchCount)
 {
@@ -1845,9 +1845,9 @@ hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasZswapBatched(hipblasHandle_t   handle,
                                     int               n,
-                                    hipDoubleComplex* x[],
+                                    hipblasDoubleComplex* x[],
                                     int               incx,
-                                    hipDoubleComplex* y[],
+                                    hipblasDoubleComplex* y[],
                                     int               incy,
                                     int               batchCount)
 {
@@ -1883,10 +1883,10 @@ hipblasStatus_t hipblasDswapStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle,
                                            int             n,
-                                           hipComplex*     x,
+                                           hipblasComplex*     x,
                                            int             incx,
                                            int             stridex,
-                                           hipComplex*     y,
+                                           hipblasComplex*     y,
                                            int             incy,
                                            int             stridey,
                                            int             batchCount)
@@ -1896,10 +1896,10 @@ hipblasStatus_t hipblasCswapStridedBatched(hipblasHandle_t handle,
 
 hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t   handle,
                                            int               n,
-                                           hipDoubleComplex* x,
+                                           hipblasDoubleComplex* x,
                                            int               incx,
                                            int               stridex,
-                                           hipDoubleComplex* y,
+                                           hipblasDoubleComplex* y,
                                            int               incy,
                                            int               stridey,
                                            int               batchCount)
@@ -1966,13 +1966,13 @@ hipblasStatus_t hipblasCgemv(hipblasHandle_t    handle,
                              hipblasOperation_t trans,
                              int                m,
                              int                n,
-                             const hipComplex*  alpha,
-                             const hipComplex*  A,
+                             const hipblasComplex*  alpha,
+                             const hipblasComplex*  A,
                              int                lda,
-                             const hipComplex*  x,
+                             const hipblasComplex*  x,
                              int                incx,
-                             const hipComplex*  beta,
-                             hipComplex*        y,
+                             const hipblasComplex*  beta,
+                             hipblasComplex*        y,
                              int                incy)
 {
     return hipCUBLASStatusToHIPStatus(cublasCgemv((cublasHandle_t)handle,
@@ -1993,13 +1993,13 @@ hipblasStatus_t hipblasZgemv(hipblasHandle_t         handle,
                              hipblasOperation_t      trans,
                              int                     m,
                              int                     n,
-                             const hipDoubleComplex* alpha,
-                             const hipDoubleComplex* A,
+                             const hipblasDoubleComplex* alpha,
+                             const hipblasDoubleComplex* A,
                              int                     lda,
-                             const hipDoubleComplex* x,
+                             const hipblasDoubleComplex* x,
                              int                     incx,
-                             const hipDoubleComplex* beta,
-                             hipDoubleComplex*       y,
+                             const hipblasDoubleComplex* beta,
+                             hipblasDoubleComplex*       y,
                              int                     incy)
 {
     return hipCUBLASStatusToHIPStatus(cublasZgemv((cublasHandle_t)handle,
@@ -2081,13 +2081,13 @@ hipblasStatus_t hipblasCgemvBatched(hipblasHandle_t         handle,
                                     hipblasOperation_t      trans,
                                     int                     m,
                                     int                     n,
-                                    const hipComplex*       alpha,
-                                    const hipComplex* const A[],
+                                    const hipblasComplex*       alpha,
+                                    const hipblasComplex* const A[],
                                     int                     lda,
-                                    const hipComplex* const x[],
+                                    const hipblasComplex* const x[],
                                     int                     incx,
-                                    const hipComplex*       beta,
-                                    hipComplex* const       y[],
+                                    const hipblasComplex*       beta,
+                                    hipblasComplex* const       y[],
                                     int                     incy,
                                     int                     batchCount)
 {
@@ -2098,13 +2098,13 @@ hipblasStatus_t hipblasZgemvBatched(hipblasHandle_t               handle,
                                     hipblasOperation_t            trans,
                                     int                           m,
                                     int                           n,
-                                    const hipDoubleComplex*       alpha,
-                                    const hipDoubleComplex* const A[],
+                                    const hipblasDoubleComplex*       alpha,
+                                    const hipblasDoubleComplex* const A[],
                                     int                           lda,
-                                    const hipDoubleComplex* const x[],
+                                    const hipblasDoubleComplex* const x[],
                                     int                           incx,
-                                    const hipDoubleComplex*       beta,
-                                    hipDoubleComplex* const       y[],
+                                    const hipblasDoubleComplex*       beta,
+                                    hipblasDoubleComplex* const       y[],
                                     int                           incy,
                                     int                           batchCount)
 {
@@ -2182,15 +2182,15 @@ hipblasStatus_t hipblasCgemvStridedBatched(hipblasHandle_t    handle,
                                            hipblasOperation_t trans,
                                            int                m,
                                            int                n,
-                                           const hipComplex*  alpha,
-                                           const hipComplex*  A,
+                                           const hipblasComplex*  alpha,
+                                           const hipblasComplex*  A,
                                            int                lda,
                                            int                strideA,
-                                           const hipComplex*  x,
+                                           const hipblasComplex*  x,
                                            int                incx,
                                            int                stridex,
-                                           const hipComplex*  beta,
-                                           hipComplex*        y,
+                                           const hipblasComplex*  beta,
+                                           hipblasComplex*        y,
                                            int                incy,
                                            int                stridey,
                                            int                batchCount)
@@ -2202,15 +2202,15 @@ hipblasStatus_t hipblasZgemvStridedBatched(hipblasHandle_t         handle,
                                            hipblasOperation_t      trans,
                                            int                     m,
                                            int                     n,
-                                           const hipDoubleComplex* alpha,
-                                           const hipDoubleComplex* A,
+                                           const hipblasDoubleComplex* alpha,
+                                           const hipblasDoubleComplex* A,
                                            int                     lda,
                                            int                     strideA,
-                                           const hipDoubleComplex* x,
+                                           const hipblasDoubleComplex* x,
                                            int                     incx,
                                            int                     stridex,
-                                           const hipDoubleComplex* beta,
-                                           hipDoubleComplex*       y,
+                                           const hipblasDoubleComplex* beta,
+                                           hipblasDoubleComplex*       y,
                                            int                     incy,
                                            int                     stridey,
                                            int                     batchCount)
@@ -2600,13 +2600,13 @@ hipblasStatus_t hipblasCgemm(hipblasHandle_t    handle,
                              int                m,
                              int                n,
                              int                k,
-                             const hipComplex*  alpha,
-                             const hipComplex*  A,
+                             const hipblasComplex*  alpha,
+                             const hipblasComplex*  A,
                              int                lda,
-                             const hipComplex*  B,
+                             const hipblasComplex*  B,
                              int                ldb,
-                             const hipComplex*  beta,
-                             hipComplex*        C,
+                             const hipblasComplex*  beta,
+                             hipblasComplex*        C,
                              int                ldc)
 {
     return hipCUBLASStatusToHIPStatus(cublasCgemm((cublasHandle_t)handle,
@@ -2631,13 +2631,13 @@ hipblasStatus_t hipblasZgemm(hipblasHandle_t         handle,
                              int                     m,
                              int                     n,
                              int                     k,
-                             const hipDoubleComplex* alpha,
-                             const hipDoubleComplex* A,
+                             const hipblasDoubleComplex* alpha,
+                             const hipblasDoubleComplex* A,
                              int                     lda,
-                             const hipDoubleComplex* B,
+                             const hipblasDoubleComplex* B,
                              int                     ldb,
-                             const hipDoubleComplex* beta,
-                             hipDoubleComplex*       C,
+                             const hipblasDoubleComplex* beta,
+                             hipblasDoubleComplex*       C,
                              int                     ldc)
 {
     return hipCUBLASStatusToHIPStatus(cublasZgemm((cublasHandle_t)handle,
@@ -2762,13 +2762,13 @@ hipblasStatus_t hipblasCgemmBatched(hipblasHandle_t         handle,
                                     int                     m,
                                     int                     n,
                                     int                     k,
-                                    const hipComplex*       alpha,
-                                    const hipComplex* const A[],
+                                    const hipblasComplex*       alpha,
+                                    const hipblasComplex* const A[],
                                     int                     lda,
-                                    const hipComplex* const B[],
+                                    const hipblasComplex* const B[],
                                     int                     ldb,
-                                    const hipComplex*       beta,
-                                    hipComplex* const       C[],
+                                    const hipblasComplex*       beta,
+                                    hipblasComplex* const       C[],
                                     int                     ldc,
                                     int                     batchCount)
 {
@@ -2795,13 +2795,13 @@ hipblasStatus_t hipblasZgemmBatched(hipblasHandle_t               handle,
                                     int                           m,
                                     int                           n,
                                     int                           k,
-                                    const hipDoubleComplex*       alpha,
-                                    const hipDoubleComplex* const A[],
+                                    const hipblasDoubleComplex*       alpha,
+                                    const hipblasDoubleComplex* const A[],
                                     int                           lda,
-                                    const hipDoubleComplex* const B[],
+                                    const hipblasDoubleComplex* const B[],
                                     int                           ldb,
-                                    const hipDoubleComplex*       beta,
-                                    hipDoubleComplex* const       C[],
+                                    const hipblasDoubleComplex*       beta,
+                                    hipblasDoubleComplex* const       C[],
                                     int                           ldc,
                                     int                           batchCount)
 {
@@ -2946,15 +2946,15 @@ hipblasStatus_t hipblasCgemmStridedBatched(hipblasHandle_t    handle,
                                            int                m,
                                            int                n,
                                            int                k,
-                                           const hipComplex*  alpha,
-                                           const hipComplex*  A,
+                                           const hipblasComplex*  alpha,
+                                           const hipblasComplex*  A,
                                            int                lda,
                                            long long          bsa,
-                                           const hipComplex*  B,
+                                           const hipblasComplex*  B,
                                            int                ldb,
                                            long long          bsb,
-                                           const hipComplex*  beta,
-                                           hipComplex*        C,
+                                           const hipblasComplex*  beta,
+                                           hipblasComplex*        C,
                                            int                ldc,
                                            long long          bsc,
                                            int                batchCount)
@@ -2985,15 +2985,15 @@ hipblasStatus_t hipblasZgemmStridedBatched(hipblasHandle_t         handle,
                                            int                     m,
                                            int                     n,
                                            int                     k,
-                                           const hipDoubleComplex* alpha,
-                                           const hipDoubleComplex* A,
+                                           const hipblasDoubleComplex* alpha,
+                                           const hipblasDoubleComplex* A,
                                            int                     lda,
                                            long long               bsa,
-                                           const hipDoubleComplex* B,
+                                           const hipblasDoubleComplex* B,
                                            int                     ldb,
                                            long long               bsb,
-                                           const hipDoubleComplex* beta,
-                                           hipDoubleComplex*       C,
+                                           const hipblasDoubleComplex* beta,
+                                           hipblasDoubleComplex*       C,
                                            int                     ldc,
                                            long long               bsc,
                                            int                     batchCount)


### PR DESCRIPTION
- The names hipComplex and hipDoubleComplex are defined in /opt/rocm/include/hip/hip_complex.h .
- To avoid HIP versus hipBLAS name conflicts, change hipBLAS to use hipblasComplex and hipblasDoubleComplex 
