### PR TITLE
Use PATH and robustly test for clang-format

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,9 +4,7 @@
 # are installed, and if so, uses the installed version to format
 # the staged changes.
 
-set -x
-
-format=/opt/rocm/hcc/bin/clang-format
+export PATH=/usr/bin:/bin:/opt/rocm/llvm/bin:/opt/rocm/hcc/bin
 
 # Redirect stdout to stderr.
 exec >&2
@@ -48,11 +46,11 @@ for file in $files; do
 done
 
 # if clang-format exists, run it on C/C++ files
-if [[ -x $format ]]; then
+if command -v clang-format >/dev/null; then
     for file in $files; do
        if [[ -e $file ]] && echo $file | grep -Eq '\.c$|\.h$|\.hpp$|\.cpp$|\.cl$|\.h\.in$|\.hpp\.in$|\.cpp\.in$'; then
-            echo "$format $file"
-            "$format" -i -style=file "$file"
+            echo "clang-format $file"
+            clang-format -i -style=file "$file"
             git add -u "$file"
         fi
     done


### PR DESCRIPTION
Make clang-format use `PATH` and use it if it's available. This is necessary because of the HCC->hip-clang change.