### PR TITLE
Fortran for solver functions

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -30,8 +30,17 @@ set(hipblas_f90_source_clients
   include/hipblas_fortran.f90
 )
 
+set(hipblas_f90_source_clients_solver
+  include/hipblas_fortran_solver.f90
+)
+
 if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_SAMPLES )
-  add_library(hipblas_fortran_client ${hipblas_f90_source_clients})
+  if( BUILD_WITH_SOLVER)
+    add_library(hipblas_fortran_client ${hipblas_f90_source_clients} ${hipblas_f90_source_clients_solver})
+  else()
+    add_library(hipblas_fortran_client ${hipblas_f90_source_clients})
+  endif()
+
   add_dependencies(hipblas_fortran_client hipblas_fortran)
   include_directories(${CMAKE_BINARY_DIR}/include)
 endif( )

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -18,26 +18,6 @@
  * ===========================================================================
  */
 
-/* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
- *
- * ************************************************************************/
-
-#include "hipblas.h"
-#include "hipblas.hpp"
-#include "hipblas_fortran.hpp"
-#include <typeinfo>
-
-/*!\file
- * \brief provide template functions interfaces to ROCBLAS C89 interfaces
-*/
-
-/*
- * ===========================================================================
- *    level 1 BLAS
- * ===========================================================================
- */
-
 // axpy
 template <>
 hipblasStatus_t hipblasAxpy<hipblasHalf>(hipblasHandle_t    handle,

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -19654,519 +19654,519 @@ hipblasStatus_t
                                              batchCount);
 }
 
-// #ifdef __HIP_PLATFORM_SOLVER__
+#ifdef __HIP_PLATFORM_SOLVER__
 
-// // getrf
-// template <>
-// hipblasStatus_t hipblasGetrf<float, true>(
-//     hipblasHandle_t handle, const int n, float* A, const int lda, int* ipiv, int* info)
-// {
-//     return hipblasSgetrfFortran(handle, n, A, lda, ipiv, info);
-// }
+// getrf
+template <>
+hipblasStatus_t hipblasGetrf<float, true>(
+    hipblasHandle_t handle, const int n, float* A, const int lda, int* ipiv, int* info)
+{
+    return hipblasSgetrfFortran(handle, n, A, lda, ipiv, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrf<double, true>(
-//     hipblasHandle_t handle, const int n, double* A, const int lda, int* ipiv, int* info)
-// {
-//     return hipblasDgetrfFortran(handle, n, A, lda, ipiv, info);
-// }
+template <>
+hipblasStatus_t hipblasGetrf<double, true>(
+    hipblasHandle_t handle, const int n, double* A, const int lda, int* ipiv, int* info)
+{
+    return hipblasDgetrfFortran(handle, n, A, lda, ipiv, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrf<hipblasComplex, true>(
-//     hipblasHandle_t handle, const int n, hipblasComplex* A, const int lda, int* ipiv, int* info)
-// {
-//     return hipblasCgetrfFortran(handle, n, A, lda, ipiv, info);
-// }
+template <>
+hipblasStatus_t hipblasGetrf<hipblasComplex, true>(
+    hipblasHandle_t handle, const int n, hipblasComplex* A, const int lda, int* ipiv, int* info)
+{
+    return hipblasCgetrfFortran(handle, n, A, lda, ipiv, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrf<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
-//                                                    const int             n,
-//                                                    hipblasDoubleComplex* A,
-//                                                    const int             lda,
-//                                                    int*                  ipiv,
-//                                                    int*                  info)
-// {
-//     return hipblasZgetrfFortran(handle, n, A, lda, ipiv, info);
-// }
+template <>
+hipblasStatus_t hipblasGetrf<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
+                                                   const int             n,
+                                                   hipblasDoubleComplex* A,
+                                                   const int             lda,
+                                                   int*                  ipiv,
+                                                   int*                  info)
+{
+    return hipblasZgetrfFortran(handle, n, A, lda, ipiv, info);
+}
 
-// // getrf_batched
-// template <>
-// hipblasStatus_t hipblasGetrfBatched<float, true>(hipblasHandle_t handle,
-//                                            const int       n,
-//                                            float* const    A[],
-//                                            const int       lda,
-//                                            int*            ipiv,
-//                                            int*            info,
-//                                            const int       batchCount)
-// {
-//     return hipblasSgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batchCount);
-// }
+// getrf_batched
+template <>
+hipblasStatus_t hipblasGetrfBatched<float, true>(hipblasHandle_t handle,
+                                           const int       n,
+                                           float* const    A[],
+                                           const int       lda,
+                                           int*            ipiv,
+                                           int*            info,
+                                           const int       batchCount)
+{
+    return hipblasSgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrfBatched<double, true>(hipblasHandle_t handle,
-//                                             const int       n,
-//                                             double* const   A[],
-//                                             const int       lda,
-//                                             int*            ipiv,
-//                                             int*            info,
-//                                             const int       batchCount)
-// {
-//     return hipblasDgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrfBatched<double, true>(hipblasHandle_t handle,
+                                            const int       n,
+                                            double* const   A[],
+                                            const int       lda,
+                                            int*            ipiv,
+                                            int*            info,
+                                            const int       batchCount)
+{
+    return hipblasDgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrfBatched<hipblasComplex, true>(hipblasHandle_t       handle,
-//                                                     const int             n,
-//                                                     hipblasComplex* const A[],
-//                                                     const int             lda,
-//                                                     int*                  ipiv,
-//                                                     int*                  info,
-//                                                     const int             batchCount)
-// {
-//     return hipblasCgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrfBatched<hipblasComplex, true>(hipblasHandle_t       handle,
+                                                    const int             n,
+                                                    hipblasComplex* const A[],
+                                                    const int             lda,
+                                                    int*                  ipiv,
+                                                    int*                  info,
+                                                    const int             batchCount)
+{
+    return hipblasCgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrfBatched<hipblasDoubleComplex, true>(hipblasHandle_t             handle,
-//                                                           const int                   n,
-//                                                           hipblasDoubleComplex* const A[],
-//                                                           const int                   lda,
-//                                                           int*                        ipiv,
-//                                                           int*                        info,
-//                                                           const int                   batchCount)
-// {
-//     return hipblasZgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrfBatched<hipblasDoubleComplex, true>(hipblasHandle_t             handle,
+                                                          const int                   n,
+                                                          hipblasDoubleComplex* const A[],
+                                                          const int                   lda,
+                                                          int*                        ipiv,
+                                                          int*                        info,
+                                                          const int                   batchCount)
+{
+    return hipblasZgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batchCount);
+}
 
-// // getrf_strided_batched
-// template <>
-// hipblasStatus_t hipblasGetrfStridedBatched<float, true>(hipblasHandle_t handle,
-//                                                   const int       n,
-//                                                   float*          A,
-//                                                   const int       lda,
-//                                                   const int       strideA,
-//                                                   int*            ipiv,
-//                                                   const int       strideP,
-//                                                   int*            info,
-//                                                   const int       batchCount)
-// {
-//     return hipblasSgetrfStridedBatchedFortran(handle, n, A, lda, strideA, ipiv, strideP, info, batchCount);
-// }
+// getrf_strided_batched
+template <>
+hipblasStatus_t hipblasGetrfStridedBatched<float, true>(hipblasHandle_t handle,
+                                                  const int       n,
+                                                  float*          A,
+                                                  const int       lda,
+                                                  const int       strideA,
+                                                  int*            ipiv,
+                                                  const int       strideP,
+                                                  int*            info,
+                                                  const int       batchCount)
+{
+    return hipblasSgetrfStridedBatchedFortran(handle, n, A, lda, strideA, ipiv, strideP, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrfStridedBatched<double, true>(hipblasHandle_t handle,
-//                                                    const int       n,
-//                                                    double*         A,
-//                                                    const int       lda,
-//                                                    const int       strideA,
-//                                                    int*            ipiv,
-//                                                    const int       strideP,
-//                                                    int*            info,
-//                                                    const int       batchCount)
-// {
-//     return hipblasDgetrfStridedBatchedFortran(handle, n, A, lda, strideA, ipiv, strideP, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrfStridedBatched<double, true>(hipblasHandle_t handle,
+                                                   const int       n,
+                                                   double*         A,
+                                                   const int       lda,
+                                                   const int       strideA,
+                                                   int*            ipiv,
+                                                   const int       strideP,
+                                                   int*            info,
+                                                   const int       batchCount)
+{
+    return hipblasDgetrfStridedBatchedFortran(handle, n, A, lda, strideA, ipiv, strideP, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrfStridedBatched<hipblasComplex, true>(hipblasHandle_t handle,
-//                                                            const int       n,
-//                                                            hipblasComplex* A,
-//                                                            const int       lda,
-//                                                            const int       strideA,
-//                                                            int*            ipiv,
-//                                                            const int       strideP,
-//                                                            int*            info,
-//                                                            const int       batchCount)
-// {
-//     return hipblasCgetrfStridedBatchedFortran(handle, n, A, lda, strideA, ipiv, strideP, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrfStridedBatched<hipblasComplex, true>(hipblasHandle_t handle,
+                                                           const int       n,
+                                                           hipblasComplex* A,
+                                                           const int       lda,
+                                                           const int       strideA,
+                                                           int*            ipiv,
+                                                           const int       strideP,
+                                                           int*            info,
+                                                           const int       batchCount)
+{
+    return hipblasCgetrfStridedBatchedFortran(handle, n, A, lda, strideA, ipiv, strideP, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrfStridedBatched<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
-//                                                                  const int             n,
-//                                                                  hipblasDoubleComplex* A,
-//                                                                  const int             lda,
-//                                                                  const int             strideA,
-//                                                                  int*                  ipiv,
-//                                                                  const int             strideP,
-//                                                                  int*                  info,
-//                                                                  const int             batchCount)
-// {
-//     return hipblasZgetrfStridedBatchedFortran(handle, n, A, lda, strideA, ipiv, strideP, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrfStridedBatched<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
+                                                                 const int             n,
+                                                                 hipblasDoubleComplex* A,
+                                                                 const int             lda,
+                                                                 const int             strideA,
+                                                                 int*                  ipiv,
+                                                                 const int             strideP,
+                                                                 int*                  info,
+                                                                 const int             batchCount)
+{
+    return hipblasZgetrfStridedBatchedFortran(handle, n, A, lda, strideA, ipiv, strideP, info, batchCount);
+}
 
-// // getrs
-// template <>
-// hipblasStatus_t hipblasGetrs<float, true>(hipblasHandle_t          handle,
-//                                     const hipblasOperation_t trans,
-//                                     const int                n,
-//                                     const int                nrhs,
-//                                     float*                   A,
-//                                     const int                lda,
-//                                     const int*               ipiv,
-//                                     float*                   B,
-//                                     const int                ldb,
-//                                     int*                     info)
-// {
-//     return hipblasSgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
-// }
+// getrs
+template <>
+hipblasStatus_t hipblasGetrs<float, true>(hipblasHandle_t          handle,
+                                    const hipblasOperation_t trans,
+                                    const int                n,
+                                    const int                nrhs,
+                                    float*                   A,
+                                    const int                lda,
+                                    const int*               ipiv,
+                                    float*                   B,
+                                    const int                ldb,
+                                    int*                     info)
+{
+    return hipblasSgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrs<double, true>(hipblasHandle_t          handle,
-//                                      const hipblasOperation_t trans,
-//                                      const int                n,
-//                                      const int                nrhs,
-//                                      double*                  A,
-//                                      const int                lda,
-//                                      const int*               ipiv,
-//                                      double*                  B,
-//                                      const int                ldb,
-//                                      int*                     info)
-// {
-//     return hipblasDgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
-// }
+template <>
+hipblasStatus_t hipblasGetrs<double, true>(hipblasHandle_t          handle,
+                                     const hipblasOperation_t trans,
+                                     const int                n,
+                                     const int                nrhs,
+                                     double*                  A,
+                                     const int                lda,
+                                     const int*               ipiv,
+                                     double*                  B,
+                                     const int                ldb,
+                                     int*                     info)
+{
+    return hipblasDgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrs<hipblasComplex, true>(hipblasHandle_t          handle,
-//                                              const hipblasOperation_t trans,
-//                                              const int                n,
-//                                              const int                nrhs,
-//                                              hipblasComplex*          A,
-//                                              const int                lda,
-//                                              const int*               ipiv,
-//                                              hipblasComplex*          B,
-//                                              const int                ldb,
-//                                              int*                     info)
-// {
-//     return hipblasCgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
-// }
+template <>
+hipblasStatus_t hipblasGetrs<hipblasComplex, true>(hipblasHandle_t          handle,
+                                             const hipblasOperation_t trans,
+                                             const int                n,
+                                             const int                nrhs,
+                                             hipblasComplex*          A,
+                                             const int                lda,
+                                             const int*               ipiv,
+                                             hipblasComplex*          B,
+                                             const int                ldb,
+                                             int*                     info)
+{
+    return hipblasCgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrs<hipblasDoubleComplex, true>(hipblasHandle_t          handle,
-//                                                    const hipblasOperation_t trans,
-//                                                    const int                n,
-//                                                    const int                nrhs,
-//                                                    hipblasDoubleComplex*    A,
-//                                                    const int                lda,
-//                                                    const int*               ipiv,
-//                                                    hipblasDoubleComplex*    B,
-//                                                    const int                ldb,
-//                                                    int*                     info)
-// {
-//     return hipblasZgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
-// }
+template <>
+hipblasStatus_t hipblasGetrs<hipblasDoubleComplex, true>(hipblasHandle_t          handle,
+                                                   const hipblasOperation_t trans,
+                                                   const int                n,
+                                                   const int                nrhs,
+                                                   hipblasDoubleComplex*    A,
+                                                   const int                lda,
+                                                   const int*               ipiv,
+                                                   hipblasDoubleComplex*    B,
+                                                   const int                ldb,
+                                                   int*                     info)
+{
+    return hipblasZgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+}
 
-// // getrs_batched
-// template <>
-// hipblasStatus_t hipblasGetrsBatched<float, true>(hipblasHandle_t          handle,
-//                                            const hipblasOperation_t trans,
-//                                            const int                n,
-//                                            const int                nrhs,
-//                                            float* const             A[],
-//                                            const int                lda,
-//                                            const int*               ipiv,
-//                                            float* const             B[],
-//                                            const int                ldb,
-//                                            int*                     info,
-//                                            const int                batchCount)
-// {
-//     return hipblasSgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info, batchCount);
-// }
+// getrs_batched
+template <>
+hipblasStatus_t hipblasGetrsBatched<float, true>(hipblasHandle_t          handle,
+                                           const hipblasOperation_t trans,
+                                           const int                n,
+                                           const int                nrhs,
+                                           float* const             A[],
+                                           const int                lda,
+                                           const int*               ipiv,
+                                           float* const             B[],
+                                           const int                ldb,
+                                           int*                     info,
+                                           const int                batchCount)
+{
+    return hipblasSgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrsBatched<double, true>(hipblasHandle_t          handle,
-//                                             const hipblasOperation_t trans,
-//                                             const int                n,
-//                                             const int                nrhs,
-//                                             double* const            A[],
-//                                             const int                lda,
-//                                             const int*               ipiv,
-//                                             double* const            B[],
-//                                             const int                ldb,
-//                                             int*                     info,
-//                                             const int                batchCount)
-// {
-//     return hipblasDgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrsBatched<double, true>(hipblasHandle_t          handle,
+                                            const hipblasOperation_t trans,
+                                            const int                n,
+                                            const int                nrhs,
+                                            double* const            A[],
+                                            const int                lda,
+                                            const int*               ipiv,
+                                            double* const            B[],
+                                            const int                ldb,
+                                            int*                     info,
+                                            const int                batchCount)
+{
+    return hipblasDgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrsBatched<hipblasComplex, true>(hipblasHandle_t          handle,
-//                                                     const hipblasOperation_t trans,
-//                                                     const int                n,
-//                                                     const int                nrhs,
-//                                                     hipblasComplex* const    A[],
-//                                                     const int                lda,
-//                                                     const int*               ipiv,
-//                                                     hipblasComplex* const    B[],
-//                                                     const int                ldb,
-//                                                     int*                     info,
-//                                                     const int                batchCount)
-// {
-//     return hipblasCgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrsBatched<hipblasComplex, true>(hipblasHandle_t          handle,
+                                                    const hipblasOperation_t trans,
+                                                    const int                n,
+                                                    const int                nrhs,
+                                                    hipblasComplex* const    A[],
+                                                    const int                lda,
+                                                    const int*               ipiv,
+                                                    hipblasComplex* const    B[],
+                                                    const int                ldb,
+                                                    int*                     info,
+                                                    const int                batchCount)
+{
+    return hipblasCgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrsBatched<hipblasDoubleComplex, true>(hipblasHandle_t             handle,
-//                                                           const hipblasOperation_t    trans,
-//                                                           const int                   n,
-//                                                           const int                   nrhs,
-//                                                           hipblasDoubleComplex* const A[],
-//                                                           const int                   lda,
-//                                                           const int*                  ipiv,
-//                                                           hipblasDoubleComplex* const B[],
-//                                                           const int                   ldb,
-//                                                           int*                        info,
-//                                                           const int                   batchCount)
-// {
-//     return hipblasZgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrsBatched<hipblasDoubleComplex, true>(hipblasHandle_t             handle,
+                                                          const hipblasOperation_t    trans,
+                                                          const int                   n,
+                                                          const int                   nrhs,
+                                                          hipblasDoubleComplex* const A[],
+                                                          const int                   lda,
+                                                          const int*                  ipiv,
+                                                          hipblasDoubleComplex* const B[],
+                                                          const int                   ldb,
+                                                          int*                        info,
+                                                          const int                   batchCount)
+{
+    return hipblasZgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info, batchCount);
+}
 
-// // getrs_strided_batched
-// template <>
-// hipblasStatus_t hipblasGetrsStridedBatched<float, true>(hipblasHandle_t          handle,
-//                                                   const hipblasOperation_t trans,
-//                                                   const int                n,
-//                                                   const int                nrhs,
-//                                                   float*                   A,
-//                                                   const int                lda,
-//                                                   const int                strideA,
-//                                                   const int*               ipiv,
-//                                                   const int                strideP,
-//                                                   float*                   B,
-//                                                   const int                ldb,
-//                                                   const int                strideB,
-//                                                   int*                     info,
-//                                                   const int                batchCount)
-// {
-//     return hipblasSgetrsStridedBatchedFortran(
-//         handle, trans, n, nrhs, A, lda, strideA, ipiv, strideP, B, ldb, strideB, info, batchCount);
-// }
+// getrs_strided_batched
+template <>
+hipblasStatus_t hipblasGetrsStridedBatched<float, true>(hipblasHandle_t          handle,
+                                                  const hipblasOperation_t trans,
+                                                  const int                n,
+                                                  const int                nrhs,
+                                                  float*                   A,
+                                                  const int                lda,
+                                                  const int                strideA,
+                                                  const int*               ipiv,
+                                                  const int                strideP,
+                                                  float*                   B,
+                                                  const int                ldb,
+                                                  const int                strideB,
+                                                  int*                     info,
+                                                  const int                batchCount)
+{
+    return hipblasSgetrsStridedBatchedFortran(
+        handle, trans, n, nrhs, A, lda, strideA, ipiv, strideP, B, ldb, strideB, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrsStridedBatched<double, true>(hipblasHandle_t          handle,
-//                                                    const hipblasOperation_t trans,
-//                                                    const int                n,
-//                                                    const int                nrhs,
-//                                                    double*                  A,
-//                                                    const int                lda,
-//                                                    const int                strideA,
-//                                                    const int*               ipiv,
-//                                                    const int                strideP,
-//                                                    double*                  B,
-//                                                    const int                ldb,
-//                                                    const int                strideB,
-//                                                    int*                     info,
-//                                                    const int                batchCount)
-// {
-//     return hipblasDgetrsStridedBatchedFortran(
-//         handle, trans, n, nrhs, A, lda, strideA, ipiv, strideP, B, ldb, strideB, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrsStridedBatched<double, true>(hipblasHandle_t          handle,
+                                                   const hipblasOperation_t trans,
+                                                   const int                n,
+                                                   const int                nrhs,
+                                                   double*                  A,
+                                                   const int                lda,
+                                                   const int                strideA,
+                                                   const int*               ipiv,
+                                                   const int                strideP,
+                                                   double*                  B,
+                                                   const int                ldb,
+                                                   const int                strideB,
+                                                   int*                     info,
+                                                   const int                batchCount)
+{
+    return hipblasDgetrsStridedBatchedFortran(
+        handle, trans, n, nrhs, A, lda, strideA, ipiv, strideP, B, ldb, strideB, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrsStridedBatched<hipblasComplex, true>(hipblasHandle_t          handle,
-//                                                            const hipblasOperation_t trans,
-//                                                            const int                n,
-//                                                            const int                nrhs,
-//                                                            hipblasComplex*          A,
-//                                                            const int                lda,
-//                                                            const int                strideA,
-//                                                            const int*               ipiv,
-//                                                            const int                strideP,
-//                                                            hipblasComplex*          B,
-//                                                            const int                ldb,
-//                                                            const int                strideB,
-//                                                            int*                     info,
-//                                                            const int                batchCount)
-// {
-//     return hipblasCgetrsStridedBatchedFortran(
-//         handle, trans, n, nrhs, A, lda, strideA, ipiv, strideP, B, ldb, strideB, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrsStridedBatched<hipblasComplex, true>(hipblasHandle_t          handle,
+                                                           const hipblasOperation_t trans,
+                                                           const int                n,
+                                                           const int                nrhs,
+                                                           hipblasComplex*          A,
+                                                           const int                lda,
+                                                           const int                strideA,
+                                                           const int*               ipiv,
+                                                           const int                strideP,
+                                                           hipblasComplex*          B,
+                                                           const int                ldb,
+                                                           const int                strideB,
+                                                           int*                     info,
+                                                           const int                batchCount)
+{
+    return hipblasCgetrsStridedBatchedFortran(
+        handle, trans, n, nrhs, A, lda, strideA, ipiv, strideP, B, ldb, strideB, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGetrsStridedBatched<hipblasDoubleComplex, true>(hipblasHandle_t          handle,
-//                                                                  const hipblasOperation_t trans,
-//                                                                  const int                n,
-//                                                                  const int                nrhs,
-//                                                                  hipblasDoubleComplex*    A,
-//                                                                  const int                lda,
-//                                                                  const int                strideA,
-//                                                                  const int*               ipiv,
-//                                                                  const int                strideP,
-//                                                                  hipblasDoubleComplex*    B,
-//                                                                  const int                ldb,
-//                                                                  const int                strideB,
-//                                                                  int*                     info,
-//                                                                  const int batchCount)
-// {
-//     return hipblasZgetrsStridedBatchedFortran(
-//         handle, trans, n, nrhs, A, lda, strideA, ipiv, strideP, B, ldb, strideB, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGetrsStridedBatched<hipblasDoubleComplex, true>(hipblasHandle_t          handle,
+                                                                 const hipblasOperation_t trans,
+                                                                 const int                n,
+                                                                 const int                nrhs,
+                                                                 hipblasDoubleComplex*    A,
+                                                                 const int                lda,
+                                                                 const int                strideA,
+                                                                 const int*               ipiv,
+                                                                 const int                strideP,
+                                                                 hipblasDoubleComplex*    B,
+                                                                 const int                ldb,
+                                                                 const int                strideB,
+                                                                 int*                     info,
+                                                                 const int batchCount)
+{
+    return hipblasZgetrsStridedBatchedFortran(
+        handle, trans, n, nrhs, A, lda, strideA, ipiv, strideP, B, ldb, strideB, info, batchCount);
+}
 
-// // geqrf
-// template <>
-// hipblasStatus_t hipblasGeqrf<float, true>(hipblasHandle_t handle,
-//                                     const int       m,
-//                                     const int       n,
-//                                     float*          A,
-//                                     const int       lda,
-//                                     float*          ipiv,
-//                                     int*            info)
-// {
-//     return hipblasSgeqrfFortran(handle, m, n, A, lda, ipiv, info);
-// }
+// geqrf
+template <>
+hipblasStatus_t hipblasGeqrf<float, true>(hipblasHandle_t handle,
+                                    const int       m,
+                                    const int       n,
+                                    float*          A,
+                                    const int       lda,
+                                    float*          ipiv,
+                                    int*            info)
+{
+    return hipblasSgeqrfFortran(handle, m, n, A, lda, ipiv, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrf<double, true>(hipblasHandle_t handle,
-//                                      const int       m,
-//                                      const int       n,
-//                                      double*         A,
-//                                      const int       lda,
-//                                      double*         ipiv,
-//                                      int*            info)
-// {
-//     return hipblasDgeqrfFortran(handle, m, n, A, lda, ipiv, info);
-// }
+template <>
+hipblasStatus_t hipblasGeqrf<double, true>(hipblasHandle_t handle,
+                                     const int       m,
+                                     const int       n,
+                                     double*         A,
+                                     const int       lda,
+                                     double*         ipiv,
+                                     int*            info)
+{
+    return hipblasDgeqrfFortran(handle, m, n, A, lda, ipiv, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrf<hipblasComplex, true>(hipblasHandle_t handle,
-//                                              const int       m,
-//                                              const int       n,
-//                                              hipblasComplex* A,
-//                                              const int       lda,
-//                                              hipblasComplex* ipiv,
-//                                              int*            info)
-// {
-//     return hipblasCgeqrfFortran(handle, m, n, A, lda, ipiv, info);
-// }
+template <>
+hipblasStatus_t hipblasGeqrf<hipblasComplex, true>(hipblasHandle_t handle,
+                                             const int       m,
+                                             const int       n,
+                                             hipblasComplex* A,
+                                             const int       lda,
+                                             hipblasComplex* ipiv,
+                                             int*            info)
+{
+    return hipblasCgeqrfFortran(handle, m, n, A, lda, ipiv, info);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrf<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
-//                                                    const int             m,
-//                                                    const int             n,
-//                                                    hipblasDoubleComplex* A,
-//                                                    const int             lda,
-//                                                    hipblasDoubleComplex* ipiv,
-//                                                    int*                  info)
-// {
-//     return hipblasZgeqrfFortran(handle, m, n, A, lda, ipiv, info);
-// }
+template <>
+hipblasStatus_t hipblasGeqrf<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
+                                                   const int             m,
+                                                   const int             n,
+                                                   hipblasDoubleComplex* A,
+                                                   const int             lda,
+                                                   hipblasDoubleComplex* ipiv,
+                                                   int*                  info)
+{
+    return hipblasZgeqrfFortran(handle, m, n, A, lda, ipiv, info);
+}
 
-// // geqrf_batched
-// template <>
-// hipblasStatus_t hipblasGeqrfBatched<float, true>(hipblasHandle_t handle,
-//                                            const int       m,
-//                                            const int       n,
-//                                            float* const    A[],
-//                                            const int       lda,
-//                                            float* const    ipiv[],
-//                                            int*            info,
-//                                            const int       batchCount)
-// {
-//     return hipblasSgeqrfBatchedFortran(handle, m, n, A, lda, ipiv, info, batchCount);
-// }
+// geqrf_batched
+template <>
+hipblasStatus_t hipblasGeqrfBatched<float, true>(hipblasHandle_t handle,
+                                           const int       m,
+                                           const int       n,
+                                           float* const    A[],
+                                           const int       lda,
+                                           float* const    ipiv[],
+                                           int*            info,
+                                           const int       batchCount)
+{
+    return hipblasSgeqrfBatchedFortran(handle, m, n, A, lda, ipiv, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrfBatched<double, true>(hipblasHandle_t handle,
-//                                             const int       m,
-//                                             const int       n,
-//                                             double* const   A[],
-//                                             const int       lda,
-//                                             double* const   ipiv[],
-//                                             int*            info,
-//                                             const int       batchCount)
-// {
-//     return hipblasDgeqrfBatchedFortran(handle, m, n, A, lda, ipiv, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGeqrfBatched<double, true>(hipblasHandle_t handle,
+                                            const int       m,
+                                            const int       n,
+                                            double* const   A[],
+                                            const int       lda,
+                                            double* const   ipiv[],
+                                            int*            info,
+                                            const int       batchCount)
+{
+    return hipblasDgeqrfBatchedFortran(handle, m, n, A, lda, ipiv, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrfBatched<hipblasComplex, true>(hipblasHandle_t       handle,
-//                                                     const int             m,
-//                                                     const int             n,
-//                                                     hipblasComplex* const A[],
-//                                                     const int             lda,
-//                                                     hipblasComplex* const ipiv[],
-//                                                     int*                  info,
-//                                                     const int             batchCount)
-// {
-//     return hipblasCgeqrfBatchedFortran(handle, m, n, A, lda, ipiv, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGeqrfBatched<hipblasComplex, true>(hipblasHandle_t       handle,
+                                                    const int             m,
+                                                    const int             n,
+                                                    hipblasComplex* const A[],
+                                                    const int             lda,
+                                                    hipblasComplex* const ipiv[],
+                                                    int*                  info,
+                                                    const int             batchCount)
+{
+    return hipblasCgeqrfBatchedFortran(handle, m, n, A, lda, ipiv, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrfBatched<hipblasDoubleComplex, true>(hipblasHandle_t             handle,
-//                                                           const int                   m,
-//                                                           const int                   n,
-//                                                           hipblasDoubleComplex* const A[],
-//                                                           const int                   lda,
-//                                                           hipblasDoubleComplex* const ipiv[],
-//                                                           int*                        info,
-//                                                           const int                   batchCount)
-// {
-//     return hipblasZgeqrfBatchedFortran(handle, m, n, A, lda, ipiv, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGeqrfBatched<hipblasDoubleComplex, true>(hipblasHandle_t             handle,
+                                                          const int                   m,
+                                                          const int                   n,
+                                                          hipblasDoubleComplex* const A[],
+                                                          const int                   lda,
+                                                          hipblasDoubleComplex* const ipiv[],
+                                                          int*                        info,
+                                                          const int                   batchCount)
+{
+    return hipblasZgeqrfBatchedFortran(handle, m, n, A, lda, ipiv, info, batchCount);
+}
 
-// // geqrf_strided_batched
-// template <>
-// hipblasStatus_t hipblasGeqrfStridedBatched<float, true>(hipblasHandle_t handle,
-//                                                   const int       m,
-//                                                   const int       n,
-//                                                   float*          A,
-//                                                   const int       lda,
-//                                                   const int       strideA,
-//                                                   float*          ipiv,
-//                                                   const int       strideP,
-//                                                   int*            info,
-//                                                   const int       batchCount)
-// {
-//     return hipblasSgeqrfStridedBatchedFortran(
-//         handle, m, n, A, lda, strideA, ipiv, strideP, info, batchCount);
-// }
+// geqrf_strided_batched
+template <>
+hipblasStatus_t hipblasGeqrfStridedBatched<float, true>(hipblasHandle_t handle,
+                                                  const int       m,
+                                                  const int       n,
+                                                  float*          A,
+                                                  const int       lda,
+                                                  const int       strideA,
+                                                  float*          ipiv,
+                                                  const int       strideP,
+                                                  int*            info,
+                                                  const int       batchCount)
+{
+    return hipblasSgeqrfStridedBatchedFortran(
+        handle, m, n, A, lda, strideA, ipiv, strideP, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrfStridedBatched<double, true>(hipblasHandle_t handle,
-//                                                    const int       m,
-//                                                    const int       n,
-//                                                    double*         A,
-//                                                    const int       lda,
-//                                                    const int       strideA,
-//                                                    double*         ipiv,
-//                                                    const int       strideP,
-//                                                    int*            info,
-//                                                    const int       batchCount)
-// {
-//     return hipblasDgeqrfStridedBatchedFortran(
-//         handle, m, n, A, lda, strideA, ipiv, strideP, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGeqrfStridedBatched<double, true>(hipblasHandle_t handle,
+                                                   const int       m,
+                                                   const int       n,
+                                                   double*         A,
+                                                   const int       lda,
+                                                   const int       strideA,
+                                                   double*         ipiv,
+                                                   const int       strideP,
+                                                   int*            info,
+                                                   const int       batchCount)
+{
+    return hipblasDgeqrfStridedBatchedFortran(
+        handle, m, n, A, lda, strideA, ipiv, strideP, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrfStridedBatched<hipblasComplex, true>(hipblasHandle_t handle,
-//                                                            const int       m,
-//                                                            const int       n,
-//                                                            hipblasComplex* A,
-//                                                            const int       lda,
-//                                                            const int       strideA,
-//                                                            hipblasComplex* ipiv,
-//                                                            const int       strideP,
-//                                                            int*            info,
-//                                                            const int       batchCount)
-// {
-//     return hipblasCgeqrfStridedBatchedFortran(
-//         handle, m, n, A, lda, strideA, ipiv, strideP, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGeqrfStridedBatched<hipblasComplex, true>(hipblasHandle_t handle,
+                                                           const int       m,
+                                                           const int       n,
+                                                           hipblasComplex* A,
+                                                           const int       lda,
+                                                           const int       strideA,
+                                                           hipblasComplex* ipiv,
+                                                           const int       strideP,
+                                                           int*            info,
+                                                           const int       batchCount)
+{
+    return hipblasCgeqrfStridedBatchedFortran(
+        handle, m, n, A, lda, strideA, ipiv, strideP, info, batchCount);
+}
 
-// template <>
-// hipblasStatus_t hipblasGeqrfStridedBatched<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
-//                                                                  const int             m,
-//                                                                  const int             n,
-//                                                                  hipblasDoubleComplex* A,
-//                                                                  const int             lda,
-//                                                                  const int             strideA,
-//                                                                  hipblasDoubleComplex* ipiv,
-//                                                                  const int             strideP,
-//                                                                  int*                  info,
-//                                                                  const int             batchCount)
-// {
-//     return hipblasZgeqrfStridedBatchedFortran(
-//         handle, m, n, A, lda, strideA, ipiv, strideP, info, batchCount);
-// }
+template <>
+hipblasStatus_t hipblasGeqrfStridedBatched<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
+                                                                 const int             m,
+                                                                 const int             n,
+                                                                 hipblasDoubleComplex* A,
+                                                                 const int             lda,
+                                                                 const int             strideA,
+                                                                 hipblasDoubleComplex* ipiv,
+                                                                 const int             strideP,
+                                                                 int*                  info,
+                                                                 const int             batchCount)
+{
+    return hipblasZgeqrfStridedBatchedFortran(
+        handle, m, n, A, lda, strideA, ipiv, strideP, info, batchCount);
+}
 
-// #endif
+#endif

--- a/clients/gtest/geqrf_batched_gtest.cpp
+++ b/clients/gtest/geqrf_batched_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> geqrf_batched_tuple;
+typedef std::tuple<vector<int>, double, int, bool> geqrf_batched_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, -1, 1, 1}, {10, 10, 10, 10}, {10, 10, 20, 100}, {600, 500, 600, 600}};
@@ -25,11 +25,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {-1, 0, 1, 2};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_geqrf_batched_arguments(geqrf_batched_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -40,6 +43,8 @@ Arguments setup_geqrf_batched_arguments(geqrf_batched_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -106,4 +111,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGeqrfBatched,
                         geqrf_batched_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/gtest/geqrf_gtest.cpp
+++ b/clients/gtest/geqrf_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> geqrf_tuple;
+typedef std::tuple<vector<int>, double, int, bool> geqrf_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, -1, 1, 1}, {10, 10, 10, 10}, {10, 10, 20, 100}, {600, 500, 600, 600}};
@@ -25,11 +25,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {1};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_geqrf_arguments(geqrf_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -40,6 +43,8 @@ Arguments setup_geqrf_arguments(geqrf_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -106,4 +111,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGeqrf,
                         geqrf_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/gtest/geqrf_strided_batched_gtest.cpp
+++ b/clients/gtest/geqrf_strided_batched_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> geqrf_strided_batched_tuple;
+typedef std::tuple<vector<int>, double, int, bool> geqrf_strided_batched_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, -1, 1, 1}, {10, 10, 10, 10}, {10, 10, 20, 100}, {600, 500, 600, 600}};
@@ -25,11 +25,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {-1, 0, 1, 2};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_geqrf_strided_batched_arguments(geqrf_strided_batched_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -40,6 +43,8 @@ Arguments setup_geqrf_strided_batched_arguments(geqrf_strided_batched_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -106,4 +111,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGeqrfStridedBatched,
                         geqrf_strided_batched_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/gtest/getrf_batched_gtest.cpp
+++ b/clients/gtest/getrf_batched_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> getrf_batched_tuple;
+typedef std::tuple<vector<int>, double, int, bool> getrf_batched_tuple;
 
 const vector<vector<int>> matrix_size_range = {{-1, -1, 1, 1},
                                                {10, 10, 10, 10},
@@ -28,11 +28,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {-1, 0, 1, 2};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_getrf_batched_arguments(getrf_batched_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -43,6 +46,8 @@ Arguments setup_getrf_batched_arguments(getrf_batched_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -109,4 +114,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGetrfBatched,
                         getrf_batched_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/gtest/getrf_gtest.cpp
+++ b/clients/gtest/getrf_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> getrf_tuple;
+typedef std::tuple<vector<int>, double, int, bool> getrf_tuple;
 
 const vector<vector<int>> matrix_size_range = {{-1, -1, 1, 1},
                                                {10, 10, 10, 10},
@@ -28,11 +28,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {1};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_getrf_arguments(getrf_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -43,6 +46,8 @@ Arguments setup_getrf_arguments(getrf_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -109,4 +114,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGetrf,
                         getrf_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/gtest/getrf_strided_batched_gtest.cpp
+++ b/clients/gtest/getrf_strided_batched_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> getrf_strided_batched_tuple;
+typedef std::tuple<vector<int>, double, int, bool> getrf_strided_batched_tuple;
 
 const vector<vector<int>> matrix_size_range = {{-1, -1, 1, 1},
                                                {10, 10, 10, 10},
@@ -28,11 +28,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {-1, 0, 1, 2};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_getrf_strided_batched_arguments(getrf_strided_batched_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -43,6 +46,8 @@ Arguments setup_getrf_strided_batched_arguments(getrf_strided_batched_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -109,4 +114,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGetrfStridedBatched,
                         getrf_strided_batched_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/gtest/getrs_batched_gtest.cpp
+++ b/clients/gtest/getrs_batched_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> getrs_batched_tuple;
+typedef std::tuple<vector<int>, double, int, bool> getrs_batched_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, 1, 1}, {10, 20, 100}, {500, 600, 600}, {1024, 1024, 1024}};
@@ -25,11 +25,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {-1, 0, 1, 2};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_getrs_batched_arguments(getrs_batched_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -39,6 +42,8 @@ Arguments setup_getrs_batched_arguments(getrs_batched_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -105,4 +110,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGetrsBatched,
                         getrs_batched_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/gtest/getrs_gtest.cpp
+++ b/clients/gtest/getrs_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> getrs_tuple;
+typedef std::tuple<vector<int>, double, int, bool> getrs_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, 1, 1}, {10, 20, 100}, {500, 600, 600}, {1024, 1024, 1024}};
@@ -25,11 +25,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {1};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_getrs_arguments(getrs_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -39,6 +42,8 @@ Arguments setup_getrs_arguments(getrs_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -105,4 +110,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGetrs,
                         getrs_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/gtest/getrs_strided_batched_gtest.cpp
+++ b/clients/gtest/getrs_strided_batched_gtest.cpp
@@ -16,7 +16,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, double, int> getrs_strided_batched_tuple;
+typedef std::tuple<vector<int>, double, int, bool> getrs_strided_batched_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, 1, 1}, {10, 20, 100}, {500, 600, 600}, {1024, 1024, 1024}};
@@ -25,11 +25,14 @@ const vector<double> stride_scale_range = {2.5};
 
 const vector<int> batch_count_range = {-1, 0, 1, 2};
 
+const vector<bool> is_fortran = {false, true};
+
 Arguments setup_getrs_strided_batched_arguments(getrs_strided_batched_tuple tup)
 {
     vector<int> matrix_size  = std::get<0>(tup);
     double      stride_scale = std::get<1>(tup);
     int         batch_count  = std::get<2>(tup);
+    bool        fortran      = std::get<3>(tup);
 
     Arguments arg;
 
@@ -39,6 +42,8 @@ Arguments setup_getrs_strided_batched_arguments(getrs_strided_batched_tuple tup)
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;
+
+    arg.fortran = fortran;
 
     return arg;
 }
@@ -105,4 +110,5 @@ INSTANTIATE_TEST_CASE_P(hipblasGetrsStridedBatched,
                         getrs_strided_batched_gtest,
                         Combine(ValuesIn(matrix_size_range),
                                 ValuesIn(stride_scale_range),
-                                ValuesIn(batch_count_range)));
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -6066,367 +6066,6 @@ hipblasStatus_t hipblasZtrsmStridedBatchedFortran(hipblasHandle_t             ha
                                                   int                         strideB,
                                                   int                         batch_count);
 
-// getrf
-hipblasStatus_t hipblasSgetrf(
-    hipblasHandle_t handle, const int n, float* A, const int lda, int* ipiv, int* info);
-
-hipblasStatus_t hipblasDgetrf(
-    hipblasHandle_t handle, const int n, double* A, const int lda, int* ipiv, int* info);
-
-hipblasStatus_t hipblasCgetrf(
-    hipblasHandle_t handle, const int n, hipblasComplex* A, const int lda, int* ipiv, int* info);
-
-hipblasStatus_t hipblasZgetrfFortran(hipblasHandle_t       handle,
-                                     const int             n,
-                                     hipblasDoubleComplex* A,
-                                     const int             lda,
-                                     int*                  ipiv,
-                                     int*                  info);
-
-// getrf_batched
-hipblasStatus_t hipblasSgetrfBatchedFortran(hipblasHandle_t handle,
-                                            const int       n,
-                                            float* const    A[],
-                                            const int       lda,
-                                            int*            ipiv,
-                                            int*            info,
-                                            const int       batch_count);
-
-hipblasStatus_t hipblasDgetrfBatchedFortran(hipblasHandle_t handle,
-                                            const int       n,
-                                            double* const   A[],
-                                            const int       lda,
-                                            int*            ipiv,
-                                            int*            info,
-                                            const int       batch_count);
-
-hipblasStatus_t hipblasCgetrfBatchedFortran(hipblasHandle_t       handle,
-                                            const int             n,
-                                            hipblasComplex* const A[],
-                                            const int             lda,
-                                            int*                  ipiv,
-                                            int*                  info,
-                                            const int             batch_count);
-
-hipblasStatus_t hipblasZgetrfBatchedFortran(hipblasHandle_t             handle,
-                                            const int                   n,
-                                            hipblasDoubleComplex* const A[],
-                                            const int                   lda,
-                                            int*                        ipiv,
-                                            int*                        info,
-                                            const int                   batch_count);
-
-// getrf_strided_batched
-hipblasStatus_t hipblasSgetrfStridedBatchedFortran(hipblasHandle_t handle,
-                                                   const int       n,
-                                                   float*          A,
-                                                   const int       lda,
-                                                   const int       strideA,
-                                                   int*            ipiv,
-                                                   const int       strideP,
-                                                   int*            info,
-                                                   const int       batch_count);
-
-hipblasStatus_t hipblasDgetrfStridedBatchedFortran(hipblasHandle_t handle,
-                                                   const int       n,
-                                                   double*         A,
-                                                   const int       lda,
-                                                   const int       strideA,
-                                                   int*            ipiv,
-                                                   const int       strideP,
-                                                   int*            info,
-                                                   const int       batch_count);
-
-hipblasStatus_t hipblasCgetrfStridedBatchedFortran(hipblasHandle_t handle,
-                                                   const int       n,
-                                                   hipblasComplex* A,
-                                                   const int       lda,
-                                                   const int       strideA,
-                                                   int*            ipiv,
-                                                   const int       strideP,
-                                                   int*            info,
-                                                   const int       batch_count);
-
-hipblasStatus_t hipblasZgetrfStridedBatchedFortran(hipblasHandle_t       handle,
-                                                   const int             n,
-                                                   hipblasDoubleComplex* A,
-                                                   const int             lda,
-                                                   const int             strideA,
-                                                   int*                  ipiv,
-                                                   const int             strideP,
-                                                   int*                  info,
-                                                   const int             batch_count);
-
-// getrs
-hipblasStatus_t hipblasSgetrsFortran(hipblasHandle_t          handle,
-                                     const hipblasOperation_t trans,
-                                     const int                n,
-                                     const int                nrhs,
-                                     float*                   A,
-                                     const int                lda,
-                                     const int*               ipiv,
-                                     float*                   B,
-                                     const int                ldb,
-                                     int*                     info);
-
-hipblasStatus_t hipblasDgetrsFortran(hipblasHandle_t          handle,
-                                     const hipblasOperation_t trans,
-                                     const int                n,
-                                     const int                nrhs,
-                                     double*                  A,
-                                     const int                lda,
-                                     const int*               ipiv,
-                                     double*                  B,
-                                     const int                ldb,
-                                     int*                     info);
-
-hipblasStatus_t hipblasCgetrsFortran(hipblasHandle_t          handle,
-                                     const hipblasOperation_t trans,
-                                     const int                n,
-                                     const int                nrhs,
-                                     hipblasComplex*          A,
-                                     const int                lda,
-                                     const int*               ipiv,
-                                     hipblasComplex*          B,
-                                     const int                ldb,
-                                     int*                     info);
-
-hipblasStatus_t hipblasZgetrsFortran(hipblasHandle_t          handle,
-                                     const hipblasOperation_t trans,
-                                     const int                n,
-                                     const int                nrhs,
-                                     hipblasDoubleComplex*    A,
-                                     const int                lda,
-                                     const int*               ipiv,
-                                     hipblasDoubleComplex*    B,
-                                     const int                ldb,
-                                     int*                     info);
-
-// getrs_batched
-hipblasStatus_t hipblasSgetrsBatchedFortran(hipblasHandle_t          handle,
-                                            const hipblasOperation_t trans,
-                                            const int                n,
-                                            const int                nrhs,
-                                            float* const             A[],
-                                            const int                lda,
-                                            const int*               ipiv,
-                                            float* const             B[],
-                                            const int                ldb,
-                                            int*                     info,
-                                            const int                batch_count);
-
-hipblasStatus_t hipblasDgetrsBatchedFortran(hipblasHandle_t          handle,
-                                            const hipblasOperation_t trans,
-                                            const int                n,
-                                            const int                nrhs,
-                                            double* const            A[],
-                                            const int                lda,
-                                            const int*               ipiv,
-                                            double* const            B[],
-                                            const int                ldb,
-                                            int*                     info,
-                                            const int                batch_count);
-
-hipblasStatus_t hipblasCgetrsBatchedFortran(hipblasHandle_t          handle,
-                                            const hipblasOperation_t trans,
-                                            const int                n,
-                                            const int                nrhs,
-                                            hipblasComplex* const    A[],
-                                            const int                lda,
-                                            const int*               ipiv,
-                                            hipblasComplex* const    B[],
-                                            const int                ldb,
-                                            int*                     info,
-                                            const int                batch_count);
-
-hipblasStatus_t hipblasZgetrsBatchedFortran(hipblasHandle_t             handle,
-                                            const hipblasOperation_t    trans,
-                                            const int                   n,
-                                            const int                   nrhs,
-                                            hipblasDoubleComplex* const A[],
-                                            const int                   lda,
-                                            const int*                  ipiv,
-                                            hipblasDoubleComplex* const B[],
-                                            const int                   ldb,
-                                            int*                        info,
-                                            const int                   batch_count);
-
-// getrs_strided_batched
-hipblasStatus_t hipblasSgetrsStridedBatchedFortran(hipblasHandle_t          handle,
-                                                   const hipblasOperation_t trans,
-                                                   const int                n,
-                                                   const int                nrhs,
-                                                   float*                   A,
-                                                   const int                lda,
-                                                   const int                strideA,
-                                                   const int*               ipiv,
-                                                   const int                strideP,
-                                                   float*                   B,
-                                                   const int                ldb,
-                                                   const int                strideB,
-                                                   int*                     info,
-                                                   const int                batch_count);
-
-hipblasStatus_t hipblasDgetrsStridedBatchedFortran(hipblasHandle_t          handle,
-                                                   const hipblasOperation_t trans,
-                                                   const int                n,
-                                                   const int                nrhs,
-                                                   double*                  A,
-                                                   const int                lda,
-                                                   const int                strideA,
-                                                   const int*               ipiv,
-                                                   const int                strideP,
-                                                   double*                  B,
-                                                   const int                ldb,
-                                                   const int                strideB,
-                                                   int*                     info,
-                                                   const int                batch_count);
-
-hipblasStatus_t hipblasCgetrsStridedBatchedFortran(hipblasHandle_t          handle,
-                                                   const hipblasOperation_t trans,
-                                                   const int                n,
-                                                   const int                nrhs,
-                                                   hipblasComplex*          A,
-                                                   const int                lda,
-                                                   const int                strideA,
-                                                   const int*               ipiv,
-                                                   const int                strideP,
-                                                   hipblasComplex*          B,
-                                                   const int                ldb,
-                                                   const int                strideB,
-                                                   int*                     info,
-                                                   const int                batch_count);
-
-hipblasStatus_t hipblasZgetrsStridedBatchedFortran(hipblasHandle_t          handle,
-                                                   const hipblasOperation_t trans,
-                                                   const int                n,
-                                                   const int                nrhs,
-                                                   hipblasDoubleComplex*    A,
-                                                   const int                lda,
-                                                   const int                strideA,
-                                                   const int*               ipiv,
-                                                   const int                strideP,
-                                                   hipblasDoubleComplex*    B,
-                                                   const int                ldb,
-                                                   const int                strideB,
-                                                   int*                     info,
-                                                   const int                batch_count);
-
-// geqrf
-hipblasStatus_t hipblasSgeqrfFortran(hipblasHandle_t handle,
-                                     const int       m,
-                                     const int       n,
-                                     float*          A,
-                                     const int       lda,
-                                     float*          ipiv,
-                                     int*            info);
-
-hipblasStatus_t hipblasDgeqrfFortran(hipblasHandle_t handle,
-                                     const int       m,
-                                     const int       n,
-                                     double*         A,
-                                     const int       lda,
-                                     double*         ipiv,
-                                     int*            info);
-
-hipblasStatus_t hipblasCgeqrfFortran(hipblasHandle_t handle,
-                                     const int       m,
-                                     const int       n,
-                                     hipblasComplex* A,
-                                     const int       lda,
-                                     hipblasComplex* ipiv,
-                                     int*            info);
-
-hipblasStatus_t hipblasZgeqrfFortran(hipblasHandle_t       handle,
-                                     const int             m,
-                                     const int             n,
-                                     hipblasDoubleComplex* A,
-                                     const int             lda,
-                                     hipblasDoubleComplex* ipiv,
-                                     int*                  info);
-
-// geqrf_batched
-hipblasStatus_t hipblasSgeqrfBatchedFortran(hipblasHandle_t handle,
-                                            const int       m,
-                                            const int       n,
-                                            float* const    A[],
-                                            const int       lda,
-                                            float* const    ipiv[],
-                                            int*            info,
-                                            const int       batch_count);
-
-hipblasStatus_t hipblasDgeqrfBatchedFortran(hipblasHandle_t handle,
-                                            const int       m,
-                                            const int       n,
-                                            double* const   A[],
-                                            const int       lda,
-                                            double* const   ipiv[],
-                                            int*            info,
-                                            const int       batch_count);
-
-hipblasStatus_t hipblasCgeqrfBatchedFortran(hipblasHandle_t       handle,
-                                            const int             m,
-                                            const int             n,
-                                            hipblasComplex* const A[],
-                                            const int             lda,
-                                            hipblasComplex* const ipiv[],
-                                            int*                  info,
-                                            const int             batch_count);
-
-hipblasStatus_t hipblasZgeqrfBatchedFortran(hipblasHandle_t             handle,
-                                            const int                   m,
-                                            const int                   n,
-                                            hipblasDoubleComplex* const A[],
-                                            const int                   lda,
-                                            hipblasDoubleComplex* const ipiv[],
-                                            int*                        info,
-                                            const int                   batch_count);
-
-// geqrf_strided_batched
-hipblasStatus_t hipblasSgeqrfStridedBatchedFortran(hipblasHandle_t handle,
-                                                   const int       m,
-                                                   const int       n,
-                                                   float*          A,
-                                                   const int       lda,
-                                                   const int       strideA,
-                                                   float*          ipiv,
-                                                   const int       strideP,
-                                                   int*            info,
-                                                   const int       batch_count);
-
-hipblasStatus_t hipblasDgeqrfStridedBatchedFortran(hipblasHandle_t handle,
-                                                   const int       m,
-                                                   const int       n,
-                                                   double*         A,
-                                                   const int       lda,
-                                                   const int       strideA,
-                                                   double*         ipiv,
-                                                   const int       strideP,
-                                                   int*            info,
-                                                   const int       batch_count);
-
-hipblasStatus_t hipblasCgeqrfStridedBatchedFortran(hipblasHandle_t handle,
-                                                   const int       m,
-                                                   const int       n,
-                                                   hipblasComplex* A,
-                                                   const int       lda,
-                                                   const int       strideA,
-                                                   hipblasComplex* ipiv,
-                                                   const int       strideP,
-                                                   int*            info,
-                                                   const int       batch_count);
-
-hipblasStatus_t hipblasZgeqrfStridedBatchedFortran(hipblasHandle_t       handle,
-                                                   const int             m,
-                                                   const int             n,
-                                                   hipblasDoubleComplex* A,
-                                                   const int             lda,
-                                                   const int             strideA,
-                                                   hipblasDoubleComplex* ipiv,
-                                                   const int             strideP,
-                                                   int*                  info,
-                                                   const int             batch_count);
-
 // gemm
 hipblasStatus_t hipblasHgemmFortran(hipblasHandle_t    handle,
                                     hipblasOperation_t transa,
@@ -6745,6 +6384,384 @@ hipblasStatus_t hipblasGemmStridedBatchedExFortran(hipblasHandle_t    handle,
                                                    int                batch_count,
                                                    hipblasDatatype_t  compute_type,
                                                    hipblasGemmAlgo_t  algo);
+
+/* ==========
+ *    Solver
+ * ========== */
+
+// getrf
+hipblasStatus_t hipblasSgetrfFortran(hipblasHandle_t handle,
+                              const int n,
+                              float* A,
+                              const int lda,
+                              int* ipiv,
+                              int* info);
+
+hipblasStatus_t hipblasDgetrfFortran(hipblasHandle_t handle,
+                              const int n,
+                              double* A,
+                              const int lda,
+                              int* ipiv,
+                              int* info);
+
+hipblasStatus_t hipblasCgetrfFortran(hipblasHandle_t handle,
+                              const int n,
+                              hipblasComplex* A,
+                              const int lda,
+                              int* ipiv,
+                              int* info);
+
+hipblasStatus_t hipblasZgetrfFortran(hipblasHandle_t handle,
+                              const int n,
+                              hipblasDoubleComplex* A,
+                              const int lda,
+                              int* ipiv,
+                              int* info);
+
+// getrf_batched
+hipblasStatus_t hipblasSgetrfBatchedFortran(hipblasHandle_t handle,
+                              const int n,
+                              float* const A[],
+                              const int lda,
+                              int* ipiv,
+                              int* info,
+                              const int batch_count);
+
+hipblasStatus_t hipblasDgetrfBatchedFortran(hipblasHandle_t handle,
+                              const int n,
+                              double* const A[],
+                              const int lda,
+                              int* ipiv,
+                              int* info,
+                              const int batch_count);
+
+hipblasStatus_t hipblasCgetrfBatchedFortran(hipblasHandle_t handle,
+                              const int n,
+                              hipblasComplex* const A[],
+                              const int lda,
+                              int* ipiv,
+                              int* info,
+                              const int batch_count);
+
+hipblasStatus_t hipblasZgetrfBatchedFortran(hipblasHandle_t handle,
+                              const int n,
+                              hipblasDoubleComplex* const A[],
+                              const int lda,
+                              int* ipiv,
+                              int* info,
+                              const int batch_count);
+
+// getrf_strided_batched
+hipblasStatus_t hipblasSgetrfStridedBatchedFortran(hipblasHandle_t handle,
+                              const int n,
+                              float* A,
+                              const int lda,
+                              const int stride_A,
+                              int* ipiv,
+                              const int stride_P,
+                              int* info,
+                              const int batch_count);
+
+hipblasStatus_t hipblasDgetrfStridedBatchedFortran(hipblasHandle_t handle,
+                              const int n,
+                              double* A,
+                              const int lda,
+                              const int stride_A,
+                              int* ipiv,
+                              const int stride_P,
+                              int* info,
+                              const int batch_count);
+
+hipblasStatus_t hipblasCgetrfStridedBatchedFortran(hipblasHandle_t handle,
+                              const int n,
+                              hipblasComplex* A,
+                              const int lda,
+                              const int stride_A,
+                              int* ipiv,
+                              const int stride_P,
+                              int* info,
+                              const int batch_count);
+
+hipblasStatus_t hipblasZgetrfStridedBatchedFortran(hipblasHandle_t handle,
+                              const int n,
+                              hipblasDoubleComplex* A,
+                              const int lda,
+                              const int stride_A,
+                              int* ipiv,
+                              const int stride_P,
+                              int* info,
+                              const int batch_count);
+
+// getrs
+hipblasStatus_t hipblasSgetrsFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     float* A,
+                                     const int lda,
+                                     const int* ipiv,
+                                     float* B,
+                                     const int ldb,
+                                     int* info);
+
+hipblasStatus_t hipblasDgetrsFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     double* A,
+                                     const int lda,
+                                     const int* ipiv,
+                                     double* B,
+                                     const int ldb,
+                                     int* info);
+
+hipblasStatus_t hipblasCgetrsFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     hipblasComplex* A,
+                                     const int lda,
+                                     const int* ipiv,
+                                     hipblasComplex* B,
+                                     const int ldb,
+                                     int* info);
+
+hipblasStatus_t hipblasZgetrsFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     hipblasDoubleComplex* A,
+                                     const int lda,
+                                     const int* ipiv,
+                                     hipblasDoubleComplex* B,
+                                     const int ldb,
+                                     int* info);
+
+// getrs_batched
+hipblasStatus_t hipblasSgetrsBatchedFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     float* const A[],
+                                     const int lda,
+                                     const int* ipiv,
+                                     float* const B[],
+                                     const int ldb,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasDgetrsBatchedFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     double* const A[],
+                                     const int lda,
+                                     const int* ipiv,
+                                     double* const B[],
+                                     const int ldb,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasCgetrsBatchedFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     hipblasComplex* const A[],
+                                     const int lda,
+                                     const int* ipiv,
+                                     hipblasComplex* const B[],
+                                     const int ldb,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasZgetrsBatchedFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     hipblasDoubleComplex* const A[],
+                                     const int lda,
+                                     const int* ipiv,
+                                     hipblasDoubleComplex* const B[],
+                                     const int ldb,
+                                     int* info,
+                                     const int batch_count);
+
+// getrs_strided_batched
+hipblasStatus_t hipblasSgetrsStridedBatchedFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     float* A,
+                                     const int lda,
+                                     const int stride_A,
+                                     const int* ipiv,
+                                     const int stride_P,
+                                     float* B,
+                                     const int ldb,
+                                     const int stride_B,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasDgetrsStridedBatchedFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     double* A,
+                                     const int lda,
+                                     const int stride_A,
+                                     const int* ipiv,
+                                     const int stride_P,
+                                     double* B,
+                                     const int ldb,
+                                     const int stride_B,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasCgetrsStridedBatchedFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     hipblasComplex* A,
+                                     const int lda,
+                                     const int stride_A,
+                                     const int* ipiv,
+                                     const int stride_P,
+                                     hipblasComplex* B,
+                                     const int ldb,
+                                     const int stride_B,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasZgetrsStridedBatchedFortran(hipblasHandle_t handle,
+                                     const hipblasOperation_t trans,
+                                     const int n,
+                                     const int nrhs,
+                                     hipblasDoubleComplex* A,
+                                     const int lda,
+                                     const int stride_A,
+                                     const int* ipiv,
+                                     const int stride_P,
+                                     hipblasDoubleComplex* B,
+                                     const int ldb,
+                                     const int stride_B,
+                                     int* info,
+                                     const int batch_count);
+
+// geqrf
+hipblasStatus_t hipblasSgeqrfFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     float* A,
+                                     const int lda,
+                                     float* tau,
+                                     int* info);
+
+hipblasStatus_t hipblasDgeqrfFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     double* A,
+                                     const int lda,
+                                     double* tau,
+                                     int* info);
+
+hipblasStatus_t hipblasCgeqrfFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     hipblasComplex* A,
+                                     const int lda,
+                                     hipblasComplex* tau,
+                                     int* info);
+
+hipblasStatus_t hipblasZgeqrfFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     hipblasDoubleComplex* A,
+                                     const int lda,
+                                     hipblasDoubleComplex* tau,
+                                     int* info);
+
+// geqrf_batched
+hipblasStatus_t hipblasSgeqrfBatchedFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     float* const A[],
+                                     const int lda,
+                                     float* const tau[],
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasDgeqrfBatchedFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     double* const A[],
+                                     const int lda,
+                                     double* const tau[],
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasCgeqrfBatchedFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     hipblasComplex* const A[],
+                                     const int lda,
+                                     hipblasComplex* const tau[],
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasZgeqrfBatchedFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     hipblasDoubleComplex* const A[],
+                                     const int lda,
+                                     hipblasDoubleComplex* const tau[],
+                                     int* info,
+                                     const int batch_count);
+
+// geqrf_strided_batched
+hipblasStatus_t hipblasSgeqrfStridedBatchedFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     float* A,
+                                     const int lda,
+                                     const int stride_A,
+                                     float* tau,
+                                     const int stride_T,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasDgeqrfStridedBatchedFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     double* A,
+                                     const int lda,
+                                     const int stride_A,
+                                     double* tau,
+                                     const int stride_T,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasCgeqrfStridedBatchedFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     hipblasComplex* A,
+                                     const int lda,
+                                     const int stride_A,
+                                     hipblasComplex* tau,
+                                     const int stride_T,
+                                     int* info,
+                                     const int batch_count);
+
+hipblasStatus_t hipblasZgeqrfStridedBatchedFortran(hipblasHandle_t handle,
+                                     const int m,
+                                     const int n,
+                                     hipblasDoubleComplex* A,
+                                     const int lda,
+                                     const int stride_A,
+                                     hipblasDoubleComplex* tau,
+                                     const int stride_T,
+                                     int* info,
+                                     const int batch_count);
+
 }
 
 #endif

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -6438,7 +6438,6 @@ hipblasStatus_t hipblasTrsmStridedBatchedExFortran(hipblasHandle_t    handle,
                                                    int                invA_size,
                                                    int                stride_invA,
                                                    hipblasDatatype_t  compute_type);
-}
 
 /* ==========
  *    Solver
@@ -6816,5 +6815,7 @@ hipblasStatus_t hipblasZgeqrfStridedBatchedFortran(hipblasHandle_t handle,
                                      const int stride_T,
                                      int* info,
                                      const int batch_count);
+
+}
 
 #endif

--- a/clients/include/hipblas_fortran_solver.f90
+++ b/clients/include/hipblas_fortran_solver.f90
@@ -1,0 +1,748 @@
+module hipblas_interface
+    use iso_c_binding
+    use hipblas
+
+    contains
+
+    !--------!
+    ! Solver !
+    !--------!
+
+    ! getrf
+    function hipblasSgetrfFortran(handle, n, A, lda, ipiv, info) &
+            result(res) &
+            bind(c, name = 'hipblasSgetrfFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasSgetrf(handle, n, A, lda, ipiv, info)
+    end function hipblasSgetrfFortran
+
+    function hipblasDgetrfFortran(handle, n, A, lda, ipiv, info) &
+            result(res) &
+            bind(c, name = 'hipblasDgetrfFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasDgetrf(handle, n, A, lda, ipiv, info)
+    end function hipblasDgetrfFortran
+
+    function hipblasCgetrfFortran(handle, n, A, lda, ipiv, info) &
+            result(res) &
+            bind(c, name = 'hipblasCgetrfFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasCgetrf(handle, n, A, lda, ipiv, info)
+    end function hipblasCgetrfFortran
+
+    function hipblasZgetrfFortran(handle, n, A, lda, ipiv, info) &
+            result(res) &
+            bind(c, name = 'hipblasZgetrfFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasZgetrf(handle, n, A, lda, ipiv, info)
+    end function hipblasZgetrfFortran
+
+    ! getrf_batched
+    function hipblasSgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasSgetrfBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasSgetrfBatched(handle, n, A, lda, ipiv, info, batch_count)
+    end function hipblasSgetrfBatchedFortran
+
+    function hipblasDgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasDgetrfBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasDgetrfBatched(handle, n, A, lda, ipiv, info, batch_count)
+    end function hipblasDgetrfBatchedFortran
+
+    function hipblasCgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasCgetrfBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasCgetrfBatched(handle, n, A, lda, ipiv, info, batch_count)
+    end function hipblasCgetrfBatchedFortran
+
+    function hipblasZgetrfBatchedFortran(handle, n, A, lda, ipiv, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasZgetrfBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasZgetrfBatched(handle, n, A, lda, ipiv, info, batch_count)
+    end function hipblasZgetrfBatchedFortran
+
+    ! getrf_strided_batched
+    function hipblasSgetrfStridedBatchedFortran(handle, n, A, lda, stride_A,&
+                ipiv, stride_P, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasSgetrfStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: ipiv
+        integer(c_int), value :: stride_P
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasSgetrfStridedBatched(handle, n, A, lda, stride_A,&
+                    ipiv, stride_P, info, batch_count)
+    end function hipblasSgetrfStridedBatchedFortran
+
+    function hipblasDgetrfStridedBatchedFortran(handle, n, A, lda, stride_A,&
+                ipiv, stride_P, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasDgetrfStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: ipiv
+        integer(c_int), value :: stride_P
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasDgetrfStridedBatched(handle, n, A, lda, stride_A,&
+                    ipiv, stride_P, info, batch_count)
+    end function hipblasDgetrfStridedBatchedFortran
+
+    function hipblasCgetrfStridedBatchedFortran(handle, n, A, lda, stride_A,&
+                ipiv, stride_P, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasCgetrfStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: ipiv
+        integer(c_int), value :: stride_P
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasCgetrfStridedBatched(handle, n, A, lda, stride_A,&
+                    ipiv, stride_P, info, batch_count)
+    end function hipblasCgetrfStridedBatchedFortran
+
+    function hipblasZgetrfStridedBatchedFortran(handle, n, A, lda, stride_A,&
+                ipiv, stride_P, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasZgetrfStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: ipiv
+        integer(c_int), value :: stride_P
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasZgetrfStridedBatched(handle, n, A, lda, stride_A,&
+                    ipiv, stride_P, info, batch_count)
+    end function hipblasZgetrfStridedBatchedFortran
+
+    ! getrs
+    function hipblasSgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv,&
+                B, ldb, info) &
+            result(res) &
+            bind(c, name = 'hipblasSgetrsFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasSgetrs(handle, trans, n, nrhs, A, lda,&
+                ipiv, B, ldb, info)
+    end function hipblasSgetrsFortran
+
+    function hipblasDgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv,&
+                B, ldb, info) &
+            result(res) &
+            bind(c, name = 'hipblasDgetrsFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasDgetrs(handle, trans, n, nrhs, A, lda,&
+                ipiv, B, ldb, info)
+    end function hipblasDgetrsFortran
+
+    function hipblasCgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv,&
+                B, ldb, info) &
+            result(res) &
+            bind(c, name = 'hipblasCgetrsFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasCgetrs(handle, trans, n, nrhs, A, lda,&
+                ipiv, B, ldb, info)
+    end function hipblasCgetrsFortran
+
+    function hipblasZgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv,&
+                B, ldb, info) &
+            result(res) &
+            bind(c, name = 'hipblasZgetrsFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasZgetrs(handle, trans, n, nrhs, A, lda,&
+                ipiv, B, ldb, info)
+    end function hipblasZgetrsFortran
+
+    ! getrs_batched
+    function hipblasSgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv,&
+                B, ldb, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasSgetrsBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasSgetrsBatched(handle, trans, n, nrhs, A, lda,&
+                ipiv, B, ldb, info, batch_count)
+    end function hipblasSgetrsBatchedFortran
+
+    function hipblasDgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv,&
+                B, ldb, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasDgetrsBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasDgetrsBatched(handle, trans, n, nrhs, A, lda,&
+                ipiv, B, ldb, info, batch_count)
+    end function hipblasDgetrsBatchedFortran
+
+    function hipblasCgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv,&
+                B, ldb, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasCgetrsBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasCgetrsBatched(handle, trans, n, nrhs, A, lda,&
+                ipiv, B, ldb, info, batch_count)
+    end function hipblasCgetrsBatchedFortran
+
+    function hipblasZgetrsBatchedFortran(handle, trans, n, nrhs, A, lda, ipiv,&
+                B, ldb, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasZgetrsBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasZgetrsBatched(handle, trans, n, nrhs, A, lda,&
+                ipiv, B, ldb, info, batch_count)
+    end function hipblasZgetrsBatchedFortran
+
+    ! getrs_strided_batched
+    function hipblasSgetrsStridedBatchedFortran(handle, trans, n, nrhs, A, lda, stride_A, ipiv,&
+                stride_P, B, ldb, stride_B, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasSgetrsStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: ipiv
+        integer(c_int), value :: stride_P
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        integer(c_int), value :: stride_B
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasSgetrsStridedBatched(handle, trans, n, nrhs, A, lda, stride_A,&
+                ipiv, stride_P, B, ldb, stride_B, info, batch_count)
+    end function hipblasSgetrsStridedBatchedFortran
+
+    function hipblasDgetrsStridedBatchedFortran(handle, trans, n, nrhs, A, lda, stride_A, ipiv,&
+                stride_P, B, ldb, stride_B, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasDgetrsStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: ipiv
+        integer(c_int), value :: stride_P
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        integer(c_int), value :: stride_B
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasDgetrsStridedBatched(handle, trans, n, nrhs, A, lda, stride_A,&
+                ipiv, stride_P, B, ldb, stride_B, info, batch_count)
+    end function hipblasDgetrsStridedBatchedFortran
+
+    function hipblasCgetrsStridedBatchedFortran(handle, trans, n, nrhs, A, lda, stride_A, ipiv,&
+                stride_P, B, ldb, stride_B, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasCgetrsStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: ipiv
+        integer(c_int), value :: stride_P
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        integer(c_int), value :: stride_B
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasCgetrsStridedBatched(handle, trans, n, nrhs, A, lda, stride_A,&
+                ipiv, stride_P, B, ldb, stride_B, info, batch_count)
+    end function hipblasCgetrsStridedBatchedFortran
+
+    function hipblasZgetrsStridedBatchedFortran(handle, trans, n, nrhs, A, lda, stride_A, ipiv,&
+                stride_P, B, ldb, stride_B, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasZgetrsStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPBLAS_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: ipiv
+        integer(c_int), value :: stride_P
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        integer(c_int), value :: stride_B
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasZgetrsStridedBatched(handle, trans, n, nrhs, A, lda, stride_A,&
+                ipiv, stride_P, B, ldb, stride_B, info, batch_count)
+    end function hipblasZgetrsStridedBatchedFortran
+
+    ! geqrf
+    function hipblasSgeqrfFortran(handle, m, n, A, lda, tau, info) &
+            result(res) &
+            bind(c, name = 'hipblasSgeqrfFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: tau
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasSgeqrf(handle, m, n, A, lda, tau, info)
+    end function hipblasSgeqrfFortran
+
+    function hipblasDgeqrfFortran(handle, m, n, A, lda, tau, info) &
+            result(res) &
+            bind(c, name = 'hipblasDgeqrfFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: tau
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasDgeqrf(handle, m, n, A, lda, tau, info)
+    end function hipblasDgeqrfFortran
+
+    function hipblasCgeqrfFortran(handle, m, n, A, lda, tau, info) &
+            result(res) &
+            bind(c, name = 'hipblasCgeqrfFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: tau
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasCgeqrf(handle, m, n, A, lda, tau, info)
+    end function hipblasCgeqrfFortran
+
+    function hipblasZgeqrfFortran(handle, m, n, A, lda, tau, info) &
+            result(res) &
+            bind(c, name = 'hipblasZgeqrfFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: tau
+        type(c_ptr), value :: info
+        integer(c_int) :: res
+        res = hipblasZgeqrf(handle, m, n, A, lda, tau, info)
+    end function hipblasZgeqrfFortran
+
+    ! geqrf_batched
+    function hipblasSgeqrfBatchedFortran(handle, m, n, A, lda, tau, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasSgeqrfBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: tau
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasSgeqrfBatched(handle, m, n, A, lda, tau, info, batch_count)
+    end function hipblasSgeqrfBatchedFortran
+
+    function hipblasDgeqrfBatchedFortran(handle, m, n, A, lda, tau, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasDgeqrfBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: tau
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasDgeqrfBatched(handle, m, n, A, lda, tau, info, batch_count)
+    end function hipblasDgeqrfBatchedFortran
+
+    function hipblasCgeqrfBatchedFortran(handle, m, n, A, lda, tau, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasCgeqrfBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: tau
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasCgeqrfBatched(handle, m, n, A, lda, tau, info, batch_count)
+    end function hipblasCgeqrfBatchedFortran
+
+    function hipblasZgeqrfBatchedFortran(handle, m, n, A, lda, tau, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasZgeqrfBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: tau
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasZgeqrfBatched(handle, m, n, A, lda, tau, info, batch_count)
+    end function hipblasZgeqrfBatchedFortran
+
+    ! geqrf_strided_batched
+    function hipblasSgeqrfStridedBatchedFortran(handle, m, n, A, lda, stride_A,&
+                tau, stride_T, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasSgeqrfStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: tau
+        integer(c_int), value :: stride_T
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasSgeqrfStridedBatched(handle, m, n, A, lda, stride_A,&
+                    tau, stride_T, info, batch_count)
+    end function hipblasSgeqrfStridedBatchedFortran
+
+function hipblasDgeqrfStridedBatchedFortran(handle, m, n, A, lda, stride_A,&
+            tau, stride_T, info, batch_count) &
+        result(res) &
+        bind(c, name = 'hipblasDgeqrfStridedBatchedFortran')
+    use iso_c_binding
+    use hipblas_enums
+    implicit none
+    type(c_ptr), value :: handle
+    integer(c_int), value :: m
+    integer(c_int), value :: n
+    type(c_ptr), value :: A
+    integer(c_int), value :: lda
+    integer(c_int), value :: stride_A
+    type(c_ptr), value :: tau
+    integer(c_int), value :: stride_T
+    type(c_ptr), value :: info
+    integer(c_int), value :: batch_count
+    integer(c_int) :: res
+    res = hipblasDgeqrfStridedBatched(handle, m, n, A, lda, stride_A,&
+                    tau, stride_T, info, batch_count)
+end function hipblasDgeqrfStridedBatchedFortran
+
+    function hipblasCgeqrfStridedBatchedFortran(handle, m, n, A, lda, stride_A,&
+                tau, stride_T, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasCgeqrfStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: tau
+        integer(c_int), value :: stride_T
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasCgeqrfStridedBatched(handle, m, n, A, lda, stride_A,&
+                    tau, stride_T, info, batch_count)
+    end function hipblasCgeqrfStridedBatchedFortran
+
+    function hipblasZgeqrfStridedBatchedFortran(handle, m, n, A, lda, stride_A,&
+                tau, stride_T, info, batch_count) &
+            result(res) &
+            bind(c, name = 'hipblasZgeqrfStridedBatchedFortran')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: tau
+        integer(c_int), value :: stride_T
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipblasZgeqrfStridedBatched(handle, m, n, A, lda, stride_A,&
+                    tau, stride_T, info, batch_count)
+    end function hipblasZgeqrfStridedBatchedFortran
+
+end module hipblas_interface

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_geqrf(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGeqrfFn = FORTRAN ? hipblasGeqrf<T, true> : hipblasGeqrf<T, false>;
+
     int M   = argus.M;
     int N   = argus.N;
     int lda = argus.lda;
@@ -64,7 +67,7 @@ hipblasStatus_t testing_geqrf(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGeqrf<T>(handle, M, N, dA, lda, dIpiv, &info);
+    status = hipblasGeqrfFn(handle, M, N, dA, lda, dIpiv, &info);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_geqrf_batched.hpp
+++ b/clients/include/testing_geqrf_batched.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_geqrf_batched(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGeqrfBatchedFn = FORTRAN ? hipblasGeqrfBatched<T, true> : hipblasGeqrfBatched<T, false>;
+
     int M           = argus.M;
     int N           = argus.N;
     int lda         = argus.lda;
@@ -84,7 +87,7 @@ hipblasStatus_t testing_geqrf_batched(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGeqrfBatched<T>(handle, M, N, dA, lda, dIpiv, &info, batch_count);
+    status = hipblasGeqrfBatchedFn(handle, M, N, dA, lda, dIpiv, &info, batch_count);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_geqrf_strided_batched.hpp
+++ b/clients/include/testing_geqrf_strided_batched.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGeqrfStridedBatchedFn = FORTRAN ? hipblasGeqrfStridedBatched<T, true> : hipblasGeqrfStridedBatched<T, false>;
+
     int    M            = argus.M;
     int    N            = argus.N;
     int    lda          = argus.lda;
@@ -77,7 +80,7 @@ hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGeqrfStridedBatched<T>(
+    status = hipblasGeqrfStridedBatchedFn(
         handle, M, N, dA, lda, strideA, dIpiv, strideP, &info, batch_count);
 
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_getrf(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGetrfFn = FORTRAN ? hipblasGetrf<T, true> : hipblasGetrf<T, false>;
+
     int M   = argus.N;
     int N   = argus.N;
     int lda = argus.lda;
@@ -67,7 +70,7 @@ hipblasStatus_t testing_getrf(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGetrf<T>(handle, N, dA, lda, dIpiv, dInfo);
+    status = hipblasGetrfFn(handle, N, dA, lda, dIpiv, dInfo);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_getrf_batched.hpp
+++ b/clients/include/testing_getrf_batched.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_getrf_batched(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGetrfBatchedFn = FORTRAN ? hipblasGetrfBatched<T, true> : hipblasGetrfBatched<T, false>;
+
     int M           = argus.N;
     int N           = argus.N;
     int lda         = argus.lda;
@@ -83,7 +86,7 @@ hipblasStatus_t testing_getrf_batched(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGetrfBatched<T>(handle, N, dA, lda, dIpiv, dInfo, batch_count);
+    status = hipblasGetrfBatchedFn(handle, N, dA, lda, dIpiv, dInfo, batch_count);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_getrf_strided_batched.hpp
+++ b/clients/include/testing_getrf_strided_batched.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_getrf_strided_batched(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGetrfStridedBatchedFn = FORTRAN ? hipblasGetrfStridedBatched<T, true> : hipblasGetrfStridedBatched<T, false>;
+
     int    M            = argus.N;
     int    N            = argus.N;
     int    lda          = argus.lda;
@@ -80,7 +83,7 @@ hipblasStatus_t testing_getrf_strided_batched(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGetrfStridedBatched<T>(
+    status = hipblasGetrfStridedBatchedFn(
         handle, N, dA, lda, strideA, dIpiv, strideP, dInfo, batch_count);
 
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_getrs(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGetrsFn = FORTRAN ? hipblasGetrs<T, true> : hipblasGetrs<T, false>;
+
     int N   = argus.N;
     int lda = argus.lda;
     int ldb = argus.ldb;
@@ -94,7 +97,7 @@ hipblasStatus_t testing_getrs(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGetrs<T>(handle, op, N, 1, dA, lda, dIpiv, dB, ldb, &info);
+    status = hipblasGetrsFn(handle, op, N, 1, dA, lda, dIpiv, dB, ldb, &info);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_getrs_batched(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGetrsBatchedFn = FORTRAN ? hipblasGetrsBatched<T, true> : hipblasGetrsBatched<T, false>;
+
     int N           = argus.N;
     int lda         = argus.lda;
     int ldb         = argus.ldb;
@@ -116,7 +119,7 @@ hipblasStatus_t testing_getrs_batched(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGetrsBatched<T>(handle, op, N, 1, dA, lda, dIpiv, dB, ldb, &info, batch_count);
+    status = hipblasGetrsBatchedFn(handle, op, N, 1, dA, lda, dIpiv, dB, ldb, &info, batch_count);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_getrs_strided_batched.hpp
+++ b/clients/include/testing_getrs_strided_batched.hpp
@@ -20,6 +20,9 @@ using namespace std;
 template <typename T>
 hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
 {
+    bool FORTRAN       = argus.fortran;
+    auto hipblasGetrsStridedBatchedFn = FORTRAN ? hipblasGetrsStridedBatched<T, true> : hipblasGetrsStridedBatched<T, false>;
+
     int    N            = argus.N;
     int    lda          = argus.lda;
     int    ldb          = argus.ldb;
@@ -111,7 +114,7 @@ hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
            HIPBLAS
     =================================================================== */
 
-    status = hipblasGetrsStridedBatched<T>(
+    status = hipblasGetrsStridedBatchedFn(
         handle, op, N, 1, dA, lda, strideA, dIpiv, strideP, dB, ldb, strideB, &info, batch_count);
 
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/library/src/hipblas_module.f90
+++ b/library/src/hipblas_module.f90
@@ -11871,4 +11871,725 @@ module hipblas
         end function hipblasTrsmStridedBatchedEx
     end interface
 
+    !--------!
+    ! Solver !
+    !--------!
+
+    ! getrf
+    interface
+        function hipblasSgetrf(handle, n, A, lda, ipiv, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgetrf')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: info
+        end function hipblasSgetrf
+    end interface
+
+    interface
+        function hipblasDgetrf(handle, n, A, lda, ipiv, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasDgetrf')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: info
+        end function hipblasDgetrf
+    end interface
+
+    interface
+        function hipblasCgetrf(handle, n, A, lda, ipiv, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgetrf')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: info
+        end function hipblasCgetrf
+    end interface
+
+    interface
+        function hipblasZgetrf(handle, n, A, lda, ipiv, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgetrf')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: info
+        end function hipblasZgetrf
+    end interface
+
+    ! getrf_batched
+    interface
+        function hipblasSgetrfBatched(handle, n, A, lda, ipiv, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgetrfBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasSgetrfBatched
+    end interface
+
+    interface
+        function hipblasDgetrfBatched(handle, n, A, lda, ipiv, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasDgetrfBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasDgetrfBatched
+    end interface
+
+    interface
+        function hipblasCgetrfBatched(handle, n, A, lda, ipiv, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgetrfBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasCgetrfBatched
+    end interface
+
+    interface
+        function hipblasZgetrfBatched(handle, n, A, lda, ipiv, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgetrfBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasZgetrfBatched
+    end interface
+
+    ! getrf_strided_batched
+    interface
+        function hipblasSgetrfStridedBatched(handle, n, A, lda, stride_A,&
+                    ipiv, stride_P, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgetrfStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: ipiv
+            integer(c_int), value :: stride_P
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasSgetrfStridedBatched
+    end interface
+
+    interface
+        function hipblasDgetrfStridedBatched(handle, n, A, lda, stride_A,&
+                    ipiv, stride_P, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasDgetrfStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: ipiv
+            integer(c_int), value :: stride_P
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasDgetrfStridedBatched
+    end interface
+
+    interface
+        function hipblasCgetrfStridedBatched(handle, n, A, lda, stride_A,&
+                    ipiv, stride_P, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgetrfStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: ipiv
+            integer(c_int), value :: stride_P
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasCgetrfStridedBatched
+    end interface
+
+    interface
+        function hipblasZgetrfStridedBatched(handle, n, A, lda, stride_A,&
+                    ipiv, stride_P, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgetrfStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: ipiv
+            integer(c_int), value :: stride_P
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasZgetrfStridedBatched
+    end interface
+
+    ! getrs
+    interface
+        function hipblasSgetrs(handle, trans, n, nrhs, A, lda, ipiv,&
+                    B, ldb, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgetrs')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: info
+        end function hipblasSgetrs
+    end interface
+
+    interface
+        function hipblasDgetrs(handle, trans, n, nrhs, A, lda, ipiv,&
+                    B, ldb, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasDgetrs')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: info
+        end function hipblasDgetrs
+    end interface
+
+    interface
+        function hipblasCgetrs(handle, trans, n, nrhs, A, lda, ipiv,&
+                    B, ldb, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgetrs')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: info
+        end function hipblasCgetrs
+    end interface
+
+    interface
+        function hipblasZgetrs(handle, trans, n, nrhs, A, lda, ipiv,&
+                    B, ldb, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgetrs')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: info
+        end function hipblasZgetrs
+    end interface
+
+    ! getrs_batched
+    interface
+        function hipblasSgetrsBatched(handle, trans, n, nrhs, A, lda, ipiv,&
+                    B, ldb, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgetrsBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasSgetrsBatched
+    end interface
+
+    interface
+        function hipblasDgetrsBatched(handle, trans, n, nrhs, A, lda, ipiv,&
+                    B, ldb, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasDgetrsBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasDgetrsBatched
+    end interface
+
+    interface
+        function hipblasCgetrsBatched(handle, trans, n, nrhs, A, lda, ipiv,&
+                    B, ldb, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgetrsBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasCgetrsBatched
+    end interface
+
+    interface
+        function hipblasZgetrsBatched(handle, trans, n, nrhs, A, lda, ipiv,&
+                    B, ldb, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgetrsBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasZgetrsBatched
+    end interface
+
+    ! getrs_strided_batched
+    interface
+        function hipblasSgetrsStridedBatched(handle, trans, n, nrhs, A, lda, stride_A, ipiv,&
+                    stride_P, B, ldb, stride_B, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgetrsStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: ipiv
+            integer(c_int), value :: stride_P
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            integer(c_int), value :: stride_B
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasSgetrsStridedBatched
+    end interface
+
+    interface
+        function hipblasDgetrsStridedBatched(handle, trans, n, nrhs, A, lda, stride_A, ipiv,&
+                    stride_P, B, ldb, stride_B, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasDgetrsStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: ipiv
+            integer(c_int), value :: stride_P
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            integer(c_int), value :: stride_B
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasDgetrsStridedBatched
+    end interface
+
+    interface
+        function hipblasCgetrsStridedBatched(handle, trans, n, nrhs, A, lda, stride_A, ipiv,&
+                    stride_P, B, ldb, stride_B, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgetrsStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: ipiv
+            integer(c_int), value :: stride_P
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            integer(c_int), value :: stride_B
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasCgetrsStridedBatched
+    end interface
+
+    interface
+        function hipblasZgetrsStridedBatched(handle, trans, n, nrhs, A, lda, stride_A, ipiv,&
+                    stride_P, B, ldb, stride_B, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgetrsStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPBLAS_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: ipiv
+            integer(c_int), value :: stride_P
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            integer(c_int), value :: stride_B
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasZgetrsStridedBatched
+    end interface
+
+    ! geqrf
+    interface
+        function hipblasSgeqrf(handle, m, n, A, lda, tau, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgeqrf')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: tau
+            type(c_ptr), value :: info
+        end function hipblasSgeqrf
+    end interface
+
+    interface
+        function hipblasDgeqrf(handle, m, n, A, lda, tau, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasDgeqrf')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: tau
+            type(c_ptr), value :: info
+        end function hipblasDgeqrf
+    end interface
+
+    interface
+        function hipblasCgeqrf(handle, m, n, A, lda, tau, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgeqrf')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: tau
+            type(c_ptr), value :: info
+        end function hipblasCgeqrf
+    end interface
+
+    interface
+        function hipblasZgeqrf(handle, m, n, A, lda, tau, info) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgeqrf')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: tau
+            type(c_ptr), value :: info
+        end function hipblasZgeqrf
+    end interface
+
+    ! geqrf_batched
+    interface
+        function hipblasSgeqrfBatched(handle, m, n, A, lda, tau, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgeqrfBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: tau
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasSgeqrfBatched
+    end interface
+
+    interface
+        function hipblasDgeqrfBatched(handle, m, n, A, lda, tau, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasDgeqrfBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: tau
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasDgeqrfBatched
+    end interface
+
+    interface
+        function hipblasCgeqrfBatched(handle, m, n, A, lda, tau, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgeqrfBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: tau
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasCgeqrfBatched
+    end interface
+
+    interface
+        function hipblasZgeqrfBatched(handle, m, n, A, lda, tau, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgeqrfBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: tau
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasZgeqrfBatched
+    end interface
+
+    ! geqrf_strided_batched
+    interface
+        function hipblasSgeqrfStridedBatched(handle, m, n, A, lda, stride_A,&
+                    tau, stride_T, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasSgeqrfStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: tau
+            integer(c_int), value :: stride_T
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasSgeqrfStridedBatched
+    end interface
+
+    interface
+    function hipblasDgeqrfStridedBatched(handle, m, n, A, lda, stride_A,&
+                tau, stride_T, info, batch_count) &
+            result(c_int) &
+            bind(c, name = 'hipblasDgeqrfStridedBatched')
+        use iso_c_binding
+        use hipblas_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(c_int), value :: m
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        integer(c_int), value :: stride_A
+        type(c_ptr), value :: tau
+        integer(c_int), value :: stride_T
+        type(c_ptr), value :: info
+        integer(c_int), value :: batch_count
+    end function hipblasDgeqrfStridedBatched
+    end interface
+
+    interface
+        function hipblasCgeqrfStridedBatched(handle, m, n, A, lda, stride_A,&
+                    tau, stride_T, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasCgeqrfStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: tau
+            integer(c_int), value :: stride_T
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasCgeqrfStridedBatched
+    end interface
+
+    interface
+        function hipblasZgeqrfStridedBatched(handle, m, n, A, lda, stride_A,&
+                    tau, stride_T, info, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipblasZgeqrfStridedBatched')
+            use iso_c_binding
+            use hipblas_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(c_int), value :: m
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            integer(c_int), value :: stride_A
+            type(c_ptr), value :: tau
+            integer(c_int), value :: stride_T
+            type(c_ptr), value :: info
+            integer(c_int), value :: batch_count
+        end function hipblasZgeqrfStridedBatched
+    end interface
+
 end module hipblas


### PR DESCRIPTION
Fortran support for all rocSolver functions (getrf, getrs, geqrf and variants).