### PR TITLE
Updating nrm2 tolerance code

### DIFF
--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -102,9 +102,8 @@ hipblasStatus_t testing_nrm2(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            T2 tolerance = 2.0 * N;
-            unit_check_nrm2<T2>(cpu_result, rocblas_result_1, tolerance);
-            unit_check_nrm2<T2>(cpu_result, rocblas_result_2, tolerance);
+            unit_check_nrm2<T2>(cpu_result, rocblas_result_1, N);
+            unit_check_nrm2<T2>(cpu_result, rocblas_result_2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -13,15 +13,6 @@ using namespace std;
 
 /* ============================================================================================ */
 
-// Tolerance of 100 fails for complex,
-// TODO: something better than arbitrary tolerance.
-template <typename T>
-constexpr double nrm2_tolerance_multiplier = 100;
-template <>
-constexpr double nrm2_tolerance_multiplier<hipblasComplex> = 110;
-template <>
-constexpr double nrm2_tolerance_multiplier<hipblasDoubleComplex> = 110;
-
 template <typename T1, typename T2>
 hipblasStatus_t testing_nrm2(const Arguments& argus)
 {
@@ -111,7 +102,7 @@ hipblasStatus_t testing_nrm2(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            T2 tolerance = nrm2_tolerance_multiplier<T1>;
+            T2 tolerance = 2.0 * N;
             unit_check_nrm2<T2>(cpu_result, rocblas_result_1, tolerance);
             unit_check_nrm2<T2>(cpu_result, rocblas_result_2, tolerance);
         }

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -116,9 +116,8 @@ hipblasStatus_t testing_nrm2_batched(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            T2 tolerance = 2.0 * N;
-            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_1, tolerance);
-            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_2, tolerance);
+            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_1, N);
+            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -13,15 +13,6 @@ using namespace std;
 
 /* ============================================================================================ */
 
-// Tolerance of 100 fails for complex,
-// TODO: something better than arbitrary tolerance.
-template <typename T>
-constexpr double nrm2_batched_tolerance_multiplier = 100;
-template <>
-constexpr double nrm2_batched_tolerance_multiplier<hipblasComplex> = 110;
-template <>
-constexpr double nrm2_batched_tolerance_multiplier<hipblasDoubleComplex> = 110;
-
 template <typename T1, typename T2>
 hipblasStatus_t testing_nrm2_batched(const Arguments& argus)
 {
@@ -125,12 +116,9 @@ hipblasStatus_t testing_nrm2_batched(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            T2 tolerance = nrm2_tolerance_multiplier<T1>;
-            for(int b = 0; b < batch_count; b++)
-            {
-                unit_check_nrm2<T2>(h_cpu_result[b], h_rocblas_result_1[b], tolerance);
-                unit_check_nrm2<T2>(h_cpu_result[b], h_rocblas_result_2[b], tolerance);
-            }
+            T2 tolerance = 2.0 * N;
+            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_1, tolerance);
+            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_2, tolerance);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -13,15 +13,6 @@ using namespace std;
 
 /* ============================================================================================ */
 
-// Tolerance of 100 fails for complex,
-// TODO: something better than arbitrary tolerance.
-template <typename T>
-constexpr double nrm2_batched_ex_tolerance_multiplier = 100;
-template <>
-constexpr double nrm2_batched_ex_tolerance_multiplier<hipblasComplex> = 110;
-template <>
-constexpr double nrm2_batched_ex_tolerance_multiplier<hipblasDoubleComplex> = 110;
-
 template <typename Tx, typename Tr = Tx, typename Tex = Tr>
 hipblasStatus_t testing_nrm2_batched_ex_template(Arguments argus)
 {
@@ -128,12 +119,9 @@ hipblasStatus_t testing_nrm2_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            Tr tolerance = Tr(nrm2_batched_ex_tolerance_multiplier<Tr>);
-            for(int b = 0; b < batch_count; b++)
-            {
-                unit_check_nrm2<Tr>(h_cpu_result[b], h_rocblas_result1[b], tolerance);
-                unit_check_nrm2<Tr>(h_cpu_result[b], h_rocblas_result2[b], tolerance);
-            }
+            Tr tolerance = 2.0 * N;
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, tolerance);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, tolerance);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -119,9 +119,8 @@ hipblasStatus_t testing_nrm2_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            Tr tolerance = 2.0 * N;
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, tolerance);
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, tolerance);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, N);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_ex.hpp
+++ b/clients/include/testing_nrm2_ex.hpp
@@ -97,9 +97,8 @@ hipblasStatus_t testing_nrm2_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            Tr tolerance = 2.0 * N;
-            unit_check_nrm2<Tr>(cpu_result, rocblas_result_1, tolerance);
-            unit_check_nrm2<Tr>(cpu_result, rocblas_result_2, tolerance);
+            unit_check_nrm2<Tr>(cpu_result, rocblas_result_1, N);
+            unit_check_nrm2<Tr>(cpu_result, rocblas_result_2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_ex.hpp
+++ b/clients/include/testing_nrm2_ex.hpp
@@ -13,15 +13,6 @@ using namespace std;
 
 /* ============================================================================================ */
 
-// Tolerance of 100 fails for complex,
-// TODO: something better than arbitrary tolerance.
-template <typename T>
-constexpr double nrm2_ex_tolerance_multiplier = 100;
-template <>
-constexpr double nrm2_ex_tolerance_multiplier<hipblasComplex> = 110;
-template <>
-constexpr double nrm2_ex_tolerance_multiplier<hipblasDoubleComplex> = 110;
-
 template <typename Tx, typename Tr = Tx, typename Tex = Tr>
 hipblasStatus_t testing_nrm2_ex_template(Arguments argus)
 {
@@ -106,7 +97,7 @@ hipblasStatus_t testing_nrm2_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            Tr tolerance = Tr(nrm2_ex_tolerance_multiplier<Tr>);
+            Tr tolerance = 2.0 * N;
             unit_check_nrm2<Tr>(cpu_result, rocblas_result_1, tolerance);
             unit_check_nrm2<Tr>(cpu_result, rocblas_result_2, tolerance);
         }

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -13,15 +13,6 @@ using namespace std;
 
 /* ============================================================================================ */
 
-// Tolerance of 100 fails for complex,
-// TODO: something better than arbitrary tolerance.
-template <typename T>
-constexpr double nrm2_strided_batched_tolerance_multiplier = 100;
-template <>
-constexpr double nrm2_strided_batched_tolerance_multiplier<hipblasComplex> = 110;
-template <>
-constexpr double nrm2_strided_batched_tolerance_multiplier<hipblasDoubleComplex> = 110;
-
 template <typename T1, typename T2>
 hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
 {
@@ -113,12 +104,9 @@ hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            T2 tolerance = nrm2_tolerance_multiplier<T1>;
-            for(int b = 0; b < batch_count; b++)
-            {
-                unit_check_nrm2<T2>(h_cpu_result[b], h_rocblas_result_1[b], tolerance);
-                unit_check_nrm2<T2>(h_cpu_result[b], h_rocblas_result_2[b], tolerance);
-            }
+            T2 tolerance = 2.0 * N;
+            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_1, tolerance);
+            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_2, tolerance);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -104,9 +104,8 @@ hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            T2 tolerance = 2.0 * N;
-            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_1, tolerance);
-            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_2, tolerance);
+            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_1, N);
+            unit_check_nrm2<T2>(batch_count, h_cpu_result, h_rocblas_result_2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -13,15 +13,6 @@ using namespace std;
 
 /* ============================================================================================ */
 
-// Tolerance of 100 fails for complex,
-// TODO: something better than arbitrary tolerance.
-template <typename T>
-constexpr double nrm2_strided_batched_ex_tolerance_multiplier = 100;
-template <>
-constexpr double nrm2_strided_batched_ex_tolerance_multiplier<hipblasComplex> = 110;
-template <>
-constexpr double nrm2_strided_batched_ex_tolerance_multiplier<hipblasDoubleComplex> = 110;
-
 template <typename Tx, typename Tr = Tx, typename Tex = Tr>
 hipblasStatus_t testing_nrm2_strided_batched_ex_template(Arguments argus)
 {
@@ -133,12 +124,9 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            Tr tolerance = Tr(nrm2_strided_batched_ex_tolerance_multiplier<Tr>);
-            for(int b = 0; b < batch_count; b++)
-            {
-                unit_check_nrm2<Tr>(h_cpu_result[b], h_rocblas_result1[b], tolerance);
-                unit_check_nrm2<Tr>(h_cpu_result[b], h_rocblas_result2[b], tolerance);
-            }
+            Tr tolerance = 2.0 * N;
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, tolerance);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, tolerance);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -124,9 +124,8 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            Tr tolerance = 2.0 * N;
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, tolerance);
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, tolerance);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, N);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -53,11 +53,11 @@ void unit_check_error(T error, T tolerance)
 }
 
 template <typename T>
-void unit_check_nrm2(T cpu_result, T gpu_result, T tolerance)
+void unit_check_nrm2(T cpu_result, T gpu_result, int vector_length)
 {
-    T allowable_error = tolerance * std::numeric_limits<T>::epsilon() * cpu_result;
+    T allowable_error = vector_length * std::numeric_limits<T>::epsilon() * cpu_result;
     if(allowable_error == 0)
-        allowable_error = tolerance * std::numeric_limits<T>::epsilon();
+        allowable_error = vector_length * std::numeric_limits<T>::epsilon();
 #ifdef GOOGLE_TEST
     ASSERT_NEAR(cpu_result, gpu_result, allowable_error);
 #endif
@@ -67,13 +67,13 @@ template <typename T>
 void unit_check_nrm2(int            batch_count,
                      host_vector<T> cpu_result,
                      host_vector<T> gpu_result,
-                     T              tolerance)
+                     int            vector_length)
 {
     for(int b = 0; b < batch_count; b++)
     {
-        T allowable_error = tolerance * std::numeric_limits<T>::epsilon() * cpu_result[b];
+        T allowable_error = vector_length * std::numeric_limits<T>::epsilon() * cpu_result[b];
         if(allowable_error == 0)
-            allowable_error = tolerance * std::numeric_limits<T>::epsilon();
+            allowable_error = vector_length * std::numeric_limits<T>::epsilon();
 #ifdef GOOGLE_TEST
         ASSERT_NEAR(cpu_result[b], gpu_result[b], allowable_error);
 #endif

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -63,4 +63,21 @@ void unit_check_nrm2(T cpu_result, T gpu_result, T tolerance)
 #endif
 }
 
+template <typename T>
+void unit_check_nrm2(int            batch_count,
+                     host_vector<T> cpu_result,
+                     host_vector<T> gpu_result,
+                     T              tolerance)
+{
+    for(int b = 0; b < batch_count; b++)
+    {
+        T allowable_error = tolerance * std::numeric_limits<T>::epsilon() * cpu_result[b];
+        if(allowable_error == 0)
+            allowable_error = tolerance * std::numeric_limits<T>::epsilon();
+#ifdef GOOGLE_TEST
+        ASSERT_NEAR(cpu_result[b], gpu_result[b], allowable_error);
+#endif
+    }
+}
+
 #endif


### PR DESCRIPTION
Matching rocBLAS tolerance checking for nrm2.
See discussion [here](https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/pull/366#discussion_r504300139).