### PR TITLE
Fixing half-precision alpha for gemm tests.

### DIFF
--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -33,8 +33,21 @@ hipblasStatus_t testing_gemm(const Arguments& argus)
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasOperation_t transB = char2hipblas_operation(argus.transB_option);
 
-    T alpha = argus.alpha;
-    T beta  = argus.beta;
+    float alpha_float = argus.alpha;
+    float beta_float  = argus.beta;
+
+    T alpha, beta;
+
+    if(is_same<T, hipblasHalf>::value)
+    {
+        alpha = float_to_half(alpha_float);
+        beta  = float_to_half(beta_float);
+    }
+    else
+    {
+        alpha = static_cast<T>(alpha_float);
+        beta  = static_cast<T>(beta_float);
+    }
 
     int A_size, B_size, C_size, A_row, A_col, B_row, B_col;
 

--- a/clients/include/testing_gemm_batched.hpp
+++ b/clients/include/testing_gemm_batched.hpp
@@ -35,17 +35,17 @@ hipblasStatus_t testing_gemm_batched(const Arguments& argus)
     float alpha_float = argus.alpha;
     float beta_float  = argus.beta;
 
-    T alpha, beta;
+    T h_alpha, h_beta;
 
     if(is_same<T, hipblasHalf>::value)
     {
-        alpha = float_to_half(alpha_float);
-        beta  = float_to_half(beta_float);
+        h_alpha = float_to_half(alpha_float);
+        h_beta  = float_to_half(beta_float);
     }
     else
     {
-        alpha = static_cast<T>(alpha_float);
-        beta  = static_cast<T>(beta_float);
+        h_alpha = static_cast<T>(alpha_float);
+        h_beta  = static_cast<T>(beta_float);
     }
 
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);

--- a/clients/include/testing_gemm_batched.hpp
+++ b/clients/include/testing_gemm_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -32,8 +32,21 @@ hipblasStatus_t testing_gemm_batched(const Arguments& argus)
     int ldb = argus.ldb;
     int ldc = argus.ldc;
 
-    T h_alpha = argus.alpha;
-    T h_beta  = argus.beta;
+    float alpha_float = argus.alpha;
+    float beta_float  = argus.beta;
+
+    T alpha, beta;
+
+    if(is_same<T, hipblasHalf>::value)
+    {
+        alpha = float_to_half(alpha_float);
+        beta  = float_to_half(beta_float);
+    }
+    else
+    {
+        alpha = static_cast<T>(alpha_float);
+        beta  = static_cast<T>(beta_float);
+    }
 
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasOperation_t transB = char2hipblas_operation(argus.transB_option);

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -44,8 +44,22 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
 
     int A_size, B_size, C_size, A_row, A_col, B_row, B_col;
     int bsa, bsb, bsc; // batch size A, B, C
-    T   alpha = argus.alpha;
-    T   beta  = argus.beta;
+
+    float alpha_float = argus.alpha;
+    float beta_float  = argus.beta;
+
+    T alpha, beta;
+
+    if(is_same<T, hipblasHalf>::value)
+    {
+        alpha = float_to_half(alpha_float);
+        beta  = float_to_half(beta_float);
+    }
+    else
+    {
+        alpha = static_cast<T>(alpha_float);
+        beta  = static_cast<T>(beta_float);
+    }
 
     double hipblas_error;
     double gpu_time_used, cpu_time_used;


### PR DESCRIPTION
Previously wasn't handling this correctly, the simple cast doesn't work as expected. This matches gemm_ex tests for now. Also it doesn't look like we have tests for a non-zero imaginary part for cgemm/zgemm, I'll make a ticket for this.