### PR TITLE
Add --clang option and enable -f16c

### DIFF
--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -3159,7 +3159,7 @@ hipblasStatus_t hipblasTrmm<float>(hipblasHandle_t    handle,
                                    float*             B,
                                    int                ldb)
 {
-    hipblasStrmm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
+    return hipblasStrmm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
 }
 
 template <>
@@ -3176,7 +3176,7 @@ hipblasStatus_t hipblasTrmm<double>(hipblasHandle_t    handle,
                                     double*            B,
                                     int                ldb)
 {
-    hipblasDtrmm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
+    return hipblasDtrmm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb);
 }
 
 // trsm

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -105,7 +105,7 @@ if( NOT CUDA_FOUND )
     # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
     target_compile_options( hipblas-test PRIVATE -Wno-unused-command-line-argument -mf16c)
 
-  elseif( CMAKE_COMPILER_IS_GNUCXX )
+  else( )
     # GCC needs specific flag to turn on f16c intrinsics
     target_compile_options( hipblas-test PRIVATE -mf16c )
 

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ function display_help()
   echo "    [-r]--relocatable] create a package to support relocatable ROCm"
   echo "    [--cuda] build library for cuda backend"
   echo "    [--hip-clang] build library with hip-clang"
+  echo "    [--clang] use clang as the host compiler"
   echo "    [-p|--cmakepp] addition to CMAKE_PREFIX_PATH"
 }
 
@@ -222,6 +223,7 @@ build_release=true
 build_relocatable=false
 cmake_prefix_path=/opt/rocm
 rocm_path=/opt/rocm
+compiler=g++
 
 # #################################################
 # Parameter parsing
@@ -230,7 +232,7 @@ rocm_path=/opt/rocm
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,cuda,cmakepp,relocatable: --options rhicdgp: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,clang,cuda,cmakepp,relocatable: --options rhicdgp: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -266,6 +268,9 @@ while true; do
         shift ;;
     --hip-clang)
         build_hip_clang=true
+        shift ;;
+    --clang)
+        compiler=clang++
         shift ;;
     --cuda)
         build_cuda=true
@@ -360,13 +365,13 @@ pushd .
 
   # Build library
   if [[ "${build_relocatable}" == true ]]; then
-    CXX=g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${rocm_path} \
+    CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX=${rocm_path} \
     -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hcc;${rocm_path}/hip;$(pwd)/../deps/deps-install;${cmake_prefix_path}" \
     -DCMAKE_SHARED_LINKER_FLAGS=${rocm_rpath} \
     -DROCM_DISABLE_LDCONFIG=ON \
     -DROCM_PATH=${rocm_path} ../..
   else
-    CXX=g++ ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..
+    CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..
   fi
   make -j$(nproc)
 


### PR DESCRIPTION
The hipblastrmm_matrix_size/trmm_gtest tests seg fault when building with --clang. Unsure how to fix this, as the loop is unable to be unrolled, and functionality is broken.