### PR TITLE
rocSOLVER support 2

### DIFF
--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -32,6 +32,30 @@ char type2char<double>()
 //      return 'z';
 //  }
 
+template <>
+int type2int<float>(float val)
+{
+    return (int)val;
+}
+
+template <>
+int type2int<double>(double val)
+{
+    return (int)val;
+}
+
+template <>
+int type2int<hipblasComplex>(hipblasComplex val)
+{
+    return (int)val.real();
+}
+
+template <>
+int type2int<hipblasDoubleComplex>(hipblasDoubleComplex val)
+{
+    return (int)val.real();
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/clients/gtest/geqrf_batched_gtest.cpp
+++ b/clients/gtest/geqrf_batched_gtest.cpp
@@ -60,7 +60,7 @@ TEST_P(geqrf_batched_gtest, geqrf_batched_gtest_float)
 
     Arguments arg = setup_geqrf_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_geqrf_batched<float>(arg);
+    hipblasStatus_t status = testing_geqrf_batched<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -82,7 +82,51 @@ TEST_P(geqrf_batched_gtest, geqrf_batched_gtest_double)
 
     Arguments arg = setup_geqrf_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_geqrf_batched<double>(arg);
+    hipblasStatus_t status = testing_geqrf_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(geqrf_batched_gtest, geqrf_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_geqrf_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_geqrf_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(geqrf_batched_gtest, geqrf_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_geqrf_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_geqrf_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/geqrf_gtest.cpp
+++ b/clients/gtest/geqrf_gtest.cpp
@@ -60,7 +60,7 @@ TEST_P(geqrf_gtest, geqrf_gtest_float)
 
     Arguments arg = setup_geqrf_arguments(GetParam());
 
-    hipblasStatus_t status = testing_geqrf<float>(arg);
+    hipblasStatus_t status = testing_geqrf<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -82,7 +82,51 @@ TEST_P(geqrf_gtest, geqrf_gtest_double)
 
     Arguments arg = setup_geqrf_arguments(GetParam());
 
-    hipblasStatus_t status = testing_geqrf<double>(arg);
+    hipblasStatus_t status = testing_geqrf<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(geqrf_gtest, geqrf_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_geqrf_arguments(GetParam());
+
+    hipblasStatus_t status = testing_geqrf<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(geqrf_gtest, geqrf_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_geqrf_arguments(GetParam());
+
+    hipblasStatus_t status = testing_geqrf<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/geqrf_strided_batched_gtest.cpp
+++ b/clients/gtest/geqrf_strided_batched_gtest.cpp
@@ -60,7 +60,7 @@ TEST_P(geqrf_strided_batched_gtest, geqrf_strided_batched_gtest_float)
 
     Arguments arg = setup_geqrf_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_geqrf_strided_batched<float>(arg);
+    hipblasStatus_t status = testing_geqrf_strided_batched<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -82,7 +82,51 @@ TEST_P(geqrf_strided_batched_gtest, geqrf_strided_batched_gtest_double)
 
     Arguments arg = setup_geqrf_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_geqrf_strided_batched<double>(arg);
+    hipblasStatus_t status = testing_geqrf_strided_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(geqrf_strided_batched_gtest, geqrf_strided_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_geqrf_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_geqrf_strided_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(geqrf_strided_batched_gtest, geqrf_strided_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_geqrf_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_geqrf_strided_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrf_batched_gtest.cpp
+++ b/clients/gtest/getrf_batched_gtest.cpp
@@ -63,7 +63,7 @@ TEST_P(getrf_batched_gtest, getrf_batched_gtest_float)
 
     Arguments arg = setup_getrf_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_batched<float>(arg);
+    hipblasStatus_t status = testing_getrf_batched<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -85,7 +85,51 @@ TEST_P(getrf_batched_gtest, getrf_batched_gtest_double)
 
     Arguments arg = setup_getrf_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_batched<double>(arg);
+    hipblasStatus_t status = testing_getrf_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getrf_batched_gtest, getrf_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getrf_batched_gtest, getrf_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrf_gtest.cpp
+++ b/clients/gtest/getrf_gtest.cpp
@@ -63,7 +63,7 @@ TEST_P(getrf_gtest, getrf_gtest_float)
 
     Arguments arg = setup_getrf_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf<float>(arg);
+    hipblasStatus_t status = testing_getrf<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -85,7 +85,51 @@ TEST_P(getrf_gtest, getrf_gtest_double)
 
     Arguments arg = setup_getrf_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf<double>(arg);
+    hipblasStatus_t status = testing_getrf<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(getrf_gtest, getrf_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(getrf_gtest, getrf_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrf_strided_batched_gtest.cpp
+++ b/clients/gtest/getrf_strided_batched_gtest.cpp
@@ -63,7 +63,7 @@ TEST_P(getrf_strided_batched_gtest, getrf_strided_batched_gtest_float)
 
     Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_strided_batched<float>(arg);
+    hipblasStatus_t status = testing_getrf_strided_batched<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -85,7 +85,51 @@ TEST_P(getrf_strided_batched_gtest, getrf_strided_batched_gtest_double)
 
     Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_strided_batched<double>(arg);
+    hipblasStatus_t status = testing_getrf_strided_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(getrf_strided_batched_gtest, getrf_strided_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_strided_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(getrf_strided_batched_gtest, getrf_strided_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_strided_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrs_batched_gtest.cpp
+++ b/clients/gtest/getrs_batched_gtest.cpp
@@ -59,7 +59,7 @@ TEST_P(getrs_batched_gtest, getrs_batched_gtest_float)
 
     Arguments arg = setup_getrs_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrs_batched<float>(arg);
+    hipblasStatus_t status = testing_getrs_batched<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -81,7 +81,51 @@ TEST_P(getrs_batched_gtest, getrs_batched_gtest_double)
 
     Arguments arg = setup_getrs_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrs_batched<double>(arg);
+    hipblasStatus_t status = testing_getrs_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.ldb < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getrs_batched_gtest, getrs_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrs_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrs_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.ldb < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getrs_batched_gtest, getrs_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrs_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrs_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrs_gtest.cpp
+++ b/clients/gtest/getrs_gtest.cpp
@@ -59,7 +59,7 @@ TEST_P(getrs_gtest, getrs_gtest_float)
 
     Arguments arg = setup_getrs_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrs<float>(arg);
+    hipblasStatus_t status = testing_getrs<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -81,7 +81,51 @@ TEST_P(getrs_gtest, getrs_gtest_double)
 
     Arguments arg = setup_getrs_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrs<double>(arg);
+    hipblasStatus_t status = testing_getrs<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.ldb < arg.N)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(getrs_gtest, getrs_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrs_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrs<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.ldb < arg.N)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(getrs_gtest, getrs_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrs_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrs<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrs_strided_batched_gtest.cpp
+++ b/clients/gtest/getrs_strided_batched_gtest.cpp
@@ -59,7 +59,7 @@ TEST_P(getrs_strided_batched_gtest, getrs_strided_batched_gtest_float)
 
     Arguments arg = setup_getrs_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrs_strided_batched<float>(arg);
+    hipblasStatus_t status = testing_getrs_strided_batched<float, float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -81,7 +81,51 @@ TEST_P(getrs_strided_batched_gtest, getrs_strided_batched_gtest_double)
 
     Arguments arg = setup_getrs_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrs_strided_batched<double>(arg);
+    hipblasStatus_t status = testing_getrs_strided_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.ldb < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(getrs_strided_batched_gtest, getrs_strided_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrs_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrs_strided_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.ldb < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status); // for cuda
+        }
+    }
+}
+
+TEST_P(getrs_strided_batched_gtest, getrs_strided_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrs_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrs_strided_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-template <typename T>
+template <typename T, typename U>
 hipblasStatus_t testing_geqrf(Arguments argus)
 {
     int M   = argus.M;
@@ -42,8 +42,8 @@ hipblasStatus_t testing_geqrf(Arguments argus)
     host_vector<T> hIpiv1(Ipiv_size);
     int            info;
 
-    device_vector<T> dA(A_size);
-    device_vector<T> dIpiv(Ipiv_size);
+    device_vector<T, 1> dA(A_size);
+    device_vector<T, 1> dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -85,7 +85,7 @@ hipblasStatus_t testing_geqrf(Arguments argus)
         // Workspace query
         host_vector<T> work(1);
         cblas_geqrf(M, N, hA.data(), lda, hIpiv.data(), work.data(), -1);
-        int lwork = (int)work[0];
+        int lwork = type2int(work[0]);
 
         // Perform factorization
         work = host_vector<T>(lwork);
@@ -93,14 +93,14 @@ hipblasStatus_t testing_geqrf(Arguments argus)
 
         if(argus.unit_check)
         {
-            T      eps       = std::numeric_limits<T>::epsilon();
+            U      eps       = std::numeric_limits<U>::epsilon();
             double tolerance = eps * 2000;
 
-            double e1 = norm_check_general<T>('M', M, N, lda, hA.data(), hA1.data());
+            double e1 = norm_check_general<T>('F', M, N, lda, hA.data(), hA1.data());
             unit_check_error(e1, tolerance);
 
             double e2
-                = norm_check_general<T>('M', min(M, N), 1, min(M, N), hIpiv.data(), hIpiv1.data());
+                = norm_check_general<T>('F', min(M, N), 1, min(M, N), hIpiv.data(), hIpiv1.data());
             unit_check_error(e2, tolerance);
         }
     }

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -42,8 +42,8 @@ hipblasStatus_t testing_geqrf(Arguments argus)
     host_vector<T> hIpiv1(Ipiv_size);
     int            info;
 
-    device_vector<T, 1> dA(A_size);
-    device_vector<T, 1> dIpiv(Ipiv_size);
+    device_vector<T> dA(A_size);
+    device_vector<T> dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -55,6 +55,18 @@ hipblasStatus_t testing_geqrf(Arguments argus)
     // Initial hA on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda);
+
+    // scale A to avoid singularities
+    for(int i = 0; i < M; i++)
+    {
+        for(int j = 0; j < N; j++)
+        {
+            if(i == j)
+                hA[i + j * lda] += 400;
+            else
+                hA[i + j * lda] -= 4;
+        }
+    }
 
     // Copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), A_size * sizeof(T), hipMemcpyHostToDevice));

--- a/clients/include/testing_geqrf_batched.hpp
+++ b/clients/include/testing_geqrf_batched.hpp
@@ -47,8 +47,8 @@ hipblasStatus_t testing_geqrf_batched(Arguments argus)
     host_vector<T> hIpiv1[batch_count];
     int            info;
 
-    device_batch_vector<T, 1> bA(batch_count, A_size);
-    device_batch_vector<T, 1> bIpiv(batch_count, Ipiv_size);
+    device_batch_vector<T> bA(batch_count, A_size);
+    device_batch_vector<T> bIpiv(batch_count, Ipiv_size);
 
     device_vector<T*, 0, T> dA(batch_count);
     device_vector<T*, 0, T> dIpiv(batch_count);
@@ -70,6 +70,18 @@ hipblasStatus_t testing_geqrf_batched(Arguments argus)
         hIpiv1[b] = host_vector<T>(Ipiv_size);
 
         hipblas_init<T>(hA[b], M, N, lda);
+
+        // scale A to avoid singularities
+        for(int i = 0; i < M; i++)
+        {
+            for(int j = 0; j < N; j++)
+            {
+                if(i == j)
+                    hA[b][i + j * lda] += 400;
+                else
+                    hA[b][i + j * lda] -= 4;
+            }
+        }
 
         // Copy data from CPU to device
         CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b].data(), A_size * sizeof(T), hipMemcpyHostToDevice));

--- a/clients/include/testing_geqrf_strided_batched.hpp
+++ b/clients/include/testing_geqrf_strided_batched.hpp
@@ -50,8 +50,8 @@ hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
     host_vector<T> hIpiv1(Ipiv_size);
     int            info;
 
-    device_vector<T, 1> dA(A_size);
-    device_vector<T, 1> dIpiv(Ipiv_size);
+    device_vector<T> dA(A_size);
+    device_vector<T> dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -67,6 +67,18 @@ hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
         T* hAb = hA.data() + b * strideA;
 
         hipblas_init<T>(hAb, M, N, lda);
+
+        // scale A to avoid singularities
+        for(int i = 0; i < M; i++)
+        {
+            for(int j = 0; j < N; j++)
+            {
+                if(i == j)
+                    hAb[i + j * lda] += 400;
+                else
+                    hAb[i + j * lda] -= 4;
+            }
+        }
     }
 
     // Copy data from CPU to device

--- a/clients/include/testing_geqrf_strided_batched.hpp
+++ b/clients/include/testing_geqrf_strided_batched.hpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-template <typename T>
+template <typename T, typename U>
 hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
 {
     int    M            = argus.M;
@@ -50,8 +50,8 @@ hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
     host_vector<T> hIpiv1(Ipiv_size);
     int            info;
 
-    device_vector<T> dA(A_size);
-    device_vector<T> dIpiv(Ipiv_size);
+    device_vector<T, 1> dA(A_size);
+    device_vector<T, 1> dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -99,7 +99,7 @@ hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
         // Workspace query
         host_vector<T> work(1);
         cblas_geqrf(M, N, hA.data(), lda, hIpiv.data(), work.data(), -1);
-        int lwork = (int)work[0];
+        int lwork = type2int(work[0]);
 
         // Perform factorization
         work = host_vector<T>(lwork);
@@ -110,14 +110,14 @@ hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
 
             if(argus.unit_check)
             {
-                T      eps       = std::numeric_limits<T>::epsilon();
+                U      eps       = std::numeric_limits<U>::epsilon();
                 double tolerance = eps * 2000;
 
                 double e1 = norm_check_general<T>(
-                    'M', M, N, lda, hA.data() + b * strideA, hA1.data() + b * strideA);
+                    'F', M, N, lda, hA.data() + b * strideA, hA1.data() + b * strideA);
                 unit_check_error(e1, tolerance);
 
-                double e2 = norm_check_general<T>('M',
+                double e2 = norm_check_general<T>('F',
                                                   min(M, N),
                                                   1,
                                                   strideP,

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-template <typename T>
+template <typename T, typename U>
 hipblasStatus_t testing_getrf(Arguments argus)
 {
     int M   = argus.N;
@@ -43,9 +43,9 @@ hipblasStatus_t testing_getrf(Arguments argus)
     host_vector<int> hInfo(1);
     host_vector<int> hInfo1(1);
 
-    device_vector<T>   dA(A_size);
-    device_vector<int> dIpiv(Ipiv_size);
-    device_vector<int> dInfo(1);
+    device_vector<T, 1>   dA(A_size);
+    device_vector<int, 1> dIpiv(Ipiv_size);
+    device_vector<int, 1> dInfo(1);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -91,10 +91,10 @@ hipblasStatus_t testing_getrf(Arguments argus)
 
         if(argus.unit_check)
         {
-            T      eps       = std::numeric_limits<T>::epsilon();
+            U      eps       = std::numeric_limits<U>::epsilon();
             double tolerance = eps * 2000;
 
-            double e = norm_check_general<T>('M', M, N, lda, hA.data(), hA1.data());
+            double e = norm_check_general<T>('F', M, N, lda, hA.data(), hA1.data());
             unit_check_error(e, tolerance);
         }
     }

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -43,9 +43,9 @@ hipblasStatus_t testing_getrf(Arguments argus)
     host_vector<int> hInfo(1);
     host_vector<int> hInfo1(1);
 
-    device_vector<T, 1>   dA(A_size);
-    device_vector<int, 1> dIpiv(Ipiv_size);
-    device_vector<int, 1> dInfo(1);
+    device_vector<T>   dA(A_size);
+    device_vector<int> dIpiv(Ipiv_size);
+    device_vector<int> dInfo(1);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -57,6 +57,18 @@ hipblasStatus_t testing_getrf(Arguments argus)
     // Initial hA on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda);
+
+    // scale A to avoid singularities
+    for(int i = 0; i < M; i++)
+    {
+        for(int j = 0; j < N; j++)
+        {
+            if(i == j)
+                hA[i + j * lda] += 400;
+            else
+                hA[i + j * lda] -= 4;
+        }
+    }
 
     // Copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), A_size * sizeof(T), hipMemcpyHostToDevice));

--- a/clients/include/testing_getrf_batched.hpp
+++ b/clients/include/testing_getrf_batched.hpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-template <typename T>
+template <typename T, typename U>
 hipblasStatus_t testing_getrf_batched(Arguments argus)
 {
     int M           = argus.N;
@@ -49,11 +49,11 @@ hipblasStatus_t testing_getrf_batched(Arguments argus)
     host_vector<int> hInfo(batch_count);
     host_vector<int> hInfo1(batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
+    device_batch_vector<T, 1> bA(batch_count, A_size);
 
     device_vector<T*, 0, T> dA(batch_count);
-    device_vector<int>      dIpiv(Ipiv_size);
-    device_vector<int>      dInfo(batch_count);
+    device_vector<int, 1>   dIpiv(Ipiv_size);
+    device_vector<int, 1>   dInfo(batch_count);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -111,10 +111,10 @@ hipblasStatus_t testing_getrf_batched(Arguments argus)
 
             if(argus.unit_check)
             {
-                T      eps       = std::numeric_limits<T>::epsilon();
+                U      eps       = std::numeric_limits<U>::epsilon();
                 double tolerance = eps * 2000;
 
-                double e = norm_check_general<T>('M', M, N, lda, hA[b].data(), hA1[b].data());
+                double e = norm_check_general<T>('F', M, N, lda, hA[b].data(), hA1[b].data());
                 unit_check_error(e, tolerance);
             }
         }

--- a/clients/include/testing_getrf_strided_batched.hpp
+++ b/clients/include/testing_getrf_strided_batched.hpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-template <typename T>
+template <typename T, typename U>
 hipblasStatus_t testing_getrf_strided_batched(Arguments argus)
 {
     int    M            = argus.N;
@@ -51,9 +51,9 @@ hipblasStatus_t testing_getrf_strided_batched(Arguments argus)
     host_vector<int> hInfo(batch_count);
     host_vector<int> hInfo1(batch_count);
 
-    device_vector<T>   dA(A_size);
-    device_vector<int> dIpiv(Ipiv_size);
-    device_vector<int> dInfo(batch_count);
+    device_vector<T, 1>   dA(A_size);
+    device_vector<int, 1> dIpiv(Ipiv_size);
+    device_vector<int, 1> dInfo(batch_count);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -108,11 +108,11 @@ hipblasStatus_t testing_getrf_strided_batched(Arguments argus)
 
             if(argus.unit_check)
             {
-                T      eps       = std::numeric_limits<T>::epsilon();
+                U      eps       = std::numeric_limits<U>::epsilon();
                 double tolerance = eps * 2000;
 
                 double e = norm_check_general<T>(
-                    'M', M, N, lda, hA.data() + b * strideA, hA1.data() + b * strideA);
+                    'F', M, N, lda, hA.data() + b * strideA, hA1.data() + b * strideA);
                 unit_check_error(e, tolerance);
             }
         }

--- a/clients/include/testing_getrf_strided_batched.hpp
+++ b/clients/include/testing_getrf_strided_batched.hpp
@@ -51,9 +51,9 @@ hipblasStatus_t testing_getrf_strided_batched(Arguments argus)
     host_vector<int> hInfo(batch_count);
     host_vector<int> hInfo1(batch_count);
 
-    device_vector<T, 1>   dA(A_size);
-    device_vector<int, 1> dIpiv(Ipiv_size);
-    device_vector<int, 1> dInfo(batch_count);
+    device_vector<T>   dA(A_size);
+    device_vector<int> dIpiv(Ipiv_size);
+    device_vector<int> dInfo(batch_count);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -69,6 +69,18 @@ hipblasStatus_t testing_getrf_strided_batched(Arguments argus)
         T* hAb = hA.data() + b * strideA;
 
         hipblas_init<T>(hAb, M, N, lda);
+
+        // scale A to avoid singularities
+        for(int i = 0; i < M; i++)
+        {
+            for(int j = 0; j < N; j++)
+            {
+                if(i == j)
+                    hAb[i + j * lda] += 400;
+                else
+                    hAb[i + j * lda] -= 4;
+            }
+        }
     }
 
     // Copy data from CPU to device

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-template <typename T>
+template <typename T, typename U>
 hipblasStatus_t testing_getrs(Arguments argus)
 {
     int N   = argus.N;
@@ -45,9 +45,9 @@ hipblasStatus_t testing_getrs(Arguments argus)
     host_vector<int> hIpiv1(Ipiv_size);
     int              info;
 
-    device_vector<T>   dA(A_size);
-    device_vector<T>   dB(B_size);
-    device_vector<int> dIpiv(Ipiv_size);
+    device_vector<T, 1>   dA(A_size);
+    device_vector<T, 1>   dB(B_size);
+    device_vector<int, 1> dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -122,10 +122,10 @@ hipblasStatus_t testing_getrs(Arguments argus)
 
         if(argus.unit_check)
         {
-            T      eps       = std::numeric_limits<T>::epsilon();
+            U      eps       = std::numeric_limits<U>::epsilon();
             double tolerance = N * eps * 100;
 
-            double e = norm_check_general<T>('M', N, 1, ldb, hB.data(), hB1.data());
+            double e = norm_check_general<T>('F', N, 1, ldb, hB.data(), hB1.data());
             unit_check_error(e, tolerance);
         }
     }

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -45,9 +45,9 @@ hipblasStatus_t testing_getrs(Arguments argus)
     host_vector<int> hIpiv1(Ipiv_size);
     int              info;
 
-    device_vector<T, 1>   dA(A_size);
-    device_vector<T, 1>   dB(B_size);
-    device_vector<int, 1> dIpiv(Ipiv_size);
+    device_vector<T>   dA(A_size);
+    device_vector<T>   dB(B_size);
+    device_vector<int> dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -61,15 +61,15 @@ hipblasStatus_t testing_getrs(Arguments argus)
     hipblas_init<T>(hA, N, N, lda);
     hipblas_init<T>(hX, N, 1, ldb);
 
-    // Put hA entries into range [0, 1], make diagonally dominant
+    // scale A to avoid singularities
     for(int i = 0; i < N; i++)
     {
         for(int j = 0; j < N; j++)
         {
-            hA[i + j * lda] = (hA[i + j * lda] - 1.0) / 10.0;
-
             if(i == j)
-                hA[i + j * lda] *= 100;
+                hA[i + j * lda] += 400;
+            else
+                hA[i + j * lda] -= 4;
         }
     }
 

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -51,12 +51,12 @@ hipblasStatus_t testing_getrs_batched(Arguments argus)
     host_vector<int> hIpiv1(Ipiv_size);
     int              info;
 
-    device_batch_vector<T, 1> bA(batch_count, A_size);
-    device_batch_vector<T, 1> bB(batch_count, B_size);
+    device_batch_vector<T> bA(batch_count, A_size);
+    device_batch_vector<T> bB(batch_count, B_size);
 
     device_vector<T*, 0, T> dA(batch_count);
     device_vector<T*, 0, T> dB(batch_count);
-    device_vector<int, 1>   dIpiv(Ipiv_size);
+    device_vector<int>      dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -78,15 +78,15 @@ hipblasStatus_t testing_getrs_batched(Arguments argus)
         hipblas_init<T>(hA[b], N, N, lda);
         hipblas_init<T>(hX[b], N, 1, ldb);
 
-        // Put hA entries into range [0, 1], make diagonally dominant
+        // scale A to avoid singularities
         for(int i = 0; i < N; i++)
         {
             for(int j = 0; j < N; j++)
             {
-                hA[b][i + j * lda] = (hA[b][i + j * lda] - 1.0) / 10.0;
-
                 if(i == j)
-                    hA[b][i + j * lda] *= 100;
+                    hA[b][i + j * lda] += 400;
+                else
+                    hA[b][i + j * lda] -= 4;
             }
         }
 

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-template <typename T>
+template <typename T, typename U>
 hipblasStatus_t testing_getrs_batched(Arguments argus)
 {
     int N           = argus.N;
@@ -51,12 +51,12 @@ hipblasStatus_t testing_getrs_batched(Arguments argus)
     host_vector<int> hIpiv1(Ipiv_size);
     int              info;
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bB(batch_count, B_size);
+    device_batch_vector<T, 1> bA(batch_count, A_size);
+    device_batch_vector<T, 1> bB(batch_count, B_size);
 
     device_vector<T*, 0, T> dA(batch_count);
     device_vector<T*, 0, T> dB(batch_count);
-    device_vector<int>      dIpiv(Ipiv_size);
+    device_vector<int, 1>   dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -143,10 +143,10 @@ hipblasStatus_t testing_getrs_batched(Arguments argus)
 
             if(argus.unit_check)
             {
-                T      eps       = std::numeric_limits<T>::epsilon();
+                U      eps       = std::numeric_limits<U>::epsilon();
                 double tolerance = N * eps * 100;
 
-                double e = norm_check_general<T>('M', N, 1, ldb, hB[b].data(), hB1[b].data());
+                double e = norm_check_general<T>('F', N, 1, ldb, hB[b].data(), hB1[b].data());
                 unit_check_error(e, tolerance);
             }
         }

--- a/clients/include/testing_getrs_strided_batched.hpp
+++ b/clients/include/testing_getrs_strided_batched.hpp
@@ -54,9 +54,9 @@ hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
     host_vector<int> hIpiv1(Ipiv_size);
     int              info;
 
-    device_vector<T, 1>   dA(A_size);
-    device_vector<T, 1>   dB(B_size);
-    device_vector<int, 1> dIpiv(Ipiv_size);
+    device_vector<T>   dA(A_size);
+    device_vector<T>   dB(B_size);
+    device_vector<int> dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -78,15 +78,15 @@ hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
         hipblas_init<T>(hAb, N, N, lda);
         hipblas_init<T>(hXb, N, 1, ldb);
 
-        // Put hA entries into range [0, 1], make diagonally dominant
+        // scale A to avoid singularities
         for(int i = 0; i < N; i++)
         {
             for(int j = 0; j < N; j++)
             {
-                hAb[i + j * lda] = (hAb[i + j * lda] - 1.0) / 10.0;
-
                 if(i == j)
-                    hAb[i + j * lda] *= 100;
+                    hAb[i + j * lda] += 400;
+                else
+                    hAb[i + j * lda] -= 4;
             }
         }
 

--- a/clients/include/testing_getrs_strided_batched.hpp
+++ b/clients/include/testing_getrs_strided_batched.hpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-template <typename T>
+template <typename T, typename U>
 hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
 {
     int    N            = argus.N;
@@ -54,9 +54,9 @@ hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
     host_vector<int> hIpiv1(Ipiv_size);
     int              info;
 
-    device_vector<T>   dA(A_size);
-    device_vector<T>   dB(B_size);
-    device_vector<int> dIpiv(Ipiv_size);
+    device_vector<T, 1>   dA(A_size);
+    device_vector<T, 1>   dB(B_size);
+    device_vector<int, 1> dIpiv(Ipiv_size);
 
     double gpu_time_used, cpu_time_used;
     double hipblasGflops, cblas_gflops;
@@ -144,11 +144,11 @@ hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
 
             if(argus.unit_check)
             {
-                T      eps       = std::numeric_limits<T>::epsilon();
+                U      eps       = std::numeric_limits<U>::epsilon();
                 double tolerance = N * eps * 100;
 
                 double e = norm_check_general<T>(
-                    'M', N, 1, ldb, hB.data() + b * strideB, hB1.data() + b * strideB);
+                    'F', N, 1, ldb, hB.data() + b * strideB, hB1.data() + b * strideB);
                 unit_check_error(e, tolerance);
             }
         }

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -472,6 +472,12 @@ template <typename T>
 char type2char();
 
 /* ============================================================================================ */
+/*! \brief  turn float -> int, double -> int, hipblas_float_complex.real() -> int,
+ * hipblas_double_complex.real() -> int */
+template <typename T>
+int type2int(T val);
+
+/* ============================================================================================ */
 /*! \brief  Debugging purpose, print out CPU and GPU result matrix, not valid in complex number  */
 template <typename T, std::enable_if_t<!is_complex<T>, int> = 0>
 void print_matrix(

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -10,18 +10,6 @@
 #include <algorithm>
 #include <math.h>
 
-#define USE_DEVICE_POINTER_MODE(handle, cmd)                        \
-    do                                                              \
-    {                                                               \
-        hipblasPointerMode_t mode;                                  \
-        hipblasGetPointerMode(handle, &mode);                       \
-        hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE); \
-                                                                    \
-        cmd;                                                        \
-                                                                    \
-        hipblasSetPointerMode(handle, mode);                        \
-    } while(0);
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -10464,30 +10452,22 @@ hipblasStatus_t hipblasZtrsmStridedBatched(hipblasHandle_t             handle,
 hipblasStatus_t hipblasSgetrf(
     hipblasHandle_t handle, const int n, float* A, const int lda, int* ipiv, int* info)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(
-        handle, status = rocsolver_sgetrf((rocblas_handle)handle, n, n, A, lda, ipiv, info));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_sgetrf((rocblas_handle)handle, n, n, A, lda, ipiv, info));
 }
 
 hipblasStatus_t hipblasDgetrf(
     hipblasHandle_t handle, const int n, double* A, const int lda, int* ipiv, int* info)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(
-        handle, status = rocsolver_dgetrf((rocblas_handle)handle, n, n, A, lda, ipiv, info));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_dgetrf((rocblas_handle)handle, n, n, A, lda, ipiv, info));
 }
 
 hipblasStatus_t hipblasCgetrf(
     hipblasHandle_t handle, const int n, hipblasComplex* A, const int lda, int* ipiv, int* info)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(
-        handle,
-        status = rocsolver_cgetrf(
-            (rocblas_handle)handle, n, n, (rocblas_float_complex*)A, lda, ipiv, info));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_cgetrf((rocblas_handle)handle, n, n, (rocblas_float_complex*)A, lda, ipiv, info));
 }
 
 hipblasStatus_t hipblasZgetrf(hipblasHandle_t       handle,
@@ -10497,12 +10477,8 @@ hipblasStatus_t hipblasZgetrf(hipblasHandle_t       handle,
                               int*                  ipiv,
                               int*                  info)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(
-        handle,
-        status = rocsolver_zgetrf(
-            (rocblas_handle)handle, n, n, (rocblas_double_complex*)A, lda, ipiv, info));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_zgetrf(
+        (rocblas_handle)handle, n, n, (rocblas_double_complex*)A, lda, ipiv, info));
 }
 
 // getrf_batched
@@ -10514,11 +10490,8 @@ hipblasStatus_t hipblasSgetrfBatched(hipblasHandle_t handle,
                                      int*            info,
                                      const int       batch_count)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_sgetrf_batched(
-                                (rocblas_handle)handle, n, n, A, lda, ipiv, n, info, batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_sgetrf_batched((rocblas_handle)handle, n, n, A, lda, ipiv, n, info, batch_count));
 }
 
 hipblasStatus_t hipblasDgetrfBatched(hipblasHandle_t handle,
@@ -10529,11 +10502,8 @@ hipblasStatus_t hipblasDgetrfBatched(hipblasHandle_t handle,
                                      int*            info,
                                      const int       batch_count)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_dgetrf_batched(
-                                (rocblas_handle)handle, n, n, A, lda, ipiv, n, info, batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_dgetrf_batched((rocblas_handle)handle, n, n, A, lda, ipiv, n, info, batch_count));
 }
 
 hipblasStatus_t hipblasCgetrfBatched(hipblasHandle_t       handle,
@@ -10544,18 +10514,8 @@ hipblasStatus_t hipblasCgetrfBatched(hipblasHandle_t       handle,
                                      int*                  info,
                                      const int             batch_count)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_cgetrf_batched((rocblas_handle)handle,
-                                                              n,
-                                                              n,
-                                                              (rocblas_float_complex**)A,
-                                                              lda,
-                                                              ipiv,
-                                                              n,
-                                                              info,
-                                                              batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_cgetrf_batched(
+        (rocblas_handle)handle, n, n, (rocblas_float_complex**)A, lda, ipiv, n, info, batch_count));
 }
 
 hipblasStatus_t hipblasZgetrfBatched(hipblasHandle_t             handle,
@@ -10566,18 +10526,15 @@ hipblasStatus_t hipblasZgetrfBatched(hipblasHandle_t             handle,
                                      int*                        info,
                                      const int                   batch_count)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_zgetrf_batched((rocblas_handle)handle,
-                                                              n,
-                                                              n,
-                                                              (rocblas_double_complex**)A,
-                                                              lda,
-                                                              ipiv,
-                                                              n,
-                                                              info,
-                                                              batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_zgetrf_batched((rocblas_handle)handle,
+                                                             n,
+                                                             n,
+                                                             (rocblas_double_complex**)A,
+                                                             lda,
+                                                             ipiv,
+                                                             n,
+                                                             info,
+                                                             batch_count));
 }
 
 // getrf_strided_batched
@@ -10591,12 +10548,8 @@ hipblasStatus_t hipblasSgetrfStridedBatched(hipblasHandle_t handle,
                                             int*            info,
                                             const int       batch_count)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(
-        handle,
-        status = rocsolver_sgetrf_strided_batched(
-            (rocblas_handle)handle, n, n, A, lda, strideA, ipiv, strideP, info, batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_sgetrf_strided_batched(
+        (rocblas_handle)handle, n, n, A, lda, strideA, ipiv, strideP, info, batch_count));
 }
 
 hipblasStatus_t hipblasDgetrfStridedBatched(hipblasHandle_t handle,
@@ -10609,12 +10562,8 @@ hipblasStatus_t hipblasDgetrfStridedBatched(hipblasHandle_t handle,
                                             int*            info,
                                             const int       batch_count)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(
-        handle,
-        status = rocsolver_dgetrf_strided_batched(
-            (rocblas_handle)handle, n, n, A, lda, strideA, ipiv, strideP, info, batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_dgetrf_strided_batched(
+        (rocblas_handle)handle, n, n, A, lda, strideA, ipiv, strideP, info, batch_count));
 }
 
 hipblasStatus_t hipblasCgetrfStridedBatched(hipblasHandle_t handle,
@@ -10627,19 +10576,16 @@ hipblasStatus_t hipblasCgetrfStridedBatched(hipblasHandle_t handle,
                                             int*            info,
                                             const int       batch_count)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_cgetrf_strided_batched((rocblas_handle)handle,
-                                                                      n,
-                                                                      n,
-                                                                      (rocblas_float_complex*)A,
-                                                                      lda,
-                                                                      strideA,
-                                                                      ipiv,
-                                                                      strideP,
-                                                                      info,
-                                                                      batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_cgetrf_strided_batched((rocblas_handle)handle,
+                                                                     n,
+                                                                     n,
+                                                                     (rocblas_float_complex*)A,
+                                                                     lda,
+                                                                     strideA,
+                                                                     ipiv,
+                                                                     strideP,
+                                                                     info,
+                                                                     batch_count));
 }
 
 hipblasStatus_t hipblasZgetrfStridedBatched(hipblasHandle_t       handle,
@@ -10652,19 +10598,16 @@ hipblasStatus_t hipblasZgetrfStridedBatched(hipblasHandle_t       handle,
                                             int*                  info,
                                             const int             batch_count)
 {
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_zgetrf_strided_batched((rocblas_handle)handle,
-                                                                      n,
-                                                                      n,
-                                                                      (rocblas_double_complex*)A,
-                                                                      lda,
-                                                                      strideA,
-                                                                      ipiv,
-                                                                      strideP,
-                                                                      info,
-                                                                      batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_zgetrf_strided_batched((rocblas_handle)handle,
+                                                                     n,
+                                                                     n,
+                                                                     (rocblas_double_complex*)A,
+                                                                     lda,
+                                                                     strideA,
+                                                                     ipiv,
+                                                                     strideP,
+                                                                     info,
+                                                                     batch_count));
 }
 
 // getrs
@@ -10698,18 +10641,8 @@ hipblasStatus_t hipblasSgetrs(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_sgetrs((rocblas_handle)handle,
-                                                      hipOperationToHCCOperation(trans),
-                                                      n,
-                                                      nrhs,
-                                                      A,
-                                                      lda,
-                                                      ipiv,
-                                                      B,
-                                                      ldb));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_sgetrs(
+        (rocblas_handle)handle, hipOperationToHCCOperation(trans), n, nrhs, A, lda, ipiv, B, ldb));
 }
 
 hipblasStatus_t hipblasDgetrs(hipblasHandle_t          handle,
@@ -10742,18 +10675,8 @@ hipblasStatus_t hipblasDgetrs(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_dgetrs((rocblas_handle)handle,
-                                                      hipOperationToHCCOperation(trans),
-                                                      n,
-                                                      nrhs,
-                                                      A,
-                                                      lda,
-                                                      ipiv,
-                                                      B,
-                                                      ldb));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_dgetrs(
+        (rocblas_handle)handle, hipOperationToHCCOperation(trans), n, nrhs, A, lda, ipiv, B, ldb));
 }
 
 hipblasStatus_t hipblasCgetrs(hipblasHandle_t          handle,
@@ -10786,18 +10709,15 @@ hipblasStatus_t hipblasCgetrs(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_cgetrs((rocblas_handle)handle,
-                                                      hipOperationToHCCOperation(trans),
-                                                      n,
-                                                      nrhs,
-                                                      (rocblas_float_complex*)A,
-                                                      lda,
-                                                      ipiv,
-                                                      (rocblas_float_complex*)B,
-                                                      ldb));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_cgetrs((rocblas_handle)handle,
+                                                     hipOperationToHCCOperation(trans),
+                                                     n,
+                                                     nrhs,
+                                                     (rocblas_float_complex*)A,
+                                                     lda,
+                                                     ipiv,
+                                                     (rocblas_float_complex*)B,
+                                                     ldb));
 }
 
 hipblasStatus_t hipblasZgetrs(hipblasHandle_t          handle,
@@ -10830,18 +10750,15 @@ hipblasStatus_t hipblasZgetrs(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_zgetrs((rocblas_handle)handle,
-                                                      hipOperationToHCCOperation(trans),
-                                                      n,
-                                                      nrhs,
-                                                      (rocblas_double_complex*)A,
-                                                      lda,
-                                                      ipiv,
-                                                      (rocblas_double_complex*)B,
-                                                      ldb));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_zgetrs((rocblas_handle)handle,
+                                                     hipOperationToHCCOperation(trans),
+                                                     n,
+                                                     nrhs,
+                                                     (rocblas_double_complex*)A,
+                                                     lda,
+                                                     ipiv,
+                                                     (rocblas_double_complex*)B,
+                                                     ldb));
 }
 
 // getrs_batched
@@ -10878,20 +10795,17 @@ hipblasStatus_t hipblasSgetrsBatched(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_sgetrs_batched((rocblas_handle)handle,
-                                                              hipOperationToHCCOperation(trans),
-                                                              n,
-                                                              nrhs,
-                                                              A,
-                                                              lda,
-                                                              ipiv,
-                                                              n,
-                                                              B,
-                                                              ldb,
-                                                              batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_sgetrs_batched((rocblas_handle)handle,
+                                                             hipOperationToHCCOperation(trans),
+                                                             n,
+                                                             nrhs,
+                                                             A,
+                                                             lda,
+                                                             ipiv,
+                                                             n,
+                                                             B,
+                                                             ldb,
+                                                             batch_count));
 }
 
 hipblasStatus_t hipblasDgetrsBatched(hipblasHandle_t          handle,
@@ -10927,20 +10841,17 @@ hipblasStatus_t hipblasDgetrsBatched(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_dgetrs_batched((rocblas_handle)handle,
-                                                              hipOperationToHCCOperation(trans),
-                                                              n,
-                                                              nrhs,
-                                                              A,
-                                                              lda,
-                                                              ipiv,
-                                                              n,
-                                                              B,
-                                                              ldb,
-                                                              batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_dgetrs_batched((rocblas_handle)handle,
+                                                             hipOperationToHCCOperation(trans),
+                                                             n,
+                                                             nrhs,
+                                                             A,
+                                                             lda,
+                                                             ipiv,
+                                                             n,
+                                                             B,
+                                                             ldb,
+                                                             batch_count));
 }
 
 hipblasStatus_t hipblasCgetrsBatched(hipblasHandle_t          handle,
@@ -10976,20 +10887,17 @@ hipblasStatus_t hipblasCgetrsBatched(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_cgetrs_batched((rocblas_handle)handle,
-                                                              hipOperationToHCCOperation(trans),
-                                                              n,
-                                                              nrhs,
-                                                              (rocblas_float_complex**)A,
-                                                              lda,
-                                                              ipiv,
-                                                              n,
-                                                              (rocblas_float_complex**)B,
-                                                              ldb,
-                                                              batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_cgetrs_batched((rocblas_handle)handle,
+                                                             hipOperationToHCCOperation(trans),
+                                                             n,
+                                                             nrhs,
+                                                             (rocblas_float_complex**)A,
+                                                             lda,
+                                                             ipiv,
+                                                             n,
+                                                             (rocblas_float_complex**)B,
+                                                             ldb,
+                                                             batch_count));
 }
 
 hipblasStatus_t hipblasZgetrsBatched(hipblasHandle_t             handle,
@@ -11025,20 +10933,17 @@ hipblasStatus_t hipblasZgetrsBatched(hipblasHandle_t             handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_zgetrs_batched((rocblas_handle)handle,
-                                                              hipOperationToHCCOperation(trans),
-                                                              n,
-                                                              nrhs,
-                                                              (rocblas_double_complex**)A,
-                                                              lda,
-                                                              ipiv,
-                                                              n,
-                                                              (rocblas_double_complex**)B,
-                                                              ldb,
-                                                              batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_zgetrs_batched((rocblas_handle)handle,
+                                                             hipOperationToHCCOperation(trans),
+                                                             n,
+                                                             nrhs,
+                                                             (rocblas_double_complex**)A,
+                                                             lda,
+                                                             ipiv,
+                                                             n,
+                                                             (rocblas_double_complex**)B,
+                                                             ldb,
+                                                             batch_count));
 }
 
 // getrs_strided_batched
@@ -11078,23 +10983,20 @@ hipblasStatus_t hipblasSgetrsStridedBatched(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status
-                            = rocsolver_sgetrs_strided_batched((rocblas_handle)handle,
-                                                               hipOperationToHCCOperation(trans),
-                                                               n,
-                                                               nrhs,
-                                                               A,
-                                                               lda,
-                                                               strideA,
-                                                               ipiv,
-                                                               strideP,
-                                                               B,
-                                                               ldb,
-                                                               strideB,
-                                                               batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_sgetrs_strided_batched((rocblas_handle)handle,
+                                         hipOperationToHCCOperation(trans),
+                                         n,
+                                         nrhs,
+                                         A,
+                                         lda,
+                                         strideA,
+                                         ipiv,
+                                         strideP,
+                                         B,
+                                         ldb,
+                                         strideB,
+                                         batch_count));
 }
 
 hipblasStatus_t hipblasDgetrsStridedBatched(hipblasHandle_t          handle,
@@ -11133,23 +11035,20 @@ hipblasStatus_t hipblasDgetrsStridedBatched(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status
-                            = rocsolver_dgetrs_strided_batched((rocblas_handle)handle,
-                                                               hipOperationToHCCOperation(trans),
-                                                               n,
-                                                               nrhs,
-                                                               A,
-                                                               lda,
-                                                               strideA,
-                                                               ipiv,
-                                                               strideP,
-                                                               B,
-                                                               ldb,
-                                                               strideB,
-                                                               batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_dgetrs_strided_batched((rocblas_handle)handle,
+                                         hipOperationToHCCOperation(trans),
+                                         n,
+                                         nrhs,
+                                         A,
+                                         lda,
+                                         strideA,
+                                         ipiv,
+                                         strideP,
+                                         B,
+                                         ldb,
+                                         strideB,
+                                         batch_count));
 }
 
 hipblasStatus_t hipblasCgetrsStridedBatched(hipblasHandle_t          handle,
@@ -11188,23 +11087,20 @@ hipblasStatus_t hipblasCgetrsStridedBatched(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status
-                            = rocsolver_cgetrs_strided_batched((rocblas_handle)handle,
-                                                               hipOperationToHCCOperation(trans),
-                                                               n,
-                                                               nrhs,
-                                                               (rocblas_float_complex*)A,
-                                                               lda,
-                                                               strideA,
-                                                               ipiv,
-                                                               strideP,
-                                                               (rocblas_float_complex*)B,
-                                                               ldb,
-                                                               strideB,
-                                                               batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_cgetrs_strided_batched((rocblas_handle)handle,
+                                         hipOperationToHCCOperation(trans),
+                                         n,
+                                         nrhs,
+                                         (rocblas_float_complex*)A,
+                                         lda,
+                                         strideA,
+                                         ipiv,
+                                         strideP,
+                                         (rocblas_float_complex*)B,
+                                         ldb,
+                                         strideB,
+                                         batch_count));
 }
 
 hipblasStatus_t hipblasZgetrsStridedBatched(hipblasHandle_t          handle,
@@ -11243,23 +11139,20 @@ hipblasStatus_t hipblasZgetrsStridedBatched(hipblasHandle_t          handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status
-                            = rocsolver_zgetrs_strided_batched((rocblas_handle)handle,
-                                                               hipOperationToHCCOperation(trans),
-                                                               n,
-                                                               nrhs,
-                                                               (rocblas_double_complex*)A,
-                                                               lda,
-                                                               strideA,
-                                                               ipiv,
-                                                               strideP,
-                                                               (rocblas_double_complex*)B,
-                                                               ldb,
-                                                               strideB,
-                                                               batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(
+        rocsolver_zgetrs_strided_batched((rocblas_handle)handle,
+                                         hipOperationToHCCOperation(trans),
+                                         n,
+                                         nrhs,
+                                         (rocblas_double_complex*)A,
+                                         lda,
+                                         strideA,
+                                         ipiv,
+                                         strideP,
+                                         (rocblas_double_complex*)B,
+                                         ldb,
+                                         strideB,
+                                         batch_count));
 }
 
 // geqrf
@@ -11286,10 +11179,7 @@ hipblasStatus_t hipblasSgeqrf(hipblasHandle_t handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_sgeqrf((rocblas_handle)handle, m, n, A, lda, tau));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_sgeqrf((rocblas_handle)handle, m, n, A, lda, tau));
 }
 
 hipblasStatus_t hipblasDgeqrf(hipblasHandle_t handle,
@@ -11315,10 +11205,7 @@ hipblasStatus_t hipblasDgeqrf(hipblasHandle_t handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_dgeqrf((rocblas_handle)handle, m, n, A, lda, tau));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_dgeqrf((rocblas_handle)handle, m, n, A, lda, tau));
 }
 
 hipblasStatus_t hipblasCgeqrf(hipblasHandle_t handle,
@@ -11344,17 +11231,8 @@ hipblasStatus_t hipblasCgeqrf(hipblasHandle_t handle,
     else
         *info = 0;
 
-    // rocsolver_status status;
-    // USE_DEVICE_POINTER_MODE(handle, status = rocsolver_cgeqrf(
-    //     (rocblas_handle)handle,
-    //     m,
-    //     n,
-    //     (rocblas_float_complex*)A,
-    //     lda,
-    //     (rocblas_float_complex*)tau));
-    // return rocBLASStatusToHIPStatus(status);
-
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    return rocBLASStatusToHIPStatus(rocsolver_cgeqrf(
+        (rocblas_handle)handle, m, n, (rocblas_float_complex*)A, lda, (rocblas_float_complex*)tau));
 }
 
 hipblasStatus_t hipblasZgeqrf(hipblasHandle_t       handle,
@@ -11380,17 +11258,12 @@ hipblasStatus_t hipblasZgeqrf(hipblasHandle_t       handle,
     else
         *info = 0;
 
-    // rocsolver_status status;
-    // USE_DEVICE_POINTER_MODE(handle, status = rocsolver_zgeqrf(
-    //     (rocblas_handle)handle,
-    //     m,
-    //     n,
-    //     (rocblas_double_complex*)A,
-    //     lda,
-    //     (rocblas_double_complex*)tau));
-    // return rocBLASStatusToHIPStatus(status);
-
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    return rocBLASStatusToHIPStatus(rocsolver_zgeqrf((rocblas_handle)handle,
+                                                     m,
+                                                     n,
+                                                     (rocblas_double_complex*)A,
+                                                     lda,
+                                                     (rocblas_double_complex*)tau));
 }
 
 // geqrf_batched
@@ -11425,10 +11298,8 @@ hipblasStatus_t hipblasSgeqrfBatched(hipblasHandle_t handle,
     if(perArray > 0)
         hipMalloc(&ipiv, batch_count * perArray * sizeof(float));
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_sgeqrf_batched(
-                                (rocblas_handle)handle, m, n, A, lda, ipiv, perArray, batch_count));
+    rocsolver_status status = rocsolver_sgeqrf_batched(
+        (rocblas_handle)handle, m, n, A, lda, ipiv, perArray, batch_count);
 
     if(status == rocblas_status_success)
     {
@@ -11478,10 +11349,8 @@ hipblasStatus_t hipblasDgeqrfBatched(hipblasHandle_t handle,
     if(perArray > 0)
         hipMalloc(&ipiv, batch_count * perArray * sizeof(double));
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(handle,
-                            status = rocsolver_dgeqrf_batched(
-                                (rocblas_handle)handle, m, n, A, lda, ipiv, perArray, batch_count));
+    rocsolver_status status = rocsolver_dgeqrf_batched(
+        (rocblas_handle)handle, m, n, A, lda, ipiv, perArray, batch_count);
 
     if(status == rocblas_status_success)
     {
@@ -11526,38 +11395,37 @@ hipblasStatus_t hipblasCgeqrfBatched(hipblasHandle_t       handle,
     else
         *info = 0;
 
-    // int perArray = std::min(m, n);
-    // rocblas_float_complex* ipiv = NULL;
-    // if (perArray > 0)
-    //     hipMalloc(&ipiv, batch_count * perArray * sizeof(rocblas_float_complex));
+    int                    perArray = std::min(m, n);
+    rocblas_float_complex* ipiv     = NULL;
+    if(perArray > 0)
+        hipMalloc(&ipiv, batch_count * perArray * sizeof(rocblas_float_complex));
 
-    // rocsolver_status status;
-    // USE_DEVICE_POINTER_MODE(handle, status = rocsolver_cgeqrf_batched(
-    //     (rocblas_handle)handle,
-    //     m,
-    //     n,
-    //     (rocblas_float_complex**)A,
-    //     lda,
-    //     (rocblas_float_complex*)ipiv,
-    //     perArray,
-    //     batch_count));
+    rocsolver_status status = rocsolver_cgeqrf_batched((rocblas_handle)handle,
+                                                       m,
+                                                       n,
+                                                       (rocblas_float_complex**)A,
+                                                       lda,
+                                                       (rocblas_float_complex*)ipiv,
+                                                       perArray,
+                                                       batch_count);
 
-    // if (status == rocblas_status_success)
-    // {
-    //     // TO DO: Copy ipiv into tau using a fast kernel call
-    //     rocblas_float_complex* hTau[batch_count];
-    //     hipMemcpy(hTau, tau, sizeof(rocblas_float_complex*) * batch_count, hipMemcpyDeviceToHost);
+    if(status == rocblas_status_success)
+    {
+        // TO DO: Copy ipiv into tau using a fast kernel call
+        rocblas_float_complex* hTau[batch_count];
+        hipMemcpy(hTau, tau, sizeof(rocblas_float_complex*) * batch_count, hipMemcpyDeviceToHost);
 
-    //     for(int b = 0; b < batch_count; b++)
-    //         hipMemcpy(hTau[b], ipiv + b * perArray, sizeof(rocblas_float_complex) * perArray, hipMemcpyDeviceToDevice);
-    // }
+        for(int b = 0; b < batch_count; b++)
+            hipMemcpy(hTau[b],
+                      ipiv + b * perArray,
+                      sizeof(rocblas_float_complex) * perArray,
+                      hipMemcpyDeviceToDevice);
+    }
 
-    // if (perArray >  0)
-    //     hipFree(ipiv);
+    if(perArray > 0)
+        hipFree(ipiv);
 
-    // return rocBLASStatusToHIPStatus(status);
-
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    return rocBLASStatusToHIPStatus(status);
 }
 
 hipblasStatus_t hipblasZgeqrfBatched(hipblasHandle_t             handle,
@@ -11586,38 +11454,37 @@ hipblasStatus_t hipblasZgeqrfBatched(hipblasHandle_t             handle,
     else
         *info = 0;
 
-    // int perArray = std::min(m, n);
-    // rocblas_double_complex* ipiv = NULL;
-    // if (perArray > 0)
-    //     hipMalloc(&ipiv, batch_count * perArray * sizeof(rocblas_double_complex));
+    int                     perArray = std::min(m, n);
+    rocblas_double_complex* ipiv     = NULL;
+    if(perArray > 0)
+        hipMalloc(&ipiv, batch_count * perArray * sizeof(rocblas_double_complex));
 
-    // rocsolver_status status;
-    // USE_DEVICE_POINTER_MODE(handle, status = rocsolver_zgeqrf_batched(
-    //     (rocblas_handle)handle,
-    //     m,
-    //     n,
-    //     (rocblas_double_complex**)A,
-    //     lda,
-    //     (rocblas_double_complex*)ipiv,
-    //     perArray,
-    //     batch_count));
+    rocsolver_status status = rocsolver_zgeqrf_batched((rocblas_handle)handle,
+                                                       m,
+                                                       n,
+                                                       (rocblas_double_complex**)A,
+                                                       lda,
+                                                       (rocblas_double_complex*)ipiv,
+                                                       perArray,
+                                                       batch_count);
 
-    // if (status == rocblas_status_success)
-    // {
-    //     // TO DO: Copy ipiv into tau using a fast kernel call
-    //     rocblas_double_complex* hTau[batch_count];
-    //     hipMemcpy(hTau, tau, sizeof(rocblas_double_complex*) * batch_count, hipMemcpyDeviceToHost);
+    if(status == rocblas_status_success)
+    {
+        // TO DO: Copy ipiv into tau using a fast kernel call
+        rocblas_double_complex* hTau[batch_count];
+        hipMemcpy(hTau, tau, sizeof(rocblas_double_complex*) * batch_count, hipMemcpyDeviceToHost);
 
-    //     for(int b = 0; b < batch_count; b++)
-    //         hipMemcpy(hTau[b], ipiv + b * perArray, sizeof(rocblas_double_complex) * perArray, hipMemcpyDeviceToDevice);
-    // }
+        for(int b = 0; b < batch_count; b++)
+            hipMemcpy(hTau[b],
+                      ipiv + b * perArray,
+                      sizeof(rocblas_double_complex) * perArray,
+                      hipMemcpyDeviceToDevice);
+    }
 
-    // if (perArray >  0)
-    //     hipFree(ipiv);
+    if(perArray > 0)
+        hipFree(ipiv);
 
-    // return rocBLASStatusToHIPStatus(status);
-
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    return rocBLASStatusToHIPStatus(status);
 }
 
 // geqrf_strided_batched
@@ -11649,12 +11516,8 @@ hipblasStatus_t hipblasSgeqrfStridedBatched(hipblasHandle_t handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(
-        handle,
-        status = rocsolver_sgeqrf_strided_batched(
-            (rocblas_handle)handle, m, n, A, lda, strideA, tau, strideT, batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_sgeqrf_strided_batched(
+        (rocblas_handle)handle, m, n, A, lda, strideA, tau, strideT, batch_count));
 }
 
 hipblasStatus_t hipblasDgeqrfStridedBatched(hipblasHandle_t handle,
@@ -11685,12 +11548,8 @@ hipblasStatus_t hipblasDgeqrfStridedBatched(hipblasHandle_t handle,
     else
         *info = 0;
 
-    rocsolver_status status;
-    USE_DEVICE_POINTER_MODE(
-        handle,
-        status = rocsolver_dgeqrf_strided_batched(
-            (rocblas_handle)handle, m, n, A, lda, strideA, tau, strideT, batch_count));
-    return rocBLASStatusToHIPStatus(status);
+    return rocBLASStatusToHIPStatus(rocsolver_dgeqrf_strided_batched(
+        (rocblas_handle)handle, m, n, A, lda, strideA, tau, strideT, batch_count));
 }
 
 hipblasStatus_t hipblasCgeqrfStridedBatched(hipblasHandle_t handle,
@@ -11721,20 +11580,15 @@ hipblasStatus_t hipblasCgeqrfStridedBatched(hipblasHandle_t handle,
     else
         *info = 0;
 
-    // rocsolver_status status;
-    // USE_DEVICE_POINTER_MODE(handle, status = rocsolver_cgeqrf_strided_batched(
-    //     (rocblas_handle)handle,
-    //     m,
-    //     n,
-    //     (rocblas_float_complex*)A,
-    //     lda,
-    //     strideA,
-    //     (rocblas_float_complex*)tau,
-    //     strideT,
-    //     batch_count));
-    // return rocBLASStatusToHIPStatus(status);
-
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    return rocBLASStatusToHIPStatus(rocsolver_cgeqrf_strided_batched((rocblas_handle)handle,
+                                                                     m,
+                                                                     n,
+                                                                     (rocblas_float_complex*)A,
+                                                                     lda,
+                                                                     strideA,
+                                                                     (rocblas_float_complex*)tau,
+                                                                     strideT,
+                                                                     batch_count));
 }
 
 hipblasStatus_t hipblasZgeqrfStridedBatched(hipblasHandle_t       handle,
@@ -11765,20 +11619,15 @@ hipblasStatus_t hipblasZgeqrfStridedBatched(hipblasHandle_t       handle,
     else
         *info = 0;
 
-    // rocsolver_status status;
-    // USE_DEVICE_POINTER_MODE(handle, status = rocsolver_zgeqrf_strided_batched(
-    //     (rocblas_handle)handle,
-    //     m,
-    //     n,
-    //     (rocblas_double_complex*)A,
-    //     lda,
-    //     strideA,
-    //     (rocblas_double_complex*)tau,
-    //     strideT,
-    //     batch_count));
-    // return rocBLASStatusToHIPStatus(status);
-
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
+    return rocBLASStatusToHIPStatus(rocsolver_zgeqrf_strided_batched((rocblas_handle)handle,
+                                                                     m,
+                                                                     n,
+                                                                     (rocblas_double_complex*)A,
+                                                                     lda,
+                                                                     strideA,
+                                                                     (rocblas_double_complex*)tau,
+                                                                     strideT,
+                                                                     batch_count));
 }
 
 #endif


### PR DESCRIPTION
Added complex support for geqrf functions and removed obsolete use of USE_DEVICE_MODE macro. geqrf_batched can now call geqrf_ptr_batched in rocSOLVER, which matches the cuBLAS method signature.