### PR TITLE
Adding updated batched vectors for tests - only on scal

### DIFF
--- a/clients/include/d_vector.hpp
+++ b/clients/include/d_vector.hpp
@@ -1,0 +1,101 @@
+/* ************************************************************************
+ * Copyright 2018-2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+
+#include "hipblas.h"
+#include <cinttypes>
+#include <gtest/gtest.h>
+
+/* ============================================================================================ */
+/*! \brief  base-class to allocate/deallocate device memory */
+template <typename T, size_t PAD, typename U>
+class d_vector
+{
+protected:
+    size_t size, bytes;
+
+    inline size_t nmemb() const noexcept
+    {
+        return size;
+    }
+
+#ifdef GOOGLE_TEST
+    U guard[PAD];
+    d_vector(size_t s)
+        : size(s)
+        , bytes((s + PAD * 2) * sizeof(T))
+    {
+        // Initialize guard with random data
+        if(PAD > 0)
+        {
+            hipblas_init_nan(guard, PAD);
+        }
+    }
+#else
+    d_vector(size_t s)
+        : size(s)
+        , bytes(s ? s * sizeof(T) : sizeof(T))
+    {
+    }
+#endif
+
+    T* device_vector_setup()
+    {
+        T* d;
+        if((hipMalloc)(&d, bytes) != hipSuccess)
+        {
+            static char* lc = setlocale(LC_NUMERIC, "");
+            fprintf(stderr, "Error allocating %'zu bytes (%zu GB)\n", bytes, bytes >> 30);
+            d = nullptr;
+        }
+#ifdef GOOGLE_TEST
+        else
+        {
+            if(PAD > 0)
+            {
+                // Copy guard to device memory before allocated memory
+                hipMemcpy(d, guard, sizeof(guard), hipMemcpyHostToDevice);
+
+                // Point to allocated block
+                d += PAD;
+
+                // Copy guard to device memory after allocated memory
+                hipMemcpy(d + size, guard, sizeof(guard), hipMemcpyHostToDevice);
+            }
+        }
+#endif
+        return d;
+    }
+
+    void device_vector_teardown(T* d)
+    {
+        if(d != nullptr)
+        {
+#ifdef GOOGLE_TEST
+            if(PAD > 0)
+            {
+                U host[PAD];
+
+                // Copy device memory after allocated memory to host
+                hipMemcpy(host, d + size, sizeof(guard), hipMemcpyDeviceToHost);
+
+                // Make sure no corruption has occurred
+                EXPECT_EQ(memcmp(host, guard, sizeof(guard)), 0);
+
+                // Point to guard before allocated memory
+                d -= PAD;
+
+                // Copy device memory after allocated memory to host
+                hipMemcpy(host, d, sizeof(guard), hipMemcpyDeviceToHost);
+
+                // Make sure no corruption has occurred
+                EXPECT_EQ(memcmp(host, guard, sizeof(guard)), 0);
+            }
+#endif
+            // Free device memory
+            CHECK_HIP_ERROR((hipFree)(d));
+        }
+    }
+};

--- a/clients/include/device_batch_vector.hpp
+++ b/clients/include/device_batch_vector.hpp
@@ -1,0 +1,298 @@
+//
+// Copyright 2018-2020 Advanced Micro Devices, Inc.
+//
+#pragma once
+
+// #include "d_vector.hpp"
+// #include "hipblas_vector.hpp"
+
+//
+// Local declaration of the host strided batch vector.
+//
+template <typename T>
+class host_batch_vector;
+
+//!
+//! @brief  pseudo-vector subclass which uses a batch of device memory pointers and
+//!  - an array of pointers in host memory
+//!  - an array of pointers in device memory
+//!
+template <typename T, size_t PAD = 4096, typename U = T>
+class device_batch_vector : private d_vector<T, PAD, U>
+{
+public:
+    //!
+    //! @brief Disallow copying.
+    //!
+    device_batch_vector(const device_batch_vector&) = delete;
+
+    //!
+    //! @brief Disallow assigning.
+    //!
+    device_batch_vector& operator=(const device_batch_vector&) = delete;
+
+    //!
+    //! @brief Constructor.
+    //! @param n           The length of the vector.
+    //! @param inc         The increment.
+    //! @param batch_count The batch count.
+    //!
+    explicit device_batch_vector(int n, int inc, int batch_count)
+        : m_n(n)
+        , m_inc(inc)
+        , m_batch_count(batch_count)
+        , d_vector<T, PAD, U>(size_t(n) * std::abs(inc))
+    {
+        if(false == this->try_initialize_memory())
+        {
+            this->free_memory();
+        }
+    }
+
+    //!
+    //! @brief Constructor.
+    //! @param n           The length of the vector.
+    //! @param inc         The increment.
+    //! @param stride      (UNUSED) The stride.
+    //! @param batch_count The batch count.
+    //!
+    explicit device_batch_vector(int n, int inc, hipblasStride stride, int batch_count)
+        : device_batch_vector(n, inc, batch_count)
+    {
+    }
+
+    //!
+    //! @brief Constructor (kept for backward compatibility only, to be removed).
+    //! @param batch_count The number of vectors.
+    //! @param size_vector The size of each vectors.
+    //!
+    explicit device_batch_vector(int batch_count, size_t size_vector)
+        : device_batch_vector(size_vector, 1, batch_count)
+    {
+    }
+
+    //!
+    //! @brief Destructor.
+    //!
+    ~device_batch_vector()
+    {
+        this->free_memory();
+    }
+
+    //!
+    //! @brief Returns the length of the vector.
+    //!
+    int n() const
+    {
+        return this->m_n;
+    }
+
+    //!
+    //! @brief Returns the increment of the vector.
+    //!
+    int inc() const
+    {
+        return this->m_inc;
+    }
+
+    //!
+    //! @brief Returns the value of batch_count.
+    //!
+    int batch_count() const
+    {
+        return this->m_batch_count;
+    }
+
+    //!
+    //! @brief Returns the stride value.
+    //!
+    hipblasStride stride() const
+    {
+        return 0;
+    }
+
+    //!
+    //! @brief Access to device data.
+    //! @return Pointer to the device data.
+    //!
+    T** ptr_on_device()
+    {
+        return this->m_device_data;
+    }
+
+    //!
+    //! @brief Const access to device data.
+    //! @return Const pointer to the device data.
+    //!
+    const T* const* ptr_on_device() const
+    {
+        return this->m_device_data;
+    }
+
+    //!
+    //! @brief access to device data.
+    //! @return Const pointer to the device data.
+    //!
+    T* const* const_batch_ptr()
+    {
+        return this->m_device_data;
+    }
+
+    //!
+    //! @brief Random access.
+    //! @param batch_index The batch index.
+    //! @return Pointer to the array on device.
+    //!
+    T* operator[](int batch_index)
+    {
+
+        return this->m_data[batch_index];
+    }
+
+    //!
+    //! @brief Constant random access.
+    //! @param batch_index The batch index.
+    //! @return Constant pointer to the array on device.
+    //!
+    const T* operator[](int batch_index) const
+    {
+
+        return this->m_data[batch_index];
+    }
+
+    //!
+    //! @brief Const cast of the data on host.
+    //!
+    operator const T* const *() const
+    {
+        return this->m_data;
+    }
+
+    //!
+    //! @brief Cast of the data on host.
+    //!
+    // clang-format off
+    operator T**()
+    // clang-format on
+    {
+        return this->m_data;
+    }
+
+    //!
+    //! @brief Tell whether ressources allocation failed.
+    //!
+    explicit operator bool() const
+    {
+        return nullptr != this->m_data;
+    }
+
+    //!
+    //! @brief Copy from a host batched vector.
+    //! @param that The host_batch_vector to copy.
+    //!
+    hipError_t transfer_from(const host_batch_vector<T>& that)
+    {
+        hipError_t hip_err;
+        //
+        // Copy each vector.
+        //
+        for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
+        {
+            if(hipSuccess
+               != (hip_err = hipMemcpy((*this)[batch_index],
+                                       that[batch_index],
+                                       sizeof(T) * this->nmemb(),
+                                       hipMemcpyHostToDevice)))
+            {
+                return hip_err;
+            }
+        }
+
+        return hipSuccess;
+    }
+
+    //!
+    //! @brief Check if memory exists.
+    //! @return hipSuccess if memory exists, hipErrorOutOfMemory otherwise.
+    //!
+    hipError_t memcheck() const
+    {
+        if(*this)
+            return hipSuccess;
+        else
+            return hipErrorOutOfMemory;
+    }
+
+private:
+    int m_n{};
+    int m_inc{};
+    int m_batch_count{};
+    T** m_data{};
+    T** m_device_data{};
+
+    //!
+    //! @brief Try to allocate the ressources.
+    //! @return true if success false otherwise.
+    //!
+    bool try_initialize_memory()
+    {
+        bool success = false;
+
+        success
+            = (hipSuccess == (hipMalloc)(&this->m_device_data, this->m_batch_count * sizeof(T*)));
+        if(success)
+        {
+            success = (nullptr != (this->m_data = (T**)calloc(this->m_batch_count, sizeof(T*))));
+            if(success)
+            {
+                for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
+                {
+                    success
+                        = (nullptr != (this->m_data[batch_index] = this->device_vector_setup()));
+                    if(!success)
+                    {
+                        break;
+                    }
+                }
+
+                if(success)
+                {
+                    success = (hipSuccess
+                               == hipMemcpy(this->m_device_data,
+                                            this->m_data,
+                                            sizeof(T*) * this->m_batch_count,
+                                            hipMemcpyHostToDevice));
+                }
+            }
+        }
+        return success;
+    }
+
+    //!
+    //! @brief Free the ressources, as much as we can.
+    //!
+    void free_memory()
+    {
+        if(nullptr != this->m_data)
+        {
+            for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
+            {
+                if(nullptr != this->m_data[batch_index])
+                {
+                    this->device_vector_teardown(this->m_data[batch_index]);
+                    this->m_data[batch_index] = nullptr;
+                }
+            }
+
+            free(this->m_data);
+            this->m_data = nullptr;
+        }
+
+        if(nullptr != this->m_device_data)
+        {
+            auto tmp_device_data = this->m_device_data;
+            this->m_device_data  = nullptr;
+            CHECK_HIP_ERROR((hipFree)(tmp_device_data));
+        }
+    }
+};

--- a/clients/include/hipblas_vector.hpp
+++ b/clients/include/hipblas_vector.hpp
@@ -5,147 +5,16 @@
 #ifndef HIPBLAS_VECTOR_H_
 #define HIPBLAS_VECTOR_H_
 
+#include "d_vector.hpp"
+#include "device_batch_vector.hpp"
 #include "hipblas.h"
+#include "host_batch_vector.hpp"
 #include "utility.h"
 #include <cinttypes>
 #include <cstdio>
 #include <gtest/gtest.h>
 #include <locale.h>
 #include <vector>
-
-/* ============================================================================================ */
-/*! \brief  base-class to allocate/deallocate device memory */
-template <typename T, size_t PAD, typename U>
-class d_vector
-{
-protected:
-    size_t size, bytes;
-
-#ifdef GOOGLE_TEST
-    U guard[PAD];
-    d_vector(size_t s)
-        : size(s)
-        , bytes((s + PAD * 2) * sizeof(T))
-    {
-        // Initialize guard with random data
-        if(PAD > 0)
-        {
-            hipblas_init_nan(guard, PAD);
-        }
-    }
-#else
-    d_vector(size_t s)
-        : size(s)
-        , bytes(s ? s * sizeof(T) : sizeof(T))
-    {
-    }
-#endif
-
-    T* device_vector_setup()
-    {
-        T* d;
-        if((hipMalloc)(&d, bytes) != hipSuccess)
-        {
-            static char* lc = setlocale(LC_NUMERIC, "");
-            fprintf(stderr, "Error allocating %'zu bytes (%zu GB)\n", bytes, bytes >> 30);
-            d = nullptr;
-        }
-#ifdef GOOGLE_TEST
-        else
-        {
-            if(PAD > 0)
-            {
-                // Copy guard to device memory before allocated memory
-                hipMemcpy(d, guard, sizeof(guard), hipMemcpyHostToDevice);
-
-                // Point to allocated block
-                d += PAD;
-
-                // Copy guard to device memory after allocated memory
-                hipMemcpy(d + size, guard, sizeof(guard), hipMemcpyHostToDevice);
-            }
-        }
-#endif
-        return d;
-    }
-
-    void device_vector_teardown(T* d)
-    {
-        if(d != nullptr)
-        {
-#ifdef GOOGLE_TEST
-            if(PAD > 0)
-            {
-                U host[PAD];
-
-                // Copy device memory after allocated memory to host
-                hipMemcpy(host, d + size, sizeof(guard), hipMemcpyDeviceToHost);
-
-                // Make sure no corruption has occurred
-                EXPECT_EQ(memcmp(host, guard, sizeof(guard)), 0);
-
-                // Point to guard before allocated memory
-                d -= PAD;
-
-                // Copy device memory after allocated memory to host
-                hipMemcpy(host, d, sizeof(guard), hipMemcpyDeviceToHost);
-
-                // Make sure no corruption has occurred
-                EXPECT_EQ(memcmp(host, guard, sizeof(guard)), 0);
-            }
-#endif
-            // Free device memory
-            CHECK_HIP_ERROR((hipFree)(d));
-        }
-    }
-};
-
-/* ============================================================================================ */
-/*! \brief  pseudo-vector subclass which uses a batch of device memory pointers and
-            an array of pointers in host memory*/
-template <typename T, size_t PAD = 4096, typename U = T>
-class device_batch_vector : private d_vector<T, PAD, U>
-{
-public:
-    explicit device_batch_vector(size_t b, size_t s)
-        : batch(b)
-        , d_vector<T, PAD, U>(s)
-    {
-        data = (T**)malloc(batch * sizeof(T*));
-        for(int b = 0; b < batch; ++b)
-            data[b] = this->device_vector_setup();
-    }
-
-    ~device_batch_vector()
-    {
-        if(data != nullptr)
-        {
-            for(int b = 0; b < batch; ++b)
-                this->device_vector_teardown(data[b]);
-            free(data);
-        }
-    }
-
-    T* operator[](int n)
-    {
-        return data[n];
-    }
-
-    // clang-format off
-    operator T**()
-    {
-        return data;
-    }
-    // clang-format on
-
-    // Disallow copying or assigning
-    device_batch_vector(const device_batch_vector&) = delete;
-    device_batch_vector& operator=(const device_batch_vector&) = delete;
-
-private:
-    T**    data;
-    size_t batch;
-};
 
 /* ============================================================================================ */
 /*! \brief  pseudo-vector subclass which uses device memory */
@@ -210,225 +79,39 @@ struct host_vector : std::vector<T>
 };
 
 //!
-//! @brief Implementation of the batch vector on host.
+//! @brief Template for initializing a host (non_batched|batched|strided_batched)vector.
+//! @param that That vector.
+//! @param rand_gen The random number generator
+//! @param seedReset Reset the seed if true, do not reset the seed otherwise.
+//!
+template <typename U, typename T>
+void hipblas_init_template(U& that, T rand_gen(), bool seedReset)
+{
+    if(seedReset)
+        hipblas_seedrand();
+
+    for(int batch_index = 0; batch_index < that.batch_count(); ++batch_index)
+    {
+        auto*     batched_data = that[batch_index];
+        ptrdiff_t inc          = that.inc();
+        auto      n            = that.n();
+        if(inc < 0)
+            batched_data -= (n - 1) * inc;
+
+        for(int i = 0; i < n; ++i)
+            batched_data[i * inc] = rand_gen();
+    }
+}
+
+//!
+//! @brief Initialize a host_batch_vector.
+//! @param that The host batch vector.
+//! @param seedReset reset the seed if true, do not reset the seed otherwise.
 //!
 template <typename T>
-class host_batch_vector
+inline void hipblas_init(host_batch_vector<T>& that, bool seedReset = false)
 {
-public:
-    //!
-    //! @brief Delete copy constructor.
-    //!
-    host_batch_vector(const host_batch_vector<T>& that) = delete;
-
-    //!
-    //! @brief Delete copy assignement.
-    //!
-    host_batch_vector& operator=(const host_batch_vector<T>& that) = delete;
-
-    //!
-    //! @brief Constructor.
-    //! @param n           The length of the vector.
-    //! @param inc         The increment.
-    //! @param batch_count The batch count.
-    //!
-    explicit host_batch_vector(int n, int inc, int batch_count)
-        : m_n(n)
-        , m_inc(inc)
-        , m_batch_count(batch_count)
-    {
-        if(false == this->try_initialize_memory())
-        {
-            this->free_memory();
-        }
-    }
-
-    //!
-    //! @brief Constructor.
-    //! @param n           The length of the vector.
-    //! @param inc         The increment.
-    //! @param stride      (UNUSED) The stride.
-    //! @param batch_count The batch count.
-    //!
-    explicit host_batch_vector(int n, int inc, ptrdiff_t stride, int batch_count)
-        : host_batch_vector(n, inc, batch_count)
-    {
-    }
-
-    //!
-    //! @brief Destructor.
-    //!
-    ~host_batch_vector()
-    {
-        this->free_memory();
-    }
-
-    //!
-    //! @brief Returns the length of the vector.
-    //!
-    int n() const
-    {
-        return this->m_n;
-    }
-
-    //!
-    //! @brief Returns the increment of the vector.
-    //!
-    int inc() const
-    {
-        return this->m_inc;
-    }
-
-    //!
-    //! @brief Returns the batch count.
-    //!
-    int batch_count() const
-    {
-        return this->m_batch_count;
-    }
-
-    //!
-    //! @brief Returns the stride value.
-    //!
-    ptrdiff_t stride() const
-    {
-        return 0;
-    }
-
-    //!
-    //! @brief Random access to the vectors.
-    //! @param batch_index the batch index.
-    //! @return The mutable pointer.
-    //!
-    T* operator[](int batch_index)
-    {
-
-        return this->m_data[batch_index];
-    }
-
-    //!
-    //! @brief Constant random access to the vectors.
-    //! @param batch_index the batch index.
-    //! @return The non-mutable pointer.
-    //!
-    const T* operator[](int batch_index) const
-    {
-
-        return this->m_data[batch_index];
-    }
-
-    //!
-    //! @brief Cast to a double pointer.
-    //!
-    // clang-format off
-    operator T**()
-    // clang-format on
-    {
-        return this->m_data;
-    }
-
-    //!
-    //! @brief Constant cast to a double pointer.
-    //!
-    operator const T* const *()
-    {
-        return this->m_data;
-    }
-
-    //!
-    //! @brief Copy from a host batched vector.
-    //! @param that the vector the data is copied from.
-    //! @return true if the copy is done successfully, false otherwise.
-    //!
-    bool copy_from(const host_batch_vector<T>& that)
-    {
-        if((this->batch_count() == that.batch_count()) && (this->n() == that.n())
-           && (this->inc() == that.inc()))
-        {
-            size_t num_bytes = this->n() * std::abs(this->inc()) * sizeof(T);
-            for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
-            {
-                memcpy((*this)[batch_index], that[batch_index], num_bytes);
-            }
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    //!
-    //! @brief Transfer from a device batched vector.
-    //! @param that the vector the data is copied from.
-    //! @return the hip error.
-    //!
-    hipError_t transfer_from(const device_batch_vector<T>& that)
-    {
-        hipError_t hip_err;
-        size_t     num_bytes = size_t(this->m_n) * std::abs(this->m_inc) * sizeof(T);
-        for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
-        {
-            if(hipSuccess
-               != (hip_err = hipMemcpy(
-                       (*this)[batch_index], that[batch_index], num_bytes, hipMemcpyDeviceToHost)))
-            {
-                return hip_err;
-            }
-        }
-        return hipSuccess;
-    }
-
-    //!
-    //! @brief Check if memory exists.
-    //! @return hipSuccess if memory exists, hipErrorOutOfMemory otherwise.
-    //!
-    hipError_t memcheck() const
-    {
-        return (nullptr != this->m_data) ? hipSuccess : hipErrorOutOfMemory;
-    }
-
-private:
-    int m_n{};
-    int m_inc{};
-    int m_batch_count{};
-    T** m_data{};
-
-    bool try_initialize_memory()
-    {
-        bool success = (nullptr != (this->m_data = (T**)calloc(this->m_batch_count, sizeof(T*))));
-        if(success)
-        {
-            size_t nmemb = size_t(this->m_n) * std::abs(this->m_inc);
-            for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
-            {
-                success = (nullptr != (this->m_data[batch_index] = (T*)calloc(nmemb, sizeof(T))));
-                if(false == success)
-                {
-                    break;
-                }
-            }
-        }
-        return success;
-    }
-
-    void free_memory()
-    {
-        if(nullptr != this->m_data)
-        {
-            for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
-            {
-                if(nullptr != this->m_data[batch_index])
-                {
-                    free(this->m_data[batch_index]);
-                    this->m_data[batch_index] = nullptr;
-                }
-            }
-
-            free(this->m_data);
-            this->m_data = nullptr;
-        }
-    }
-};
+    hipblas_init_template(that, random_generator<T>, seedReset);
+}
 
 #endif

--- a/clients/include/host_batch_vector.hpp
+++ b/clients/include/host_batch_vector.hpp
@@ -1,0 +1,234 @@
+//
+// Copyright 2018-2020 Advanced Micro Devices, Inc.
+//
+#pragma once
+
+#include <string.h>
+
+//
+// Local declaration of the device batch vector.
+//
+template <typename T, size_t PAD, typename U>
+class device_batch_vector;
+
+//!
+//! @brief Implementation of the batch vector on host.
+//!
+template <typename T>
+class host_batch_vector
+{
+public:
+    //!
+    //! @brief Delete copy constructor.
+    //!
+    host_batch_vector(const host_batch_vector<T>& that) = delete;
+
+    //!
+    //! @brief Delete copy assignement.
+    //!
+    host_batch_vector& operator=(const host_batch_vector<T>& that) = delete;
+
+    //!
+    //! @brief Constructor.
+    //! @param n           The length of the vector.
+    //! @param inc         The increment.
+    //! @param batch_count The batch count.
+    //!
+    explicit host_batch_vector(int n, int inc, int batch_count)
+        : m_n(n)
+        , m_inc(inc)
+        , m_batch_count(batch_count)
+    {
+        if(false == this->try_initialize_memory())
+        {
+            this->free_memory();
+        }
+    }
+
+    //!
+    //! @brief Constructor.
+    //! @param n           The length of the vector.
+    //! @param inc         The increment.
+    //! @param stride      (UNUSED) The stride.
+    //! @param batch_count The batch count.
+    //!
+    explicit host_batch_vector(int n, int inc, hipblasStride stride, int batch_count)
+        : host_batch_vector(n, inc, batch_count)
+    {
+    }
+
+    //!
+    //! @brief Destructor.
+    //!
+    ~host_batch_vector()
+    {
+        this->free_memory();
+    }
+
+    //!
+    //! @brief Returns the length of the vector.
+    //!
+    int n() const
+    {
+        return this->m_n;
+    }
+
+    //!
+    //! @brief Returns the increment of the vector.
+    //!
+    int inc() const
+    {
+        return this->m_inc;
+    }
+
+    //!
+    //! @brief Returns the batch count.
+    //!
+    int batch_count() const
+    {
+        return this->m_batch_count;
+    }
+
+    //!
+    //! @brief Returns the stride value.
+    //!
+    hipblasStride stride() const
+    {
+        return 0;
+    }
+
+    //!
+    //! @brief Random access to the vectors.
+    //! @param batch_index the batch index.
+    //! @return The mutable pointer.
+    //!
+    T* operator[](int batch_index)
+    {
+
+        return this->m_data[batch_index];
+    }
+
+    //!
+    //! @brief Constant random access to the vectors.
+    //! @param batch_index the batch index.
+    //! @return The non-mutable pointer.
+    //!
+    const T* operator[](int batch_index) const
+    {
+
+        return this->m_data[batch_index];
+    }
+
+    //!
+    //! @brief Cast to a double pointer.
+    //!
+    // clang-format off
+    operator T**()
+    // clang-format on
+    {
+        return this->m_data;
+    }
+
+    //!
+    //! @brief Constant cast to a double pointer.
+    //!
+    operator const T* const *()
+    {
+        return this->m_data;
+    }
+
+    //!
+    //! @brief Copy from a host batched vector.
+    //! @param that the vector the data is copied from.
+    //! @return true if the copy is done successfully, false otherwise.
+    //!
+    bool copy_from(const host_batch_vector<T>& that)
+    {
+        if((this->batch_count() == that.batch_count()) && (this->n() == that.n())
+           && (this->inc() == that.inc()))
+        {
+            size_t num_bytes = this->n() * std::abs(this->inc()) * sizeof(T);
+            for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
+            {
+                memcpy((*this)[batch_index], that[batch_index], num_bytes);
+            }
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    //!
+    //! @brief Transfer from a device batched vector.
+    //! @param that the vector the data is copied from.
+    //! @return the hip error.
+    //!
+    hipError_t transfer_from(const device_batch_vector<T>& that)
+    {
+        hipError_t hip_err;
+        size_t     num_bytes = size_t(this->m_n) * std::abs(this->m_inc) * sizeof(T);
+        for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
+        {
+            if(hipSuccess
+               != (hip_err = hipMemcpy(
+                       (*this)[batch_index], that[batch_index], num_bytes, hipMemcpyDeviceToHost)))
+            {
+                return hip_err;
+            }
+        }
+        return hipSuccess;
+    }
+
+    //!
+    //! @brief Check if memory exists.
+    //! @return hipSuccess if memory exists, hipErrorOutOfMemory otherwise.
+    //!
+    hipError_t memcheck() const
+    {
+        return (nullptr != this->m_data) ? hipSuccess : hipErrorOutOfMemory;
+    }
+
+private:
+    int m_n{};
+    int m_inc{};
+    int m_batch_count{};
+    T** m_data{};
+
+    bool try_initialize_memory()
+    {
+        bool success = (nullptr != (this->m_data = (T**)calloc(this->m_batch_count, sizeof(T*))));
+        if(success)
+        {
+            size_t nmemb = size_t(this->m_n) * std::abs(this->m_inc);
+            for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
+            {
+                success = (nullptr != (this->m_data[batch_index] = (T*)calloc(nmemb, sizeof(T))));
+                if(false == success)
+                {
+                    break;
+                }
+            }
+        }
+        return success;
+    }
+
+    void free_memory()
+    {
+        if(nullptr != this->m_data)
+        {
+            for(int batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
+            {
+                if(nullptr != this->m_data[batch_index])
+                {
+                    free(this->m_data[batch_index]);
+                    this->m_data[batch_index] = nullptr;
+                }
+            }
+
+            free(this->m_data);
+            this->m_data = nullptr;
+        }
+    }
+};


### PR DESCRIPTION
This adds the `host_batch_vector` and `device_batch_vector` implementations from rocBLAS. I've updated the implementation of scal_batched tests to the intended use. I will update all other tests in another PR to keep this one moderately small and easy to review.