### PR TITLE
Adding rocblas_path build variable for custom rocblas path.

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -49,7 +49,12 @@ target_include_directories( hipblas
 # Build hipblas from source on AMD platform
 if( NOT CUDA_FOUND )
   if( NOT TARGET rocblas )
-    find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocblas )
+    if( CUSTOM_ROCBLAS )
+      set ( ENV{rocblas_DIR} ${CUSTOM_ROCBLAS})
+      find_package( rocblas REQUIRED CONFIG NO_CMAKE_PATH )
+    else( )
+      find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocblas )
+    endif( )
   endif( )
 
   target_compile_definitions( hipblas PRIVATE __HIP_PLATFORM_HCC__ )


### PR DESCRIPTION
[SWDEV-235957](http://ontrack-internal.amd.com/browse/SWDEV-235957)

Adds --rocblas-path command line option to choose a path to a pre-built rocblas to use. If a rocblas install cannot be found at that path, the regular search continues, and will find the installed rocblas in /opt/rocm.