### PR TITLE
Missing types master

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -2273,7 +2273,7 @@ void cblas_gemm<hipblasDoubleComplex>(hipblasOperation_t    transA,
                 C,
                 ldc);
 }
-#include <iostream>
+
 template <>
 void cblas_gemm<int8_t, int32_t, int32_t>(hipblasOperation_t transA,
                                           hipblasOperation_t transB,

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -33,6 +33,17 @@ typedef std::tuple<vector<int>, vector<double>, vector<char>, vector<hipblasData
 // clang-format off
 // vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
 // add/delete as a group
+const vector<vector<int>> int8_matrix_size_range = {
+
+    { 4,  4,  4,  4,  4,  4},
+    { 8,  8,  8,  8,  8,  8},
+    {12, 12, 12, 12, 12, 12},
+    {16, 16, 16, 16, 16, 16},
+    {20, 20, 20, 20, 20, 20},
+    { 8,  4,  4,  8,  8,  8},
+    { 8, 12, 12, 12, 12, 12},
+};
+
 const vector<vector<int>> small_matrix_size_range = {
     { 1,  1,  1,  1,  1,  1},
     { 1,  2,  3,  4,  5,  6},
@@ -201,6 +212,25 @@ const vector<vector<hipblasDatatype_t>> precision_double = {{ HIPBLAS_R_64F,
                                                               HIPBLAS_R_64F,
                                                               HIPBLAS_R_64F  }};
 
+const vector<vector<hipblasDatatype_t>> precision_single_complex = {{ HIPBLAS_C_32F,
+                                                              HIPBLAS_C_32F,
+                                                              HIPBLAS_C_32F,
+                                                              HIPBLAS_C_32F,
+                                                              HIPBLAS_C_32F  }};
+
+const vector<vector<hipblasDatatype_t>> precision_double_complex = {{ HIPBLAS_C_64F,
+                                                              HIPBLAS_C_64F,
+                                                              HIPBLAS_C_64F,
+                                                              HIPBLAS_C_64F,
+                                                              HIPBLAS_C_64F  }};
+
+const vector<vector<hipblasDatatype_t>> precision_int8 = {{ HIPBLAS_R_8I,
+                                                              HIPBLAS_R_8I,
+                                                              HIPBLAS_R_32I,
+                                                              HIPBLAS_R_32I,
+                                                              HIPBLAS_R_32I  }};
+
+
 const vector<vector<hipblasDatatype_t>> precision_type_range = {{HIPBLAS_R_16F,
                                                                  HIPBLAS_R_16F,
                                                                  HIPBLAS_R_16F,
@@ -220,7 +250,22 @@ const vector<vector<hipblasDatatype_t>> precision_type_range = {{HIPBLAS_R_16F,
                                                                  HIPBLAS_R_64F,
                                                                  HIPBLAS_R_64F,
                                                                  HIPBLAS_R_64F,
-                                                                 HIPBLAS_R_64F}};
+                                                                 HIPBLAS_R_64F},
+                                                                {HIPBLAS_C_32F,
+                                                                 HIPBLAS_C_32F,
+                                                                 HIPBLAS_C_32F,
+                                                                 HIPBLAS_C_32F,
+                                                                 HIPBLAS_C_32F},
+                                                                {HIPBLAS_C_64F,
+                                                                 HIPBLAS_C_64F,
+                                                                 HIPBLAS_C_64F,
+                                                                 HIPBLAS_C_64F,
+                                                                 HIPBLAS_C_64F},
+                                                                {HIPBLAS_R_8I,
+                                                                 HIPBLAS_R_8I,
+                                                                 HIPBLAS_R_32I,
+                                                                 HIPBLAS_R_32I,
+                                                                 HIPBLAS_R_32I}};
 
 const int batch_count_range[] = { -1, 1, 5 };
 const int batch_count_range_small[] = { 1 };
@@ -502,6 +547,34 @@ INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_double,
                                 ValuesIn(precision_double),
                                 ValuesIn(batch_count_range_small),
                                 ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_single_complex,
+                        parameterized_gemm_ex,
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(precision_single_complex),
+                                ValuesIn(batch_count_range_small),
+                                ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_double_complex,
+                        parameterized_gemm_ex,
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(precision_double_complex),
+                                ValuesIn(batch_count_range_small),
+                                ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_int8,
+                        parameterized_gemm_ex,
+                        Combine(ValuesIn(int8_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(precision_int8),
+                                ValuesIn(batch_count_range_small),
+                                ValuesIn(is_fortran)));
+
 //----medium
 INSTANTIATE_TEST_CASE_P(pre_checkin_blas_ex_medium_hpa_half,
                         parameterized_gemm_ex,
@@ -573,5 +646,32 @@ INSTANTIATE_TEST_CASE_P(quick_blas_batched_ex_small_double,
                                 ValuesIn(alpha_beta_range),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_double),
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_CASE_P(quick_blas_batched_ex_small_single_complex,
+                        parameterized_gemm_batched_ex,
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(precision_single_complex),
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_CASE_P(quick_blas_batched_ex_small_double_complex,
+                        parameterized_gemm_batched_ex,
+                        Combine(ValuesIn(small_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(precision_double_complex),
+                                ValuesIn(batch_count_range),
+                                ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_CASE_P(quick_blas_batched_ex_small_int8,
+                        parameterized_gemm_batched_ex,
+                        Combine(ValuesIn(int8_matrix_size_range),
+                                ValuesIn(alpha_beta_range),
+                                ValuesIn(transA_transB_range),
+                                ValuesIn(precision_int8),
                                 ValuesIn(batch_count_range),
                                 ValuesIn(is_fortran)));

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -180,6 +180,12 @@ const vector<vector<double>> small_alpha_beta_range = {
 const vector<vector<double>> full_alpha_beta_range = {
     {1.0, 0.0}, {-1.0, -1.0}, {2.0, 1.0}, {0.0, 1.0}};
 
+// For Cuda v < 10.0, only alpha and beta = 1 or = 0 are
+// supported.
+const vector<vector<double>> alpha_beta_range_int8 = {
+    {1.0, 1.0}, {1.0, 0.0},
+};
+
 // vector of vector, each pair is a {transA, transB};
 // add/delete this list in pairs, like {'N', 'T'}
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
@@ -569,7 +575,7 @@ INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_double_complex,
 INSTANTIATE_TEST_CASE_P(quick_blas_ex_small_int8,
                         parameterized_gemm_ex,
                         Combine(ValuesIn(int8_matrix_size_range),
-                                ValuesIn(alpha_beta_range),
+                                ValuesIn(alpha_beta_range_int8),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_int8),
                                 ValuesIn(batch_count_range_small),
@@ -670,7 +676,7 @@ INSTANTIATE_TEST_CASE_P(quick_blas_batched_ex_small_double_complex,
 INSTANTIATE_TEST_CASE_P(quick_blas_batched_ex_small_int8,
                         parameterized_gemm_batched_ex,
                         Combine(ValuesIn(int8_matrix_size_range),
-                                ValuesIn(alpha_beta_range),
+                                ValuesIn(alpha_beta_range_int8),
                                 ValuesIn(transA_transB_range),
                                 ValuesIn(precision_int8),
                                 ValuesIn(batch_count_range),

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -415,12 +415,18 @@ TEST_P(parameterized_gemm_batched_ex, standard_batched)
         {
             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
         }
-        else
+        else if(status == HIPBLAS_STATUS_ARCH_MISMATCH)
         {
             // Only available in cuda cc >= 5.0.
             // If we want we can change this to call query_device_property() and
             // call this only if cc < 5.0 on a CUDA device, else fail.
             EXPECT_EQ(HIPBLAS_STATUS_ARCH_MISMATCH, status);
+        }
+        else
+        {
+            // cublas/rocblas do not have identical support
+            // (i.e. cublas doesn't support i8/i32 here)
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
         }
     }
 }
@@ -451,12 +457,18 @@ TEST_P(parameterized_gemm_batched_ex, standard_strided_batched)
         {
             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
         }
-        else
+        else if(status == HIPBLAS_STATUS_ARCH_MISMATCH)
         {
             // Only available in cuda cc >= 5.0.
             // If we want we can change this to call query_device_property() and
             // call this only if cc < 5.0 on a CUDA device, else fail.
             EXPECT_EQ(HIPBLAS_STATUS_ARCH_MISMATCH, status);
+        }
+        else
+        {
+            // cublas/rocblas do not have identical support
+            // (i.e. cublas doesn't support i8/i32 here)
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
         }
     }
 }

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -312,19 +312,19 @@ void cblas_geam(hipblasOperation_t transa,
                 int                ldc);
 
 // gemm
-template <typename T>
+template <typename Ti, typename To = Ti, typename Tc = To>
 void cblas_gemm(hipblasOperation_t transA,
                 hipblasOperation_t transB,
                 int                m,
                 int                n,
                 int                k,
-                T                  alpha,
-                T*                 A,
+                Tc                 alpha,
+                Ti*                A,
                 int                lda,
-                T*                 B,
+                Ti*                B,
                 int                ldb,
-                T                  beta,
-                T*                 C,
+                Tc                 beta,
+                To*                C,
                 int                ldc);
 
 // hemm

--- a/clients/include/testing_gemm_batched.hpp
+++ b/clients/include/testing_gemm_batched.hpp
@@ -220,12 +220,12 @@ hipblasStatus_t testing_GemmBatched(Arguments argus)
                       N,
                       K,
                       h_alpha,
-                      hA_array[i],
+                      (T*)hA_array[i],
                       lda,
-                      hB_array[i],
+                      (T*)hB_array[i],
                       ldb,
                       h_beta,
-                      hC_copy_array[i],
+                      (T*)hC_copy_array[i],
                       ldc);
     }
 

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -144,7 +144,10 @@ hipblasStatus_t testing_gemm_batched_ex_template(hipblasOperation_t transA,
         hipblas_init<Tc>(hC[b], M, N, ldc);
 
         hC_gold[b] = hC[b];
-
+#ifdef __HIP_PLATFORM_NVCC__
+        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b].data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(bB[b], hB[b].data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+#else
         if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N)
         {
             vector<Ta> hA_packed(hA[b]);
@@ -170,7 +173,7 @@ hipblasStatus_t testing_gemm_batched_ex_template(hipblasOperation_t transA,
             CHECK_HIP_ERROR(
                 hipMemcpy(bB[b], hB[b].data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
         }
-
+#endif
         CHECK_HIP_ERROR(hipMemcpy(bC[b], hC[b].data(), sizeof(Tc) * size_C, hipMemcpyHostToDevice));
     }
 

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -186,6 +186,12 @@ hipblasStatus_t testing_gemm_ex_template(hipblasOperation_t transA,
     hC_gold = hC;
 
     // copy data from CPU to device
+
+    // CUDA doesn't do packing
+#ifdef __HIP_PLATFORM_NVCC__
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+#else
     if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N)
     {
         vector<Ta> hA_packed(hA);
@@ -209,7 +215,7 @@ hipblasStatus_t testing_gemm_ex_template(hipblasOperation_t transA,
     {
         CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
     }
-
+#endif
     CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(Tc) * size_C, hipMemcpyHostToDevice));
 
     status = hipblasGemmExFn(handle,

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -24,7 +24,7 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename Td, typename Tc>
+template <typename Ta, typename Tb = Ta, typename Tc = Tb, typename Tex = Tc>
 hipblasStatus_t testing_gemm_strided_batched_ex_template(hipblasOperation_t transA,
                                                          hipblasOperation_t transB,
                                                          int                M,
@@ -51,46 +51,38 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(hipblasOperation_t tran
     uint32_t          solution_index = 0;
     uint32_t          flags          = 0;
 
-    Td h_alpha_Td;
-    Td h_beta_Td;
+    Tex h_alpha_Tc;
+    Tex h_beta_Tc;
 
-    if(is_same<Td, hipblasHalf>::value)
-    {
-        h_alpha_Td = float_to_half(alpha_float);
-        h_beta_Td  = float_to_half(beta_float);
-    }
-    else if(is_same<Td, float>::value)
-    {
-        h_alpha_Td = static_cast<Td>(alpha_float);
-        h_beta_Td  = static_cast<Td>(beta_float);
-    }
-    else if(is_same<Td, double>::value)
-    {
-        h_alpha_Td = static_cast<Td>(alpha_float);
-        h_beta_Td  = static_cast<Td>(beta_float);
-    }
-    else
-    {
-        return HIPBLAS_STATUS_NOT_SUPPORTED;
-    }
-
-    Tc h_alpha_Tc;
-    Tc h_beta_Tc;
-
-    if(is_same<Tc, hipblasHalf>::value)
+    if(is_same<Tex, hipblasHalf>::value)
     {
         h_alpha_Tc = float_to_half(alpha_float);
         h_beta_Tc  = float_to_half(beta_float);
     }
-    else if(is_same<Tc, float>::value)
+    else if(is_same<Tex, float>::value)
     {
-        h_alpha_Tc = static_cast<Tc>(alpha_float);
-        h_beta_Tc  = static_cast<Tc>(beta_float);
+        h_alpha_Tc = static_cast<Tex>(alpha_float);
+        h_beta_Tc  = static_cast<Tex>(beta_float);
     }
-    else if(is_same<Tc, double>::value)
+    else if(is_same<Tex, double>::value)
     {
-        h_alpha_Tc = static_cast<Tc>(alpha_float);
-        h_beta_Tc  = static_cast<Tc>(beta_float);
+        h_alpha_Tc = static_cast<Tex>(alpha_float);
+        h_beta_Tc  = static_cast<Tex>(beta_float);
+    }
+    else if(is_same<Tex, hipblasComplex>::value)
+    {
+        h_alpha_Tc = static_cast<Tex>(alpha_float);
+        h_beta_Tc  = static_cast<Tex>(beta_float);
+    }
+    else if(is_same<Tex, hipblasDoubleComplex>::value)
+    {
+        h_alpha_Tc = static_cast<Tex>(alpha_float);
+        h_beta_Tc  = static_cast<Tex>(beta_float);
+    }
+    else if(is_same<Tex, int32_t>::value)
+    {
+        h_alpha_Tc = static_cast<Tex>(alpha_float);
+        h_beta_Tc  = static_cast<Tex>(beta_float);
     }
     else
     {
@@ -116,9 +108,9 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(hipblasOperation_t tran
     const size_t size_B = stride_B * batch_count;
     const size_t size_C = stride_C * batch_count;
 
-    device_vector<Td> dA(size_A);
-    device_vector<Td> dB(size_B);
-    device_vector<Td> dC(size_C);
+    device_vector<Ta> dA(size_A);
+    device_vector<Tb> dB(size_B);
+    device_vector<Tc> dC(size_C);
 
     device_vector<Tc> d_alpha_Tc(1);
     device_vector<Tc> d_beta_Tc(1);
@@ -134,22 +126,44 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(hipblasOperation_t tran
     hipblasCreate(&handle);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<Td> hA(size_A);
-    host_vector<Td> hB(size_B);
-    host_vector<Td> hC(size_C);
-    host_vector<Td> hC_gold(size_C);
+    host_vector<Ta> hA(size_A);
+    host_vector<Tb> hB(size_B);
+    host_vector<Tc> hC(size_C);
+    host_vector<Tc> hC_gold(size_C);
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init<Td>(hA, A_row, A_col, lda, stride_A, batch_count);
-    hipblas_init_alternating_sign<Td>(hB, B_row, B_col, ldb, stride_B, batch_count);
-    hipblas_init<Td>(hC, M, N, ldc, stride_C, batch_count);
+    hipblas_init<Ta>(hA, A_row, A_col, lda, stride_A, batch_count);
+    hipblas_init_alternating_sign<Tb>(hB, B_row, B_col, ldb, stride_B, batch_count);
+    hipblas_init<Tc>(hC, M, N, ldc, stride_C, batch_count);
     hC_gold = hC;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Td) * size_A, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Td) * size_B, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(Td) * size_C, hipMemcpyHostToDevice));
+    if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N)
+    {
+        vector<Ta> hA_packed(hA);
+        hipblas_packInt8(hA_packed, M, K, lda, batch_count, stride_A);
+        CHECK_HIP_ERROR(
+            hipMemcpy(dA, hA_packed.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+    }
+    else
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+    }
+
+    if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N)
+    {
+        vector<Tb> hB_packed(hB);
+        hipblas_packInt8(hB_packed, N, K, ldb, batch_count, stride_B);
+        CHECK_HIP_ERROR(
+            hipMemcpy(dB, hB_packed.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+    }
+    else
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+    }
+
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(Tc) * size_C, hipMemcpyHostToDevice));
 
     status = hipblasGemmStridedBatchedExFn(handle,
                                            transA,
@@ -181,24 +195,24 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(hipblasOperation_t tran
         return status;
     }
 
-    CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(Td) * size_C, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
 
     // CPU BLAS
     for(int b = 0; b < batch_count; b++)
     {
-        cblas_gemm<Td>(transA,
-                       transB,
-                       M,
-                       N,
-                       K,
-                       h_alpha_Td,
-                       hA.data() + b * stride_A,
-                       lda,
-                       hB.data() + b * stride_B,
-                       ldb,
-                       h_beta_Td,
-                       hC_gold.data() + b * stride_C,
-                       ldc);
+        cblas_gemm<Ta, Tc, Tex>(transA,
+                                transB,
+                                M,
+                                N,
+                                K,
+                                h_alpha_Tc,
+                                hA.data() + b * stride_A,
+                                lda,
+                                hB.data() + b * stride_B,
+                                ldb,
+                                h_beta_Tc,
+                                hC_gold.data() + b * stride_C,
+                                ldc);
     }
 
     // enable unit check, notice unit check is not invasive, but norm check is,
@@ -207,7 +221,7 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(hipblasOperation_t tran
     {
         for(int b = 0; b < batch_count; b++)
         {
-            unit_check_general<Td>(
+            unit_check_general<Tc>(
                 M, N, ldc, hC_gold.data() + b * stride_C, hC.data() + b * stride_C);
         }
     }
@@ -247,73 +261,98 @@ hipblasStatus_t testing_gemm_strided_batched_ex(Arguments argus)
     if(a_type == HIPBLAS_R_16F && b_type == HIPBLAS_R_16F && c_type == HIPBLAS_R_16F
        && c_type == HIPBLAS_R_16F && compute_type == HIPBLAS_R_16F)
     {
-        status = testing_gemm_strided_batched_ex_template<hipblasHalf, hipblasHalf>(transA,
-                                                                                    transB,
-                                                                                    M,
-                                                                                    N,
-                                                                                    K,
-                                                                                    alpha,
-                                                                                    lda,
-                                                                                    ldb,
-                                                                                    beta,
-                                                                                    ldc,
-                                                                                    norm_check,
-                                                                                    unit_check,
-                                                                                    a_type,
-                                                                                    b_type,
-                                                                                    c_type,
-                                                                                    batch_count,
-                                                                                    compute_type,
-                                                                                    argus.fortran);
+        status = testing_gemm_strided_batched_ex_template<hipblasHalf>(transA,
+                                                                       transB,
+                                                                       M,
+                                                                       N,
+                                                                       K,
+                                                                       alpha,
+                                                                       lda,
+                                                                       ldb,
+                                                                       beta,
+                                                                       ldc,
+                                                                       norm_check,
+                                                                       unit_check,
+                                                                       a_type,
+                                                                       b_type,
+                                                                       c_type,
+                                                                       batch_count,
+                                                                       compute_type,
+                                                                       argus.fortran);
     }
     else if(a_type == HIPBLAS_R_16F && b_type == HIPBLAS_R_16F && c_type == HIPBLAS_R_16F
             && c_type == HIPBLAS_R_16F && compute_type == HIPBLAS_R_32F)
     {
-        status = testing_gemm_strided_batched_ex_template<hipblasHalf, float>(transA,
-                                                                              transB,
-                                                                              M,
-                                                                              N,
-                                                                              K,
-                                                                              alpha,
-                                                                              lda,
-                                                                              ldb,
-                                                                              beta,
-                                                                              ldc,
-                                                                              norm_check,
-                                                                              unit_check,
-                                                                              a_type,
-                                                                              b_type,
-                                                                              c_type,
-                                                                              batch_count,
-                                                                              compute_type,
-                                                                              argus.fortran);
+        status = testing_gemm_strided_batched_ex_template<hipblasHalf,
+                                                          hipblasHalf,
+                                                          hipblasHalf,
+                                                          float>(transA,
+                                                                 transB,
+                                                                 M,
+                                                                 N,
+                                                                 K,
+                                                                 alpha,
+                                                                 lda,
+                                                                 ldb,
+                                                                 beta,
+                                                                 ldc,
+                                                                 norm_check,
+                                                                 unit_check,
+                                                                 a_type,
+                                                                 b_type,
+                                                                 c_type,
+                                                                 batch_count,
+                                                                 compute_type,
+                                                                 argus.fortran);
     }
     else if(a_type == HIPBLAS_R_32F && b_type == HIPBLAS_R_32F && c_type == HIPBLAS_R_32F
             && c_type == HIPBLAS_R_32F && compute_type == HIPBLAS_R_32F)
     {
-        status = testing_gemm_strided_batched_ex_template<float, float>(transA,
-                                                                        transB,
-                                                                        M,
-                                                                        N,
-                                                                        K,
-                                                                        alpha,
-                                                                        lda,
-                                                                        ldb,
-                                                                        beta,
-                                                                        ldc,
-                                                                        norm_check,
-                                                                        unit_check,
-                                                                        a_type,
-                                                                        b_type,
-                                                                        c_type,
-                                                                        batch_count,
-                                                                        compute_type,
-                                                                        argus.fortran);
+        status = testing_gemm_strided_batched_ex_template<float>(transA,
+                                                                 transB,
+                                                                 M,
+                                                                 N,
+                                                                 K,
+                                                                 alpha,
+                                                                 lda,
+                                                                 ldb,
+                                                                 beta,
+                                                                 ldc,
+                                                                 norm_check,
+                                                                 unit_check,
+                                                                 a_type,
+                                                                 b_type,
+                                                                 c_type,
+                                                                 batch_count,
+                                                                 compute_type,
+                                                                 argus.fortran);
     }
     else if(a_type == HIPBLAS_R_64F && b_type == HIPBLAS_R_64F && c_type == HIPBLAS_R_64F
             && c_type == HIPBLAS_R_64F && compute_type == HIPBLAS_R_64F)
     {
-        status = testing_gemm_strided_batched_ex_template<double, double>(transA,
+        status = testing_gemm_strided_batched_ex_template<double>(transA,
+                                                                  transB,
+                                                                  M,
+                                                                  N,
+                                                                  K,
+                                                                  alpha,
+                                                                  lda,
+                                                                  ldb,
+                                                                  beta,
+                                                                  ldc,
+                                                                  norm_check,
+                                                                  unit_check,
+                                                                  a_type,
+                                                                  b_type,
+                                                                  c_type,
+                                                                  batch_count,
+                                                                  compute_type,
+                                                                  argus.fortran);
+    }
+    else if(a_type == HIPBLAS_C_32F && b_type == HIPBLAS_C_32F && c_type == HIPBLAS_C_32F
+            && c_type == HIPBLAS_C_32F && compute_type == HIPBLAS_C_32F)
+    {
+        status = testing_gemm_strided_batched_ex_template<hipblasComplex>(transA,
                                                                           transB,
                                                                           M,
                                                                           N,
@@ -331,6 +370,51 @@ hipblasStatus_t testing_gemm_strided_batched_ex(Arguments argus)
                                                                           batch_count,
                                                                           compute_type,
                                                                           argus.fortran);
+    }
+    else if(a_type == HIPBLAS_C_64F && b_type == HIPBLAS_C_64F && c_type == HIPBLAS_C_64F
+            && c_type == HIPBLAS_C_64F && compute_type == HIPBLAS_C_64F)
+    {
+        status = testing_gemm_strided_batched_ex_template<hipblasDoubleComplex>(transA,
+                                                                                transB,
+                                                                                M,
+                                                                                N,
+                                                                                K,
+                                                                                alpha,
+                                                                                lda,
+                                                                                ldb,
+                                                                                beta,
+                                                                                ldc,
+                                                                                norm_check,
+                                                                                unit_check,
+                                                                                a_type,
+                                                                                b_type,
+                                                                                c_type,
+                                                                                batch_count,
+                                                                                compute_type,
+                                                                                argus.fortran);
+    }
+    else if(a_type == HIPBLAS_R_8I && b_type == HIPBLAS_R_8I && c_type == HIPBLAS_R_32I
+            && c_type == HIPBLAS_R_32I && compute_type == HIPBLAS_R_32I)
+    {
+        status = testing_gemm_strided_batched_ex_template<int8_t, int8_t, int32_t, int32_t>(
+            transA,
+            transB,
+            M,
+            N,
+            K,
+            alpha,
+            lda,
+            ldb,
+            beta,
+            ldc,
+            norm_check,
+            unit_check,
+            a_type,
+            b_type,
+            c_type,
+            batch_count,
+            compute_type,
+            argus.fortran);
     }
     else
     {

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -139,6 +139,10 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(hipblasOperation_t tran
     hC_gold = hC;
 
     // copy data from CPU to device
+#ifdef __HIP_PLATFORM_NVCC__
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+#else
     if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N)
     {
         vector<Ta> hA_packed(hA);
@@ -162,7 +166,7 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(hipblasOperation_t tran
     {
         CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
     }
-
+#endif
     CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(Tc) * size_C, hipMemcpyHostToDevice));
 
     status = hipblasGemmStridedBatchedExFn(handle,

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -78,7 +78,7 @@ hipblasStatus_t testing_getrs(Arguments argus)
 
     // Calculate hB = hA*hX;
     hipblasOperation_t op = HIPBLAS_OP_N;
-    cblas_gemm<T>(op, op, N, 1, N, 1, hA.data(), lda, hX.data(), ldb, 0, hB.data(), ldb);
+    cblas_gemm<T>(op, op, N, 1, N, (T)1, hA.data(), lda, hX.data(), ldb, (T)0, hB.data(), ldb);
 
     // LU factorize hA on the CPU
     info = cblas_getrf<T>(N, N, hA.data(), lda, hIpiv.data());

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -96,7 +96,7 @@ hipblasStatus_t testing_getrs_batched(Arguments argus)
 
         // Calculate hB = hA*hX;
         cblas_gemm<T>(
-            op, op, N, 1, N, 1, hA[b].data(), lda, hX[b].data(), ldb, 0, hB[b].data(), ldb);
+            op, op, N, 1, N, (T)1, hA[b].data(), lda, hX[b].data(), ldb, (T)0, hB[b].data(), ldb);
 
         // LU factorize hA on the CPU
         info = cblas_getrf<T>(N, N, hA[b].data(), lda, hIpiv.data() + b * strideP);

--- a/clients/include/testing_getrs_strided_batched.hpp
+++ b/clients/include/testing_getrs_strided_batched.hpp
@@ -95,7 +95,7 @@ hipblasStatus_t testing_getrs_strided_batched(Arguments argus)
         }
 
         // Calculate hB = hA*hX;
-        cblas_gemm<T>(op, op, N, 1, N, 1, hAb, lda, hXb, ldb, 0, hBb, ldb);
+        cblas_gemm<T>(op, op, N, 1, N, (T)1, hAb, lda, hXb, ldb, (T)0, hBb, ldb);
 
         // LU factorize hA on the CPU
         info = cblas_getrf<T>(N, N, hAb, lda, hIpivb);

--- a/clients/include/testing_tpsv.hpp
+++ b/clients/include/testing_tpsv.hpp
@@ -72,8 +72,19 @@ hipblasStatus_t testing_tpsv(Arguments argus)
     hipblas_init<T>(hA, N, N, 1);
 
     //  calculate AAT = hA * hA ^ T
-    cblas_gemm<T>(
-        HIPBLAS_OP_N, HIPBLAS_OP_T, N, N, N, 1.0, hA.data(), N, hA.data(), N, 0.0, AAT.data(), N);
+    cblas_gemm<T>(HIPBLAS_OP_N,
+                  HIPBLAS_OP_T,
+                  N,
+                  N,
+                  N,
+                  (T)1.0,
+                  hA.data(),
+                  N,
+                  hA.data(),
+                  N,
+                  (T)0.0,
+                  AAT.data(),
+                  N);
 
     //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
     for(int i = 0; i < N; i++)

--- a/clients/include/testing_tpsv_batched.hpp
+++ b/clients/include/testing_tpsv_batched.hpp
@@ -99,7 +99,19 @@ hipblasStatus_t testing_tpsv_batched(Arguments argus)
         hipblas_init<T>(hA[b], N, N, N);
 
         //  calculate AAT = hA * hA ^ T
-        cblas_gemm<T>(HIPBLAS_OP_N, HIPBLAS_OP_T, N, N, N, 1.0, hA[b], N, hA[b], N, 0.0, AAT[b], N);
+        cblas_gemm<T>(HIPBLAS_OP_N,
+                      HIPBLAS_OP_T,
+                      N,
+                      N,
+                      N,
+                      (T)1.0,
+                      (T*)hA[b],
+                      N,
+                      (T*)hA[b],
+                      N,
+                      (T)0.0,
+                      (T*)AAT[b],
+                      N);
 
         //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
         for(int i = 0; i < N; i++)

--- a/clients/include/testing_tpsv_strided_batched.hpp
+++ b/clients/include/testing_tpsv_strided_batched.hpp
@@ -87,7 +87,7 @@ hipblasStatus_t testing_tpsv_strided_batched(Arguments argus)
         T* AATb = AAT.data() + b * strideA;
         T* hbb  = hb.data() + b * stridex;
         //  calculate AAT = hA * hA ^ T
-        cblas_gemm<T>(HIPBLAS_OP_N, HIPBLAS_OP_T, N, N, N, 1.0, hAb, N, hAb, N, 0.0, AATb, N);
+        cblas_gemm<T>(HIPBLAS_OP_N, HIPBLAS_OP_T, N, N, N, (T)1.0, hAb, N, hAb, N, (T)0.0, AATb, N);
 
         //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
         for(int i = 0; i < N; i++)

--- a/clients/include/testing_trsv.hpp
+++ b/clients/include/testing_trsv.hpp
@@ -87,12 +87,12 @@ hipblasStatus_t testing_trsv(Arguments argus)
                   M,
                   M,
                   M,
-                  1.0,
+                  (T)1.0,
                   hA.data(),
                   lda,
                   hA.data(),
                   lda,
-                  0.0,
+                  (T)0.0,
                   AAT.data(),
                   lda);
 

--- a/clients/include/testing_trsv_batched.hpp
+++ b/clients/include/testing_trsv_batched.hpp
@@ -97,8 +97,19 @@ hipblasStatus_t testing_trsv_batched(Arguments argus)
         hipblas_init<T>(hA[b], M, M, lda);
 
         //  calculate AAT = hA * hA ^ T
-        cblas_gemm<T>(
-            HIPBLAS_OP_N, HIPBLAS_OP_T, M, M, M, 1.0, hA[b], lda, hA[b], lda, 0.0, AAT[b], lda);
+        cblas_gemm<T>(HIPBLAS_OP_N,
+                      HIPBLAS_OP_T,
+                      M,
+                      M,
+                      M,
+                      (T)1.0,
+                      (T*)hA[b],
+                      lda,
+                      (T*)hA[b],
+                      lda,
+                      (T)0.0,
+                      (T*)AAT[b],
+                      lda);
 
         //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
         for(int i = 0; i < M; i++)

--- a/clients/include/testing_trsv_strided_batched.hpp
+++ b/clients/include/testing_trsv_strided_batched.hpp
@@ -87,7 +87,8 @@ hipblasStatus_t testing_trsv_strided_batched(Arguments argus)
         T* AATb = AAT.data() + b * strideA;
         T* hbb  = hb.data() + b * stridex;
         //  calculate AAT = hA * hA ^ T
-        cblas_gemm<T>(HIPBLAS_OP_N, HIPBLAS_OP_T, M, M, M, 1.0, hAb, lda, hAb, lda, 0.0, AATb, lda);
+        cblas_gemm<T>(
+            HIPBLAS_OP_N, HIPBLAS_OP_T, M, M, M, (T)1.0, hAb, lda, hAb, lda, (T)0.0, AATb, lda);
 
         //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
         for(int i = 0; i < M; i++)

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -329,6 +329,23 @@ inline hipblasDoubleComplex random_generator_negative<hipblasDoubleComplex>()
 /* ============================================================================================ */
 
 /* ============================================================================================ */
+/*! \brief Packs strided_batched matricies into groups of 4 in N */
+template <typename T>
+void hipblas_packInt8(
+    std::vector<T>& A, size_t M, size_t N, size_t lda, size_t batch_count = 1, size_t stride_a = 0)
+{
+    std::vector<T> temp(A);
+    for(size_t b = 0; b < batch_count; b++)
+        for(size_t colBase = 0; colBase < N; colBase += 4)
+            for(size_t row = 0; row < lda; row++)
+                for(size_t colOffset = 0; colOffset < 4; colOffset++)
+                    A[(colBase * lda + 4 * row) + colOffset + (stride_a * b)]
+                        = temp[(colBase + colOffset) * lda + row + (stride_a * b)];
+}
+
+/* ============================================================================================ */
+
+/* ============================================================================================ */
 /*! \brief  matrix/vector initialization: */
 // for vector x (M=1, N=lengthX, lda=incx);
 // for complex number, the real/imag part would be initialized with the same value

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -173,6 +173,12 @@ rocblas_datatype HIPDatatypeToRocblasDatatype(hipblasDatatype_t type)
     case HIPBLAS_R_64F:
         return rocblas_datatype_f64_r;
 
+    case HIPBLAS_R_8I:
+        return rocblas_datatype_i8_r;
+
+    case HIPBLAS_R_32I:
+        return rocblas_datatype_i32_r;
+
     case HIPBLAS_C_16F:
         return rocblas_datatype_f16_c;
 
@@ -199,6 +205,12 @@ hipblasDatatype_t RocblasDatatypeToHIPDatatype(rocblas_datatype type)
 
     case rocblas_datatype_f64_r:
         return HIPBLAS_R_64F;
+
+    case rocblas_datatype_i8_r:
+        return HIPBLAS_R_8I;
+
+    case rocblas_datatype_i32_r:
+        return HIPBLAS_R_32I;
 
     case rocblas_datatype_f16_c:
         return HIPBLAS_C_16F;

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -169,6 +169,12 @@ cudaDataType_t HIPDatatypeToCudaDatatype(hipblasDatatype_t type)
     case HIPBLAS_R_64F:
         return CUDA_R_64F;
 
+    case HIPBLAS_R_8I:
+        return CUDA_R_8I;
+
+    case HIPBLAS_R_32I:
+        return CUDA_R_32I;
+
     case HIPBLAS_C_16F:
         return CUDA_C_16F;
 


### PR DESCRIPTION
- Added missing conversion functions for these types in hipblas:
  - `HIPBLAS_R_8I`
  - `HIPBLAS_R_32I`

This enables support for some additional gemmEx functions which we support in rocBLAS (mainly i8/i32 mixed precision).

- Added missing tests for complex gemmEx
- Added missing tests for i8/i32 gemmEx

Most of the changes here are incidental from changing the cblas interface. I tried to make few changes in the testing code since this is going to master, but the gemm testing can definitely be cleanup up quite a bit later.
Also apparently in cublas before v10, gemmEx only supports alpha, beta = 0 or 1 for i8/i32 precision. Also that precision isn't supported in their batched versions.