### PR TITLE
Fixing cuda build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,13 +63,13 @@ option( BUILD_VERBOSE "Output additional build information" OFF )
 option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 
 # Find HCC/HIP dependencies
-if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
-  message( STATUS "Building with ROCm tools" )
-  find_package( hcc REQUIRED CONFIG PATHS /opt/rocm )
-endif( )
+#if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
+#  message( STATUS "Building with ROCm tools" )
+#  find_package( hcc REQUIRED CONFIG PATHS /opt/rocm )
+#endif( )
 
 # Hip headers required of all clients; clients use hip to allocate device memory
-find_package( hip REQUIRED CONFIG PATHS /opt/rocm )
+find_package( HIP REQUIRED )
 
 # Look for libamdhip64
 find_library(

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -27,7 +27,7 @@ if( BUILD_VERBOSE )
   message( STATUS "\t==>CMAKE_EXE_LINKER link flags: " ${CMAKE_EXE_LINKER_FLAGS} )
 endif( )
 
-find_package( hip REQUIRED CONFIG PATHS /opt/rocm )
+find_package( HIP REQUIRED )
 
 # configure a header file to pass the CMake version settings to the source, and package the header files in the output archive
 configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/hipblas-version.h.in" "${PROJECT_BINARY_DIR}/include/hipblas-version.h" )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -114,7 +114,7 @@ rocm_install_targets(
 rocm_export_targets(
   TARGETS roc::hipblas
   PREFIX hipblas
-  DEPENDS PACKAGE hip
+  DEPENDS PACKAGE HIP
   NAMESPACE roc::
  )
 


### PR DESCRIPTION
Addresses [SWDEV-225175](http://ontrack-internal.amd.com/browse/SWDEV-225175).
Takes the proposed fixes in the ticket and implements them. Seems to work when building on a cuda machine using ./install.sh --cuda. There are still some issues building the client on cuda, will address these in another PR.
I know Fei is working on hipFFT and was mentioning improvements in the build system. At a later time it's probably a good idea to have these libraries have similar build systems (hipFFT, hipSPARSE, hipBLAS, etc.), but I'm probably not the best person to take the lead on that since I lack experience in cmake, but I'm always willing to help!