### PR TITLE
Fix complex to not depend on C++; reimplement functions for client tests in terms of std::complex

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,30 @@
+;; This causes emacs to abide by formatting rules: No tab characters, except
+;; in Makefiles; BSD-style indendation, with a 4-character indentation offset
+;; (8 in assembly code and Makefiles); no whitespace at the end of lines; and
+;; a newline at the end of file.
+
+(
+ (nil . (
+  (require-final-newline . t)
+  (indent-tabs-mode . nil)
+  (eval add-hook 'before-save-hook 'delete-trailing-whitespace)
+  (eval add-hook 'before-save-hook (lambda () (untabify (point-min) (point-max))))
+ ) )
+ (prog-mode . (
+  (tab-width . 4)
+  (c-basic-offset . 4)
+  (c-file-style . "bsd")
+ ) )
+ (asm-mode . (
+  (tab-width . 8)
+ ) )
+ (makefile-mode . (
+  (indent-tabs-mode . t)
+  (tab-width . 8)
+  (eval remove-hook `before-save-hook (lambda () (untabify (point-min) (point-max))))
+ ) )
+ (fundamental-mode . (
+  (eval require 'yaml-mode)
+  (eval set-auto-mode t)
+  ) )
+)

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@
 
 # build-in-source directory
 build*
+
+# emacs temporary/backup files
+.\#*
+\#*\#
+*~

--- a/clients/common/near.cpp
+++ b/clients/common/near.cpp
@@ -59,12 +59,12 @@
 
 #define NEAR_ASSERT_HALF(a, b, err) ASSERT_NEAR(float(a), float(b), err)
 
-#define NEAR_ASSERT_COMPLEX(a, b, err) \
-    do                                 \
-    {                                  \
-        auto ta = (a), tb = (b);       \
-        ASSERT_NEAR(ta.x, tb.x, err);  \
-        ASSERT_NEAR(ta.y, tb.y, err);  \
+#define NEAR_ASSERT_COMPLEX(a, b, err)          \
+    do                                          \
+    {                                           \
+        auto ta = (a), tb = (b);                \
+        ASSERT_NEAR(ta.real(), tb.real(), err); \
+        ASSERT_NEAR(ta.imag(), tb.imag(), err); \
     } while(0)
 
 template <>

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -12,14 +12,15 @@
  * ==================================================== */
 
 /*! \brief Template: gtest unit compare two matrices float/double/complex */
-// Do not put a wrapper over ASSERT_FLOAT_EQ, sincer assert exit the current function NOT the test
-// case
-// a wrapper will cause the loop keep going
+// This returns from the current function if an error occurs
 
 #ifndef GOOGLE_TEST
+
 #define UNIT_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, UNIT_ASSERT_EQ)
 #define UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, UNIT_ASSERT_EQ)
-#else
+
+#else // GOOGLE_TEST
+
 #define UNIT_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, UNIT_ASSERT_EQ)      \
     do                                                                               \
     {                                                                                \
@@ -36,6 +37,7 @@
                                        hGPU[i + j * lda + k * strideA]);             \
                     }                                                                \
     } while(0)
+
 #define UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, UNIT_ASSERT_EQ)            \
     do                                                                              \
     {                                                                               \
@@ -51,23 +53,24 @@
                         UNIT_ASSERT_EQ(hCPU[k][i + j * lda], hGPU[k][i + j * lda]); \
                     }                                                               \
     } while(0)
-#endif
+
+#endif // GOOGLE_TEST
 
 #define ASSERT_HALF_EQ(a, b) ASSERT_FLOAT_EQ(half_to_float(a), half_to_float(b))
 #define ASSERT_BFLOAT16_EQ(a, b) ASSERT_FLOAT_EQ(bfloat16_to_float(a), bfloat16_to_float(b))
 
-#define ASSERT_FLOAT_COMPLEX_EQ(a, b) \
-    do                                \
-    {                                 \
-        ASSERT_FLOAT_EQ(a.x, b.x);    \
-        ASSERT_FLOAT_EQ(a.y, b.y);    \
+#define ASSERT_FLOAT_COMPLEX_EQ(a, b)        \
+    do                                       \
+    {                                        \
+        ASSERT_FLOAT_EQ(a.real(), b.real()); \
+        ASSERT_FLOAT_EQ(a.imag(), b.imag()); \
     } while(0)
 
-#define ASSERT_DOUBLE_COMPLEX_EQ(a, b) \
-    do                                 \
-    {                                  \
-        ASSERT_DOUBLE_EQ(a.x, b.x);    \
-        ASSERT_DOUBLE_EQ(a.y, b.y);    \
+#define ASSERT_DOUBLE_COMPLEX_EQ(a, b)        \
+    do                                        \
+    {                                         \
+        ASSERT_DOUBLE_EQ(a.real(), b.real()); \
+        ASSERT_DOUBLE_EQ(a.imag(), b.imag()); \
     } while(0)
 
 template <>
@@ -97,36 +100,28 @@ void unit_check_general(int M, int N, int lda, double* hCPU, double* hGPU)
 template <>
 void unit_check_general(int M, int N, int lda, hipblasComplex* hCPU, hipblasComplex* hGPU)
 {
-#pragma unroll
+#ifdef GOOGLE_TEST
     for(int j = 0; j < N; j++)
-    {
-#pragma unroll
         for(int i = 0; i < M; i++)
         {
-#ifdef GOOGLE_TEST
-            ASSERT_FLOAT_EQ(hCPU[i + j * lda].x, hGPU[i + j * lda].x);
-            ASSERT_FLOAT_EQ(hCPU[i + j * lda].y, hGPU[i + j * lda].y);
-#endif
+            ASSERT_FLOAT_EQ(hCPU[i + j * lda].real(), hGPU[i + j * lda].real());
+            ASSERT_FLOAT_EQ(hCPU[i + j * lda].imag(), hGPU[i + j * lda].imag());
         }
-    }
+#endif
 }
 
 template <>
 void unit_check_general(
     int M, int N, int lda, hipblasDoubleComplex* hCPU, hipblasDoubleComplex* hGPU)
 {
-#pragma unroll
+#ifdef GOOGLE_TEST
     for(int j = 0; j < N; j++)
-    {
-#pragma unroll
         for(int i = 0; i < M; i++)
         {
-#ifdef GOOGLE_TEST
-            ASSERT_DOUBLE_EQ(hCPU[i + j * lda].x, hGPU[i + j * lda].x);
-            ASSERT_DOUBLE_EQ(hCPU[i + j * lda].y, hGPU[i + j * lda].y);
-#endif
+            ASSERT_DOUBLE_EQ(hCPU[i + j * lda].real(), hGPU[i + j * lda].real());
+            ASSERT_DOUBLE_EQ(hCPU[i + j * lda].imag(), hGPU[i + j * lda].imag());
         }
-    }
+#endif
 }
 
 template <>

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -120,7 +120,6 @@ target_include_directories( hipblas-test
 set( THREADS_PREFER_PTHREAD_FLAG ON )
 find_package( Threads REQUIRED )
 target_link_libraries( hipblas-test PRIVATE Threads::Threads )
-target_compile_features( hipblas-test PUBLIC cxx_std_14 )
 
 target_compile_definitions( hipblas-test PRIVATE GOOGLE_TEST )
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -120,7 +120,7 @@ target_include_directories( hipblas-test
 set( THREADS_PREFER_PTHREAD_FLAG ON )
 find_package( Threads REQUIRED )
 target_link_libraries( hipblas-test PRIVATE Threads::Threads )
-target_compile_features( hipblas-test PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type)
+target_compile_features( hipblas-test PUBLIC cxx_std_14 )
 
 target_compile_definitions( hipblas-test PRIVATE GOOGLE_TEST )
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -144,7 +144,7 @@ if( NOT CUDA_FOUND )
 
   # Remove following when hcc is fixed; hcc emits following spurious warning
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-  target_compile_options( hipblas-test PRIVATE -Wno-unused-command-line-argument -mf16c)
+  target_compile_options( hipblas-test PRIVATE -mf16c)
 
   if( CUSTOM_TARGET )
     target_link_libraries( hipblas-test PRIVATE hip::${CUSTOM_TARGET} )

--- a/clients/include/complex.hpp
+++ b/clients/include/complex.hpp
@@ -1,0 +1,191 @@
+/* ************************************************************************
+ * Copyright 2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#ifndef HIPBLAS_COMPLEX_HPP
+#define HIPBLAS_COMPLEX_HPP
+
+#include "hipblas.h"
+#include <complex>
+
+inline hipblasComplex& operator+=(hipblasComplex& lhs, const hipblasComplex& rhs)
+{
+    reinterpret_cast<std::complex<float>&>(lhs)
+        += reinterpret_cast<const std::complex<float>&>(rhs);
+    return lhs;
+}
+
+inline hipblasDoubleComplex& operator+=(hipblasDoubleComplex& lhs, const hipblasDoubleComplex& rhs)
+{
+    reinterpret_cast<std::complex<double>&>(lhs)
+        += reinterpret_cast<const std::complex<double>&>(rhs);
+    return lhs;
+}
+
+inline hipblasComplex operator+(hipblasComplex lhs, const hipblasComplex& rhs)
+{
+    return lhs += rhs;
+}
+
+inline hipblasDoubleComplex operator+(hipblasDoubleComplex lhs, const hipblasDoubleComplex& rhs)
+{
+    return lhs += rhs;
+}
+
+inline hipblasComplex& operator-=(hipblasComplex& lhs, const hipblasComplex& rhs)
+{
+    reinterpret_cast<std::complex<float>&>(lhs)
+        -= reinterpret_cast<const std::complex<float>&>(rhs);
+    return lhs;
+}
+
+inline hipblasDoubleComplex& operator-=(hipblasDoubleComplex& lhs, const hipblasDoubleComplex& rhs)
+{
+    reinterpret_cast<std::complex<double>&>(lhs)
+        -= reinterpret_cast<const std::complex<double>&>(rhs);
+    return lhs;
+}
+
+inline hipblasComplex operator-(hipblasComplex lhs, const hipblasComplex& rhs)
+{
+    return lhs -= rhs;
+}
+
+inline hipblasDoubleComplex operator-(hipblasDoubleComplex lhs, const hipblasDoubleComplex& rhs)
+{
+    return lhs -= rhs;
+}
+
+inline hipblasComplex& operator*=(hipblasComplex& lhs, const hipblasComplex& rhs)
+{
+    reinterpret_cast<std::complex<float>&>(lhs)
+        *= reinterpret_cast<const std::complex<float>&>(rhs);
+    return lhs;
+}
+
+inline hipblasDoubleComplex& operator*=(hipblasDoubleComplex& lhs, const hipblasDoubleComplex& rhs)
+{
+    reinterpret_cast<std::complex<double>&>(lhs)
+        *= reinterpret_cast<const std::complex<double>&>(rhs);
+    return lhs;
+}
+
+inline hipblasComplex operator*(hipblasComplex lhs, const hipblasComplex& rhs)
+{
+    return lhs *= rhs;
+}
+
+inline hipblasDoubleComplex operator*(hipblasDoubleComplex lhs, const hipblasDoubleComplex& rhs)
+{
+    return lhs *= rhs;
+}
+
+inline hipblasComplex& operator/=(hipblasComplex& lhs, const hipblasComplex& rhs)
+{
+    reinterpret_cast<std::complex<float>&>(lhs)
+        /= reinterpret_cast<const std::complex<float>&>(rhs);
+    return lhs;
+}
+
+inline hipblasDoubleComplex& operator/=(hipblasDoubleComplex& lhs, const hipblasDoubleComplex& rhs)
+{
+    reinterpret_cast<std::complex<double>&>(lhs)
+        /= reinterpret_cast<const std::complex<double>&>(rhs);
+    return lhs;
+}
+
+inline hipblasComplex operator/(hipblasComplex lhs, const hipblasComplex& rhs)
+{
+    return lhs /= rhs;
+}
+
+inline hipblasDoubleComplex operator/(hipblasDoubleComplex lhs, const hipblasDoubleComplex& rhs)
+{
+    return lhs /= rhs;
+}
+
+inline bool operator==(const hipblasComplex& lhs, const hipblasComplex& rhs)
+{
+    return reinterpret_cast<const std::complex<float>&>(lhs)
+           == reinterpret_cast<const std::complex<float>&>(rhs);
+}
+
+inline bool operator!=(const hipblasComplex& lhs, const hipblasComplex& rhs)
+{
+    return !(lhs == rhs);
+}
+
+inline bool operator==(const hipblasDoubleComplex& lhs, const hipblasDoubleComplex& rhs)
+{
+    return reinterpret_cast<const std::complex<double>&>(lhs)
+           == reinterpret_cast<const std::complex<double>&>(rhs);
+}
+
+inline bool operator!=(const hipblasDoubleComplex& lhs, const hipblasDoubleComplex& rhs)
+{
+    return !(lhs == rhs);
+}
+
+inline hipblasComplex operator-(const hipblasComplex& x)
+{
+    return {-x.real(), -x.imag()};
+}
+
+inline hipblasDoubleComplex operator-(const hipblasDoubleComplex& x)
+{
+    return {-x.real(), -x.imag()};
+}
+
+inline hipblasComplex operator+(const hipblasComplex& x)
+{
+    return x;
+}
+
+inline hipblasDoubleComplex operator+(const hipblasDoubleComplex& x)
+{
+    return x;
+}
+
+namespace std
+{
+    inline float real(const hipblasComplex& z)
+    {
+        return z.real();
+    }
+
+    inline double real(const hipblasDoubleComplex& z)
+    {
+        return z.real();
+    }
+
+    inline float imag(const hipblasComplex& z)
+    {
+        return z.imag();
+    }
+
+    inline double imag(const hipblasDoubleComplex& z)
+    {
+        return z.imag();
+    }
+
+    inline hipblasComplex conj(const hipblasComplex& z)
+    {
+        return {z.real(), -z.imag()};
+    }
+
+    inline hipblasDoubleComplex conj(const hipblasDoubleComplex& z)
+    {
+        return {z.real(), -z.imag()};
+    }
+
+    inline float abs(const hipblasComplex& z)
+    {
+        return abs(reinterpret_cast<const complex<float>&>(z));
+    }
+
+    inline double abs(const hipblasDoubleComplex& z)
+    {
+        return abs(reinterpret_cast<const complex<double>&>(z));
+    }
+}
+
+#endif

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_axpy.hpp
+++ b/clients/include/testing_axpy.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_axpy_batched.hpp
+++ b/clients/include/testing_axpy_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2016-2020 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_axpy_strided_batched.hpp
+++ b/clients/include/testing_axpy_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2016-2020 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_copy.hpp
+++ b/clients/include/testing_copy.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_iamax.hpp
+++ b/clients/include/testing_iamax.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_iamax_iamin_batched.hpp
+++ b/clients/include/testing_iamax_iamin_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2016-2020 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/testing_iamax_iamin_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016 Advanced Micro Devices, Inc.
+ * Copyright 2016-2020 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rot.hpp
+++ b/clients/include/testing_rot.hpp
@@ -13,7 +13,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rot_strided_batched.hpp
+++ b/clients/include/testing_rot_strided_batched.hpp
@@ -13,7 +13,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotg.hpp
+++ b/clients/include/testing_rotg.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotg_batched.hpp
+++ b/clients/include/testing_rotg_batched.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotg_strided_batched.hpp
+++ b/clients/include/testing_rotg_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotm.hpp
+++ b/clients/include/testing_rotm.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotm_batched.hpp
+++ b/clients/include/testing_rotm_batched.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotm_strided_batched.hpp
+++ b/clients/include/testing_rotm_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotmg.hpp
+++ b/clients/include/testing_rotmg.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotmg_batched.hpp
+++ b/clients/include/testing_rotmg_batched.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "near.h"
 #include "norm.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_scal_batched.hpp
+++ b/clients/include/testing_scal_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_swap.hpp
+++ b/clients/include/testing_swap.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -12,7 +12,6 @@
 #include "norm.h"
 #include "unit.h"
 #include "utility.h"
-#include <complex.h>
 
 using namespace std;
 

--- a/clients/include/testing_trsm.hpp
+++ b/clients/include/testing_trsm.hpp
@@ -136,8 +136,6 @@ hipblasStatus_t testing_trsm(Arguments argus)
         //      print_matrix(hB_copy, hB, min(M, 3), min(N,3), ldb);
 
         // if enable norm check, norm check is invasive
-        // any typeinfo(T) will not work here, because template deduction is matched in compilation
-        // time
         real_t<T> eps       = std::numeric_limits<real_t<T>>::epsilon();
         double    tolerance = eps * 40 * M;
 

--- a/clients/include/testing_trsm_batched.hpp
+++ b/clients/include/testing_trsm_batched.hpp
@@ -181,8 +181,6 @@ hipblasStatus_t testing_trsm_batched(Arguments argus)
         }
 
         // if enable norm check, norm check is invasive
-        // any typeinfo(T) will not work here, because template deduction is matched in compilation
-        // time
         real_t<T> eps       = std::numeric_limits<real_t<T>>::epsilon();
         double    tolerance = eps * 40 * M;
 

--- a/clients/include/testing_trsm_strided_batched.hpp
+++ b/clients/include/testing_trsm_strided_batched.hpp
@@ -179,8 +179,6 @@ hipblasStatus_t testing_trsm_strided_batched(Arguments argus)
         }
 
         // if enable norm check, norm check is invasive
-        // any typeinfo(T) will not work here, because template deduction is matched in compilation
-        // time
         real_t<T> eps       = std::numeric_limits<real_t<T>>::epsilon();
         double    tolerance = eps * 40 * M;
 

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -38,6 +38,9 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched;example-c
   set_target_properties( ${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
   target_include_directories( ${exe} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> )
 
+  # C++14
+  target_compile_features( ${exe} PUBLIC cxx_std_14 )
+
   if( NOT CUDA_FOUND )
     target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
 

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -7,16 +7,23 @@ set( hipblas_samples_common ../common/utility.cpp )
 add_executable( example-sscal example_sscal.cpp ${hipblas_samples_common} )
 add_executable( example-sgemm example_sgemm.cpp ${hipblas_samples_common} )
 add_executable( example-sgemm-strided-batched example_sgemm_strided_batched.cpp ${hipblas_samples_common} )
+add_executable( example-c example-c.c ${hipblas_samples_common} )
+
+# We test for C99 compatibility in the example-c.c test
+set_source_files_properties(example-c.c PROPERTIES LANGUAGE CXX)
+set_source_files_properties(example-c.c PROPERTIES COMPILE_FLAGS "-xc -std=c99")
+
+# We test for C++11 compatibility in one of the samples
+set_source_files_properties(example_sgemm_strided_batched.cpp PROPERTIES COMPILE_FLAGS "-std=c++11")
 
 if( NOT TARGET hipblas )
   find_package( hipblas CONFIG PATHS ${ROCM_PATH}/hipblas )
-
   if( NOT hipblas_FOUND )
     message( FATAL_ERROR "hipBLAS is a required dependency and is not found; try adding rocblas path to CMAKE_PREFIX_PATH")
   endif( )
 endif( )
 
-foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
+foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched;example-c )
 
   target_link_libraries( ${exe} PRIVATE roc::hipblas )
 
@@ -26,10 +33,7 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
       $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
       ${ROCM_PATH}/hsa/include
   )
-
-  # Try to test for specific compiler features if cmake version is recent enough
-  target_compile_features( ${exe} PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type )
-
+  set_target_properties(${exe} PROPERTIES LINKER_LANGUAGE CXX)
   set_target_properties( ${exe} PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO )
   set_target_properties( ${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
   target_include_directories( ${exe} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> )
@@ -39,7 +43,7 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
 
   # Remove following when hcc is fixed; hcc emits following spurious warning
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-  target_compile_options( ${exe} PRIVATE -Wno-unused-command-line-argument -mf16c)
+  target_compile_options( ${exe} PRIVATE -mf16c)
 
   if( CUSTOM_TARGET )
     target_link_libraries( ${exe} PRIVATE hip::${CUSTOM_TARGET} )
@@ -50,12 +54,6 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
       get_target_property( HIP_HCC_LOCATION hip::hip_hcc IMPORTED_LOCATION_RELEASE )
       target_link_libraries( ${exe} PRIVATE ${HIP_HCC_LOCATION} )
     endif( )
-  endif( )
-
-  # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.3
-  # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
-    target_compile_options( ${exe} PRIVATE -Wno-unused-command-line-argument )
   endif( )
 
   if( CMAKE_COMPILER_IS_GNUCXX )
@@ -76,4 +74,3 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched )
   endif( )
 
 endforeach( )
-

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -38,9 +38,6 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched;example-c
   set_target_properties( ${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
   target_include_directories( ${exe} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> )
 
-  # C++14
-  target_compile_features( ${exe} PUBLIC cxx_std_14 )
-
   if( NOT CUDA_FOUND )
     target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
 

--- a/clients/samples/example-c.c
+++ b/clients/samples/example-c.c
@@ -1,28 +1,26 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
- *
+ * Copyright 2020 Advanced Micro Devices, Inc.
  * ************************************************************************ */
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <vector>
 
 #include "hipblas.h"
 #include "utility.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* ============================================================================================ */
 
 int main()
 {
-
     int             N      = 10240;
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
     float           alpha  = 10.0;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    std::vector<float> hx(N);
-    std::vector<float> hz(N);
-    float*             dx;
+    float* hx = (float*)calloc(N, sizeof(*hx));
+    float* hz = (float*)calloc(N, sizeof(*hz));
+    float* dx;
 
     double gpu_time_used;
 
@@ -30,35 +28,30 @@ int main()
     hipblasCreate(&handle);
 
     // allocate memory on device
-    hipMalloc(&dx, N * sizeof(float));
+    hipMalloc((void**)&dx, N * sizeof(float));
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init<float>(hx, 1, N, 1);
 
-    // copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
-    hz = hx;
+    for(int i = 0; i < N; ++i)
+        hx[i] = rand();
 
-    hipMemcpy(dx, hx.data(), sizeof(float) * N, hipMemcpyHostToDevice);
+    memcpy(hz, hx, sizeof(*hz) * N);
+
+    hipMemcpy(dx, hx, sizeof(*dx) * N, hipMemcpyHostToDevice);
 
     printf("N        hipblas(us)     \n");
 
     gpu_time_used = get_time_us(); // in microseconds
 
-    /* =====================================================================
-         ROCBLAS  C interface
-    =================================================================== */
-
     status = hipblasSscal(handle, N, &alpha, dx, 1);
     if(status != HIPBLAS_STATUS_SUCCESS)
-    {
         return status;
-    }
 
     gpu_time_used = get_time_us() - gpu_time_used;
 
     // copy output from device to CPU
-    hipMemcpy(hx.data(), dx, sizeof(float) * N, hipMemcpyDeviceToHost);
+    hipMemcpy(hx, dx, sizeof(*hx) * N, hipMemcpyDeviceToHost);
 
     // verify hipblas_scal result
     bool error_in_element = false;
@@ -75,15 +68,13 @@ int main()
     printf("%d    %8.2f        \n", (int)N, gpu_time_used);
 
     if(error_in_element)
-    {
         printf("SSCAL TEST FAILS\n");
-    }
     else
-    {
         printf("SSCAL TEST PASSES\n");
-    }
 
     hipFree(dx);
     hipblasDestroy(handle);
+    free(hx);
+    free(hz);
     return EXIT_SUCCESS;
 }

--- a/clients/samples/example_sgemm.cpp
+++ b/clients/samples/example_sgemm.cpp
@@ -9,8 +9,6 @@
 #include <stdlib.h>
 #include <vector>
 
-using namespace std;
-
 #ifndef CHECK_HIP_ERROR
 #define CHECK_HIP_ERROR(error)                    \
     if(error != hipSuccess)                       \
@@ -91,14 +89,14 @@ int main()
     int m = DIM1, n = DIM2, k = DIM3;
     int lda, ldb, ldc, size_a, size_b, size_c;
     int a_stride_1, a_stride_2, b_stride_1, b_stride_2;
-    cout << "sgemm example" << endl;
+    std::cout << "sgemm example" << std::endl;
     if(transa == HIPBLAS_OP_N)
     {
         lda        = m;
         size_a     = k * lda;
         a_stride_1 = 1;
         a_stride_2 = lda;
-        cout << "N";
+        std::cout << "N";
     }
     else
     {
@@ -106,7 +104,7 @@ int main()
         size_a     = m * lda;
         a_stride_1 = lda;
         a_stride_2 = 1;
-        cout << "T";
+        std::cout << "T";
     }
     if(transb == HIPBLAS_OP_N)
     {
@@ -114,7 +112,7 @@ int main()
         size_b     = n * ldb;
         b_stride_1 = 1;
         b_stride_2 = ldb;
-        cout << "N: ";
+        std::cout << "N: ";
     }
     else
     {
@@ -122,16 +120,16 @@ int main()
         size_b     = k * ldb;
         b_stride_1 = ldb;
         b_stride_2 = 1;
-        cout << "T: ";
+        std::cout << "T: ";
     }
     ldc    = m;
     size_c = n * ldc;
 
     // Naming: da is in GPU (device) memory. ha is in CPU (host) memory
-    vector<float> ha(size_a);
-    vector<float> hb(size_b);
-    vector<float> hc(size_c);
-    vector<float> hc_gold(size_c);
+    std::vector<float> ha(size_a);
+    std::vector<float> hb(size_b);
+    std::vector<float> hc(size_c);
+    std::vector<float> hc_gold(size_c);
 
     // initial data on host
     srand(1);
@@ -169,10 +167,10 @@ int main()
     // copy output from device to CPU
     CHECK_HIP_ERROR(hipMemcpy(hc.data(), dc, sizeof(float) * size_c, hipMemcpyDeviceToHost));
 
-    cout << "m, n, k, lda, ldb, ldc = " << m << ", " << n << ", " << k << ", " << lda << ", " << ldb
-         << ", " << ldc << endl;
+    std::cout << "m, n, k, lda, ldb, ldc = " << m << ", " << n << ", " << k << ", " << lda << ", "
+              << ldb << ", " << ldc << std::endl;
 
-    float max_relative_error = numeric_limits<float>::min();
+    float max_relative_error = std::numeric_limits<float>::min();
 
     // calculate golden or correct result
     mat_mat_mult<float>(alpha,
@@ -197,15 +195,15 @@ int main()
         max_relative_error
             = relative_error < max_relative_error ? max_relative_error : relative_error;
     }
-    float eps       = numeric_limits<float>::epsilon();
+    float eps       = std::numeric_limits<float>::epsilon();
     float tolerance = 10;
     if(max_relative_error != max_relative_error || max_relative_error > eps * tolerance)
     {
-        cout << "FAIL: max_relative_error = " << max_relative_error << endl;
+        std::cout << "FAIL: max_relative_error = " << max_relative_error << std::endl;
     }
     else
     {
-        cout << "PASS: max_relative_error = " << max_relative_error << endl;
+        std::cout << "PASS: max_relative_error = " << max_relative_error << std::endl;
     }
 
     CHECK_HIP_ERROR(hipFree(da));

--- a/clients/samples/example_sgemm_strided_batched.cpp
+++ b/clients/samples/example_sgemm_strided_batched.cpp
@@ -9,8 +9,6 @@
 #include <stdlib.h>
 #include <vector>
 
-using namespace std;
-
 #ifndef CHECK_HIP_ERROR
 #define CHECK_HIP_ERROR(error)                    \
     if(error != hipSuccess)                       \
@@ -137,10 +135,10 @@ int main()
     int size_c = bsc * batch_count;
 
     // Naming: da is in GPU (device) memory. ha is in CPU (host) memory
-    vector<float> ha(size_a);
-    vector<float> hb(size_b);
-    vector<float> hc(size_c);
-    vector<float> hc_gold(size_c);
+    std::vector<float> ha(size_a);
+    std::vector<float> hb(size_b);
+    std::vector<float> hc(size_c);
+    std::vector<float> hc_gold(size_c);
 
     // initial data on host
     srand(1);
@@ -216,7 +214,7 @@ int main()
                             ldc);
     }
 
-    float max_relative_error = numeric_limits<float>::min();
+    float max_relative_error = std::numeric_limits<float>::min();
     for(int i = 0; i < size_c; i++)
     {
         float relative_error = (hc_gold[i] - hc[i]) / hc_gold[i];
@@ -224,7 +222,7 @@ int main()
         max_relative_error
             = relative_error < max_relative_error ? max_relative_error : relative_error;
     }
-    float eps       = numeric_limits<float>::epsilon();
+    float eps       = std::numeric_limits<float>::epsilon();
     float tolerance = 10;
     if(max_relative_error != max_relative_error || max_relative_error > eps * tolerance)
     {

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -12,96 +12,127 @@
 //
 #ifndef HIPBLAS_H
 #define HIPBLAS_H
-#pragma once
+
 #include "hipblas-export.h"
 #include "hipblas-version.h"
 #include <hip/hip_runtime_api.h>
+#include <stdint.h>
 
 typedef void* hipblasHandle_t;
 
 typedef uint16_t hipblasHalf;
 
-struct hipblasBfloat16
+typedef struct hipblasBfloat16
 {
     uint16_t data;
-};
+} hipblasBfloat16;
 
-template <typename T>
-struct hip_complex_number
+typedef struct hipblasComplex
 {
-    T x, y;
+#ifndef __cplusplus
 
-    template <typename U>
-    hip_complex_number(U a, U b)
-        : x(a)
-        , y(b)
+    float x, y;
+
+#else
+
+private:
+    float x, y;
+
+public:
+#if __cplusplus >= 201103L
+    hipblasComplex() = default;
+#else
+    hipblasComplex() {}
+#endif
+
+    hipblasComplex(float r, float i = 0)
+        : x(r)
+        , y(i)
     {
     }
-    template <typename U>
-    hip_complex_number(U a)
-        : x(a)
-        , y(0)
-    {
-    }
-    hip_complex_number()
-        : x(0)
-        , y(0)
-    {
-    }
 
-    hip_complex_number& operator*=(const hip_complex_number& rhs)
+    float real() const
     {
-        return *this = {x * rhs.x - y * rhs.y, y * rhs.x + x * rhs.y};
+        return x;
     }
-
-    hip_complex_number operator*(const hip_complex_number& rhs) const
+    float imag() const
     {
-        auto lhs = *this;
-        return lhs *= rhs;
+        return y;
+    }
+    void real(float r)
+    {
+        x = r;
+    }
+    void imag(float i)
+    {
+        y = i;
     }
 
-    hip_complex_number& operator+=(const hip_complex_number& rhs)
+#endif
+} hipblasComplex;
+
+typedef struct hipblasDoubleComplex
+{
+#ifndef __cplusplus
+
+    double x, y;
+
+#else
+
+private:
+    double x, y;
+
+public:
+
+#if __cplusplus >= 201103L
+    hipblasDoubleComplex() = default;
+#else
+    hipblasDoubleComplex() {}
+#endif
+
+    hipblasDoubleComplex(double r, double i = 0)
+        : x(r)
+        , y(i)
     {
-        return *this = {x + rhs.x, y + rhs.y};
+    }
+    double real() const
+    {
+        return x;
+    }
+    double imag() const
+    {
+        return y;
+    }
+    void real(double r)
+    {
+        x = r;
+    }
+    void imag(double i)
+    {
+        y = i;
     }
 
-    hip_complex_number& operator/(const hip_complex_number& rhs)
-    {
-        if(abs(rhs.x) > abs(rhs.y))
-        {
-            T ratio = rhs.y / rhs.x;
-            T scale = 1 / (rhs.x + rhs.y * ratio);
-            *this   = {(x + y * ratio) * scale, (y - x * ratio) * scale};
-        }
-        else
-        {
-            T ratio = rhs.x / rhs.y;
-            T scale = 1 / (rhs.x * ratio + rhs.y);
-            *this   = {(y + x * ratio) * scale, (y * ratio - x) * scale};
-        }
-        return *this;
-    }
+#endif
+} hipblasDoubleComplex;
 
-    hip_complex_number& operator-(const hip_complex_number& rhs)
-    {
-        return *this = {x - rhs.x, y - rhs.y};
-    }
+#if __cplusplus >= 201103L
+#include <type_traits>
+static_assert(std::is_standard_layout<hipblasComplex>{},
+              "hipblasComplex is not a standard layout type, and thus is incompatible with C.");
+static_assert(
+    std::is_standard_layout<hipblasDoubleComplex>{},
+    "hipblasDoubleComplex is not a standard layout type, and thus is incompatible with C.");
+static_assert(std::is_trivial<hipblasComplex>{},
+              "hipblasComplex is not a trivial type, and thus is incompatible with C.");
+static_assert(std::is_trivial<hipblasDoubleComplex>{},
+              "hipblasDoubleComplex is not a trivial type, and thus is incompatible with C.");
+static_assert(sizeof(hipblasComplex) == sizeof(float) * 2
+                  && sizeof(hipblasDoubleComplex) == sizeof(double) * 2
+                  && sizeof(hipblasDoubleComplex) == sizeof(hipblasComplex) * 2,
+              "Sizes of hipblasComplex or hipblasDoubleComplex are inconsistent");
+#endif
 
-    bool operator!=(const hip_complex_number& rhs) const
-    {
-        return !(x == y);
-    }
-
-    bool operator==(const hip_complex_number& rhs) const
-    {
-        return (x == rhs.x && y == rhs.y);
-    }
-};
-
-typedef hip_complex_number<float>  hipblasComplex;
-typedef hip_complex_number<double> hipblasDoubleComplex;
-
-enum hipblasStatus_t
+typedef enum
 {
     HIPBLAS_STATUS_SUCCESS           = 0, // Function succeeds
     HIPBLAS_STATUS_NOT_INITIALIZED   = 1, // HIPBLAS library not initialized
@@ -112,44 +143,44 @@ enum hipblasStatus_t
     HIPBLAS_STATUS_INTERNAL_ERROR    = 6, // an internal HIPBLAS operation failed
     HIPBLAS_STATUS_NOT_SUPPORTED     = 7, // function not implemented
     HIPBLAS_STATUS_ARCH_MISMATCH     = 8,
-    HIPBLAS_STATUS_HANDLE_IS_NULLPTR = 9 // hipBLAS handle is null pointer
-};
+    HIPBLAS_STATUS_HANDLE_IS_NULLPTR = 9, // hipBLAS handle is null pointer
+} hipblasStatus_t;
 
 // set the values of enum constants to be the same as those used in cblas
-enum hipblasOperation_t
+typedef enum
 {
     HIPBLAS_OP_N = 111,
     HIPBLAS_OP_T = 112,
-    HIPBLAS_OP_C = 113
-};
+    HIPBLAS_OP_C = 113,
+} hipblasOperation_t;
 
-enum hipblasPointerMode_t
+typedef enum
 {
     HIPBLAS_POINTER_MODE_HOST,
-    HIPBLAS_POINTER_MODE_DEVICE
-};
+    HIPBLAS_POINTER_MODE_DEVICE,
+} hipblasPointerMode_t;
 
-enum hipblasFillMode_t
+typedef enum
 {
     HIPBLAS_FILL_MODE_UPPER = 121,
     HIPBLAS_FILL_MODE_LOWER = 122,
-    HIPBLAS_FILL_MODE_FULL  = 123
-};
+    HIPBLAS_FILL_MODE_FULL  = 123,
+} hipblasFillMode_t;
 
-enum hipblasDiagType_t
+typedef enum
 {
     HIPBLAS_DIAG_NON_UNIT = 131,
-    HIPBLAS_DIAG_UNIT     = 132
-};
+    HIPBLAS_DIAG_UNIT     = 132,
+} hipblasDiagType_t;
 
-enum hipblasSideMode_t
+typedef enum
 {
     HIPBLAS_SIDE_LEFT  = 141,
     HIPBLAS_SIDE_RIGHT = 142,
-    HIPBLAS_SIDE_BOTH  = 143
-};
+    HIPBLAS_SIDE_BOTH  = 143,
+} hipblasSideMode_t;
 
-enum hipblasDatatype_t
+typedef enum
 {
     HIPBLAS_R_16F = 150, /**< 16 bit floating point, real */
     HIPBLAS_R_32F = 151, /**< 32 bit floating point, real */
@@ -167,12 +198,12 @@ enum hipblasDatatype_t
     HIPBLAS_C_32U = 167, /**< 32 bit unsigned integer, complex */
     HIPBLAS_R_16B = 168, /**< 16 bit bfloat, real */
     HIPBLAS_C_16B = 169, /**< 16 bit bfloat, complex */
-};
+} hipblasDatatype_t;
 
-enum hipblasGemmAlgo_t
+typedef enum
 {
-    HIPBLAS_GEMM_DEFAULT = 160
-};
+    HIPBLAS_GEMM_DEFAULT = 160,
+} hipblasGemmAlgo_t;
 
 #ifdef __cplusplus
 extern "C" {

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -39,9 +39,6 @@ target_include_directories( hipblas
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
 )
 
-# C++14
-target_compile_features( hipblas PUBLIC cxx_std_14 )
-
 # Build hipblas from source on AMD platform
 if( NOT CUDA_FOUND )
   if( NOT TARGET rocblas )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -39,8 +39,8 @@ target_include_directories( hipblas
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
 )
 
-# Test for specific compiler features if cmake version is recent enough
-target_compile_features( hipblas PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type )
+# C++14
+target_compile_features( hipblas PUBLIC cxx_std_14 )
 
 # Build hipblas from source on AMD platform
 if( NOT CUDA_FOUND )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -77,7 +77,6 @@ if( NOT CUDA_FOUND )
   # Remove following when hcc is fixed; hcc emits following spurious warning ROCm v1.6.3
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
-    target_compile_options( hipblas PRIVATE -Wno-unused-command-line-argument )
     target_link_libraries( hipblas PRIVATE hip::hip_hcc )
   endif( )
 

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -4,7 +4,9 @@
 #include "hipblas.h"
 #include "limits.h"
 #include "rocblas.h"
+#ifdef __HIP_PLATFORM_SOLVER__
 #include "rocsolver.h"
+#endif
 #include <algorithm>
 #include <math.h>
 

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -5,6 +5,7 @@
 #include "limits.h"
 #include "rocblas.h"
 #include "rocsolver.h"
+#include <algorithm>
 #include <math.h>
 
 #define USE_DEVICE_POINTER_MODE(handle, cmd)                        \


### PR DESCRIPTION
**This supercedes PR# 191, which was not a full solution.**

This only uses C in the `hipblas.h` header, unless `__cplusplus` is defined.

It re-implements the test functions in terms of `std::complex`, which has a guaranteed layout and hence `reinterpret_cast<std::complex<float>&>(hipComplex)` and `reinterpret_cast<std::complex<double>&>(hipDoubleComplex)` can be used to cast them into `std::complex` to use the functions in there (to avoid dependence on `rocblas-complex-functions.h`).