### PR TITLE
Updating int8 gemm_ex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log for hipBLAS
 
-## [(Unreleased) hipBLAS 0.42.0 for ROCm 4.1.0]
+## [hipBLAS 0.44 for ROCm 4.2.0]
+### Added
+- Made necessary changes to work with rocBLAS' gemm_ex changes. When using rocBLAS backend, hipBLAS will query the preferable
+  layout of int8 data to be passed to gemm_ex, and will pass in the resulting flag. Users must be sure to use the preferable
+  data format when calling gemm_ex with a rocBLAS backend.
+
+## [hipBLAS 0.42.0 for ROCm 4.1.0]
 ### Added
 - Added the following functions. All added functions include batched and strided-batched support with rocBLAS backend:
     - axpy_ex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for hipBLAS
 
-## [hipBLAS 0.44 for ROCm 4.2.0]
+## [hipBLAS 0.44.0 for ROCm 4.2.0]
 ### Added
 - Made necessary changes to work with rocBLAS' gemm_ex changes. When using rocBLAS backend, hipBLAS will query the preferable
   layout of int8 data to be passed to gemm_ex, and will pass in the resulting flag. Users must be sure to use the preferable

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -157,6 +157,28 @@ void set_device(int device_id)
         printf("Set device error: cannot set device ID %d, there may not be such device ID\n",
                (int)device_id);
     }
+}
+
+/*******************************************************************************
+ * GPU architecture-related functions
+ ******************************************************************************/
+
+int getArch()
+{
+    int device;
+    hipGetDevice(&device);
+    hipDeviceProp_t deviceProperties;
+    hipGetDeviceProperties(&deviceProperties, device);
+    return deviceProperties.gcnArch;
+}
+
+/*******************************************************************************
+ * gemm_ex int8 layout
+ ******************************************************************************/
+bool layout_pack_int8()
+{
+    int arch = getArch();
+    return arch != 908;
 }
 
 #ifdef __cplusplus

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -150,7 +150,7 @@ hipblasStatus_t testing_gemm_batched_ex_template(const Arguments& argus)
         CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b].data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(bB[b], hB[b].data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
 #else
-        if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N)
+        if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N && layout_pack_int8())
         {
             vector<Ta> hA_packed(hA[b]);
             hipblas_packInt8(hA_packed, M, K, lda);
@@ -163,7 +163,7 @@ hipblasStatus_t testing_gemm_batched_ex_template(const Arguments& argus)
                 hipMemcpy(bA[b], hA[b].data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
         }
 
-        if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N)
+        if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N && layout_pack_int8())
         {
             vector<Tb> hB_packed(hB[b]);
             hipblas_packInt8(hB_packed, N, K, ldb);

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -133,7 +133,7 @@ hipblasStatus_t testing_gemm_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
 #else
-    if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N)
+    if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N && layout_pack_int8())
     {
         vector<Ta> hA_packed(hA);
         hipblas_packInt8(hA_packed, M, K, lda);
@@ -145,7 +145,7 @@ hipblasStatus_t testing_gemm_ex_template(const Arguments& argus)
         CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
     }
 
-    if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N)
+    if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N && layout_pack_int8())
     {
         vector<Tb> hB_packed(hB);
         hipblas_packInt8(hB_packed, N, K, ldb);

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -145,7 +145,7 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
 #else
-    if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N)
+    if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N && layout_pack_int8())
     {
         vector<Ta> hA_packed(hA);
         hipblas_packInt8(hA_packed, M, K, lda, batch_count, stride_A);
@@ -157,7 +157,7 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(const Arguments& argus)
         CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
     }
 
-    if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N)
+    if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N && layout_pack_int8())
     {
         vector<Tb> hB_packed(hB);
         hipblas_packInt8(hB_packed, N, K, ldb, batch_count, stride_B);

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -7,6 +7,7 @@
 #define _TESTING_UTILITY_H_
 
 #include "hipblas.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 #include "cblas_interface.h"

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -662,6 +662,14 @@ int query_device_property();
 
 /*  set current device to device_id */
 void set_device(int device_id);
+
+/* get architecture number */
+int getArch();
+
+/* query what rocBLAS recommends for int8 layout. We are /always/ passing in the flag which
+/* rocBLAS recommends, thus we need to know what layout to format our data in our tests.
+/* returns true if should be packed. */
+bool layout_pack_int8();
 
 /* ============================================================================================ */
 /*  timing: HIP only provides very limited timers function clock() and not general;

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -14239,8 +14239,9 @@ hipblasStatus_t hipblasZgemmStridedBatched(hipblasHandle_t             handle,
 }
 
 // gemm_ex
-// First, we are querying the intended int8 layout from rocBLAS and passing in the result.
-// Users should ensure that they are passing in the correct data layout for this function.
+// Note for int8 users - For rocBLAS backend, please read rocblas_gemm_ex documentation on int8
+// data layout requirements. hipBLAS makes the assumption that the data layout is in the preferred
+// format for a given device as documented in rocBLAS.
 hipblasStatus_t hipblasGemmEx(hipblasHandle_t    handle,
                               hipblasOperation_t transa,
                               hipblasOperation_t transb,

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 #include "hipblas.h"
 #include "limits.h"
@@ -14239,6 +14239,8 @@ hipblasStatus_t hipblasZgemmStridedBatched(hipblasHandle_t             handle,
 }
 
 // gemm_ex
+// First, we are querying the intended int8 layout from rocBLAS and passing in the result.
+// Users should ensure that they are passing in the correct data layout for this function.
 hipblasStatus_t hipblasGemmEx(hipblasHandle_t    handle,
                               hipblasOperation_t transa,
                               hipblasOperation_t transb,
@@ -14259,8 +14261,12 @@ hipblasStatus_t hipblasGemmEx(hipblasHandle_t    handle,
                               hipblasDatatype_t  compute_type,
                               hipblasGemmAlgo_t  algo)
 {
-    uint32_t solution_index = 0;
-    uint32_t flags          = 0;
+    uint32_t           solution_index = 0;
+    rocblas_gemm_flags flags          = rocblas_gemm_flags_none;
+
+    rocblas_status status = rocblas_query_int8_layout_flag((rocblas_handle)handle, &flags);
+    if(status != rocblas_status_success)
+        return rocBLASStatusToHIPStatus(status);
 
     return rocBLASStatusToHIPStatus(rocblas_gemm_ex((rocblas_handle)handle,
                                                     hipOperationToHCCOperation(transa),


### PR DESCRIPTION
Updating hipBLAS to work correctly with the new rocBLAS gemm_ex.

- When calling hipblasGemmEx with a rocBLAS backend, we now query the preferable data format for the architecture. This preferred data format is then passed into the call for rocblas_gemm_ex.
- Slight additions were needed to be able to query the architecture from hipBLAS clients to get our tests to work. Note I haven't tested this on gfx908 yet, will wait for CI.

The changes to the testing infrastructure (that is, adding the architecture query) is needed as we are not exposing the rocblas_query API function in hipBLAS with this PR. Any user that is building a program to run on multiple architectures will have to do something similar, unless we decide to expose the query API in hipBLAS as well.