### PR TITLE
Removing rocm dependency for CUDA builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,15 @@ include( ROCMInstallSymlinks )
 set ( VERSION_STRING "0.41.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
+if( NOT DEFINED $ENV{HIP_PATH})
+    set( HIP_PATH "/opt/rocm-3.9.0/hip" )
+else( )
+    set (HIP_PATH $ENV{HIP_PATH} )
+endif( )
+
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake  ${HIP_PATH}/cmake)
 
 # NOTE:  workaround until hip cmake modules fixes symlink logic in their config files; remove when fixed
 list( APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/llvm /opt/rocm/hip )
@@ -72,7 +78,7 @@ option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 
 
 # Hip headers required of all clients; clients use hip to allocate device memory
-find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
+find_package( HIP REQUIRED )
 
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,10 @@ if(USE_CUDA)
     find_package( CUDA QUIET )
 endif()
 
+if( USE_CUDA )
+    list( APPEND HIP_INCLUDE_DIRS "${HIP_ROOT_DIR}/include" )
+endif( )
+
 # CMake list of machine targets
 set( AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target" )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set ( VERSION_STRING "0.41.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 if( NOT DEFINED $ENV{HIP_PATH})
-    set( HIP_PATH "/opt/rocm-3.9.0/hip" )
+    set( HIP_PATH "/opt/rocm/hip" )
 else( )
     set (HIP_PATH $ENV{HIP_PATH} )
 endif( )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,16 +76,19 @@ endif( )
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 
-
-# Hip headers required of all clients; clients use hip to allocate device memory
-find_package( HIP REQUIRED )
-
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend
 option(USE_CUDA "Look for CUDA and use that as a backend if found" ON)
 if(USE_CUDA)
     find_package( CUDA QUIET )
 endif()
+
+# Hip headers required of all clients; clients use hip to allocate device memory
+if( USE_CUDA)
+    find_package( HIP REQUIRED )
+else( )
+    find_package(hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
+endif( )
 
 if( USE_CUDA )
     list( APPEND HIP_INCLUDE_DIRS "${HIP_ROOT_DIR}/include" )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -5,7 +5,7 @@
 # This is incremented when the ABI to the library changes
 set( hipblas_SOVERSION 0.1 )
 
-list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
+list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${HIP_PATH}/cmake )
 
 # This option only works for make/nmake and the ninja generators, but no reason it shouldn't be on all the time
 # This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -60,8 +60,10 @@ add_subdirectory( src )
 # endif( )
 
 # Package specific CPACK vars
-set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocblas (>= 2.35.0), rocsolver (>= 3.11.0)" )
-set( CPACK_RPM_PACKAGE_REQUIRES "rocblas >= 2.35.0, rocsolver >= 3.11.0" )
+if( NOT USE_CUDA )
+    set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocblas (>= 2.35.0), rocsolver (>= 3.11.0)" )
+    set( CPACK_RPM_PACKAGE_REQUIRES "rocblas >= 2.35.0, rocsolver >= 3.11.0" )
+endif( )
 
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -125,13 +125,14 @@ if ( NOT USE_CUDA )
     rocm_export_targets(
         TARGETS roc::hipblas
 	PREFIX hipblas
-	DEPENDS PACKAGE HIP
+	DEPENDS PACKAGE hip
 	NAMESPACE roc::
     )
 else( )
     rocm_export_targets(
         TARGETS roc::hipblas
 	PREFIX hipblas
+	DEPENDS PACKAGE HIP
 	NAMESPACE roc::
     )
 endif( )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -121,12 +121,20 @@ rocm_install_targets(
 )
 #         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
 
-rocm_export_targets(
-  TARGETS roc::hipblas
-  PREFIX hipblas
-  DEPENDS PACKAGE HIP
-  NAMESPACE roc::
- )
+if ( NOT USE_CUDA )
+    rocm_export_targets(
+        TARGETS roc::hipblas
+	PREFIX hipblas
+	DEPENDS PACKAGE HIP
+	NAMESPACE roc::
+    )
+else( )
+    rocm_export_targets(
+        TARGETS roc::hipblas
+	PREFIX hipblas
+	NAMESPACE roc::
+    )
+endif( )
 
 # Force installation of .f90 module files
 install(FILES "hipblas_module.f90"


### PR DESCRIPTION
After removing all rocm libraries, and installing hip-nvcc, this seems to work on a CUDA machine, tests are currently running. This seems to be consistent with hipSPARSE for the most part. @YvanMokwinski if you notice anything that drastically differs, let me know!

Sidenote: The dependency installation seems to be weird on my CUDA machine, I had to do a small workaround to get them to be found, I'll look into this tomorrow, but it's unrelated to this PR.