### PR TITLE
Cuda fixes

### DIFF
--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -307,7 +307,10 @@ TEST_P(parameterized_gemm_ex, standard)
         }
         else
         {
-            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+            // Only available in cuda cc >= 5.0.
+            // If we want we can change this to call query_device_property() and
+            // call this only if cc < 5.0 on a CUDA device, else fail.
+            EXPECT_EQ(HIPBLAS_STATUS_ARCH_MISMATCH, status);
         }
     }
 }
@@ -349,7 +352,10 @@ TEST_P(parameterized_chunk_gemm_ex, float)
         }
         else
         {
-            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+            // Only available in cuda cc >= 5.0.
+            // If we want we can change this to call query_device_property() and
+            // call this only if cc < 5.0 on a CUDA device, else fail.
+            EXPECT_EQ(HIPBLAS_STATUS_ARCH_MISMATCH, status);
         }
     }
 }

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -212,6 +212,19 @@ hipblasStatus_t testing_gemm_ex_template(hipblasOperation_t transA,
                            compute_type,
                            algo);
 
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        hipblasDestroy(handle);
+
+        CHECK_HIP_ERROR(hipFree(dA));
+        CHECK_HIP_ERROR(hipFree(dB));
+        CHECK_HIP_ERROR(hipFree(dC));
+
+        CHECK_HIP_ERROR(hipFree(d_alpha_Tc));
+        CHECK_HIP_ERROR(hipFree(d_beta_Tc));
+        return status;
+    }
+
     CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(Td) * size_C, hipMemcpyDeviceToHost));
 
     //      std::cout << std::endl << "-----hD_1---------------------------------------" <<

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -178,7 +178,7 @@ rocblas_datatype HIPDatatypeToRocblasDatatype(hipblasDatatype_t type)
         return rocblas_datatype_f64_c;
 
     default:
-        throw "Non existant DataType";
+        throw "Non existent DataType";
     }
 }
 
@@ -205,7 +205,7 @@ hipblasDatatype_t RocblasDatatypeToHIPDatatype(rocblas_datatype type)
         return HIPBLAS_C_64F;
 
     default:
-        throw "Non existant DataType";
+        throw "Non existent DataType";
     }
 }
 
@@ -217,7 +217,7 @@ rocblas_gemm_algo HIPGemmAlgoToRocblasGemmAlgo(hipblasGemmAlgo_t algo)
         return rocblas_gemm_algo_standard;
 
     default:
-        throw "Non existant GemmAlgo";
+        throw "Non existent GemmAlgo";
     }
 }
 
@@ -229,7 +229,7 @@ hipblasGemmAlgo_t RocblasGemmAlgoToHIPGemmAlgo(rocblas_gemm_algo algo)
         return HIPBLAS_GEMM_DEFAULT;
 
     default:
-        throw "Non existant GemmAlgo";
+        throw "Non existent GemmAlgo";
     }
 }
 

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -179,7 +179,7 @@ cudaDataType_t HIPDatatypeToCudaDatatype(hipblasDatatype_t type)
         return CUDA_C_64F;
 
     default:
-        throw "Non existant DataType";
+        throw "Non existent DataType";
     }
 }
 
@@ -192,7 +192,7 @@ cublasGemmAlgo_t HIPGemmAlgoToCudaGemmAlgo(hipblasGemmAlgo_t algo)
         return CUBLAS_GEMM_DEFAULT;
 
     default:
-        throw "Non existant GemmAlgo";
+        throw "Non existent GemmAlgo";
     }
 }
 

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -156,6 +156,46 @@ hipblasPointerMode_t CudaPointerModeToHIPPointerMode(cublasPointerMode_t mode)
     }
 }
 
+cudaDataType_t HIPDatatypeToCudaDatatype(hipblasDatatype_t type)
+{
+    switch(type)
+    {
+    case HIPBLAS_R_16F:
+        return CUDA_R_16F;
+
+    case HIPBLAS_R_32F:
+        return CUDA_R_32F;
+
+    case HIPBLAS_R_64F:
+        return CUDA_R_64F;
+
+    case HIPBLAS_C_16F:
+        return CUDA_C_16F;
+
+    case HIPBLAS_C_32F:
+        return CUDA_C_32F;
+
+    case HIPBLAS_C_64F:
+        return CUDA_C_64F;
+
+    default:
+        throw "Non existant DataType";
+    }
+}
+
+cublasGemmAlgo_t HIPGemmAlgoToCudaGemmAlgo(hipblasGemmAlgo_t algo)
+{
+    // Only support Default Algo for now
+    switch(algo)
+    {
+    case HIPBLAS_GEMM_DEFAULT:
+        return CUBLAS_GEMM_DEFAULT;
+
+    default:
+        throw "Non existant GemmAlgo";
+    }
+}
+
 hipblasStatus_t hipCUBLASStatusToHIPStatus(cublasStatus_t cuStatus)
 {
     switch(cuStatus)
@@ -4356,3 +4396,44 @@ hipblasStatus_t hipblasZgemmStridedBatched(hipblasHandle_t             handle,
 #ifdef __cplusplus
 }
 #endif
+
+extern "C" hipblasStatus_t hipblasGemmEx(hipblasHandle_t    handle,
+                                         hipblasOperation_t transa,
+                                         hipblasOperation_t transb,
+                                         int                m,
+                                         int                n,
+                                         int                k,
+                                         const void*        alpha,
+                                         const void*        A,
+                                         hipblasDatatype_t  a_type,
+                                         int                lda,
+                                         const void*        B,
+                                         hipblasDatatype_t  b_type,
+                                         int                ldb,
+                                         const void*        beta,
+                                         void*              C,
+                                         hipblasDatatype_t  c_type,
+                                         int                ldc,
+                                         hipblasDatatype_t  compute_type,
+                                         hipblasGemmAlgo_t  algo)
+{
+    return hipCUBLASStatusToHIPStatus(cublasGemmEx((cublasHandle_t)handle,
+                                                   hipOperationToCudaOperation(transa),
+                                                   hipOperationToCudaOperation(transb),
+                                                   m,
+                                                   n,
+                                                   k,
+                                                   alpha,
+                                                   A,
+                                                   HIPDatatypeToCudaDatatype(a_type),
+                                                   lda,
+                                                   B,
+                                                   HIPDatatypeToCudaDatatype(b_type),
+                                                   ldb,
+                                                   beta,
+                                                   C,
+                                                   HIPDatatypeToCudaDatatype(c_type),
+                                                   ldc,
+                                                   HIPDatatypeToCudaDatatype(compute_type),
+                                                   HIPGemmAlgoToCudaGemmAlgo(algo)));
+}


### PR DESCRIPTION
Problem: hipBLAS clients didn't work when building on CUDA. This was because we were attempting to test `gemmEx` which wasn't implemented for CUDA.

Fix: Implement `gemmEx` for CUDA. Note that `gemmEx` is only available in CUDA for compute capabilities >= 5.0. We do not check for this, it will just return `HIPBLAS_STATUS_ARCH_MISMATCH`.

Small changes to gemmEx testing to ensure that `HIPBLAS_STATUS_SUCCESS` was returned from `gemmEx`. If not, we check that `HIPBLAS_STATUS_ARCH_MISMATCH` was returned instead. Could fix this in the future to ensure that when `ARCH_MISMATCH` is returned, the compute capability is _actually_ < 5.0 and is a CUDA device.