### PR TITLE
Fixed erroneous caxpy and zaxpy method signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for hipBLAS
 
+## [(Unreleased) hipBLAS 0.42.0 for ROCm 4.1.0]
+### Fixed
+- Fixed complex unit test bug caused by incorrect caxpy and zaxpy function signatures
+
 ## [hipBLAS 0.40.0 for ROCm 4.0.0]
 ### Added
 - Added changelog

--- a/clients/common/norm.cpp
+++ b/clients/common/norm.cpp
@@ -38,9 +38,14 @@ double dlansy_(char* norm_type, char* uplo, int* n, double* A, int* lda, double*
 
 void saxpy_(int* n, float* alpha, float* x, int* incx, float* y, int* incy);
 void daxpy_(int* n, double* alpha, double* x, int* incx, double* y, int* incy);
-void caxpy_(int* n, float* alpha, hipblasComplex* x, int* incx, hipblasComplex* y, int* incy);
-void zaxpy_(
-    int* n, double* alpha, hipblasDoubleComplex* x, int* incx, hipblasDoubleComplex* y, int* incy);
+void caxpy_(
+    int* n, hipblasComplex* alpha, hipblasComplex* x, int* incx, hipblasComplex* y, int* incy);
+void zaxpy_(int*                  n,
+            hipblasDoubleComplex* alpha,
+            hipblasDoubleComplex* x,
+            int*                  incx,
+            hipblasDoubleComplex* y,
+            int*                  incy);
 
 #ifdef __cplusplus
 }
@@ -92,10 +97,10 @@ double norm_check_general<hipblasComplex>(
 {
     //norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
-    float work[1];
-    int   incx  = 1;
-    float alpha = -1.0f;
-    int   size  = lda * N;
+    float          work[1];
+    int            incx  = 1;
+    hipblasComplex alpha = -1.0f;
+    int            size  = lda * N;
 
     float cpu_norm = clange_(&norm_type, &M, &N, hCPU, &lda, work);
     caxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
@@ -111,10 +116,10 @@ double norm_check_general<hipblasDoubleComplex>(
 {
     //norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
-    double work[1];
-    int    incx  = 1;
-    double alpha = -1.0;
-    int    size  = lda * N;
+    double               work[1];
+    int                  incx  = 1;
+    hipblasDoubleComplex alpha = -1.0;
+    int                  size  = lda * N;
 
     double cpu_norm = zlange_(&norm_type, &M, &N, hCPU, &lda, work);
     zaxpy_(&size, &alpha, hCPU, &incx, hGPU, &incx);
@@ -211,7 +216,7 @@ double norm_check_symmetric<double>(
 //
 //    float work[1];
 //    int incx = 1;
-//    float alpha = -1.0f;
+//    hipblasComplex alpha = -1.0f;
 //    int size = lda * N;
 //
 //    float cpu_norm = clanhe_(&norm_type, &uplo, &N, hCPU, &lda, work);
@@ -230,7 +235,7 @@ double norm_check_symmetric<double>(
 //
 //    double work[1];
 //    int incx = 1;
-//    double alpha = -1.0;
+//    hipblasDoubleComplex alpha = -1.0;
 //    int size = lda * N;
 //
 //    double cpu_norm = zlanhe_(&norm_type, &uplo, &N, hCPU, &lda, work);

--- a/docker/dockerfile-build-nvidia-cuda
+++ b/docker/dockerfile-build-nvidia-cuda
@@ -38,12 +38,12 @@ RUN useradd --create-home -u ${user_uid} -o -G sudo --shell /bin/bash jenkins &&
     mkdir -p /etc/sudoers.d/ && \
     echo '%sudo   ALL=(ALL) NOPASSWD:ALL' | tee /etc/sudoers.d/sudo-nopasswd
 
-ARG HIPBLAS_SRC_ROOT=/usr/local/src/rocBLAS
+ARG HIPBLAS_SRC_ROOT=/usr/local/src/hipBLAS
 
 # Clone hipblas repo
 # Build client dependencies and install into /usr/local (LAPACK & GTEST)
 RUN mkdir -p ${HIPBLAS_SRC_ROOT} && cd ${HIPBLAS_SRC_ROOT} && \
-    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocBLAS . && \
+    git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/hipBLAS . && \
     mkdir -p build/deps && cd build/deps && \
     cmake -DBUILD_BOOST=OFF ${HIPBLAS_SRC_ROOT}/deps && \
     make -j $(nproc) install && \


### PR DESCRIPTION
Related to https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/188

The method signature for caxpy in norm.cpp had alpha as a float, whereas the LAPACK signature has alpha as a single complex. A similar error affects the norm.cpp version of zaxpy.

A separate fix has dockerfile-build-nvidia-cuda point to hipBLAS directories, rather than rocBLAS.