### PR TITLE
Add features to performance scripts

### DIFF
--- a/scripts/performance/blas/commandrunner.py
+++ b/scripts/performance/blas/commandrunner.py
@@ -708,6 +708,9 @@ class RunConfiguration(object):
     def _machine_specs_filename(self):
         return os.path.join(self.output_directory, "specs.json")
 
+    def _machine_specs_filanem_compare(self):
+        return os.path.join(self.output_directory_compare, "specs.json")
+
     def save_specifications(self, device_num, cuda):
         filename = self._machine_specs_filename()
         MachineSpecs.collect_specs([device_num], cuda, self.user_args.install_path).save(filename)
@@ -716,6 +719,9 @@ class RunConfiguration(object):
 
     def load_specifications(self):
         return MachineSpecs.from_file(self._machine_specs_filename())
+
+    def load_specifications_compare(self):
+        return MachineSpecs.from_file(self._machine_specs_filanem_compare())
 
 class RunConfigurationsList(list):
     def group_by_label(self):

--- a/scripts/performance/blas/commandrunner.py
+++ b/scripts/performance/blas/commandrunner.py
@@ -118,23 +118,23 @@ class SystemMonitor(object):
         self.metrics = metrics
         self.data = {metric:{} for metric in self.metrics}
 
-    def record_line(self):
+    def record_line(self, cuda):
         now = datetime.datetime.now()
         for metric in self.metrics:
-            self.data[metric][now] = self.measure(metric)
+            self.data[metric][now] = self.measure(metric, cuda)
 
-    def measure(self, metric, device=None):
+    def measure(self, metric, cuda, device=None):
         if device is None:
-            device = smi.listDevices(showall=False)[0]
+            device = getspecs.listdevices(cuda, smi)[0]
         if smi is None:
             return 0.0
         elif metric == 'fan_speed_percent':
-            return smi.getFanSpeed(device)[1]
-        elif metric.find('clk') >=0 and metric.split('_')[0] in smi.validClockNames:
-            return int(smi.getCurrentClock(device, metric.split('_')[0], 'freq').strip('Mhz'))
+            return getspecs.getfanspeedpercent(device, cuda, smi)[1]
+        elif metric.find('clk') >=0 and metric.split('_')[0] in getspecs.validclocknames(cuda, smi):
+            return int(getspecs.getcurrentclockfreq(device, metric.split('_')[0], cuda, smi).strip('Mhz'))
         elif 'used_memory_percent':
-            used_bytes, total_bytes = smi.getMemInfo(device, 'vram')
-            return int(used_bytes)*100.0/int(total_bytes)
+            used_bytes, total_bytes = getspecs.getmeminfo(device, 'vram', cuda, smi)
+            return int(used_bytes.split()[0])*100.0/int(total_bytes.split()[0])
         else:
             raise ValueError('Unrecognized metric requested: {}'.format(metric))
 
@@ -485,7 +485,7 @@ class ArgumentSetABC(object):
                 try:
                     while proc.poll() is None:
                         if smi is not None and poll_metric_count % 20 == 0:
-                            system_monitor.record_line()
+                            system_monitor.record_line(self.user_args.cuda)
                         time.sleep(0.01)
                         poll_metric_count += 1
                 except Exception as e:
@@ -574,7 +574,7 @@ class ArgumentSetSort(OrderedDict):
 
 class MachineSpecs(dict):
     @classmethod
-    def collect_specs(cls, device_numbers, install_path):
+    def collect_specs(cls, device_numbers, cuda, install_path):
         # Helper to translate bytes into human readable units
         def to_mem_units(num_bytes):
             num_bytes = int(num_bytes)
@@ -592,37 +592,41 @@ class MachineSpecs(dict):
         host_info['kernel version'] = getspecs.getkernel()
         host_info['rocm version'] = getspecs.getrocmversion()
         rv['Host'] = host_info
-
         for device_num in device_numbers:
             device_info = {}
-            device_info['device'] = getspecs.getdeviceinfo(device_num)
-            device_info['vbios version'] = getspecs.getvbios(device_num)
-            device_info['vram'] = getspecs.getvram(device_num)
-            device_info['performance level'] = getspecs.getperflevel(device_num)
-            device_info['system clock'] = getspecs.getsclk(device_num)
-            device_info['memory clock'] = getspecs.getmclk(device_num)
+            device_info['device'] = getspecs.getdeviceinfo(device_num, cuda)
+            device_info['vbios version'] = getspecs.getvbios(device_num, cuda)
+            device_info['vram'] = getspecs.getvram(device_num, cuda)
+            device_info['performance level'] = getspecs.getperflevel(device_num, cuda)
+            device_info['system clock'] = getspecs.getsclk(device_num, cuda)
+            device_info['memory clock'] = getspecs.getmclk(device_num, cuda)
             rv['Device {0:2d}'.format(device_num)] = device_info
 
         smi = import_rocm_smi(install_path)
-        if smi is not None:
-            devices = smi.listDevices(showall=False)
-            for device in devices:
-                smi_info = {}
-                smi_info['Bus'] = smi.getBus(device)
-                smi_info['Profile'] = smi.getProfile(device)
-                smi_info['Start Fan Speed'] = str(smi.getFanSpeed(device)[1]) + '%'
-                for clock in smi.validClockNames:
-                    freq = smi.getCurrentClock(device, clock, 'freq')
-                    measured_level = smi.getCurrentClock(device, clock, 'level')
-                    max_level = smi.getMaxLevel(device, clock)
-                    smi_info['Start ' + clock] = '{} - Level {}/{}'.format(freq, measured_level, max_level)
-                for mem_type in smi.validMemTypes:
-                    key = 'Start {} Memory'.format(mem_type)
-                    used_bytes, total_bytes = smi.getMemInfo(device, mem_type)
-                    smi_info[key] = '{} / {}'.format(to_mem_units(used_bytes), to_mem_units(total_bytes))
-                for component in smi.validVersionComponents:
-                    smi_info[component.capitalize() + ' Version'] = smi.getVersion([device], component)
-                rv['ROCm ' + device.capitalize()] = smi_info
+        devices = getspecs.listdevices(cuda, smi)
+        for device in devices:
+            smi_info = {}
+            smi_info['Bus'] = getspecs.getbus(device, cuda, smi)
+            smi_info['Profile'] = getspecs.getprofile(device, cuda, smi)
+            smi_info['Start Fan Speed'] = getspecs.getfanspeedpercent(device, cuda, smi) + '%'
+            for clock in getspecs.validclocknames(cuda, smi):
+                freq = getspecs.getcurrentclockfreq(device, clock, cuda, smi)
+                measured_level = getspecs.getcurrentclocklevel(device, clock, cuda, smi)
+                max_level = getspecs.getmaxlevel(device, clock, cuda, smi)
+                smi_info['Start ' + clock] = '{} - Level {}/{}'.format(freq, measured_level, max_level)
+            for mem_type in getspecs.validmemtypes(cuda, smi):
+                key = 'Start {} Memory'.format(mem_type)
+                used_bytes, total_bytes = getspecs.getmeminfo(device, mem_type, cuda, smi)
+                print('used, total')
+                print (used_bytes)
+                print (total_bytes)
+                smi_info[key] = '{} / {}'.format(to_mem_units(used_bytes.split()[0]), to_mem_units(total_bytes.split()[0]))
+            for component in getspecs.validversioncomponents(cuda, smi):
+                smi_info[component.capitalize() + ' Version'] = getspecs.getversion(device, component, cuda, smi)
+            if cuda:
+                rv['Card' + str(device)] = smi_info
+            else:
+                rv[device.capitalize()] = smi_info
 
         return rv
 
@@ -700,9 +704,9 @@ class RunConfiguration(object):
     def _machine_specs_filename(self):
         return os.path.join(self.output_directory, "specs.json")
 
-    def save_specifications(self, device_num):
+    def save_specifications(self, device_num, cuda):
         filename = self._machine_specs_filename()
-        MachineSpecs.collect_specs([device_num], self.user_args.install_path).save(filename)
+        MachineSpecs.collect_specs([device_num], cuda, self.user_args.install_path).save(filename)
         # Does not return the specs because to use them robustly, they need to be loaded
         # from disk. Collecting could overwrite saved specs when post-processing results.
 
@@ -998,6 +1002,7 @@ class CommandRunner(object):
         executable_directories = user_args.input_executables
         output_directories = user_args.output_directories
         labels = user_args.labels
+        cuda = user_args.cuda
 
         print('Excecutable directories: ', executable_directories)
 
@@ -1018,6 +1023,12 @@ class CommandRunner(object):
         self.executable_directories = executable_directories
         self.output_directories = output_directories
         self.labels = labels
+        self.cuda = cuda
+
+        if self.cuda:
+            print('Running for a CUDA system')
+        else:
+            print('Not running for a CUDA system')
 
         self.run_configurations = RunConfigurationsList()
         for exec_dir, out_dir, label in zip(executable_directories, output_directories, labels):
@@ -1070,7 +1081,7 @@ class CommandRunner(object):
 
     def main(self):
         self.execute()
-        self.show_plots()
+        self.show_plots(self.cuda)
         self.get_system_summary()
         self.output_summary()
 
@@ -1129,7 +1140,7 @@ class CommandRunner(object):
         for run_configuration in self.run_configurations:
             if self.is_run_tool():
                 run_configuration.make_output_directory()
-                run_configuration.save_specifications(self.user_args.device_num)
+                run_configuration.save_specifications(self.user_args.device_num, self.cuda)
             elif not self.is_dry_run():
                 run_configuration.assert_exists()
 
@@ -1169,7 +1180,7 @@ class CommandRunner(object):
         if self.is_run_tool() or self.is_dry_run():
             command_list.execute_shuffled(overwrite = self.is_overwrite(), dry_run = self.is_dry_run())
 
-    def show_plots(self):
+    def show_plots(self, cuda):
         if self.is_dry_run():
             return
         grouped_run_configurations = self.run_configurations.group_by_label()
@@ -1205,7 +1216,7 @@ class CommandRunner(object):
             # Add any Matplotlib plots using Comparison.plot()
             if self.is_use_matplotlib():
                 figure, axes = plt.subplots(figsize = (7, 7))
-                plot_success = comparison.plot(self.run_configurations, axes)
+                plot_success = comparison.plot(self.run_configurations, axes, cuda)
                 print(comparison.get_caption(self.run_configurations))
                 if plot_success:
                     axes.legend(fontsize = 10, bbox_to_anchor=(0., 1.02, 1., .102), loc='lower left',
@@ -1294,6 +1305,7 @@ def parse_input_arguments(parser):
     def to_test_methods(s):
         return to_multiple_choices(all_test_methods, s)
 
+    parser.add_argument('--cuda', default=False, action='store_true', help='Run on a CUDA device.')
     parser.add_argument('-i', '--input-executables', action='append', required=True,
                         help='Input executable location, can be added multiple times.')
     parser.add_argument('-o', '--output-directories', action='append', default=[],

--- a/scripts/performance/blas/commandrunner.py
+++ b/scripts/performance/blas/commandrunner.py
@@ -708,7 +708,7 @@ class RunConfiguration(object):
     def _machine_specs_filename(self):
         return os.path.join(self.output_directory, "specs.json")
 
-    def _machine_specs_filanem_compare(self):
+    def _machine_specs_filename_compare(self):
         return os.path.join(self.output_directory_compare, "specs.json")
 
     def save_specifications(self, device_num, cuda):
@@ -721,7 +721,7 @@ class RunConfiguration(object):
         return MachineSpecs.from_file(self._machine_specs_filename())
 
     def load_specifications_compare(self):
-        return MachineSpecs.from_file(self._machine_specs_filanem_compare())
+        return MachineSpecs.from_file(self._machine_specs_filename_compare())
 
 class RunConfigurationsList(list):
     def group_by_label(self):
@@ -1242,7 +1242,6 @@ class CommandRunner(object):
                 plot_success = comparison.plot(self.run_configurations, axes, cuda, compare)
                 print(comparison.get_caption(self.run_configurations))
                 if plot_success:
-                    # TODO:
                     axes.legend(fontsize = 10, bbox_to_anchor=(0., 1.02, 1., .102), loc='lower left',
                                  mode='expand', borderaxespad=0.)
                     figure.tight_layout(rect=(0,0.05,1.0,1.0))

--- a/scripts/performance/blas/getspecs.py
+++ b/scripts/performance/blas/getspecs.py
@@ -17,6 +17,11 @@ def _subprocess_helper(cmd, *args, **kwargs):
         pass
     return success, cout
 
+def get_smi_exec(cuda):
+    if cuda:
+        return "nvidia-smi"
+    else:
+        return "/opt/rocm/bin/rocm-smi"
 
 # Get the hostname
 def gethostname():
@@ -84,11 +89,16 @@ def getrocmversion():
 
 
 # Get the vbios version for the specified device
-def getvbios(devicenum):
-    cmd = ["/opt/rocm/bin/rocm-smi", "-v", "-d", str(devicenum)]
+def getvbios(devicenum, cuda):
+    cmd = [get_smi_exec(cuda), "-v", "-d", str(devicenum)]
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=vbios_version", "--format=csv,noheader", "-i", str(devicenum)]
     success, cout = _subprocess_helper(cmd)
     if not success:
         return "N/A"
+    if cuda:
+        return cout
+
     searchstr = "GPU["+str(devicenum)+"]"
     for line in cout.split("\n"):
         if line.startswith(searchstr):
@@ -97,14 +107,18 @@ def getvbios(devicenum):
             return tmp[pos+1:].strip()
     return ""
 
-def getgpuid(devicenum):
+def getgpuid(devicenum, cuda):
     import re
     name = ""
-    # We also use rocm-smi to get more info
-    cmd = ["/opt/rocm/bin/rocm-smi", "-i", "-d", str(devicenum)]
+    cmd = [get_smi_exec(cuda), "-i", "-d", str(devicenum)]
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=name", "--format=csv,noheader", "-i", str(devicenum)]
     success, cout = _subprocess_helper(cmd)
     if not success:
         return "N/A"
+    if cuda:
+        return cout
+
     searchstr = "GPU["+str(devicenum)+"]"
     for line in cout.split("\n"):
         if line.startswith(searchstr):
@@ -116,7 +130,7 @@ def getgpuid(devicenum):
     return name
 
 # Get the name of the device from lshw which has index devicenum
-def getdeviceinfo(devicenum):
+def getdeviceinfo(devicenum, cuda):
     import re
     cmd = ["lshw", "-C", "video"]
     success, cout = _subprocess_helper(cmd)
@@ -134,16 +148,22 @@ def getdeviceinfo(devicenum):
             if re.search(searchstr, line) != None:
                 pos = line.find(":")
                 name += line[pos+1:].strip()
-    name += " " + getgpuid(devicenum)
+    name += " " + getgpuid(devicenum, cuda)
     return name
 
 # Get the vram for the specified device
-def getvram(devicenum):
+def getvram(devicenum, cuda):
     import re
-    cmd = ["/opt/rocm/bin/rocm-smi", "--showmeminfo", "vram", "-d", str(devicenum)]
+    cmd = [get_smi_exec(cuda), "--showmeminfo", "vram", "-d", str(devicenum)]
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=memory.total", "--format=csv,noheader", "-i", str(devicenum)]
     success, cout = _subprocess_helper(cmd)
+
     if not success:
         return "N/A"
+    if cuda:
+        return cout
+
     searchstr = "GPU["+str(devicenum)+"]"
     for line in cout.split("\n"):
         if line.startswith(searchstr):
@@ -153,15 +173,21 @@ def getvram(devicenum):
             line = re.sub("vram", "", line)
             line = re.sub("total", "", line)
             pos = line.find("used")
+            print(line[:pos].strip())
             return line[:pos].strip()
 
 # Get the performance level for the specified device
-def getperflevel(devicenum):
+def getperflevel(devicenum, cuda):
     import re
-    cmd = ["/opt/rocm/bin/rocm-smi", "-p", "-d", str(devicenum)]
+    cmd = [get_smi_exec(cuda), "-p", "-d", str(devicenum)]
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=pstate", "--format=csv,noheader", "-i", str(devicenum)]
     success, cout = _subprocess_helper(cmd)
     if not success:
         return "N/A"
+    if cuda:
+        return cout
+
     searchstr = "GPU["+str(devicenum)+"]"
     for line in cout.split("\n"):
         if line.startswith(searchstr):
@@ -171,12 +197,17 @@ def getperflevel(devicenum):
             return line
 
 # Get the memory clock for the specified device
-def getmclk(devicenum):
+def getmclk(devicenum, cuda):
     import re
-    cmd = ["/opt/rocm/bin/rocm-smi", "--showclocks", "-d", str(devicenum)]
+    cmd = [get_smi_exec(cuda), "--showclocks", "-d", str(devicenum)]
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=clocks.mem", "--format=csv,noheader", "-i", str(devicenum)]
     success, cout = _subprocess_helper(cmd)
     if not success:
         return "N/A"
+    if cuda:
+        return cout
+
     searchstr = "mclk"
     for line in cout.split("\n"):
         m = re.search(searchstr, line)
@@ -186,12 +217,17 @@ def getmclk(devicenum):
             return line[p0+1:p1]
 
 # Get the system clock for the specified device
-def getsclk(devicenum):
+def getsclk(devicenum, cuda):
     import re
-    cmd = ["/opt/rocm/bin/rocm-smi", "--showclocks", "-d", str(devicenum)]
+    cmd = [get_smi_exec(cuda), "--showclocks", "-d", str(devicenum)]
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=clocks.sm", "--format=csv,noheader", "-i", str(devicenum)]
     success, cout = _subprocess_helper(cmd)
     if not success:
         return "N/A"
+    if cuda:
+        return cout
+
     searchstr = "sclk"
     for line in cout.split("\n"):
         m = re.search(searchstr, line)
@@ -200,8 +236,117 @@ def getsclk(devicenum):
             p1 = line.find(")")
             return line[p0+1:p1]
 
-def getbandwidth(devicenum):
-    gpuid = getgpuid(devicenum)
+def getbandwidth(devicenum, cuda):
+    gpuid = getgpuid(devicenum, cuda)
     if gpuid == "0x66af":
         # radeon7: float: 13.8 TFLOPs, double: 3.46 TFLOPs, 1024 GB/s
         return (13.8, 3.46, 1024)
+
+def listdevices(cuda, smi=None):
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=count", "--format=csv,noheader", "-i", '0']
+        success, cout = _subprocess_helper(cmd)
+        if not success:
+            return []
+        return list(range(0, int(cout)))
+        # something
+    elif smi is not None:
+        return smi.listDevices(showall=False)
+
+def getbus(devicenum, cuda, smi=None):
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=pci.bus_id", "--format=csv,noheader", "-i", str(devicenum)]
+        success, cout = _subprocess_helper(cmd)
+        if not success:
+            return "N/A"
+        return cout
+    else:
+        if smi is not None:
+            return smi.getBus(devicenum)
+
+def getprofile(devicenum, cuda, smi=None):
+    if cuda:
+        return "N/A"
+    else:
+        if smi is not None:
+            return smi.getProfile(devicenum)
+
+def getfanspeedpercent(devicenum, cuda, smi=None):
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=fan.speed", "--format=csv,noheader", "-i", str(devicenum)]
+        success, cout = _subprocess_helper(cmd)
+        if not success:
+            return "N/A"
+        return str(cout)
+    elif smi is not None:
+        return str(smi.getFanSpeed(devicenum)[1])
+
+def validclocknames(cuda, smi=None):
+    if cuda:
+        return ["graphics", "sm", "memory", "video"]
+    elif smi is not None:
+        return smi.validClockNames
+
+def getcurrentclockfreq(devicenum, clock, cuda, smi=None):
+    if cuda:
+        cmd = [get_smi_exec(cuda), "--query-gpu=clocks.current." + clock, "--format=csv,noheader", "-i", str(devicenum)]
+        success, cout = _subprocess_helper(cmd)
+        if not success:
+            return "N/A"
+        return cout
+    elif smi is not None:
+        return smi.getCurrentClock(devicenum, clock, 'freq')
+
+def getcurrentclocklevel(devicenum, clock, cuda, smi=None):
+    if cuda:
+        return "N/A"
+    elif smi is not None:
+        return smi.getCurrentClock(devicenum, clock, 'level')
+
+def getmaxlevel(devicenum, clock, cuda, smi=None):
+    if cuda:
+        return "N/A"
+    elif smi is not None:
+        return smi.getMaxLevel(devicenum, clock)
+
+def validmemtypes(cuda, smi=None):
+    if cuda:
+        return ["vram"]
+    elif smi is not None:
+        return smi.validMemTypes
+
+def getmeminfo(devicenum, mem_type, cuda, smi=None):
+    if cuda:
+        if mem_type == 'vram':
+            cmd = [get_smi_exec(cuda), "--query-gpu=memory.total", "--format=csv,noheader", "-i", str(devicenum)]
+            success, cout_total = _subprocess_helper(cmd)
+            if not success:
+                return "N/A"
+            cmd = [get_smi_exec(cuda), "--query-gpu=memory.used", "--format=csv,noheader", "-i", str(devicenum)]
+            success, cout_used = _subprocess_helper(cmd)
+            if not success:
+                return "N/A"
+            return cout_used, cout_total
+        else:
+            return "N/A"
+    elif smi is not None:
+        return smi.getMemInfo(devicenum, mem_type)
+
+def validversioncomponents(cuda, smi=None):
+    if cuda:
+        return ['driver']
+    elif smi is not None:
+        return smi.validVersionComponents
+
+def getversion(devicenum, component, cuda, smi=None):
+    if cuda:
+        if component == 'driver':
+            cmd = [get_smi_exec(cuda), "--query-gpu=driver_version", "--format=csv,noheader", "-i", str(devicenum)]
+            success, cout = _subprocess_helper(cmd)
+            if not success:
+                return "N/A"
+            return cout
+        else:
+            return "N/A"
+    elif smi is not None:
+        return smi.getVersion([devicenum], component)

--- a/scripts/performance/blas/performancereport.py
+++ b/scripts/performance/blas/performancereport.py
@@ -530,15 +530,25 @@ class FlopsComparison(HipBlasYamlComparison):
                 mhz_str = "Mhz"
                 mem_clk_str = "mclk"
                 sys_clk_str = "sclk"
+                mhz_str_cuda = "MHz"
+                mem_clk_str_cuda = "memory"
+                sys_clk_str_cuda = "sm"
                 if cuda:
-                    mhz_str = "MHz"
-                    mem_clk_str = "memory"
-                    sys_clk_str = "sm"
-                mclk = 1200.0
-                sclk = 1087.0
-                # mclk = run_configuration.load_specifications()['Card0']["Start " + mem_clk_str].split(mhz_str)[0]
-                # sclk = run_configuration.load_specifications()['Card0']["Start " + sys_clk_str].split(mhz_str)[0]
-                sclk_cuda = 1530.0
+                    mhz_str = mhz_str_cuda
+                    mem_clk_str = mem_clk_str_cuda
+                    sys_clk_str = sys_clk_str_cuda
+                # Reference: MI-100 clocks by default
+                # mclk = 1200.0
+                # sclk = 1087.0
+                mclk = run_configuration.load_specifications()['Card0']["Start " + mem_clk_str].split(mhz_str)[0]
+                sclk = run_configuration.load_specifications()['Card0']["Start " + sys_clk_str].split(mhz_str)[0]
+
+                # Reference: V-100 clock by default
+                # sclk_cuda = 1530.0
+                if compare:
+                    sclk_cuda = run_configuration.load_specifications_compare()['Card0']["Start " + sys_clk_str_cuda].split(mhz_str_cuda)[0]
+                else:
+                    sclk_cuda = 0
                 theoMax = 0
                 theoMax_cuda = 0
                 precisionBits = int(re.search(r'\d+', precision).group())
@@ -687,15 +697,25 @@ class EfficiencyComparison(HipBlasYamlComparison):
                 mhz_str = "Mhz"
                 mem_clk_str = "mclk"
                 sys_clk_str = "sclk"
+                mhz_str_cuda = "MHz"
+                mem_clk_str_cuda = "memory"
+                sys_clk_str_cuda = "sm"
                 if cuda:
-                    mhz_str = "MHz"
-                    mem_clk_str = "memory"
-                    sys_clk_str = "sm"
-                mclk = 1200.0
-                sclk = 1087.0
-                # mclk = run_configuration.load_specifications()['Card0']["Start " + mem_clk_str].split(mhz_str)[0]
-                # sclk = run_configuration.load_specifications()['Card0']["Start " + sys_clk_str].split(mhz_str)[0]
-                sclk_cuda = 1530.0
+                    mhz_str = mhz_str_cuda
+                    mem_clk_str = mem_clk_str_cuda
+                    sys_clk_str = sys_clk_str_cuda
+                # Reference: MI-100 clocks by default
+                # mclk = 1200.0
+                # sclk = 1087.0
+                mclk = run_configuration.load_specifications()['Card0']["Start " + mem_clk_str].split(mhz_str)[0]
+                sclk = run_configuration.load_specifications()['Card0']["Start " + sys_clk_str].split(mhz_str)[0]
+
+                # Reference: V-100 clock by default
+                # sclk_cuda = 1530.0
+                if compare:
+                    sclk_cuda = run_configuration.load_specifications_compare()['Card0']["Start " + sys_clk_str_cuda].split(mhz_str_cuda)[0]
+                else:
+                    sclk_cuda = 0
                 theoMax = 0
                 theoMax_cuda = 0
                 precisionBits = int(re.search(r'\d+', precision).group())

--- a/scripts/performance/blas/performancereport.py
+++ b/scripts/performance/blas/performancereport.py
@@ -427,7 +427,7 @@ class FlopsComparison(HipBlasYamlComparison):
             print('{} does not exist'.format(output_filename))
         return rv
 
-    def plot(self, run_configurations, axes):
+    def plot(self, run_configurations, axes, cuda):
         num_argument_sets = len(self.argument_sets)
         if num_argument_sets == 0:
             return
@@ -480,8 +480,15 @@ class FlopsComparison(HipBlasYamlComparison):
 
         for group_label, run_configuration_group in grouped_run_configurations.items():
             for run_configuration in run_configuration_group:
-                mclk = run_configuration.load_specifications()['ROCm Card0']["Start mclk"].split("Mhz")[0]
-                sclk = run_configuration.load_specifications()['ROCm Card0']["Start sclk"].split("Mhz")[0]
+                mhz_str = "Mhz"
+                mem_clk_str = "mclk"
+                sys_clk_str = "sclk"
+                if cuda:
+                    mhz_str = "MHz"
+                    mem_clk_str = "memory"
+                    sys_clk_str = "sm"
+                mclk = run_configuration.load_specifications()['Card0']["Start " + mem_clk_str].split(mhz_str)[0]
+                sclk = run_configuration.load_specifications()['Card0']["Start " + sys_clk_str].split(mhz_str)[0]
                 theoMax = 0
                 precisionBits = int(re.search(r'\d+', precision).group())
                 if(function == 'gemm' and precisionBits == 32): #xdlops

--- a/scripts/performance/blas/performancereport.py
+++ b/scripts/performance/blas/performancereport.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 
-from matplotlib.ticker import (AutoMinorLocator, MultipleLocator)
+from matplotlib.ticker import (AutoMinorLocator)
 
 import hipblas_gentest as gt
 
@@ -139,7 +139,7 @@ class HipBlasArgumentSet(cr.ArgumentSetABC):
     def collect_timing(self, run_configuration, data_type='gflops'):
         output_filename = self.get_output_file(run_configuration)
         rv = {}
-        print('Processing AMD {}'.format(output_filename))
+        print('Processing {}'.format(output_filename))
         if os.path.exists(output_filename):
             lines = open(output_filename, 'r').readlines()
             us_vals = []
@@ -174,7 +174,7 @@ class HipBlasArgumentSet(cr.ArgumentSetABC):
     def collect_timing_compare(self, run_configuration, data_type='gflops'):
         output_filename = self.get_output_file_compare(run_configuration)
         rv = {}
-        print('Processing CUDA {}'.format(output_filename))
+        print('Processing {}'.format(output_filename))
         if os.path.exists(output_filename):
             lines = open(output_filename, 'r').readlines()
             us_vals = []

--- a/scripts/performance/blas/performancereport.py
+++ b/scripts/performance/blas/performancereport.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 
-from matplotlib.ticker import (AutoMinorLocator)
+from matplotlib.ticker import (AutoMinorLocator, MultipleLocator)
 
 import hipblas_gentest as gt
 
@@ -139,7 +139,42 @@ class HipBlasArgumentSet(cr.ArgumentSetABC):
     def collect_timing(self, run_configuration, data_type='gflops'):
         output_filename = self.get_output_file(run_configuration)
         rv = {}
-        print('Processing {}'.format(output_filename))
+        print('Processing AMD {}'.format(output_filename))
+        if os.path.exists(output_filename):
+            lines = open(output_filename, 'r').readlines()
+            us_vals = []
+            gf_vals = []
+            bw_vals = []
+            gf_string = "hipblas-Gflops"
+            bw_string = "hipblas-GB/s"
+            us_string = "us"
+            for i in range(0, len(lines)):
+                if re.search(r"\b" + re.escape(us_string) + r"\b", lines[i]) is not None:
+                    us_line = lines[i].strip().split(",")
+                    index = [idx for idx, s in enumerate(us_line) if us_string in s][0] #us_line.index()
+                    us_vals.append(float(re.split(r',\s*(?![^()]*\))', lines[i+1])[index]))
+                if gf_string in lines[i]:
+                    gf_line = lines[i].split(",")
+                    index = gf_line.index(gf_string)
+                    gf_vals.append(float(re.split(r',\s*(?![^()]*\))', lines[i+1])[index]))
+                if bw_string in lines[i]:
+                    bw_line = lines[i].split(",")
+                    index = bw_line.index(bw_string)
+                    bw_vals.append(float(re.split(r',\s*(?![^()]*\))', lines[i+1])[index]))
+            if len(us_vals) > 0 and data_type == 'time':
+                rv['Time (microseconds)'] = us_vals
+            if len(bw_vals) > 0 and data_type == 'bandwidth':
+                rv['Bandwidth (GB/s)'] = bw_vals
+            if len(gf_vals) > 0 and data_type == 'gflops':
+                rv['GFLOP/s'] = gf_vals
+        else:
+            print('{} does not exist'.format(output_filename))
+        return rv
+
+    def collect_timing_compare(self, run_configuration, data_type='gflops'):
+        output_filename = self.get_output_file_compare(run_configuration)
+        rv = {}
+        print('Processing CUDA {}'.format(output_filename))
         if os.path.exists(output_filename):
             lines = open(output_filename, 'r').readlines()
             us_vals = []
@@ -427,7 +462,7 @@ class FlopsComparison(HipBlasYamlComparison):
             print('{} does not exist'.format(output_filename))
         return rv
 
-    def plot(self, run_configurations, axes, cuda):
+    def plot(self, run_configurations, axes, cuda, compare):
         num_argument_sets = len(self.argument_sets)
         if num_argument_sets == 0:
             return
@@ -458,15 +493,18 @@ class FlopsComparison(HipBlasYamlComparison):
 
         # loop over independent outputs
         y_scatter_by_group = OrderedDict()
+        y_scatter_by_group_cuda = OrderedDict()
         for group_label, run_configuration_group in grouped_run_configurations.items():
             # x_scatter_by_group[group_label] = []
             y_scatter_by_group[group_label] = []
+            y_scatter_by_group_cuda[group_label] = []
             # loop over argument sets that differ other than the swept variable(s)
             for subset_label, partial_argument_sets in sorted_argument_sets.items():
                 if len(partial_argument_sets) != 1:
                     raise ValueError('Assumed that sorting argument sets with no keys has a single element per sort.')
                 argument_set = partial_argument_sets[0]
                 y_list_by_metric = OrderedDict() # One array of y values for each metric
+                y_list_by_metric_cuda = OrderedDict()
                 # loop over number of coarse grain runs and concatenate results
                 for run_configuration in run_configuration_group:
                     results = argument_set.collect_timing(run_configuration)
@@ -474,9 +512,18 @@ class FlopsComparison(HipBlasYamlComparison):
                         if not metric_label in y_list_by_metric:
                             y_list_by_metric[metric_label] = []
                         y_list_by_metric[metric_label].extend(results[metric_label])
+                    if compare:
+                        results_cuda = argument_set.collect_timing_compare(run_configuration)
+                        for metric_label in results_cuda:
+                            if not metric_label in y_list_by_metric_cuda:
+                                y_list_by_metric_cuda[metric_label] = []
+                            y_list_by_metric_cuda[metric_label].extend(results_cuda[metric_label])
                 # For each metric, add a set of bars in the bar chart.
                 for metric_label, y_list in y_list_by_metric.items():
                     y_scatter_by_group[group_label].extend(sorted(y_list))
+                if compare:
+                    for metric_label, y_list in y_list_by_metric_cuda.items():
+                        y_scatter_by_group_cuda[group_label].extend(sorted(y_list))
 
         for group_label, run_configuration_group in grouped_run_configurations.items():
             for run_configuration in run_configuration_group:
@@ -487,16 +534,23 @@ class FlopsComparison(HipBlasYamlComparison):
                     mhz_str = "MHz"
                     mem_clk_str = "memory"
                     sys_clk_str = "sm"
-                mclk = run_configuration.load_specifications()['Card0']["Start " + mem_clk_str].split(mhz_str)[0]
-                sclk = run_configuration.load_specifications()['Card0']["Start " + sys_clk_str].split(mhz_str)[0]
+                mclk = 1200.0
+                sclk = 1087.0
+                # mclk = run_configuration.load_specifications()['Card0']["Start " + mem_clk_str].split(mhz_str)[0]
+                # sclk = run_configuration.load_specifications()['Card0']["Start " + sys_clk_str].split(mhz_str)[0]
+                sclk_cuda = 1530.0
                 theoMax = 0
+                theoMax_cuda = 0
                 precisionBits = int(re.search(r'\d+', precision).group())
                 if(function == 'gemm' and precisionBits == 32): #xdlops
                     theoMax = float(sclk)/1000.00 * 256 * 120 #scaling to appropriate precision
+                    theoMax_cuda = float(sclk_cuda)/1000.00 * 128 * 80
                 elif(function == 'trsm' or function == 'gemm'):  #TODO better logic to decide memory bound vs compute bound
                     theoMax = float(sclk)/1000.00 * 128 * 120  * 32.00 / precisionBits #scaling to appropriate precision
+                    theoMax_cuda = float(sclk_cuda)/1000.00 * 128 * 80 * 32.00 / precisionBits
                 elif self.flops and self.mem:
                     try:
+                        # TODO: Add calculation for theoMax_cuda
                         n=100000
                         flops = eval(self.flops)
                         mem = eval(self.mem)
@@ -507,7 +561,12 @@ class FlopsComparison(HipBlasYamlComparison):
                     theoMax = round(theoMax)
                     x_co = (test[0], test[len(test)-1])
                     y_co = (theoMax, theoMax)
-                    axes.plot(x_co, y_co, label = "Theoretical Peak Performance: "+str(theoMax)+" GFLOP/s")
+                    theo_amd, = axes.plot(x_co, y_co, color='#ED1C24', label = "Theoretical Peak Performance MI-100: "+str(theoMax)+" GFLOP/s")
+                    if compare:
+                        theoMax_cuda = round(theoMax_cuda)
+                        x_co_cuda = (test[0], test[len(test)-1])
+                        y_co_cuda = (theoMax_cuda, theoMax_cuda)
+                        theo_cuda, = axes.plot(x_co_cuda, y_co_cuda, color='#76B900', label = "Theoretical Peak Performance V-100: "+ str(theoMax_cuda)+" GFLOP/s")
 
         for group_label in y_scatter_by_group:
             axes.scatter(
@@ -515,7 +574,8 @@ class FlopsComparison(HipBlasYamlComparison):
                     test,
                     y_scatter_by_group[group_label],
                     # gap_scalar * width,
-                    color='black',
+                    color='#ED1C24',
+                    label = 'MI-100 Performance'
                     # label = group_label,
                     )
             axes.plot(
@@ -524,7 +584,28 @@ class FlopsComparison(HipBlasYamlComparison):
                     y_scatter_by_group[group_label],
                     # 'k*',
                     '-ok',
+                    color='#ED1C24',
                     )
+
+        if compare:
+            for group_label in y_scatter_by_group:
+                axes.scatter(
+                        # x_bar_by_group[group_label],
+                        test,
+                        y_scatter_by_group_cuda[group_label],
+                        # gap_scalar * width,
+                        color='#76B900',
+                        label = "V-100 Performance"
+                        # label = group_label,
+                        )
+                axes.plot(
+                        # x_scatter_by_group[group_label],
+                        test,
+                        y_scatter_by_group_cuda[group_label],
+                        # 'k*',
+                        '-ok',
+                        color='#76B900',
+                        )
 
         axes.xaxis.set_minor_locator(AutoMinorLocator())
         axes.yaxis.set_minor_locator(AutoMinorLocator())
@@ -533,7 +614,127 @@ class FlopsComparison(HipBlasYamlComparison):
         axes.set_xlabel('='.join(xLabel))
         return True
 
+class EfficiencyComparison(HipBlasYamlComparison):
+    def __init__(self, **kwargs):
+        HipBlasYamlComparison.__init__(self, data_type='gflops', **kwargs)
+
+    def plot(self, run_configurations, axes, cuda, compare):
+        num_argument_sets = len(self.argument_sets)
+        if num_argument_sets == 0:
+            return
+
+        sorted_argument_sets = self.sort_argument_sets(isolate_keys=[]) # No sort applied, but labels provided
+        argument_diff = cr.ArgumentSetDifference(self.argument_sets, ignore_keys=self._get_sweep_keys())
+        differences = argument_diff.get_differences()
+        test = []
+        xLabel = []
+        for key in differences:
+            xLabel.append(key)
+        for argument_set_hash, argument_sets in sorted_argument_sets.items():
+            argument_set = argument_sets[0]
+            precision = argument_set.get("compute_type").get_value()
+            function = argument_set.get("function").get_value()
+            for key in differences:
+                argument = argument_set.get(key)
+                test.append(argument.get_value() if argument.is_set() else 'DEFAULT')
+                break;
+
+        grouped_run_configurations = run_configurations.group_by_label()
+
+        num_groups = len(grouped_run_configurations)
+        metric_labels = [key for key in self.argument_sets[0].collect_timing(run_configurations[0])]
+        num_metrics = len(metric_labels)
+        if num_metrics == 0:
+            return
+
+        # loop over independent outputs
+        y_scatter_by_group = OrderedDict()
+        y_scatter_by_group_cuda = OrderedDict()
+        for group_label, run_configuration_group in grouped_run_configurations.items():
+            # x_scatter_by_group[group_label] = []
+            y_scatter_by_group[group_label] = []
+            if compare:
+                y_scatter_by_group_cuda[group_label] = []
+            # loop over argument sets that differ other than the swept variable(s)
+            for subset_label, partial_argument_sets in sorted_argument_sets.items():
+                if len(partial_argument_sets) != 1:
+                    raise ValueError('Assumed that sorting argument sets with no keys has a single element per sort.')
+                argument_set = partial_argument_sets[0]
+                y_list_by_metric = OrderedDict() # One array of y values for each metric
+                y_list_by_metric_cuda = OrderedDict()
+                # loop over number of coarse grain runs and concatenate results
+                for run_configuration in run_configuration_group:
+                    results = argument_set.collect_timing(run_configuration)
+                    for metric_label in results:
+                        if not metric_label in y_list_by_metric:
+                            y_list_by_metric[metric_label] = []
+                        y_list_by_metric[metric_label].extend(results[metric_label])
+                    if compare:
+                        results_cuda = argument_set.collect_timing_compare(run_configuration)
+                        for metric_label in results_cuda:
+                            if not metric_label in y_list_by_metric_cuda:
+                                y_list_by_metric_cuda[metric_label] = []
+                            y_list_by_metric_cuda[metric_label].extend(results_cuda[metric_label])
+                # For each metric, add a set of bars in the bar chart.
+                for metric_label, y_list in y_list_by_metric.items():
+                    y_scatter_by_group[group_label].extend(sorted(y_list))
+                if compare:
+                    for metric_label, y_list in y_list_by_metric_cuda.items():
+                        y_scatter_by_group_cuda[group_label].extend(sorted(y_list))
+
+        for group_label, run_configuration_group in grouped_run_configurations.items():
+            for run_configuration in run_configuration_group:
+                mhz_str = "Mhz"
+                mem_clk_str = "mclk"
+                sys_clk_str = "sclk"
+                if cuda:
+                    mhz_str = "MHz"
+                    mem_clk_str = "memory"
+                    sys_clk_str = "sm"
+                mclk = 1200.0
+                sclk = 1087.0
+                # mclk = run_configuration.load_specifications()['Card0']["Start " + mem_clk_str].split(mhz_str)[0]
+                # sclk = run_configuration.load_specifications()['Card0']["Start " + sys_clk_str].split(mhz_str)[0]
+                sclk_cuda = 1530.0
+                theoMax = 0
+                theoMax_cuda = 0
+                precisionBits = int(re.search(r'\d+', precision).group())
+                if(function == 'gemm' and precisionBits == 32): #xdlops
+                    theoMax = float(sclk)/1000.00 * 256 * 120 #scaling to appropriate precision
+                    theoMax_cuda = float(sclk_cuda)/1000.00 * 128 * 80
+                elif(function == 'trsm' or function == 'gemm'):  #TODO better logic to decide memory bound vs compute bound
+                    theoMax = float(sclk)/1000.00 * 128 * 120  * 32.00 / precisionBits #scaling to appropriate precision
+                    theoMax_cuda = float(sclk_cuda)/1000.00 * 128 * 80 * 32.00 / precisionBits
+                elif self.flops and self.mem:
+                    # TODO: cuda here
+                    try:
+                        n=100000
+                        flops = eval(self.flops)
+                        mem = eval(self.mem)
+                        theoMax = float(mclk) / float(eval(self.mem)) * eval(self.flops) * 32 / precisionBits / 4
+                    except:
+                        print("flops and mem equations produce errors")
+
+                # Comparing efficiency
+                amd_performance_eff = OrderedDict()
+                cuda_performance_eff = OrderedDict()
+                amd_perf_list = [x / theoMax for x in y_scatter_by_group[group_label]]
+                axes.plot(test, amd_perf_list, color='#ED1C24', label = "MI-100 Efficiency")
+                if compare:
+                    cuda_perf_list = [x / theoMax_cuda for x in y_scatter_by_group_cuda[group_label]]
+                    axes.plot(test, cuda_perf_list, color='#76B900', label = "V-100 Efficiency")
+                axes.grid(True, which='major')
+                axes.grid(True, which='minor')
+                axes.yaxis.set_minor_locator(AutoMinorLocator(2))
+                axes.set_ylim([0, 1])
+                axes.set_ylabel('Efficiency')
+
+        axes.set_ylabel(metric_labels[0] if len(metric_labels) == 1 else 'Time (s)' )
+        axes.set_xlabel('='.join(xLabel))
+        return True
+
 data_type_classes['gflops'] = FlopsComparison
+data_type_classes['efficiency'] = EfficiencyComparison
 class BandwidthComparison(HipBlasYamlComparison):
     def __init__(self, **kwargs):
         HipBlasYamlComparison.__init__(self, data_type='bandwidth', **kwargs)


### PR DESCRIPTION
This adds the following features to the hipBLAS performance scripts:
- Allows performance scripts to be ran on CUDA machines.
- Allows the creation of efficiency plots (this takes GFLOPS and compares it to the theoretical max for GFLOPS)
- Allows 2 runs to be compared on the same plot. Currently this is solely to compare a single run to an already-completed run from a CUDA machine. This can be expanded in the future if people are interested in comparing other data.

I've also opened [this ticket](http://ontrack-internal.amd.com/browse/LWPMLSE-102) to clean up some of the performance plotting code.

Note that I'm the only one that's currently using these scripts and that the changes to them are ongoing, they still need a lot of improvement, but these changes currently work for my needs.