### PR TITLE
Make the return type explicit.

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -49,7 +49,7 @@ struct hip_complex_number
     {
     }
 
-    auto& operator*=(const hip_complex_number& rhs)
+    hip_complex_number& operator*=(const hip_complex_number& rhs)
     {
         return *this = {x * rhs.x - y * rhs.y, y * rhs.x + x * rhs.y};
     }
@@ -60,12 +60,12 @@ struct hip_complex_number
         return lhs *= rhs;
     }
 
-    auto& operator+=(const hip_complex_number& rhs)
+    hip_complex_number& operator+=(const hip_complex_number& rhs)
     {
         return *this = {x + rhs.x, y + rhs.y};
     }
 
-    auto& operator/(const hip_complex_number& rhs)
+    hip_complex_number& operator/(const hip_complex_number& rhs)
     {
         if(abs(rhs.x) > abs(rhs.y))
         {


### PR DESCRIPTION
- Remove unnecessary `auto` return type as only C++14 starts to deduce
  that automatically. As that header would be included in other
  projects, that unnecessary dependency should be removed or
  internalized.

resolves #___

Summary of proposed changes:
-
-
-
