### PR TITLE
trmm legacy flop calculations

### DIFF
--- a/clients/gtest/trmm_gtest.cpp
+++ b/clients/gtest/trmm_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -140,7 +140,7 @@ Arguments setup_trmm_arguments(trmm_tuple tup)
     arg.transA_option = side_uplo_transA_diag[2];
     arg.diag_option   = side_uplo_transA_diag[3];
 
-    arg.timing = 1;
+    arg.timing = 0;
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -203,7 +203,7 @@ constexpr double gemm_gbyte_count(int m, int n, int k)
 template <typename T>
 constexpr double trmm_gbyte_count(int m, int n, int k)
 {
-    return (sizeof(T) * (m * n + tri_count(k))) / 1e9;
+    return (sizeof(T) * (m * n * 2 + k * k / 2)) / 1e9;
 }
 
 /* \brief byte counts of TRSM */

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -722,19 +722,19 @@ constexpr double syrkx_gflop_count<hipblasDoubleComplex>(int n, int k)
 template <typename T>
 constexpr double trmm_gflop_count(int m, int n, int k)
 {
-    return (1.0 * m * n * (k + 1)) / 1e9;
+    return (1.0 * m * n * k) / 1e9;
 }
 
 template <>
 constexpr double trmm_gflop_count<hipblasComplex>(int m, int n, int k)
 {
-    return 4 * (1.0 * m * n * (k + 1)) / 1e9;
+    return 4 * (1.0 * m * n * k) / 1e9;
 }
 
 template <>
 constexpr double trmm_gflop_count<hipblasDoubleComplex>(int m, int n, int k)
 {
-    return 4 * (1.0 * m * n * (k + 1)) / 1e9;
+    return 4 * (1.0 * m * n * k) / 1e9;
 }
 
 /* \brief floating point counts of TRSM */


### PR DESCRIPTION
Matching trmm flop calculations from http://www.netlib.org/blas/sblas3time.f. See #311 for some discussion.