### PR TITLE
Remove setting a different default device memory size

### DIFF
--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -297,9 +297,6 @@ hipblasStatus_t hipblasCreate(hipblasHandle_t* handle)
     if(!handle)
         return HIPBLAS_STATUS_HANDLE_IS_NULLPTR;
 
-    // We set the default device memory size to a larger size than rocBLAS's default
-    rocblas_device_malloc_set_default_memory_size(16 * 1024 * 1024);
-
     // Create the rocBLAS handle
     return rocBLASStatusToHIPStatus(rocblas_create_handle((rocblas_handle*)handle));
 }


### PR DESCRIPTION
With the size of rocBLAS's default device memory allocation increased to 32 MB, we don't really need to allocate a different default in hipBLAS.