### PR TITLE
Hotfix: dgmm test fix

### DIFF
--- a/clients/gtest/dgmm_gtest.cpp
+++ b/clients/gtest/dgmm_gtest.cpp
@@ -122,22 +122,22 @@ TEST_P(dgmm_gtest, dgmm_gtest_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    // Arguments arg = setup_dgmm_arguments(GetParam());
+    Arguments arg = setup_dgmm_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_dgmm<float>(arg);
+    hipblasStatus_t status = testing_dgmm<float>(arg);
 
-    // // if not success, then the input argument is problematic, so detect the error message
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M || arg.ldc < arg.M || arg.incx == 0)
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-    //     }
-    //     else
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
-    //     }
-    // }
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M || arg.ldc < arg.M)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
 }
 
 TEST_P(dgmm_gtest, dgmm_gtest_float_complex)
@@ -147,22 +147,22 @@ TEST_P(dgmm_gtest, dgmm_gtest_float_complex)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    // Arguments arg = setup_dgmm_arguments(GetParam());
+    Arguments arg = setup_dgmm_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_dgmm<hipblasComplex>(arg);
+    hipblasStatus_t status = testing_dgmm<hipblasComplex>(arg);
 
-    // // if not success, then the input argument is problematic, so detect the error message
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M || arg.ldc < arg.M || arg.incx == 0)
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-    //     }
-    //     else
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
-    //     }
-    // }
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.M < 0 || arg.N < 0 || arg.lda < arg.M || arg.ldc < arg.M)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
 }
 
 TEST_P(dgmm_gtest, dgmm_batched_gtest_float)

--- a/clients/include/hipblas_vector.hpp
+++ b/clients/include/hipblas_vector.hpp
@@ -131,7 +131,7 @@ public:
         return data[n];
     }
 
-    operator T**()
+    operator T* *()
     {
         return data;
     }

--- a/clients/include/testing_dgmm.hpp
+++ b/clients/include/testing_dgmm.hpp
@@ -37,12 +37,14 @@ hipblasStatus_t testing_dgmm(Arguments argus)
     int C_size = size_t(ldc) * N;
     int k      = (side == HIPBLAS_SIDE_RIGHT ? N : M);
     int X_size = size_t(incx) * k;
+    if(!X_size)
+        X_size = 1;
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || lda < M || ldc < M || incx == 0)
+    if(M < 0 || N < 0 || lda < M || ldc < M)
     {
         status = HIPBLAS_STATUS_INVALID_VALUE;
         return status;
@@ -110,11 +112,11 @@ hipblasStatus_t testing_dgmm(Arguments argus)
             {
                 if(HIPBLAS_SIDE_RIGHT == side)
                 {
-                    hC_gold[i1 + i2 * ldc] = hA_copy[i1 + i2 * lda] + hx_copy[i2 * incx];
+                    hC_gold[i1 + i2 * ldc] = hA_copy[i1 + i2 * lda] * hx_copy[i2 * incx];
                 }
                 else
                 {
-                    hC_gold[i1 + i2 * ldc] = hA_copy[i1 + i2 * lda] + hx_copy[i1 * incx];
+                    hC_gold[i1 + i2 * ldc] = hA_copy[i1 + i2 * lda] * hx_copy[i1 * incx];
                 }
             }
         }

--- a/clients/include/testing_dgmm_batched.hpp
+++ b/clients/include/testing_dgmm_batched.hpp
@@ -39,12 +39,14 @@ hipblasStatus_t testing_dgmm_batched(Arguments argus)
     int C_size = size_t(ldc) * N;
     int k      = (side == HIPBLAS_SIDE_RIGHT ? N : M);
     int X_size = size_t(incx) * k;
+    if(!X_size)
+        X_size = 1;
 
     hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || lda < M || ldc < M || incx == 0 || batch_count < 0)
+    if(M < 0 || N < 0 || lda < M || ldc < M || batch_count < 0)
     {
         status = HIPBLAS_STATUS_INVALID_VALUE;
         return status;
@@ -142,12 +144,12 @@ hipblasStatus_t testing_dgmm_batched(Arguments argus)
                     if(HIPBLAS_SIDE_RIGHT == side)
                     {
                         hC_gold[b][i1 + i2 * ldc]
-                            = hA_copy[b][i1 + i2 * lda] + hx_copy[b][i2 * incx];
+                            = hA_copy[b][i1 + i2 * lda] * hx_copy[b][i2 * incx];
                     }
                     else
                     {
                         hC_gold[b][i1 + i2 * ldc]
-                            = hA_copy[b][i1 + i2 * lda] + hx_copy[b][i1 * incx];
+                            = hA_copy[b][i1 + i2 * lda] * hx_copy[b][i1 * incx];
                     }
                 }
             }

--- a/clients/include/testing_dgmm_strided_batched.hpp
+++ b/clients/include/testing_dgmm_strided_batched.hpp
@@ -40,6 +40,8 @@ hipblasStatus_t testing_dgmm_strided_batched(Arguments argus)
     int stride_A = size_t(lda) * N * stride_scale;
     int stride_x = size_t(incx) * k * stride_scale;
     int stride_C = size_t(ldc) * N * stride_scale;
+    if(!stride_x)
+        stride_x = 1;
 
     int A_size = stride_A * batch_count;
     int C_size = stride_C * batch_count;
@@ -49,7 +51,7 @@ hipblasStatus_t testing_dgmm_strided_batched(Arguments argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || lda < M || ldc < M || incx == 0 || batch_count < 0)
+    if(M < 0 || N < 0 || lda < M || ldc < M || batch_count < 0)
     {
         status = HIPBLAS_STATUS_INVALID_VALUE;
         return status;
@@ -123,11 +125,11 @@ hipblasStatus_t testing_dgmm_strided_batched(Arguments argus)
                 {
                     if(HIPBLAS_SIDE_RIGHT == side)
                     {
-                        hC_goldb[i1 + i2 * ldc] = hA_copyb[i1 + i2 * lda] + hx_copyb[i2 * incx];
+                        hC_goldb[i1 + i2 * ldc] = hA_copyb[i1 + i2 * lda] * hx_copyb[i2 * incx];
                     }
                     else
                     {
-                        hC_goldb[i1 + i2 * ldc] = hA_copyb[i1 + i2 * lda] + hx_copyb[i1 * incx];
+                        hC_goldb[i1 + i2 * ldc] = hA_copyb[i1 + i2 * lda] * hx_copyb[i1 * incx];
                     }
                 }
             }

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -20,7 +20,7 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_geqrf(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
+    bool FORTRAN        = argus.fortran;
     auto hipblasGeqrfFn = FORTRAN ? hipblasGeqrf<T, true> : hipblasGeqrf<T, false>;
 
     int M   = argus.M;

--- a/clients/include/testing_geqrf_batched.hpp
+++ b/clients/include/testing_geqrf_batched.hpp
@@ -20,8 +20,9 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_geqrf_batched(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
-    auto hipblasGeqrfBatchedFn = FORTRAN ? hipblasGeqrfBatched<T, true> : hipblasGeqrfBatched<T, false>;
+    bool FORTRAN = argus.fortran;
+    auto hipblasGeqrfBatchedFn
+        = FORTRAN ? hipblasGeqrfBatched<T, true> : hipblasGeqrfBatched<T, false>;
 
     int M           = argus.M;
     int N           = argus.N;

--- a/clients/include/testing_geqrf_strided_batched.hpp
+++ b/clients/include/testing_geqrf_strided_batched.hpp
@@ -20,8 +20,9 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_geqrf_strided_batched(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
-    auto hipblasGeqrfStridedBatchedFn = FORTRAN ? hipblasGeqrfStridedBatched<T, true> : hipblasGeqrfStridedBatched<T, false>;
+    bool FORTRAN = argus.fortran;
+    auto hipblasGeqrfStridedBatchedFn
+        = FORTRAN ? hipblasGeqrfStridedBatched<T, true> : hipblasGeqrfStridedBatched<T, false>;
 
     int    M            = argus.M;
     int    N            = argus.N;

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -20,7 +20,7 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_getrf(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
+    bool FORTRAN        = argus.fortran;
     auto hipblasGetrfFn = FORTRAN ? hipblasGetrf<T, true> : hipblasGetrf<T, false>;
 
     int M   = argus.N;

--- a/clients/include/testing_getrf_batched.hpp
+++ b/clients/include/testing_getrf_batched.hpp
@@ -20,8 +20,9 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_getrf_batched(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
-    auto hipblasGetrfBatchedFn = FORTRAN ? hipblasGetrfBatched<T, true> : hipblasGetrfBatched<T, false>;
+    bool FORTRAN = argus.fortran;
+    auto hipblasGetrfBatchedFn
+        = FORTRAN ? hipblasGetrfBatched<T, true> : hipblasGetrfBatched<T, false>;
 
     int M           = argus.N;
     int N           = argus.N;

--- a/clients/include/testing_getrf_strided_batched.hpp
+++ b/clients/include/testing_getrf_strided_batched.hpp
@@ -20,8 +20,9 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_getrf_strided_batched(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
-    auto hipblasGetrfStridedBatchedFn = FORTRAN ? hipblasGetrfStridedBatched<T, true> : hipblasGetrfStridedBatched<T, false>;
+    bool FORTRAN = argus.fortran;
+    auto hipblasGetrfStridedBatchedFn
+        = FORTRAN ? hipblasGetrfStridedBatched<T, true> : hipblasGetrfStridedBatched<T, false>;
 
     int    M            = argus.N;
     int    N            = argus.N;

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -20,7 +20,7 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_getrs(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
+    bool FORTRAN        = argus.fortran;
     auto hipblasGetrsFn = FORTRAN ? hipblasGetrs<T, true> : hipblasGetrs<T, false>;
 
     int N   = argus.N;

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -20,8 +20,9 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_getrs_batched(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
-    auto hipblasGetrsBatchedFn = FORTRAN ? hipblasGetrsBatched<T, true> : hipblasGetrsBatched<T, false>;
+    bool FORTRAN = argus.fortran;
+    auto hipblasGetrsBatchedFn
+        = FORTRAN ? hipblasGetrsBatched<T, true> : hipblasGetrsBatched<T, false>;
 
     int N           = argus.N;
     int lda         = argus.lda;

--- a/clients/include/testing_getrs_strided_batched.hpp
+++ b/clients/include/testing_getrs_strided_batched.hpp
@@ -20,8 +20,9 @@ using namespace std;
 template <typename T, typename U>
 hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
 {
-    bool FORTRAN       = argus.fortran;
-    auto hipblasGetrsStridedBatchedFn = FORTRAN ? hipblasGetrsStridedBatched<T, true> : hipblasGetrsStridedBatched<T, false>;
+    bool FORTRAN = argus.fortran;
+    auto hipblasGetrsStridedBatchedFn
+        = FORTRAN ? hipblasGetrsStridedBatched<T, true> : hipblasGetrsStridedBatched<T, false>;
 
     int    N            = argus.N;
     int    lda          = argus.lda;


### PR DESCRIPTION
Resolves [LWPMLSE-62](http://ontrack-internal.amd.com/browse/LWPMLSE-62).

Hotfix for hipBLAS. Since rocBLAS was fixed, hipBLAS was failing since I didn't disable dgmm_batched and dgmm_strided_batched tests, they were still enabled with incorrect reference code.

This enables all dgmm tests and fixes the reference code. Passed on CUDA, haven't tested on hip so hopefully this works on CI.