### PR TITLE
Don't look for CUDA by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 if( USE_CUDA)
     find_package( HIP REQUIRED MODULE )
 else( )
-    find_package(hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
+    find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
 endif( )
 
 if( USE_CUDA )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,8 @@ option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend
 option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
-if(USE_CUDA)
-    find_package( CUDA QUIET )
+if (USE_CUDA)
+    find_package( CUDA REQUIRED )
 endif()
 
 # Hip headers required of all clients; clients use hip to allocate device memory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 
 # Hip headers required of all clients; clients use hip to allocate device memory
 if( USE_CUDA)
-    find_package( HIP REQUIRED )
+    find_package( HIP REQUIRED MODULE )
 else( )
     find_package(hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
 endif( )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 
 # Quietly look for CUDA, but if not found it's not an error
 # The presense of hip is not sufficient to determine if we want a rocm or cuda backend
-option(USE_CUDA "Look for CUDA and use that as a backend if found" ON)
+option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
 if(USE_CUDA)
     find_package( CUDA QUIET )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,7 @@ endif( )
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 
-# Quietly look for CUDA, but if not found it's not an error
-# The presense of hip is not sufficient to determine if we want a rocm or cuda backend
+# Find CUDA if the user wants a CUDA version.
 option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
 if (USE_CUDA)
     find_package( CUDA REQUIRED )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 
 # Hip headers required of all clients; clients use hip to allocate device memory
 if( USE_CUDA)
-    find_package( HIP REQUIRED MODULE )
+    find_package( HIP MODULE REQUIRED )
 else( )
     find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
 endif( )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -58,14 +58,12 @@ target_link_libraries( hipblas-bench PRIVATE hipblas_fortran_client roc::hipblas
 # need mf16c flag for float->half convertion
 target_compile_options( hipblas-bench PRIVATE -mf16c)
 
-if( NOT CUDA_FOUND )
-  target_compile_definitions( hipblas-bench PRIVATE __HIP_PLATFORM_HCC__ )
+if( NOT USE_CUDA )
+  target_link_libraries( hipblas-bench PRIVATE hip::host )
 
   if( CUSTOM_TARGET )
-    target_link_libraries( hipblas-bench PRIVATE hip::${CUSTOM_TARGET} hip::host )
-  else( )
-    target_link_libraries( hipblas-bench PRIVATE hip::host )
-  endif( )
+    target_link_libraries( hipblas-bench PRIVATE hip::${CUSTOM_TARGET} )
+  endif()
 
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
     # hip-clang needs specific flag to turn on pthread and m

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -150,14 +150,11 @@ target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack ${GTEST_LI
 # need mf16c flag for float->half convertion
 target_compile_options( hipblas-test PRIVATE -mf16c )
 
-if( NOT CUDA_FOUND )
-  target_compile_definitions( hipblas-test PRIVATE __HIP_PLATFORM_HCC__ )
-
+if( NOT USE_CUDA )
+  target_link_libraries( hipblas-test PRIVATE hip::host )
 
   if( CUSTOM_TARGET )
-    target_link_libraries( hipblas-test PRIVATE hip::${CUSTOM_TARGET} hip::host )
-  else( )
-      target_link_libraries( hipblas-test PRIVATE hip::host )
+    target_link_libraries( hipblas-test PRIVATE hip::${CUSTOM_TARGET} )
   endif( )
 
   if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -38,13 +38,11 @@ foreach( exe example-sscal;example-sgemm;example-sgemm-strided-batched;example-c
 
   target_link_libraries( ${exe} PRIVATE roc::hipblas )
 
-  if( NOT CUDA_FOUND )
-    target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_HCC__ )
+  if( NOT USE_CUDA )
+    target_link_libraries( ${exe} PRIVATE hip::host )
 
     if( CUSTOM_TARGET )
-      target_link_libraries( ${exe} PRIVATE hip::${CUSTOM_TARGET} hip::host )
-    else( )
-      target_link_libraries( ${exe} PRIVATE hip::host )
+      target_link_libraries( ${exe} PRIVATE hip::${CUSTOM_TARGET} )
     endif( )
 
   else( )

--- a/install.sh
+++ b/install.sh
@@ -450,7 +450,9 @@ pushd .
   fi
 
   # cuda
-  if [[ "${build_cuda}" == false ]]; then
+  if [[ "${build_cuda}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DUSE_CUDA=ON"
+  else
     cmake_common_options="${cmake_common_options} -DUSE_CUDA=OFF"
   fi
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -74,7 +74,7 @@ endif( )
 set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib" )
 
 # Give hipblas compiled for CUDA backend a different name
-if( NOT CUDA_FOUND )
+if( NOT USE_CUDA )
     set( package_name hipblas )
 else( )
     set( package_name hipblas-alt )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -21,7 +21,7 @@ endfunction( )
 # ########################################################################
 prepend_path( ".." hipblas_headers_public relative_hipblas_headers_public )
 
-if( NOT CUDA_FOUND )
+if( NOT USE_CUDA )
   set( hipblas_source "${CMAKE_CURRENT_SOURCE_DIR}/hcc_detail/hipblas.cpp" )
 else( )
   set( hipblas_source "${CMAKE_CURRENT_SOURCE_DIR}/nvcc_detail/hipblas.cpp" )
@@ -47,7 +47,7 @@ target_include_directories( hipblas
 )
 
 # Build hipblas from source on AMD platform
-if( NOT CUDA_FOUND )
+if( NOT USE_CUDA )
   if( NOT TARGET rocblas )
     if( CUSTOM_ROCBLAS )
       set ( ENV{rocblas_DIR} ${CUSTOM_ROCBLAS})
@@ -57,9 +57,7 @@ if( NOT CUDA_FOUND )
     endif( )
   endif( )
 
-  target_compile_definitions( hipblas PRIVATE __HIP_PLATFORM_HCC__ )
-
-  target_link_libraries( hipblas PRIVATE roc::rocblas )
+  target_link_libraries( hipblas PRIVATE roc::rocblas hip::host )
 
   # Add rocSOLVER as a dependency if BUILD_WITH_SOLVER is on
   if( BUILD_WITH_SOLVER )
@@ -71,8 +69,6 @@ if( NOT CUDA_FOUND )
 
   if( CUSTOM_TARGET )
     target_link_libraries( hipblas PRIVATE hip::${CUSTOM_TARGET} )
-  else( )
-    target_link_libraries( hipblas PRIVATE hip::host )
   endif( )
 
 else( )


### PR DESCRIPTION
Detection of whether HIP uses HCC or NVCC should really be improved, but I leave that up to AMD.

How it's done here with `USE_CUDA=ON` by default, and then

```
if( NOT CUDA_FOUND )
  target_compile_definitions( hipblas-bench PRIVATE __HIP_PLATFORM_HCC__ )
```

is really poor practice, cause you can have a system CUDA install but still have HIP configured with HCC.

Please just infer from the HIP config file if the compiler is HCC or NVCC, don't assume "if the user has CUDA they likely want CUDA".


Thanks!
