### PR TITLE
Fix for SWDEV-213043

### DIFF
--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -37,9 +37,6 @@ hipblasStatus_t testing_asum_strided_batched(Arguments argus)
     double gpu_time_used, cpu_time_used;
     double rocblas_error;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     // check to prevent undefined memory allocation error
     if(N < 0 || incx < 0 || batch_count < 0)
     {
@@ -50,6 +47,9 @@ hipblasStatus_t testing_asum_strided_batched(Arguments argus)
         // return early so we don't get invalid_value from rocblas because of bad result pointer
         return HIPBLAS_STATUS_SUCCESS;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T1> hx(sizeX);

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -40,10 +40,6 @@ hipblasStatus_t testing_gemm(Arguments argus)
 
     int A_size, B_size, C_size, A_row, A_col, B_row, B_col;
 
-    hipblasHandle_t handle;
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-    hipblasCreate(&handle);
-
     if(transA == HIPBLAS_OP_N)
     {
         A_row = M;
@@ -75,6 +71,11 @@ hipblasStatus_t testing_gemm(Arguments argus)
     {
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
+
+    hipblasHandle_t handle;
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasCreate(&handle);
+
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     vector<T> hA(A_size);
     vector<T> hB(B_size);

--- a/clients/include/testing_gemm_batched.hpp
+++ b/clients/include/testing_gemm_batched.hpp
@@ -83,8 +83,6 @@ hipblasStatus_t testing_GemmBatched(Arguments argus)
     hipblasStatus_t status   = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
 
     int A_row, A_col, B_row, B_col;
 
@@ -114,6 +112,9 @@ hipblasStatus_t testing_GemmBatched(Arguments argus)
     {
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     int A_mat_size = A_col * lda;
     int B_mat_size = B_col * ldb;

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -93,10 +93,6 @@ hipblasStatus_t testing_gemm_ex_template(hipblasOperation_t transA,
         return HIPBLAS_STATUS_NOT_SUPPORTED;
     }
 
-    hipblasHandle_t handle;
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-    hipblasCreate(&handle);
-
     int A_row = transA == HIPBLAS_OP_N ? M : K;
     int A_col = transA == HIPBLAS_OP_N ? K : M;
     int B_row = transB == HIPBLAS_OP_N ? K : N;
@@ -147,6 +143,10 @@ hipblasStatus_t testing_gemm_ex_template(hipblasOperation_t transA,
         PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
         return HIPBLAS_STATUS_ALLOC_FAILED;
     }
+
+    hipblasHandle_t handle;
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasCreate(&handle);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
     vector<Td> hA(size_A);

--- a/clients/include/testing_ger_batched.hpp
+++ b/clients/include/testing_ger_batched.hpp
@@ -39,9 +39,6 @@ hipblasStatus_t testing_ger_batched(Arguments argus)
 
     T alpha = (T)argus.alpha;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
@@ -54,6 +51,9 @@ hipblasStatus_t testing_ger_batched(Arguments argus)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA[batch_count];

--- a/clients/include/testing_rot.hpp
+++ b/clients/include/testing_rot.hpp
@@ -31,9 +31,6 @@ hipblasStatus_t testing_rot(Arguments arg)
     hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
@@ -41,6 +38,9 @@ hipblasStatus_t testing_rot(Arguments arg)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     size_t size_x = N * size_t(incx);
     size_t size_y = N * size_t(incy);
@@ -125,5 +125,6 @@ hipblasStatus_t testing_rot(Arguments arg)
         if(status_4 != HIPBLAS_STATUS_SUCCESS)
             return status_4;
     }
+    hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -31,22 +31,20 @@ hipblasStatus_t testing_rot_batched(Arguments arg)
     hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0 || incy <= 0 || batch_count == 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_SUCCESS;
     }
     if(batch_count < 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     size_t size_x = N * size_t(incx);
     size_t size_y = N * size_t(incy);

--- a/clients/include/testing_rot_strided_batched.hpp
+++ b/clients/include/testing_rot_strided_batched.hpp
@@ -35,22 +35,20 @@ hipblasStatus_t testing_rot_strided_batched(Arguments arg)
     hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0 || incy <= 0 || batch_count == 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_SUCCESS;
     }
     else if(batch_count < 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     size_t size_x = N * size_t(incx) + size_t(stride_x) * size_t(batch_count - 1);
     size_t size_y = N * size_t(incy) + size_t(stride_y) * size_t(batch_count - 1);

--- a/clients/include/testing_rotg_batched.hpp
+++ b/clients/include/testing_rotg_batched.hpp
@@ -27,22 +27,20 @@ hipblasStatus_t testing_rotg_batched(Arguments arg)
     hipblasStatus_t status_3    = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_4    = HIPBLAS_STATUS_SUCCESS;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
     if(batch_count == 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_SUCCESS;
     }
     else if(batch_count < 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     // Initial Data on CPU
     host_vector<T> ha[batch_count];

--- a/clients/include/testing_rotg_strided_batched.hpp
+++ b/clients/include/testing_rotg_strided_batched.hpp
@@ -33,22 +33,20 @@ hipblasStatus_t testing_rotg_strided_batched(Arguments arg)
     hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
     if(batch_count == 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_SUCCESS;
     }
     else if(batch_count < 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     size_t size_a = size_t(stride_a) * size_t(batch_count);
     size_t size_b = size_t(stride_b) * size_t(batch_count);

--- a/clients/include/testing_rotm.hpp
+++ b/clients/include/testing_rotm.hpp
@@ -30,9 +30,6 @@ hipblasStatus_t testing_rotm(Arguments arg)
     hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
@@ -40,6 +37,9 @@ hipblasStatus_t testing_rotm(Arguments arg)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     size_t size_x = N * size_t(incx);
     size_t size_y = N * size_t(incy);

--- a/clients/include/testing_rotm_batched.hpp
+++ b/clients/include/testing_rotm_batched.hpp
@@ -29,17 +29,16 @@ hipblasStatus_t testing_rotm_batched(Arguments arg)
     hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0 || incy <= 0 || batch_count <= 0)
     {
-        hipblasDestroy(handle);
         return (batch_count < 0) ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     size_t size_x = N * size_t(incx);
     size_t size_y = N * size_t(incy);

--- a/clients/include/testing_rotm_strided_batched.hpp
+++ b/clients/include/testing_rotm_strided_batched.hpp
@@ -34,17 +34,16 @@ hipblasStatus_t testing_rotm_strided_batched(Arguments arg)
     hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0 || incy <= 0 || batch_count <= 0)
     {
-        hipblasDestroy(handle);
         return (batch_count < 0) ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     size_t size_x     = N * size_t(incx) + size_t(stride_x) * size_t(batch_count - 1);
     size_t size_y     = N * size_t(incy) + size_t(stride_y) * size_t(batch_count - 1);

--- a/clients/include/testing_rotmg_batched.hpp
+++ b/clients/include/testing_rotmg_batched.hpp
@@ -23,9 +23,6 @@ hipblasStatus_t testing_rotmg_batched(Arguments arg)
 {
     int batch_count = arg.batch_count;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
@@ -36,14 +33,15 @@ hipblasStatus_t testing_rotmg_batched(Arguments arg)
     // check to prevent undefined memory allocation error
     if(batch_count == 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_SUCCESS;
     }
     else if(batch_count < 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     // Initial Data on CPU
     host_vector<T> hd1[batch_count];

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -29,9 +29,6 @@ hipblasStatus_t testing_rotmg_strided_batched(Arguments arg)
     int    stride_y1    = stride_scale;
     int    stride_param = 5 * stride_scale;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
     hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
@@ -42,14 +39,15 @@ hipblasStatus_t testing_rotmg_strided_batched(Arguments arg)
     // check to prevent undefined memory allocation error
     if(batch_count == 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_SUCCESS;
     }
     else if(batch_count < 0)
     {
-        hipblasDestroy(handle);
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     size_t size_d1    = batch_count * stride_d1;
     size_t size_d2    = batch_count * stride_d2;

--- a/clients/include/testing_syr_batched.hpp
+++ b/clients/include/testing_syr_batched.hpp
@@ -40,9 +40,6 @@ hipblasStatus_t testing_syr_batched(Arguments argus)
 
     T alpha = (T)argus.alpha;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
@@ -56,6 +53,9 @@ hipblasStatus_t testing_syr_batched(Arguments argus)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA[batch_count];

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -269,13 +269,13 @@ inline hipblasBfloat16 random_generator_negative<hipblasBfloat16>()
 template <>
 inline hipblasComplex random_generator_negative<hipblasComplex>()
 {
-    hipblasComplex(-(rand() % 10 + 1), -(rand() % 10 + 1));
+    return hipblasComplex(-(rand() % 10 + 1), -(rand() % 10 + 1));
 }
 
 template <>
 inline hipblasDoubleComplex random_generator_negative<hipblasDoubleComplex>()
 {
-    hipblasDoubleComplex(-(rand() % 10 + 1), -(rand() % 10 + 1));
+    return hipblasDoubleComplex(-(rand() % 10 + 1), -(rand() % 10 + 1));
 }
 
 /* ============================================================================================ */


### PR DESCRIPTION
Fix for SWDEV-213043:

- Fixes memory leaks in testing involving not calling hipblasDestroy(handle)
- Fixed error in utility.h where nothing was returned in the random number generators