### PR TITLE
Make constexpr variable specializations static, to satisfy ODR

### DIFF
--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -142,10 +142,10 @@ template <typename T>
 static constexpr bool is_complex = false;
 
 template <>
-constexpr bool is_complex<hipblasComplex> = true;
+HIPBLAS_CLANG_STATIC constexpr bool is_complex<hipblasComplex> = true;
 
 template <>
-constexpr bool is_complex<hipblasDoubleComplex> = true;
+HIPBLAS_CLANG_STATIC constexpr bool is_complex<hipblasDoubleComplex> = true;
 
 // Get base types from complex types.
 template <typename T, typename = void>

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -18,6 +18,12 @@
 #include <hip/hip_runtime_api.h>
 #include <stdint.h>
 
+#if __clang__
+#define HIPBLAS_CLANG_STATIC static
+#else
+#define HIPBLAS_CLANG_STATIC
+#endif
+
 typedef void* hipblasHandle_t;
 
 typedef uint16_t hipblasHalf;


### PR DESCRIPTION
The C++ standard is ambiguous; there are many conflicting specs:
1. A `constexpr` or `const` _non-template_ variable has _internal linkage_, unless declared `extern`.
2. A `constexpr` or `const` _template_ variable has _external linkage_, unless declared `static`.
3. In C++17, a `constexpr` variable is implicitly `inline`; in C++14, variables cannot be `inline`. `inline` variables can be defined in multiple compilation units without violating ODR. Some compilers treat C++14 `constexpr` variables as `inline` even though C++14 does not recognize `inline` variables.
4. A template specialization is not allowed to have a _storage class specifier_ like `static`, but it is unclear whether this was intended to apply to variable templates, or whether _storage class specifier_ and _linkage_ are distinct concepts as far as template specializations go.

See also https://github.com/ROCmSoftwarePlatform/rocBLAS/pull/551 and the links it refers to.

This change makes the variable template specializations static, to satisfy ODR (prevent multiple definitions), but it is unclear whether this should really be required.