### PR TITLE
Divide time by iterations in bench logging

### DIFF
--- a/clients/include/argument_model.hpp
+++ b/clients/include/argument_model.hpp
@@ -43,7 +43,8 @@ public:
 
         // append performance fields
         name_line << ",hipblas-Gflops,hipblas-GB/s,hipblas-us,";
-        val_line << ", " << hipblas_gflops << ", " << hipblas_GBps << ", " << gpu_us << ", ";
+        val_line << ", " << hipblas_gflops << ", " << hipblas_GBps << ", " << gpu_us / hot_calls
+                 << ", ";
 
         if(arg.unit_check || arg.norm_check)
         {


### PR DESCRIPTION
The time taken to run a benchmark is now the average over all iterations, rather than the cumulative sum.