### PR TITLE
hipBLAS changes to support multiple ROCM installation (#126)

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -87,7 +87,7 @@ target_include_directories( hipblas-test
     $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-    /opt/rocm/hsa/include
+    ${ROCM_PATH}/hsa/include
 )
 
 target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack ${GTEST_LIBRARIES} ${Boost_LIBRARIES} )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
   target_include_directories( ${exe}
     SYSTEM PRIVATE
       $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-      /opt/rocm/hsa/include
+      ${ROCM_PATH}/hsa/include
   )
 
   # Try to test for specific compiler features if cmake version is recent enough


### PR DESCRIPTION
- New mode of building is added "-r,--relocatable" which is used
  for ROCm stack installed in /opt/rocm-ver.
- Below CMAKE parameters are set/overwritten in above mode
  CMAKE_INSTALL_PREFIX
  CMAKE_PREFIX_PATH
  CMAKE_SHARED_LINKER_FLAGS
  ROCM_DISABLE_LDCONFIG
  ROCM_PATH

Signed-off-by: Pruthvi Madugundu <mpruthvi@gmail.com>
