### PR TITLE
Use add_definitions( -D__HIP_PLATFORM_SOLVER__ ) for hipBLAS directory and below, rather than for each individual target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,10 @@ option( BUILD_VERBOSE "Output additional build information" OFF )
 
 option( BUILD_WITH_SOLVER "Add additional functions from rocSOLVER" ON )
 
+if( BUILD_WITH_SOLVER )
+    add_definitions( -D__HIP_PLATFORM_SOLVER__ )
+endif( )
+
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -137,10 +137,6 @@ target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack ${GTEST_LI
 if( NOT CUDA_FOUND )
   target_compile_definitions( hipblas-test PRIVATE __HIP_PLATFORM_HCC__ )
 
-  if( BUILD_WITH_SOLVER )
-    target_compile_definitions( hipblas-test PRIVATE __HIP_PLATFORM_SOLVER__ )
-  endif( )
-
   # Remove following when hcc is fixed; hcc emits following spurious warning
   # "clang-5.0: warning: argument unused during compilation: '-isystem /opt/rocm/include'"
   target_compile_options( hipblas-test PRIVATE -mf16c)
@@ -167,10 +163,6 @@ if( NOT CUDA_FOUND )
   endif()
 else( )
   target_compile_definitions( hipblas-test PRIVATE __HIP_PLATFORM_NVCC__ )
-
-  if( BUILD_WITH_SOLVER )
-    target_compile_definitions( hipblas-test PRIVATE __HIP_PLATFORM_SOLVER__ )
-  endif( )
 
   target_include_directories( hipblas-test
     PRIVATE

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -54,9 +54,6 @@ if( NOT CUDA_FOUND )
     if( NOT TARGET rocsolver )
       find_package( rocsolver REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocsolver /usr/local/rocsolver )
     endif( )
-
-    target_compile_definitions( hipblas PRIVATE __HIP_PLATFORM_SOLVER__ )
-
     target_link_libraries( hipblas PRIVATE roc::rocsolver )
   endif( )
 
@@ -82,10 +79,6 @@ else( )
   target_compile_definitions( hipblas PRIVATE __HIP_PLATFORM_NVCC__ )
 
   target_link_libraries( hipblas PRIVATE ${CUDA_CUBLAS_LIBRARIES} )
-
-  if( BUILD_WITH_SOLVER )
-    target_compile_definitions( hipblas PRIVATE __HIP_PLATFORM_SOLVER__ )
-  endif( )
 
   # External header includes included as system files
   target_include_directories( hipblas


### PR DESCRIPTION
I'm having to rebuild rocSOLVER and rocBLAS in my environment to test this, but this is simpler and less error-prone than adding `-D__HIP_PLATFORM_SOLVER__` for each target separately. The `samples` builds were not including it before.
