### PR TITLE
Updating hemv, her, her2, hpmv, hpr, hpr2 tests

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -557,11 +557,11 @@ struct perf_blas<
             {"hpr", testing_hpr<T>},
             {"hpr_batched", testing_hpr_batched<T>},
             {"hpr_strided_batched", testing_hpr_strided_batched<T>},
+            {"hpr2", testing_hpr2<T>},
+            {"hpr2_batched", testing_hpr2_batched<T>},
+            {"hpr2_strided_batched", testing_hpr2_strided_batched<T>},
             /*
                 // L2
-                {"hpr2", testing_hpr2<T>},
-                {"hpr2_batched", testing_hpr2_batched<T>},
-                {"hpr2_strided_batched", testing_hpr2_strided_batched<T>},
                 {"spr", testing_spr<T>},
                 {"spr_batched", testing_spr_batched<T>},
                 {"spr_strided_batched", testing_spr_strided_batched<T>},

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -554,11 +554,11 @@ struct perf_blas<
             {"hpmv", testing_hpmv<T>},
             {"hpmv_batched", testing_hpmv_batched<T>},
             {"hpmv_strided_batched", testing_hpmv_strided_batched<T>},
+            {"hpr", testing_hpr<T>},
+            {"hpr_batched", testing_hpr_batched<T>},
+            {"hpr_strided_batched", testing_hpr_strided_batched<T>},
             /*
                 // L2
-                {"hpr", testing_hpr<T>},
-                {"hpr_batched", testing_hpr_batched<T>},
-                {"hpr_strided_batched", testing_hpr_strided_batched<T>},
                 {"hpr2", testing_hpr2<T>},
                 {"hpr2_batched", testing_hpr2_batched<T>},
                 {"hpr2_strided_batched", testing_hpr2_strided_batched<T>},

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -548,11 +548,11 @@ struct perf_blas<
             {"her", testing_her<T>},
             {"her_batched", testing_her_batched<T>},
             {"her_strided_batched", testing_her_strided_batched<T>},
+            {"her2", testing_her2<T>},
+            {"her2_batched", testing_her2_batched<T>},
+            {"her2_strided_batched", testing_her2_strided_batched<T>},
             /*
                 // L2
-                {"her2", testing_her2<T>},
-                {"her2_batched", testing_her2_batched<T>},
-                {"her2_strided_batched", testing_her2_strided_batched<T>},
                 {"hpmv", testing_hpmv<T>},
                 {"hpmv_batched", testing_hpmv_batched<T>},
                 {"hpmv_strided_batched", testing_hpmv_strided_batched<T>},

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -551,11 +551,11 @@ struct perf_blas<
             {"her2", testing_her2<T>},
             {"her2_batched", testing_her2_batched<T>},
             {"her2_strided_batched", testing_her2_strided_batched<T>},
+            {"hpmv", testing_hpmv<T>},
+            {"hpmv_batched", testing_hpmv_batched<T>},
+            {"hpmv_strided_batched", testing_hpmv_strided_batched<T>},
             /*
                 // L2
-                {"hpmv", testing_hpmv<T>},
-                {"hpmv_batched", testing_hpmv_batched<T>},
-                {"hpmv_strided_batched", testing_hpmv_strided_batched<T>},
                 {"hpr", testing_hpr<T>},
                 {"hpr_batched", testing_hpr_batched<T>},
                 {"hpr_strided_batched", testing_hpr_strided_batched<T>},

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -545,11 +545,11 @@ struct perf_blas<
             {"hemv", testing_hemv<T>},
             {"hemv_batched", testing_hemv_batched<T>},
             {"hemv_strided_batched", testing_hemv_strided_batched<T>},
+            {"her", testing_her<T>},
+            {"her_batched", testing_her_batched<T>},
+            {"her_strided_batched", testing_her_strided_batched<T>},
             /*
                 // L2
-                {"her", testing_her<T>},
-                {"her_batched", testing_her_batched<T>},
-                {"her_strided_batched", testing_her_strided_batched<T>},
                 {"her2", testing_her2<T>},
                 {"her2_batched", testing_her2_batched<T>},
                 {"her2_strided_batched", testing_her2_strided_batched<T>},

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -542,11 +542,11 @@ struct perf_blas<
             {"hbmv", testing_hbmv<T>},
             {"hbmv_batched", testing_hbmv_batched<T>},
             {"hbmv_strided_batched", testing_hbmv_strided_batched<T>},
+            {"hemv", testing_hemv<T>},
+            {"hemv_batched", testing_hemv_batched<T>},
+            {"hemv_strided_batched", testing_hemv_strided_batched<T>},
             /*
                 // L2
-                {"hemv", testing_hemv<T>},
-                {"hemv_batched", testing_hemv_batched<T>},
-                {"hemv_strided_batched", testing_hemv_strided_batched<T>},
                 {"her", testing_her<T>},
                 {"her_batched", testing_her_batched<T>},
                 {"her_strided_batched", testing_her_strided_batched<T>},

--- a/clients/gtest/hemv_batched_gtest.cpp
+++ b/clients/gtest/hemv_batched_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -145,7 +145,7 @@ TEST_P(hemv_gtest_batched, hemv_gtest_float_complex)
 {
     Arguments arg = setup_hemv_arguments(GetParam());
 
-    hipblasStatus_t status = testing_hemvBatched<hipblasComplex>(arg);
+    hipblasStatus_t status = testing_hemv_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/hemv_strided_batched_gtest.cpp
+++ b/clients/gtest/hemv_strided_batched_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -156,7 +156,7 @@ TEST_P(hemv_gtest_strided_batched, hemv_gtest_float_complex)
 {
     Arguments arg = setup_hemv_arguments(GetParam());
 
-    hipblasStatus_t status = testing_hemvStridedBatched<hipblasComplex>(arg);
+    hipblasStatus_t status = testing_hemv_strided_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/her_gtest.cpp
+++ b/clients/gtest/her_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -131,7 +131,7 @@ TEST_P(blas2_her_gtest, her_gtest_float)
 
     Arguments arg = setup_her_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_her<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -156,7 +156,7 @@ TEST_P(blas2_her_gtest, her_gtest_double)
 
     Arguments arg = setup_her_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_her<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -182,7 +182,7 @@ TEST_P(blas2_her_gtest, her_batched_gtest_float)
 
     Arguments arg = setup_her_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_her_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -207,7 +207,7 @@ TEST_P(blas2_her_gtest, her_batched_gtest_double)
 
     Arguments arg = setup_her_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_her_batched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -233,7 +233,7 @@ TEST_P(blas2_her_gtest, her_strided_batched_gtest_float)
 
     Arguments arg = setup_her_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her_strided_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_her_strided_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -258,7 +258,7 @@ TEST_P(blas2_her_gtest, her_strided_batched_gtest_double)
 
     Arguments arg = setup_her_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her_strided_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_her_strided_batched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/hpr_gtest.cpp
+++ b/clients/gtest/hpr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -113,7 +113,7 @@ TEST_P(blas2_hpr_gtest, hpr_gtest_float)
 
     Arguments arg = setup_hpr_arguments(GetParam());
 
-    hipblasStatus_t status = testing_hpr<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_hpr<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -138,7 +138,7 @@ TEST_P(blas2_hpr_gtest, hpr_gtest_double)
 
     Arguments arg = setup_hpr_arguments(GetParam());
 
-    hipblasStatus_t status = testing_hpr<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_hpr<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -164,7 +164,7 @@ TEST_P(blas2_hpr_gtest, hpr_batched_gtest_float)
 
     Arguments arg = setup_hpr_arguments(GetParam());
 
-    hipblasStatus_t status = testing_hpr_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_hpr_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -189,7 +189,7 @@ TEST_P(blas2_hpr_gtest, hpr_batched_gtest_double)
 
     Arguments arg = setup_hpr_arguments(GetParam());
 
-    hipblasStatus_t status = testing_hpr_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_hpr_batched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -215,7 +215,7 @@ TEST_P(blas2_hpr_gtest, hpr_strided_batched_gtest_float)
 
     Arguments arg = setup_hpr_arguments(GetParam());
 
-    hipblasStatus_t status = testing_hpr_strided_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_hpr_strided_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -240,7 +240,7 @@ TEST_P(blas2_hpr_gtest, hpr_strided_batched_gtest_double)
 
     Arguments arg = setup_hpr_arguments(GetParam());
 
-    hipblasStatus_t status = testing_hpr_strided_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_hpr_strided_batched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -143,6 +143,13 @@ constexpr double hemv_gbyte_count(int n)
     return (8.0 * n * n + 8.0 * n) / 1e9;
 }
 
+/* \brief byte counts of HPMV */
+template <typename T>
+constexpr double hpmv_gbyte_count(int n)
+{
+    return (sizeof(T) * ((n * (n + 1.0)) / 2.0) + 3.0 * n) / 1e9;
+}
+
 /* \brief byte counts of HPR */
 template <typename T>
 constexpr double hpr_gbyte_count(int n)

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -140,7 +140,7 @@ constexpr double hbmv_gbyte_count(int n, int k)
 template <typename T>
 constexpr double hemv_gbyte_count(int n)
 {
-    return (8.0 * n * n + 8.0 * n) / 1e9;
+    return (sizeof(T) * (((n * (n + 1.0)) / 2.0) + 3.0 * n)) / 1e9;
 }
 
 /* \brief byte counts of HPMV */

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -136,6 +136,13 @@ constexpr double hbmv_gbyte_count(int n, int k)
     return (sizeof(T) * (n * k1 - ((k1 * (k1 + 1)) / 2.0) + 3 * n)) / 1e9;
 }
 
+/* \brief byte counts of HEMV */
+template <typename T>
+constexpr double hemv_gbyte_count(int n)
+{
+    return (8.0 * n * n + 8.0 * n) / 1e9;
+}
+
 /* \brief byte counts of HPR */
 template <typename T>
 constexpr double hpr_gbyte_count(int n)

--- a/clients/include/testing_gbmv.hpp
+++ b/clients/include/testing_gbmv.hpp
@@ -68,8 +68,8 @@ hipblasStatus_t testing_gbmv(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
-    T h_beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     hipblasLocalHandle handle(argus);
 
@@ -161,7 +161,7 @@ hipblasStatus_t testing_gbmv(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_M, e_N, e_KL, e_KU, e_lda, e_incx, e_incy>{}.log_args<T>(
+        ArgumentModel<e_M, e_N, e_KL, e_KU, e_alpha, e_lda, e_incx, e_beta, e_incy>{}.log_args<T>(
             std::cout,
             argus,
             gpu_time_used,

--- a/clients/include/testing_gbmv_batched.hpp
+++ b/clients/include/testing_gbmv_batched.hpp
@@ -66,8 +66,8 @@ hipblasStatus_t testing_gbmv_batched(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
-    T h_beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);
@@ -201,14 +201,14 @@ hipblasStatus_t testing_gbmv_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_M, e_N, e_KL, e_KU, e_lda, e_incx, e_incy, e_batch_count>{}.log_args<T>(
-            std::cout,
-            argus,
-            gpu_time_used,
-            gbmv_gflop_count<T>(transA, M, N, KL, KU),
-            gbmv_gbyte_count<T>(transA, M, N, KL, KU),
-            hipblas_error_host,
-            hipblas_error_device);
+        ArgumentModel<e_M, e_N, e_KL, e_KU, e_alpha, e_lda, e_incx, e_beta, e_incy, e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         gbmv_gflop_count<T>(transA, M, N, KL, KU),
+                         gbmv_gbyte_count<T>(transA, M, N, KL, KU),
+                         hipblas_error_host,
+                         hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_gbmv_strided_batched.hpp
+++ b/clients/include/testing_gbmv_strided_batched.hpp
@@ -86,8 +86,8 @@ hipblasStatus_t testing_gbmv_strided_batched(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
-    T h_beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     hipblasLocalHandle handle(argus);
 
@@ -232,10 +232,12 @@ hipblasStatus_t testing_gbmv_strided_batched(const Arguments& argus)
                       e_N,
                       e_KL,
                       e_KU,
+                      e_alpha,
                       e_lda,
                       e_stride_a,
                       e_incx,
                       e_stride_x,
+                      e_beta,
                       e_incy,
                       e_stride_y>{}
             .log_args<T>(std::cout,

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -66,8 +66,8 @@ hipblasStatus_t testing_gemv(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
-    T h_beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     hipblasLocalHandle handle(argus);
 

--- a/clients/include/testing_gemv_batched.hpp
+++ b/clients/include/testing_gemv_batched.hpp
@@ -63,8 +63,8 @@ hipblasStatus_t testing_gemv_batched(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
-    T h_beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_gemv_strided_batched.hpp
+++ b/clients/include/testing_gemv_strided_batched.hpp
@@ -83,8 +83,8 @@ hipblasStatus_t testing_gemv_strided_batched(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
-    T h_beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     hipblasLocalHandle handle(argus);
 

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -124,13 +124,14 @@ hipblasStatus_t testing_ger(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_M, e_N, e_incx, e_incy, e_lda>{}.log_args<T>(std::cout,
-                                                                     argus,
-                                                                     gpu_time_used,
-                                                                     ger_gflop_count<T, CONJ>(M, N),
-                                                                     ger_gbyte_count<T>(M, N),
-                                                                     hipblas_error_host,
-                                                                     hipblas_error_device);
+        ArgumentModel<e_M, e_N, e_alpha, e_incx, e_incy, e_lda>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            ger_gflop_count<T, CONJ>(M, N),
+            ger_gbyte_count<T>(M, N),
+            hipblas_error_host,
+            hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_ger_batched.hpp
+++ b/clients/include/testing_ger_batched.hpp
@@ -167,7 +167,7 @@ hipblasStatus_t testing_ger_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_M, e_N, e_incx, e_incy, e_lda, e_batch_count>{}.log_args<T>(
+        ArgumentModel<e_M, e_N, e_alpha, e_incx, e_incy, e_lda, e_batch_count>{}.log_args<T>(
             std::cout,
             argus,
             gpu_time_used,

--- a/clients/include/testing_ger_strided_batched.hpp
+++ b/clients/include/testing_ger_strided_batched.hpp
@@ -64,7 +64,7 @@ hipblasStatus_t testing_ger_strided_batched(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
+    T h_alpha = argus.get_alpha<T>();
 
     hipblasLocalHandle handle(argus);
 
@@ -190,6 +190,7 @@ hipblasStatus_t testing_ger_strided_batched(const Arguments& argus)
 
         ArgumentModel<e_M,
                       e_N,
+                      e_alpha,
                       e_incx,
                       e_stride_x,
                       e_incy,

--- a/clients/include/testing_hbmv.hpp
+++ b/clients/include/testing_hbmv.hpp
@@ -131,13 +131,14 @@ hipblasStatus_t testing_hbmv(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_K, e_lda, e_incx, e_incy>{}.log_args<T>(std::cout,
-                                                                     argus,
-                                                                     gpu_time_used,
-                                                                     hbmv_gflop_count<T>(N, K),
-                                                                     hbmv_gbyte_count<T>(N, K),
-                                                                     hipblas_error_host,
-                                                                     hipblas_error_device);
+        ArgumentModel<e_N, e_K, e_alpha, e_lda, e_incx, e_beta, e_incy>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            hbmv_gflop_count<T>(N, K),
+            hbmv_gbyte_count<T>(N, K),
+            hipblas_error_host,
+            hipblas_error_device);
     }
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hbmv_batched.hpp
+++ b/clients/include/testing_hbmv_batched.hpp
@@ -180,14 +180,14 @@ hipblasStatus_t testing_hbmv_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_K, e_lda, e_incx, e_incy, e_batch_count>{}.log_args<T>(
-            std::cout,
-            argus,
-            gpu_time_used,
-            hbmv_gflop_count<T>(N, K),
-            hbmv_gbyte_count<T>(N, K),
-            hipblas_error_host,
-            hipblas_error_device);
+        ArgumentModel<e_N, e_K, e_alpha, e_lda, e_incx, e_beta, e_incy, e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         hbmv_gflop_count<T>(N, K),
+                         hbmv_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_hbmv_strided_batched.hpp
+++ b/clients/include/testing_hbmv_strided_batched.hpp
@@ -202,10 +202,12 @@ hipblasStatus_t testing_hbmv_strided_batched(const Arguments& argus)
 
         ArgumentModel<e_N,
                       e_K,
+                      e_alpha,
                       e_lda,
                       e_stride_a,
                       e_incx,
                       e_stride_x,
+                      e_beta,
                       e_incy,
                       e_stride_y,
                       e_batch_count>{}

--- a/clients/include/testing_hemv.hpp
+++ b/clients/include/testing_hemv.hpp
@@ -52,8 +52,8 @@ hipblasStatus_t testing_hemv(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
-    T h_beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     hipblasLocalHandle handle(argus);
 
@@ -130,13 +130,14 @@ hipblasStatus_t testing_hemv(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_lda, e_incx, e_incy>{}.log_args<T>(std::cout,
-                                                                argus,
-                                                                gpu_time_used,
-                                                                hemv_gflop_count<T>(N),
-                                                                hemv_gbyte_count<T>(N),
-                                                                hipblas_error_host,
-                                                                hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_lda, e_incx, e_beta, e_incy>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            hemv_gflop_count<T>(N),
+            hemv_gbyte_count<T>(N),
+            hipblas_error_host,
+            hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_hemv.hpp
+++ b/clients/include/testing_hemv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -27,36 +27,35 @@ hipblasStatus_t testing_hemv(const Arguments& argus)
 
     int A_size = lda * N;
 
-    hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
-    hipblasStatus_t   status = HIPBLAS_STATUS_SUCCESS;
+    hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || lda < N || incx == 0 || incy == 0)
     {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
     host_vector<T> hx(N * incx);
     host_vector<T> hy(N * incy);
-    host_vector<T> hz(N * incy);
+    host_vector<T> hy_cpu(N * incy);
+    host_vector<T> hy_host(N * incy);
+    host_vector<T> hy_device(N * incy);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(N * incx);
     device_vector<T> dy(N * incy);
+    device_vector<T> d_alpha(1);
+    device_vector<T> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = (T)argus.alpha;
-    T beta  = (T)argus.beta;
+    T h_alpha = (T)argus.alpha;
+    T h_beta  = (T)argus.beta;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -64,48 +63,81 @@ hipblasStatus_t testing_hemv(const Arguments& argus)
     hipblas_init<T>(hx, 1, N, incx);
     hipblas_init<T>(hy, 1, N, incy);
 
-    // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
-    hz = hy;
+    // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
+    hy_cpu = hy;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    for(int iter = 0; iter < 1; iter++)
-    {
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHemvFn(handle, uplo, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
 
-        status = hipblasHemvFn(handle, uplo, N, (T*)&alpha, dA, lda, dx, incx, (T*)&beta, dy, incy);
+    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHemvFn(handle, uplo, N, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
 
-    // copy output from device to CPU
-    hipMemcpy(hy.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
 
-        cblas_hemv<T>(uplo, N, alpha, hA.data(), lda, hx.data(), incx, beta, hz.data(), incy);
+        cblas_hemv<T>(
+            uplo, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, incy, hz, hy);
+            unit_check_general<T>(1, N, incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, incy, hy_cpu, hy_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(
+                hipblasHemvFn(handle, uplo, N, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_lda, e_incx, e_incy>{}.log_args<T>(std::cout,
+                                                                argus,
+                                                                gpu_time_used,
+                                                                hemv_gflop_count<T>(N),
+                                                                hemv_gbyte_count<T>(N),
+                                                                hipblas_error_host,
+                                                                hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hemv_batched.hpp
+++ b/clients/include/testing_hemv_batched.hpp
@@ -51,8 +51,8 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T h_alpha = (T)argus.alpha;
-    T h_beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);
@@ -176,7 +176,7 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_lda, e_incx, e_incy, e_batch_count>{}.log_args<T>(
+        ArgumentModel<e_N, e_alpha, e_lda, e_incx, e_beta, e_incy, e_batch_count>{}.log_args<T>(
             std::cout,
             argus,
             gpu_time_used,

--- a/clients/include/testing_hemv_batched.hpp
+++ b/clients/include/testing_hemv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -15,7 +15,7 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename T>
-hipblasStatus_t testing_hemvBatched(const Arguments& argus)
+hipblasStatus_t testing_hemv_batched(const Arguments& argus)
 {
     bool FORTRAN = argus.fortran;
     auto hipblasHemvBatchedFn
@@ -36,8 +36,6 @@ hipblasStatus_t testing_hemvBatched(const Arguments& argus)
     X_size                 = N * incx;
     Y_size                 = N * incy;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || lda < N || incx <= 0 || incy <= 0 || batch_count < 0)
@@ -49,110 +47,81 @@ hipblasStatus_t testing_hemvBatched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = (T)argus.alpha;
-    T beta  = (T)argus.beta;
+    T h_alpha = (T)argus.alpha;
+    T h_beta  = (T)argus.beta;
 
     // arrays of pointers-to-host on host
-    host_vector<T> hA_array[batch_count];
-    host_vector<T> hx_array[batch_count];
-    host_vector<T> hy_array[batch_count];
-    host_vector<T> hz_array[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
+    host_batch_vector<T> hy_host(N, incy, batch_count);
+    host_batch_vector<T> hy_device(N, incy, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy, batch_count);
 
-    // arrays of pointers-to-device on host
-    device_batch_vector<T> bA_array(batch_count, A_size);
-    device_batch_vector<T> bx_array(batch_count, X_size);
-    device_batch_vector<T> by_array(batch_count, Y_size);
+    // device arrays
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
+    device_vector<T>       d_alpha(1);
+    device_vector<T>       d_beta(1);
 
-    // arrays of pointers-to-device on device
-    device_vector<T*, 0, T> dA_array(batch_count);
-    device_vector<T*, 0, T> dx_array(batch_count);
-    device_vector<T*, 0, T> dy_array(batch_count);
-
-    int last = batch_count - 1;
-    if(!dA_array || !dx_array || !dy_array || (!bA_array[last] && A_size)
-       || (!bx_array[last] && X_size) || (!by_array[last] && Y_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dy.memcheck());
 
     // Initial Data on CPU
-    hipError_t err_A, err_x, err_y;
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA_array[b] = host_vector<T>(A_size);
-        hx_array[b] = host_vector<T>(X_size);
-        hy_array[b] = host_vector<T>(Y_size);
-        hz_array[b] = host_vector<T>(Y_size);
+    hipblas_init(hA, true);
+    hipblas_init(hx);
+    hipblas_init(hy);
+    hy_cpu.copy_from(hy);
 
-        // initialize matrices on host
-        srand(1);
-        hipblas_init<T>(hA_array[b], N, N, lda);
-        hipblas_init<T>(hx_array[b], 1, N, incx);
-        hipblas_init<T>(hy_array[b], 1, N, incy);
-
-        hz_array[b] = hy_array[b];
-        err_A = hipMemcpy(bA_array[b], hA_array[b], sizeof(T) * A_size, hipMemcpyHostToDevice);
-        err_x = hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * X_size, hipMemcpyHostToDevice);
-        err_y = hipMemcpy(by_array[b], hy_array[b], sizeof(T) * Y_size, hipMemcpyHostToDevice);
-
-        if(err_A != hipSuccess || err_x != hipSuccess || err_y != hipSuccess)
-        {
-            hipblasDestroy(handle);
-            return HIPBLAS_STATUS_MAPPING_ERROR;
-        }
-    }
-
-    err_A = hipMemcpy(dA_array, bA_array, batch_count * sizeof(T*), hipMemcpyHostToDevice);
-    err_x = hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice);
-    err_y = hipMemcpy(dy_array, by_array, batch_count * sizeof(T*), hipMemcpyHostToDevice);
-    if(err_A != hipSuccess || err_x != hipSuccess || err_y != hipSuccess)
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_MAPPING_ERROR;
-    }
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(dy.transfer_from(hy));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHemvBatchedFn(handle,
-                                      uplo,
-                                      N,
-                                      (T*)&alpha,
-                                      dA_array,
-                                      lda,
-                                      dx_array,
-                                      incx,
-                                      (T*)&beta,
-                                      dy_array,
-                                      incy,
-                                      batch_count);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHemvBatchedFn(handle,
+                                             uplo,
+                                             N,
+                                             (T*)&h_alpha,
+                                             dA.ptr_on_device(),
+                                             lda,
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             (T*)&h_beta,
+                                             dy.ptr_on_device(),
+                                             incy,
+                                             batch_count));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            // here in cuda
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+    CHECK_HIP_ERROR(dy.transfer_from(hy));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipMemcpy(hy_array[b], by_array[b], sizeof(T) * Y_size, hipMemcpyDeviceToHost);
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHemvBatchedFn(handle,
+                                             uplo,
+                                             N,
+                                             d_alpha,
+                                             dA.ptr_on_device(),
+                                             lda,
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             d_beta,
+                                             dy.ptr_on_device(),
+                                             incy,
+                                             batch_count));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -160,18 +129,62 @@ hipblasStatus_t testing_hemvBatched(const Arguments& argus)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hemv<T>(
-                uplo, N, alpha, hA_array[b], lda, hx_array[b], incx, beta, hz_array[b], incy);
+            cblas_hemv<T>(uplo, N, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, Y_size, batch_count, incy, hz_array, hy_array);
+            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(dy.transfer_from(hy));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHemvBatchedFn(handle,
+                                                     uplo,
+                                                     N,
+                                                     d_alpha,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     dx.ptr_on_device(),
+                                                     incx,
+                                                     d_beta,
+                                                     dy.ptr_on_device(),
+                                                     incy,
+                                                     batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_lda, e_incx, e_incy, e_batch_count>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            hemv_gflop_count<T>(N),
+            hemv_gbyte_count<T>(N),
+            hipblas_error_host,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hemv_strided_batched.hpp
+++ b/clients/include/testing_hemv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -15,7 +15,7 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename T>
-hipblasStatus_t testing_hemvStridedBatched(const Arguments& argus)
+hipblasStatus_t testing_hemv_strided_batched(const Arguments& argus)
 {
     bool FORTRAN = argus.fortran;
     auto hipblasHemvStridedBatchedFn
@@ -42,8 +42,6 @@ hipblasStatus_t testing_hemvStridedBatched(const Arguments& argus)
     X_size   = stride_x * batch_count;
     Y_size   = stride_y * batch_count;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || lda < N || incx <= 0 || incy <= 0 || batch_count < 0)
@@ -55,21 +53,22 @@ hipblasStatus_t testing_hemvStridedBatched(const Arguments& argus)
     host_vector<T> hA(A_size);
     host_vector<T> hx(X_size);
     host_vector<T> hy(Y_size);
-    host_vector<T> hz(Y_size);
+    host_vector<T> hy_cpu(Y_size);
+    host_vector<T> hy_host(Y_size);
+    host_vector<T> hy_device(Y_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(X_size);
     device_vector<T> dy(Y_size);
+    device_vector<T> d_alpha(1);
+    device_vector<T> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = (T)argus.alpha;
-    T beta  = (T)argus.beta;
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -77,47 +76,59 @@ hipblasStatus_t testing_hemvStridedBatched(const Arguments& argus)
     hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
     hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
 
-    // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
-    hz = hy;
+    // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
+    hy_cpu = hy;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHemvStridedBatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             (T*)&alpha,
-                                             dA,
-                                             lda,
-                                             stride_A,
-                                             dx,
-                                             incx,
-                                             stride_x,
-                                             (T*)&beta,
-                                             dy,
-                                             incy,
-                                             stride_y,
-                                             batch_count);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHemvStridedBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    (T*)&h_alpha,
+                                                    dA,
+                                                    lda,
+                                                    stride_A,
+                                                    dx,
+                                                    incx,
+                                                    stride_x,
+                                                    (T*)&h_beta,
+                                                    dy,
+                                                    incy,
+                                                    stride_y,
+                                                    batch_count));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            // here in cuda
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
 
-    // copy output from device to CPU
-    hipMemcpy(hy.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHemvStridedBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    d_alpha,
+                                                    dA,
+                                                    lda,
+                                                    stride_A,
+                                                    dx,
+                                                    incx,
+                                                    stride_x,
+                                                    d_beta,
+                                                    dy,
+                                                    incy,
+                                                    stride_y,
+                                                    batch_count));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -127,13 +138,13 @@ hipblasStatus_t testing_hemvStridedBatched(const Arguments& argus)
         {
             cblas_hemv<T>(uplo,
                           N,
-                          alpha,
+                          h_alpha,
                           hA.data() + b * stride_A,
                           lda,
                           hx.data() + b * stride_x,
                           incx,
-                          beta,
-                          hz.data() + b * stride_y,
+                          h_beta,
+                          hy_cpu.data() + b * stride_y,
                           incy);
         }
 
@@ -141,10 +152,65 @@ hipblasStatus_t testing_hemvStridedBatched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incy, stride_y, hz, hy);
+            unit_check_general<T>(1, N, batch_count, incy, stride_y, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, incy, stride_y, hy_cpu, hy_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, N, incy, stride_y, hy_cpu, hy_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, N, incy, stride_y, hy_cpu, hy_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHemvStridedBatchedFn(handle,
+                                                            uplo,
+                                                            N,
+                                                            d_alpha,
+                                                            dA,
+                                                            lda,
+                                                            stride_A,
+                                                            dx,
+                                                            incx,
+                                                            stride_x,
+                                                            d_beta,
+                                                            dy,
+                                                            incy,
+                                                            stride_y,
+                                                            batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N,
+                      e_lda,
+                      e_stride_a,
+                      e_incx,
+                      e_stride_x,
+                      e_incy,
+                      e_stride_y,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         hemv_gflop_count<T>(N),
+                         hemv_gbyte_count<T>(N),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hemv_strided_batched.hpp
+++ b/clients/include/testing_hemv_strided_batched.hpp
@@ -196,10 +196,12 @@ hipblasStatus_t testing_hemv_strided_batched(const Arguments& argus)
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
         ArgumentModel<e_N,
+                      e_alpha,
                       e_lda,
                       e_stride_a,
                       e_incx,
                       e_stride_x,
+                      e_beta,
                       e_incy,
                       e_stride_y,
                       e_batch_count>{}

--- a/clients/include/testing_her.hpp
+++ b/clients/include/testing_her.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_her(const Arguments& argus)
 {
+    using U           = real_t<T>;
     bool FORTRAN      = argus.fortran;
     auto hipblasHerFn = FORTRAN ? hipblasHer<T, U, true> : hipblasHer<T, U, false>;
 
@@ -27,8 +28,6 @@ hipblasStatus_t testing_her(const Arguments& argus)
     int               A_size = lda * N;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || lda < N || incx == 0)
@@ -38,71 +37,94 @@ hipblasStatus_t testing_her(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(A_size);
+    host_vector<T> hA_cpu(A_size);
+    host_vector<T> hA_host(A_size);
+    host_vector<T> hA_device(A_size);
     host_vector<T> hx(N * incx);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(N * incx);
+    device_vector<U> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    U alpha = argus.get_alpha<U>();
+    U h_alpha = argus.get_alpha<U>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, N, lda);
     hipblas_init<T>(hx, 1, N, incx);
 
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    hB = hA;
+    // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
+    hA_cpu = hA;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHerFn(handle, uplo, N, (U*)&h_alpha, dx, incx, dA, lda));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
+    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * N * lda, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * N * lda, hipMemcpyHostToDevice));
 
-        status = hipblasHerFn(handle, uplo, N, (U*)&alpha, dx, incx, dA, lda);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHerFn(handle, uplo, N, d_alpha, dx, incx, dA, lda));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * N * lda, hipMemcpyDeviceToHost));
 
-    // copy output from device to CPU
-    hipMemcpy(hA.data(), dA, sizeof(T) * N * lda, hipMemcpyDeviceToHost);
-
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_her<T>(uplo, N, alpha, hx.data(), incx, hB.data(), lda);
+        cblas_her<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data(), lda);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, lda, hB.data(), hA.data());
+            unit_check_general<T>(N, N, lda, hA_cpu.data(), hA_host.data());
+            unit_check_general<T>(N, N, lda, hA_cpu.data(), hA_device.data());
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', N, N, lda, hA_cpu, hA_host);
+            hipblas_error_device = norm_check_general<T>('F', N, N, lda, hA_cpu, hA_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHerFn(handle, uplo, N, d_alpha, dx, incx, dA, lda));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_lda>{}.log_args<T>(std::cout,
+                                                        argus,
+                                                        gpu_time_used,
+                                                        her_gflop_count<T>(N),
+                                                        her_gbyte_count<T>(N),
+                                                        hipblas_error_host,
+                                                        hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_her.hpp
+++ b/clients/include/testing_her.hpp
@@ -117,13 +117,13 @@ hipblasStatus_t testing_her(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_lda>{}.log_args<T>(std::cout,
-                                                        argus,
-                                                        gpu_time_used,
-                                                        her_gflop_count<T>(N),
-                                                        her_gbyte_count<T>(N),
-                                                        hipblas_error_host,
-                                                        hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_lda>{}.log_args<U>(std::cout,
+                                                                 argus,
+                                                                 gpu_time_used,
+                                                                 her_gflop_count<T>(N),
+                                                                 her_gbyte_count<T>(N),
+                                                                 hipblas_error_host,
+                                                                 hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_her2.hpp
+++ b/clients/include/testing_her2.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -28,8 +28,6 @@ hipblasStatus_t testing_her2(const Arguments& argus)
     int               A_size = lda * N;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || lda < N || incx == 0 || incy == 0)
@@ -39,22 +37,22 @@ hipblasStatus_t testing_her2(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(A_size);
+    host_vector<T> hA_cpu(A_size);
+    host_vector<T> hA_host(A_size);
+    host_vector<T> hA_device(A_size);
     host_vector<T> hx(N * incx);
     host_vector<T> hy(N * incy);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(N * incx);
     device_vector<T> dy(N * incy);
+    device_vector<T> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
+    T h_alpha = argus.get_alpha<T>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -62,52 +60,76 @@ hipblasStatus_t testing_her2(const Arguments& argus)
     hipblas_init<T>(hx, 1, N, incx);
     hipblas_init<T>(hy, 1, N, incy);
 
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    hB = hA;
+    // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
+    hA_cpu = hA;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHer2Fn(handle, uplo, N, (T*)&h_alpha, dx, incx, dy, incy, dA, lda));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
+    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
 
-        status = hipblasHer2Fn(handle, uplo, N, (T*)&alpha, dx, incx, dy, incy, dA, lda);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHer2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA, lda));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
 
-    // copy output from device to CPU
-    hipMemcpy(hA.data(), dA, sizeof(T) * N * lda, hipMemcpyDeviceToHost);
-
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_her2<T>(uplo, N, alpha, hx.data(), incx, hy.data(), incy, hB.data(), lda);
+        cblas_her2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data(), lda);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, lda, hB.data(), hA.data());
+            unit_check_general<T>(N, N, lda, hA_cpu.data(), hA_host.data());
+            unit_check_general<T>(N, N, lda, hA_cpu.data(), hA_device.data());
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', N, N, lda, hA_cpu, hA_host);
+            hipblas_error_device = norm_check_general<T>('F', N, N, lda, hA_cpu, hA_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(
+                hipblasHer2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA, lda));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy, e_lda>{}.log_args<T>(std::cout,
+                                                                argus,
+                                                                gpu_time_used,
+                                                                her2_gflop_count<T>(N),
+                                                                her2_gbyte_count<T>(N),
+                                                                hipblas_error_host,
+                                                                hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_her2.hpp
+++ b/clients/include/testing_her2.hpp
@@ -122,13 +122,13 @@ hipblasStatus_t testing_her2(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_incy, e_lda>{}.log_args<T>(std::cout,
-                                                                argus,
-                                                                gpu_time_used,
-                                                                her2_gflop_count<T>(N),
-                                                                her2_gbyte_count<T>(N),
-                                                                hipblas_error_host,
-                                                                hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_incy, e_lda>{}.log_args<T>(std::cout,
+                                                                         argus,
+                                                                         gpu_time_used,
+                                                                         her2_gflop_count<T>(N),
+                                                                         her2_gbyte_count<T>(N),
+                                                                         hipblas_error_host,
+                                                                         hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_her2_batched.hpp
+++ b/clients/include/testing_her2_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -32,13 +32,9 @@ hipblasStatus_t testing_her2_batched(const Arguments& argus)
     int               y_size = N * incy;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    T h_alpha = argus.get_alpha<T>();
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -51,97 +47,132 @@ hipblasStatus_t testing_her2_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> hB[batch_count];
-    host_vector<T> hx[batch_count];
-    host_vector<T> hy[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hA_cpu(A_size, 1, batch_count);
+    host_batch_vector<T> hA_host(A_size, 1, batch_count);
+    host_batch_vector<T> hA_device(A_size, 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bx(batch_count, x_size);
-    device_batch_vector<T> by(batch_count, y_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
+    device_vector<T>       d_alpha(1);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dx(batch_count);
-    device_vector<T*, 0, T> dy(batch_count);
-
-    int last = batch_count - 1;
-    if(!dA || !dx || !dy || (!bA[last] && A_size) || (!bx[last] && x_size) || (!by[last] && y_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dy.memcheck());
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA[b] = host_vector<T>(A_size);
-        hB[b] = host_vector<T>(A_size);
-        hx[b] = host_vector<T>(x_size);
-        hy[b] = host_vector<T>(y_size);
+    hipblas_init(hA, true);
+    hipblas_init(hx);
+    hipblas_init(hy);
 
-        srand(1);
-        hipblas_init<T>(hA[b], N, N, lda);
-        hipblas_init<T>(hx[b], 1, N, incx);
-        hipblas_init<T>(hy[b], 1, N, incy);
-        hB[b] = hA[b];
-
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b], sizeof(T) * A_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(T) * x_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(by[b], hy[b], sizeof(T) * y_size, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, bx, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, by, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    hA_cpu.copy_from(hA);
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(dy.transfer_from(hy));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHer2BatchedFn(handle,
+                                             uplo,
+                                             N,
+                                             (T*)&h_alpha,
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             dy.ptr_on_device(),
+                                             incy,
+                                             dA.ptr_on_device(),
+                                             lda,
+                                             batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHer2BatchedFn(
-            handle, uplo, N, (T*)&alpha, dx, incx, dy, incy, dA, lda, batch_count);
+    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHer2BatchedFn(handle,
+                                             uplo,
+                                             N,
+                                             d_alpha,
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             dy.ptr_on_device(),
+                                             incy,
+                                             dA.ptr_on_device(),
+                                             lda,
+                                             batch_count));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipMemcpy(hA[b], bA[b], sizeof(T) * A_size, hipMemcpyDeviceToHost);
-    }
+    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her2<T>(uplo, N, alpha, hx[b], incx, hy[b], incy, hB[b], lda);
+            cblas_her2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b], lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, lda, hB, hA);
+            unit_check_general<T>(N, N, batch_count, lda, hA_cpu, hA_host);
+            unit_check_general<T>(N, N, batch_count, lda, hA_cpu, hA_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', N, N, lda, hA_cpu, hA_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', N, N, lda, hA_cpu, hA_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHer2BatchedFn(handle,
+                                                     uplo,
+                                                     N,
+                                                     d_alpha,
+                                                     dx.ptr_on_device(),
+                                                     incx,
+                                                     dy.ptr_on_device(),
+                                                     incy,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy, e_lda, e_batch_count>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            her2_gflop_count<T>(N),
+            her2_gbyte_count<T>(N),
+            hipblas_error_host,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_her2_batched.hpp
+++ b/clients/include/testing_her2_batched.hpp
@@ -164,7 +164,7 @@ hipblasStatus_t testing_her2_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_incy, e_lda, e_batch_count>{}.log_args<T>(
+        ArgumentModel<e_N, e_alpha, e_incx, e_incy, e_lda, e_batch_count>{}.log_args<T>(
             std::cout,
             argus,
             gpu_time_used,

--- a/clients/include/testing_her2_strided_batched.hpp
+++ b/clients/include/testing_her2_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -36,8 +36,6 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
     int               y_size   = stride_y * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || lda < N || incx == 0 || incy == 0 || batch_count < 0)
@@ -51,22 +49,22 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(A_size);
+    host_vector<T> hA_cpu(A_size);
+    host_vector<T> hA_host(A_size);
+    host_vector<T> hA_device(A_size);
     host_vector<T> hx(x_size);
     host_vector<T> hy(y_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(x_size);
     device_vector<T> dy(y_size);
+    device_vector<T> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
+    T h_alpha = argus.get_alpha<T>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -74,50 +72,56 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
     hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
     hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
 
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    hB = hA;
+    // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
+    hA_cpu = hA;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHer2StridedBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    (T*)&h_alpha,
+                                                    dx,
+                                                    incx,
+                                                    stride_x,
+                                                    dy,
+                                                    incy,
+                                                    stride_y,
+                                                    dA,
+                                                    lda,
+                                                    stride_A,
+                                                    batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHer2StridedBatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             (T*)&alpha,
-                                             dx,
-                                             incx,
-                                             stride_x,
-                                             dy,
-                                             incy,
-                                             stride_y,
-                                             dA,
-                                             lda,
-                                             stride_A,
-                                             batch_count);
+    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHer2StridedBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    d_alpha,
+                                                    dx,
+                                                    incx,
+                                                    stride_x,
+                                                    dy,
+                                                    incy,
+                                                    stride_y,
+                                                    dA,
+                                                    lda,
+                                                    stride_A,
+                                                    batch_count));
 
-    // copy output from device to CPU
-    hipMemcpy(hA.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -126,12 +130,12 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
         {
             cblas_her2<T>(uplo,
                           N,
-                          alpha,
+                          h_alpha,
                           hx.data() + b * stride_x,
                           incx,
                           hy.data() + b * stride_y,
                           incy,
-                          hB.data() + b * stride_A,
+                          hA_cpu.data() + b * stride_A,
                           lda);
         }
 
@@ -139,10 +143,65 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, lda, stride_A, hB.data(), hA.data());
+            unit_check_general<T>(N, N, batch_count, lda, stride_A, hA_cpu.data(), hA_host.data());
+            unit_check_general<T>(
+                N, N, batch_count, lda, stride_A, hA_cpu.data(), hA_device.data());
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host = norm_check_general<T>(
+                'F', N, N, lda, stride_A, hA_cpu.data(), hA_host.data(), batch_count);
+            hipblas_error_device = norm_check_general<T>(
+                'F', N, N, lda, stride_A, hA_cpu.data(), hA_device.data(), batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHer2StridedBatchedFn(handle,
+                                                            uplo,
+                                                            N,
+                                                            d_alpha,
+                                                            dx,
+                                                            incx,
+                                                            stride_x,
+                                                            dy,
+                                                            incy,
+                                                            stride_y,
+                                                            dA,
+                                                            lda,
+                                                            stride_A,
+                                                            batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N,
+                      e_incx,
+                      e_stride_x,
+                      e_incy,
+                      e_stride_y,
+                      e_lda,
+                      e_stride_a,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         her2_gflop_count<T>(N),
+                         her2_gbyte_count<T>(N),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_her2_strided_batched.hpp
+++ b/clients/include/testing_her2_strided_batched.hpp
@@ -187,6 +187,7 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
         ArgumentModel<e_N,
+                      e_alpha,
                       e_incx,
                       e_stride_x,
                       e_incy,

--- a/clients/include/testing_her_batched.hpp
+++ b/clients/include/testing_her_batched.hpp
@@ -145,13 +145,14 @@ hipblasStatus_t testing_her_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_lda, e_batch_count>{}.log_args<T>(std::cout,
-                                                                       argus,
-                                                                       gpu_time_used,
-                                                                       her_gflop_count<T>(N),
-                                                                       her_gbyte_count<T>(N),
-                                                                       hipblas_error_host,
-                                                                       hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_lda, e_batch_count>{}.log_args<U>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            her_gflop_count<T>(N),
+            her_gbyte_count<T>(N),
+            hipblas_error_host,
+            hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_her_batched.hpp
+++ b/clients/include/testing_her_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_her_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasHerBatchedFn
         = FORTRAN ? hipblasHerBatched<T, U, true> : hipblasHerBatched<T, U, false>;
@@ -30,13 +31,9 @@ hipblasStatus_t testing_her_batched(const Arguments& argus)
     int               x_size = N * incx;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    U alpha = argus.get_alpha<U>();
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    U h_alpha = argus.get_alpha<U>();
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -53,85 +50,110 @@ hipblasStatus_t testing_her_batched(const Arguments& argus)
     hipblasCreate(&handle);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> hB[batch_count];
-    host_vector<T> hx[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hA_cpu(A_size, 1, batch_count);
+    host_batch_vector<T> hA_host(A_size, 1, batch_count);
+    host_batch_vector<T> hA_device(A_size, 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bx(batch_count, x_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_vector<U>       d_alpha(1);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dx(batch_count);
-
-    int last = batch_count - 1;
-    if(!dA || !dx || (!bA[last] && A_size) || (!bx[last] && x_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA[b] = host_vector<T>(A_size);
-        hB[b] = host_vector<T>(A_size);
-        hx[b] = host_vector<T>(x_size);
+    hipblas_init(hA, true);
+    hipblas_init(hx);
 
-        srand(1);
-        hipblas_init<T>(hA[b], N, N, lda);
-        hipblas_init<T>(hx[b], 1, N, incx);
-        hB[b] = hA[b];
-
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b], sizeof(T) * A_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(T) * x_size, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, bx, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    hA_cpu.copy_from(hA);
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHerBatchedFn(handle,
+                                            uplo,
+                                            N,
+                                            (U*)&h_alpha,
+                                            dx.ptr_on_device(),
+                                            incx,
+                                            dA.ptr_on_device(),
+                                            lda,
+                                            batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHerBatchedFn(handle, uplo, N, (U*)&alpha, dx, incx, dA, lda, batch_count);
+    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHerBatchedFn(
+        handle, uplo, N, d_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), lda, batch_count));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipMemcpy(hA[b], bA[b], sizeof(T) * A_size, hipMemcpyDeviceToHost);
-    }
+    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her<T>(uplo, N, alpha, hx[b], incx, hB[b], lda);
+            cblas_her<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b], lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, lda, hB, hA);
+            unit_check_general<T>(N, N, batch_count, lda, hA_cpu, hA_host);
+            unit_check_general<T>(N, N, batch_count, lda, hA_cpu, hA_host);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', N, N, lda, hA_cpu, hA_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', N, N, lda, hA_cpu, hA_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHerBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    d_alpha,
+                                                    dx.ptr_on_device(),
+                                                    incx,
+                                                    dA.ptr_on_device(),
+                                                    lda,
+                                                    batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_lda, e_batch_count>{}.log_args<T>(std::cout,
+                                                                       argus,
+                                                                       gpu_time_used,
+                                                                       her_gflop_count<T>(N),
+                                                                       her_gbyte_count<T>(N),
+                                                                       hipblas_error_host,
+                                                                       hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_her_batched.hpp
+++ b/clients/include/testing_her_batched.hpp
@@ -46,8 +46,7 @@ hipblasStatus_t testing_her_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_her_strided_batched.hpp
+++ b/clients/include/testing_her_strided_batched.hpp
@@ -142,7 +142,7 @@ hipblasStatus_t testing_her_strided_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_lda, e_stride_a, e_batch_count>{}.log_args<T>(
+        ArgumentModel<e_N, e_incx, e_stride_x, e_lda, e_stride_a, e_batch_count>{}.log_args<T>(
             std::cout,
             argus,
             gpu_time_used,

--- a/clients/include/testing_her_strided_batched.hpp
+++ b/clients/include/testing_her_strided_batched.hpp
@@ -142,14 +142,14 @@ hipblasStatus_t testing_her_strided_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_stride_x, e_lda, e_stride_a, e_batch_count>{}.log_args<T>(
-            std::cout,
-            argus,
-            gpu_time_used,
-            her_gflop_count<T>(N),
-            her_gbyte_count<T>(N),
-            hipblas_error_host,
-            hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_stride_x, e_lda, e_stride_a, e_batch_count>{}
+            .log_args<U>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         her_gflop_count<T>(N),
+                         her_gbyte_count<T>(N),
+                         hipblas_error_host,
+                         hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_her_strided_batched.hpp
+++ b/clients/include/testing_her_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_her_strided_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasHerStridedBatchedFn
         = FORTRAN ? hipblasHerStridedBatched<T, U, true> : hipblasHerStridedBatched<T, U, false>;
@@ -33,8 +34,6 @@ hipblasStatus_t testing_her_strided_batched(const Arguments& argus)
     int               x_size   = stride_x * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || lda < N || incx == 0 || batch_count < 0)
@@ -48,75 +47,110 @@ hipblasStatus_t testing_her_strided_batched(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(A_size);
+    host_vector<T> hA_cpu(A_size);
+    host_vector<T> hA_host(A_size);
+    host_vector<T> hA_device(A_size);
     host_vector<T> hx(x_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(x_size);
+    device_vector<U> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    U alpha = argus.get_alpha<U>();
+    U h_alpha = argus.get_alpha<U>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, N, lda, stride_A, batch_count);
     hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
 
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    hB = hA;
+    // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
+    hA_cpu = hA;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHerStridedBatchedFn(
+        handle, uplo, N, (U*)&h_alpha, dx, incx, stride_x, dA, lda, stride_A, batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHerStridedBatchedFn(
-            handle, uplo, N, (U*)&alpha, dx, incx, stride_x, dA, lda, stride_A, batch_count);
+    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHerStridedBatchedFn(
+        handle, uplo, N, d_alpha, dx, incx, stride_x, dA, lda, stride_A, batch_count));
 
-    // copy output from device to CPU
-    hipMemcpy(hA.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her<T>(
-                uplo, N, alpha, hx.data() + b * stride_x, incx, hB.data() + b * stride_A, lda);
+            cblas_her<T>(uplo,
+                         N,
+                         h_alpha,
+                         hx.data() + b * stride_x,
+                         incx,
+                         hA_cpu.data() + b * stride_A,
+                         lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, lda, stride_A, hB.data(), hA.data());
+            unit_check_general<T>(N, N, batch_count, lda, stride_A, hA_cpu.data(), hA_host.data());
+            unit_check_general<T>(
+                N, N, batch_count, lda, stride_A, hA_cpu.data(), hA_device.data());
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host = norm_check_general<T>(
+                'F', N, N, lda, stride_A, hA_cpu.data(), hA_host.data(), batch_count);
+            hipblas_error_device = norm_check_general<T>(
+                'F', N, N, lda, stride_A, hA_cpu.data(), hA_device.data(), batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHerStridedBatchedFn(
+                handle, uplo, N, d_alpha, dx, incx, stride_x, dA, lda, stride_A, batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_lda, e_stride_a, e_batch_count>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            her_gflop_count<T>(N),
+            her_gbyte_count<T>(N),
+            hipblas_error_host,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpmv.hpp
+++ b/clients/include/testing_hpmv.hpp
@@ -127,13 +127,13 @@ hipblasStatus_t testing_hpmv(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_incy>{}.log_args<T>(std::cout,
-                                                         argus,
-                                                         gpu_time_used,
-                                                         hpmv_gflop_count<T>(N),
-                                                         hpmv_gbyte_count<T>(N),
-                                                         hipblas_error_host,
-                                                         hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_beta, e_incy>{}.log_args<T>(std::cout,
+                                                                          argus,
+                                                                          gpu_time_used,
+                                                                          hpmv_gflop_count<T>(N),
+                                                                          hpmv_gbyte_count<T>(N),
+                                                                          hipblas_error_host,
+                                                                          hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_hpmv.hpp
+++ b/clients/include/testing_hpmv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -26,36 +26,35 @@ hipblasStatus_t testing_hpmv(const Arguments& argus)
 
     int A_size = N * (N + 1) / 2;
 
-    hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
-    hipblasStatus_t   status = HIPBLAS_STATUS_SUCCESS;
+    hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || incx == 0 || incy == 0)
     {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
     host_vector<T> hx(N * incx);
     host_vector<T> hy(N * incy);
-    host_vector<T> hz(N * incy);
+    host_vector<T> hy_cpu(N * incy);
+    host_vector<T> hy_host(N * incy);
+    host_vector<T> hy_device(N * incy);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(N * incx);
     device_vector<T> dy(N * incy);
+    device_vector<T> d_alpha(1);
+    device_vector<T> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
-    T beta  = argus.get_beta<T>();
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -63,47 +62,79 @@ hipblasStatus_t testing_hpmv(const Arguments& argus)
     hipblas_init<T>(hx, 1, N, incx);
     hipblas_init<T>(hy, 1, N, incy);
 
-    // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
-    hz = hy;
+    // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
+    hy_cpu = hy;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHpmvFn(handle, uplo, N, (T*)&alpha, dA, dx, incx, (T*)&beta, dy, incy);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHpmvFn(handle, uplo, N, (T*)&h_alpha, dA, dx, incx, (T*)&h_beta, dy, incy));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
 
-    // copy output from device to CPU
-    hipMemcpy(hy.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHpmvFn(handle, uplo, N, d_alpha, dA, dx, incx, d_beta, dy, incy));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
 
-        cblas_hpmv<T>(uplo, N, alpha, hA.data(), hx.data(), incx, beta, hz.data(), incy);
+        cblas_hpmv<T>(uplo, N, h_alpha, hA.data(), hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, incy, hz, hy);
+            unit_check_general<T>(1, N, incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, incy, hy_cpu, hy_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(
+                hipblasHpmvFn(handle, uplo, N, d_alpha, dA, dx, incx, d_beta, dy, incy));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy>{}.log_args<T>(std::cout,
+                                                         argus,
+                                                         gpu_time_used,
+                                                         hpmv_gflop_count<T>(N),
+                                                         hpmv_gbyte_count<T>(N),
+                                                         hipblas_error_host,
+                                                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpmv_batched.hpp
+++ b/clients/include/testing_hpmv_batched.hpp
@@ -172,13 +172,14 @@ hipblasStatus_t testing_hpmv_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<T>(std::cout,
-                                                                        argus,
-                                                                        gpu_time_used,
-                                                                        hpmv_gflop_count<T>(N),
-                                                                        hpmv_gbyte_count<T>(N),
-                                                                        hipblas_error_host,
-                                                                        hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_beta, e_incy, e_batch_count>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            hpmv_gflop_count<T>(N),
+            hpmv_gbyte_count<T>(N),
+            hipblas_error_host,
+            hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_hpmv_batched.hpp
+++ b/clients/include/testing_hpmv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -35,8 +35,6 @@ hipblasStatus_t testing_hpmv_batched(const Arguments& argus)
     X_size                 = N * incx;
     Y_size                 = N * incy;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || incx <= 0 || incy <= 0 || batch_count < 0)
@@ -51,106 +49,77 @@ hipblasStatus_t testing_hpmv_batched(const Arguments& argus)
     hipblasHandle_t handle;
     hipblasCreate(&handle);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
-    T beta  = argus.get_beta<T>();
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     // arrays of pointers-to-host on host
-    host_vector<T> hA_array[batch_count];
-    host_vector<T> hx_array[batch_count];
-    host_vector<T> hy_array[batch_count];
-    host_vector<T> hz_array[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy, batch_count);
+    host_batch_vector<T> hy_host(N, incy, batch_count);
+    host_batch_vector<T> hy_device(N, incy, batch_count);
 
     // arrays of pointers-to-device on host
-    device_batch_vector<T> bA_array(batch_count, A_size);
-    device_batch_vector<T> bx_array(batch_count, X_size);
-    device_batch_vector<T> by_array(batch_count, Y_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
+    device_vector<T>       d_alpha(1);
+    device_vector<T>       d_beta(1);
 
-    // arrays of pointers-to-device on device
-    device_vector<T*, 0, T> dA_array(batch_count);
-    device_vector<T*, 0, T> dx_array(batch_count);
-    device_vector<T*, 0, T> dy_array(batch_count);
-
-    int last = batch_count - 1;
-    if(!dA_array || !dx_array || !dy_array || (!bA_array[last] && A_size)
-       || (!bx_array[last] && X_size) || (!by_array[last] && Y_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dy.memcheck());
 
     // Initial Data on CPU
-    hipError_t err_A, err_x, err_y;
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA_array[b] = host_vector<T>(A_size);
-        hx_array[b] = host_vector<T>(X_size);
-        hy_array[b] = host_vector<T>(Y_size);
-        hz_array[b] = host_vector<T>(Y_size);
+    hipblas_init(hA, true);
+    hipblas_init(hx);
+    hipblas_init(hy);
+    hy_cpu.copy_from(hy);
 
-        // initialize matrices on host
-        srand(1);
-        hipblas_init<T>(hA_array[b], 1, A_size, 1);
-        hipblas_init<T>(hx_array[b], 1, N, incx);
-        hipblas_init<T>(hy_array[b], 1, N, incy);
-
-        hz_array[b] = hy_array[b];
-        err_A = hipMemcpy(bA_array[b], hA_array[b], sizeof(T) * A_size, hipMemcpyHostToDevice);
-        err_x = hipMemcpy(bx_array[b], hx_array[b], sizeof(T) * X_size, hipMemcpyHostToDevice);
-        err_y = hipMemcpy(by_array[b], hy_array[b], sizeof(T) * Y_size, hipMemcpyHostToDevice);
-
-        if(err_A != hipSuccess || err_x != hipSuccess || err_y != hipSuccess)
-        {
-            hipblasDestroy(handle);
-            return HIPBLAS_STATUS_MAPPING_ERROR;
-        }
-    }
-
-    err_A = hipMemcpy(dA_array, bA_array, batch_count * sizeof(T*), hipMemcpyHostToDevice);
-    err_x = hipMemcpy(dx_array, bx_array, batch_count * sizeof(T*), hipMemcpyHostToDevice);
-    err_y = hipMemcpy(dy_array, by_array, batch_count * sizeof(T*), hipMemcpyHostToDevice);
-    if(err_A != hipSuccess || err_x != hipSuccess || err_y != hipSuccess)
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_MAPPING_ERROR;
-    }
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(dy.transfer_from(hy));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHpmvBatchedFn(handle,
-                                      uplo,
-                                      N,
-                                      (T*)&alpha,
-                                      dA_array,
-                                      dx_array,
-                                      incx,
-                                      (T*)&beta,
-                                      dy_array,
-                                      incy,
-                                      batch_count);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHpmvBatchedFn(handle,
+                                             uplo,
+                                             N,
+                                             (T*)&h_alpha,
+                                             dA.ptr_on_device(),
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             (T*)&h_beta,
+                                             dy.ptr_on_device(),
+                                             incy,
+                                             batch_count));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            // here in cuda
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+    CHECK_HIP_ERROR(dy.transfer_from(hy));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipMemcpy(hy_array[b], by_array[b], sizeof(T) * Y_size, hipMemcpyDeviceToHost);
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHpmvBatchedFn(handle,
+                                             uplo,
+                                             N,
+                                             d_alpha,
+                                             dA.ptr_on_device(),
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             d_beta,
+                                             dy.ptr_on_device(),
+                                             incy,
+                                             batch_count));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -158,17 +127,60 @@ hipblasStatus_t testing_hpmv_batched(const Arguments& argus)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpmv<T>(uplo, N, alpha, hA_array[b], hx_array[b], incx, beta, hz_array[b], incy);
+            cblas_hpmv<T>(uplo, N, h_alpha, hA[b], hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, Y_size, batch_count, incy, hz_array, hy_array);
+            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(dy.transfer_from(hy));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHpmvBatchedFn(handle,
+                                                     uplo,
+                                                     N,
+                                                     d_alpha,
+                                                     dA.ptr_on_device(),
+                                                     dx.ptr_on_device(),
+                                                     incx,
+                                                     d_beta,
+                                                     dy.ptr_on_device(),
+                                                     incy,
+                                                     batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<T>(std::cout,
+                                                                        argus,
+                                                                        gpu_time_used,
+                                                                        hpmv_gflop_count<T>(N),
+                                                                        hpmv_gbyte_count<T>(N),
+                                                                        hipblas_error_host,
+                                                                        hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpmv_batched.hpp
+++ b/clients/include/testing_hpmv_batched.hpp
@@ -46,8 +46,7 @@ hipblasStatus_t testing_hpmv_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 

--- a/clients/include/testing_hpmv_strided_batched.hpp
+++ b/clients/include/testing_hpmv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -42,8 +42,6 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
     X_size   = stride_x * batch_count;
     Y_size   = stride_y * batch_count;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || incx <= 0 || incy <= 0 || batch_count < 0)
@@ -55,21 +53,22 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
     host_vector<T> hA(A_size);
     host_vector<T> hx(X_size);
     host_vector<T> hy(Y_size);
-    host_vector<T> hz(Y_size);
+    host_vector<T> hy_cpu(Y_size);
+    host_vector<T> hy_host(Y_size);
+    host_vector<T> hy_device(Y_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(X_size);
     device_vector<T> dy(Y_size);
+    device_vector<T> d_alpha(1);
+    device_vector<T> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
-    T beta  = argus.get_beta<T>();
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -77,46 +76,57 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
     hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
     hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
 
-    // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
-    hz = hy;
+    // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
+    hy_cpu = hy;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHpmvStridedBatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             (T*)&alpha,
-                                             dA,
-                                             stride_A,
-                                             dx,
-                                             incx,
-                                             stride_x,
-                                             (T*)&beta,
-                                             dy,
-                                             incy,
-                                             stride_y,
-                                             batch_count);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHpmvStridedBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    (T*)&h_alpha,
+                                                    dA,
+                                                    stride_A,
+                                                    dx,
+                                                    incx,
+                                                    stride_x,
+                                                    (T*)&h_beta,
+                                                    dy,
+                                                    incy,
+                                                    stride_y,
+                                                    batch_count));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            // here in cuda
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
 
-    // copy output from device to CPU
-    hipMemcpy(hy.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHpmvStridedBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    d_alpha,
+                                                    dA,
+                                                    stride_A,
+                                                    dx,
+                                                    incx,
+                                                    stride_x,
+                                                    d_beta,
+                                                    dy,
+                                                    incy,
+                                                    stride_y,
+                                                    batch_count));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -126,12 +136,12 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
         {
             cblas_hpmv<T>(uplo,
                           N,
-                          alpha,
+                          h_alpha,
                           hA.data() + b * stride_A,
                           hx.data() + b * stride_x,
                           incx,
-                          beta,
-                          hz.data() + b * stride_y,
+                          h_beta,
+                          hy_cpu.data() + b * stride_y,
                           incy);
         }
 
@@ -139,10 +149,57 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incy, stride_y, hz, hy);
+            unit_check_general<T>(1, N, batch_count, incy, stride_y, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, incy, stride_y, hy_cpu, hy_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, N, incy, stride_y, hy_cpu, hy_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, N, incy, stride_y, hy_cpu, hy_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHpmvStridedBatchedFn(handle,
+                                                            uplo,
+                                                            N,
+                                                            d_alpha,
+                                                            dA,
+                                                            stride_A,
+                                                            dx,
+                                                            incx,
+                                                            stride_x,
+                                                            d_beta,
+                                                            dy,
+                                                            incy,
+                                                            stride_y,
+                                                            batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_stride_a, e_incx, e_stride_x, e_incy, e_stride_y, e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         hpmv_gflop_count<T>(N),
+                         hpmv_gbyte_count<T>(N),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpmv_strided_batched.hpp
+++ b/clients/include/testing_hpmv_strided_batched.hpp
@@ -105,8 +105,8 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
                                                     stride_y,
                                                     batch_count));
 
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
 
     CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
     CHECK_HIPBLAS_ERROR(hipblasHpmvStridedBatchedFn(handle,
@@ -124,7 +124,7 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
                                                     stride_y,
                                                     batch_count));
 
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {

--- a/clients/include/testing_hpmv_strided_batched.hpp
+++ b/clients/include/testing_hpmv_strided_batched.hpp
@@ -191,7 +191,15 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_stride_a, e_incx, e_stride_x, e_incy, e_stride_y, e_batch_count>{}
+        ArgumentModel<e_N,
+                      e_alpha,
+                      e_stride_a,
+                      e_incx,
+                      e_stride_x,
+                      e_beta,
+                      e_incy,
+                      e_stride_y,
+                      e_batch_count>{}
             .log_args<T>(std::cout,
                          argus,
                          gpu_time_used,

--- a/clients/include/testing_hpr.hpp
+++ b/clients/include/testing_hpr.hpp
@@ -116,13 +116,13 @@ hipblasStatus_t testing_hpr(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx>{}.log_args<T>(std::cout,
-                                                 argus,
-                                                 gpu_time_used,
-                                                 hpr_gflop_count<T>(N),
-                                                 hpr_gbyte_count<T>(N),
-                                                 hipblas_error_host,
-                                                 hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx>{}.log_args<U>(std::cout,
+                                                          argus,
+                                                          gpu_time_used,
+                                                          hpr_gflop_count<T>(N),
+                                                          hpr_gbyte_count<T>(N),
+                                                          hipblas_error_host,
+                                                          hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_hpr.hpp
+++ b/clients/include/testing_hpr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_hpr(const Arguments& argus)
 {
+    using U           = real_t<T>;
     bool FORTRAN      = argus.fortran;
     auto hipblasHprFn = FORTRAN ? hipblasHpr<T, U, true> : hipblasHpr<T, U, false>;
 
@@ -25,8 +26,6 @@ hipblasStatus_t testing_hpr(const Arguments& argus)
 
     int               A_size = N * (N + 1) / 2;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -37,71 +36,94 @@ hipblasStatus_t testing_hpr(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(A_size);
+    host_vector<T> hA_cpu(A_size);
+    host_vector<T> hA_host(A_size);
+    host_vector<T> hA_device(A_size);
     host_vector<T> hx(N * incx);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(N * incx);
+    device_vector<U> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    U alpha = argus.get_alpha<U>();
+    U h_alpha = argus.get_alpha<U>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, A_size, 1);
     hipblas_init<T>(hx, 1, N, incx);
 
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    hB = hA;
+    // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
+    hA_cpu = hA;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHprFn(handle, uplo, N, (U*)&h_alpha, dx, incx, dA));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
+    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
 
-        status = hipblasHprFn(handle, uplo, N, (U*)&alpha, dx, incx, dA);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHprFn(handle, uplo, N, d_alpha, dx, incx, dA));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
 
-    // copy output from device to CPU
-    hipMemcpy(hA.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost);
-
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_hpr<T>(uplo, N, alpha, hx.data(), incx, hB.data());
+        cblas_hpr<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data());
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, A_size, 1, hB.data(), hA.data());
+            unit_check_general<T>(1, A_size, 1, hA_cpu.data(), hA_host.data());
+            unit_check_general<T>(1, A_size, 1, hA_cpu.data(), hA_device.data());
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', 1, A_size, 1, hA_cpu, hA_host);
+            hipblas_error_device = norm_check_general<T>('F', 1, A_size, 1, hA_cpu, hA_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHprFn(handle, uplo, N, d_alpha, dx, incx, dA));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx>{}.log_args<T>(std::cout,
+                                                 argus,
+                                                 gpu_time_used,
+                                                 hpr_gflop_count<T>(N),
+                                                 hpr_gbyte_count<T>(N),
+                                                 hipblas_error_host,
+                                                 hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpr2.hpp
+++ b/clients/include/testing_hpr2.hpp
@@ -122,13 +122,13 @@ hipblasStatus_t testing_hpr2(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_incy>{}.log_args<T>(std::cout,
-                                                         argus,
-                                                         gpu_time_used,
-                                                         hpr2_gflop_count<T>(N),
-                                                         hpr2_gbyte_count<T>(N),
-                                                         hipblas_error_host,
-                                                         hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_incy>{}.log_args<T>(std::cout,
+                                                                  argus,
+                                                                  gpu_time_used,
+                                                                  hpr2_gflop_count<T>(N),
+                                                                  hpr2_gbyte_count<T>(N),
+                                                                  hipblas_error_host,
+                                                                  hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_hpr2.hpp
+++ b/clients/include/testing_hpr2.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -27,8 +27,6 @@ hipblasStatus_t testing_hpr2(const Arguments& argus)
     int               A_size = N * (N + 1) / 2;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || incx == 0 || incy == 0)
@@ -38,22 +36,22 @@ hipblasStatus_t testing_hpr2(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(A_size);
+    host_vector<T> hA_cpu(A_size);
+    host_vector<T> hA_host(A_size);
+    host_vector<T> hA_device(A_size);
     host_vector<T> hx(N * incx);
     host_vector<T> hy(N * incy);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(N * incx);
     device_vector<T> dy(N * incy);
+    device_vector<T> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
+    T h_alpha = argus.get_alpha<T>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -61,52 +59,77 @@ hipblasStatus_t testing_hpr2(const Arguments& argus)
     hipblas_init<T>(hx, 1, N, incx);
     hipblas_init<T>(hy, 1, N, incy);
 
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    hB = hA;
+    // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
+    hA_cpu = hA;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHpr2Fn(handle, uplo, N, (T*)&h_alpha, dx, incx, dy, incy, dA));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
+    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
 
-        status = hipblasHpr2Fn(handle, uplo, N, (T*)&alpha, dx, incx, dy, incy, dA);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHpr2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
 
-    // copy output from device to CPU
-    hipMemcpy(hA.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost);
-
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_hpr2<T>(uplo, N, alpha, hx.data(), incx, hy.data(), incy, hB.data());
+        cblas_hpr2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data());
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, A_size, 1, hB.data(), hA.data());
+            unit_check_general<T>(1, A_size, 1, hA_cpu.data(), hA_host.data());
+            unit_check_general<T>(1, A_size, 1, hA_cpu.data(), hA_device.data());
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, A_size, 1, hA_cpu.data(), hA_host.data());
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, A_size, 1, hA_cpu.data(), hA_device.data());
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHpr2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy>{}.log_args<T>(std::cout,
+                                                         argus,
+                                                         gpu_time_used,
+                                                         hpr2_gflop_count<T>(N),
+                                                         hpr2_gbyte_count<T>(N),
+                                                         hipblas_error_host,
+                                                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpr2_batched.hpp
+++ b/clients/include/testing_hpr2_batched.hpp
@@ -160,13 +160,14 @@ hipblasStatus_t testing_hpr2_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<T>(std::cout,
-                                                                        argus,
-                                                                        gpu_time_used,
-                                                                        hpr2_gflop_count<T>(N),
-                                                                        hpr2_gbyte_count<T>(N),
-                                                                        hipblas_error_host,
-                                                                        hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_incy, e_batch_count>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            hpr2_gflop_count<T>(N),
+            hpr2_gbyte_count<T>(N),
+            hipblas_error_host,
+            hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_hpr2_batched.hpp
+++ b/clients/include/testing_hpr2_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -31,13 +31,9 @@ hipblasStatus_t testing_hpr2_batched(const Arguments& argus)
     int               y_size = N * incy;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    T h_alpha = argus.get_alpha<T>();
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -50,97 +46,128 @@ hipblasStatus_t testing_hpr2_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> hB[batch_count];
-    host_vector<T> hx[batch_count];
-    host_vector<T> hy[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hA_cpu(A_size, 1, batch_count);
+    host_batch_vector<T> hA_host(A_size, 1, batch_count);
+    host_batch_vector<T> hA_device(A_size, 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bx(batch_count, x_size);
-    device_batch_vector<T> by(batch_count, y_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
+    device_vector<T>       d_alpha(1);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dx(batch_count);
-    device_vector<T*, 0, T> dy(batch_count);
-
-    int last = batch_count - 1;
-    if(!dA || !dx || !dy || (!bA[last] && A_size) || (!bx[last] && x_size) || (!by[last] && y_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dy.memcheck());
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA[b] = host_vector<T>(A_size);
-        hB[b] = host_vector<T>(A_size);
-        hx[b] = host_vector<T>(x_size);
-        hy[b] = host_vector<T>(y_size);
+    hipblas_init(hA, true);
+    hipblas_init(hx);
+    hipblas_init(hy);
 
-        srand(1);
-        hipblas_init<T>(hA[b], 1, A_size, 1);
-        hipblas_init<T>(hx[b], 1, N, incx);
-        hipblas_init<T>(hy[b], 1, N, incy);
-        hB[b] = hA[b];
-
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b], sizeof(T) * A_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(T) * x_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(by[b], hy[b], sizeof(T) * y_size, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, bx, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, by, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    hA_cpu.copy_from(hA);
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(dy.transfer_from(hy));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHpr2BatchedFn(handle,
+                                             uplo,
+                                             N,
+                                             (T*)&h_alpha,
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             dy.ptr_on_device(),
+                                             incy,
+                                             dA.ptr_on_device(),
+                                             batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHpr2BatchedFn(
-            handle, uplo, N, (T*)&alpha, dx, incx, dy, incy, dA, batch_count);
+    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHpr2BatchedFn(handle,
+                                             uplo,
+                                             N,
+                                             d_alpha,
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             dy.ptr_on_device(),
+                                             incy,
+                                             dA.ptr_on_device(),
+                                             batch_count));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipMemcpy(hA[b], bA[b], sizeof(T) * A_size, hipMemcpyDeviceToHost);
-    }
+    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpr2<T>(uplo, N, alpha, hx[b], incx, hy[b], incy, hB[b]);
+            cblas_hpr2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, A_size, batch_count, 1, hB, hA);
+            unit_check_general<T>(1, A_size, batch_count, 1, hA_cpu, hA_host);
+            unit_check_general<T>(1, A_size, batch_count, 1, hA_cpu, hA_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, A_size, 1, hA_cpu, hA_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, A_size, 1, hA_cpu, hA_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHpr2BatchedFn(handle,
+                                                     uplo,
+                                                     N,
+                                                     d_alpha,
+                                                     dx.ptr_on_device(),
+                                                     incx,
+                                                     dy.ptr_on_device(),
+                                                     incy,
+                                                     dA.ptr_on_device(),
+                                                     batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<T>(std::cout,
+                                                                        argus,
+                                                                        gpu_time_used,
+                                                                        hpr2_gflop_count<T>(N),
+                                                                        hpr2_gbyte_count<T>(N),
+                                                                        hipblas_error_host,
+                                                                        hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpr2_strided_batched.hpp
+++ b/clients/include/testing_hpr2_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -36,8 +36,6 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
     int               y_size   = stride_y * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || incx == 0 || incy == 0 || batch_count < 0)
@@ -51,22 +49,22 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(A_size);
+    host_vector<T> hA_cpu(A_size);
+    host_vector<T> hA_host(A_size);
+    host_vector<T> hA_device(A_size);
     host_vector<T> hx(x_size);
     host_vector<T> hy(y_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dx(x_size);
     device_vector<T> dy(y_size);
+    device_vector<T> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    T alpha = argus.get_alpha<T>();
+    T h_alpha = argus.get_alpha<T>();
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -74,49 +72,54 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
     hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
     hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
 
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    hB = hA;
+    // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
+    hA_cpu = hA;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice);
-    hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHpr2StridedBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    (T*)&h_alpha,
+                                                    dx,
+                                                    incx,
+                                                    stride_x,
+                                                    dy,
+                                                    incy,
+                                                    stride_y,
+                                                    dA,
+                                                    stride_A,
+                                                    batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHpr2StridedBatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             (T*)&alpha,
-                                             dx,
-                                             incx,
-                                             stride_x,
-                                             dy,
-                                             incy,
-                                             stride_y,
-                                             dA,
-                                             stride_A,
-                                             batch_count);
+    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHpr2StridedBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    d_alpha,
+                                                    dx,
+                                                    incx,
+                                                    stride_x,
+                                                    dy,
+                                                    incy,
+                                                    stride_y,
+                                                    dA,
+                                                    stride_A,
+                                                    batch_count));
 
-    // copy output from device to CPU
-    hipMemcpy(hA.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -125,22 +128,70 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
         {
             cblas_hpr2<T>(uplo,
                           N,
-                          alpha,
+                          h_alpha,
                           hx.data() + b * stride_x,
                           incx,
                           hy.data() + b * stride_y,
                           incy,
-                          hB.data() + b * stride_A);
+                          hA_cpu.data() + b * stride_A);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, dim_A, batch_count, 1, stride_A, hB.data(), hA.data());
+            unit_check_general<T>(
+                1, dim_A, batch_count, 1, stride_A, hA_cpu.data(), hA_host.data());
+            unit_check_general<T>(
+                1, dim_A, batch_count, 1, stride_A, hA_cpu.data(), hA_device.data());
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host = norm_check_general<T>(
+                'F', 1, dim_A, 1, stride_A, hA_cpu.data(), hA_host.data(), batch_count);
+            hipblas_error_device = norm_check_general<T>(
+                'F', 1, dim_A, 1, stride_A, hA_cpu.data(), hA_device.data(), batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHpr2StridedBatchedFn(handle,
+                                                            uplo,
+                                                            N,
+                                                            d_alpha,
+                                                            dx,
+                                                            incx,
+                                                            stride_x,
+                                                            dy,
+                                                            incy,
+                                                            stride_y,
+                                                            dA,
+                                                            stride_A,
+                                                            batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_stride_x, e_incy, e_stride_y, e_stride_a, e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         hpr2_gflop_count<T>(N),
+                         hpr2_gbyte_count<T>(N),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpr2_strided_batched.hpp
+++ b/clients/include/testing_hpr2_strided_batched.hpp
@@ -183,7 +183,14 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_stride_x, e_incy, e_stride_y, e_stride_a, e_batch_count>{}
+        ArgumentModel<e_N,
+                      e_alpha,
+                      e_incx,
+                      e_stride_x,
+                      e_incy,
+                      e_stride_y,
+                      e_stride_a,
+                      e_batch_count>{}
             .log_args<T>(std::cout,
                          argus,
                          gpu_time_used,

--- a/clients/include/testing_hpr_batched.hpp
+++ b/clients/include/testing_hpr_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_hpr_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasHprBatchedFn
         = FORTRAN ? hipblasHprBatched<T, U, true> : hipblasHprBatched<T, U, false>;
@@ -29,13 +30,9 @@ hipblasStatus_t testing_hpr_batched(const Arguments& argus)
     int               x_size = N * incx;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    U alpha = argus.get_alpha<U>();
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    U h_alpha = argus.get_alpha<U>();
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -48,89 +45,105 @@ hipblasStatus_t testing_hpr_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(argus);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> hB[batch_count];
-    host_vector<T> hx[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hA_cpu(A_size, 1, batch_count);
+    host_batch_vector<T> hA_host(A_size, 1, batch_count);
+    host_batch_vector<T> hA_device(A_size, 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bx(batch_count, x_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_vector<U>       d_alpha(1);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dx(batch_count);
-
-    int last = batch_count - 1;
-    if(!dA || !dx || (!bA[last] && A_size) || (!bx[last] && x_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA[b] = host_vector<T>(A_size);
-        hB[b] = host_vector<T>(A_size);
-        hx[b] = host_vector<T>(x_size);
+    hipblas_init(hA, true);
+    hipblas_init(hx);
 
-        srand(1);
-        hipblas_init<T>(hA[b], 1, A_size, 1);
-        hipblas_init<T>(hx[b], 1, N, incx);
-        hB[b] = hA[b];
-
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b], sizeof(T) * A_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(T) * x_size, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, bx, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    hA_cpu.copy_from(hA);
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHprBatchedFn(
+        handle, uplo, N, (U*)&h_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHprBatchedFn(handle, uplo, N, (U*)&alpha, dx, incx, dA, batch_count);
+    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHprBatchedFn(
+        handle, uplo, N, d_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipMemcpy(hA[b], bA[b], sizeof(T) * A_size, hipMemcpyDeviceToHost);
-    }
+    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpr<T>(uplo, N, alpha, hx[b], incx, hB[b]);
+            cblas_hpr<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, A_size, batch_count, 1, hB, hA);
+            unit_check_general<T>(1, A_size, batch_count, 1, hA_cpu, hA_host);
+            unit_check_general<T>(1, A_size, batch_count, 1, hA_cpu, hA_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, A_size, 1, hA_cpu, hA_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, A_size, 1, hA_cpu, hA_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHprBatchedFn(handle,
+                                                    uplo,
+                                                    N,
+                                                    d_alpha,
+                                                    dx.ptr_on_device(),
+                                                    incx,
+                                                    dA.ptr_on_device(),
+                                                    batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_batch_count>{}.log_args<T>(std::cout,
+                                                                argus,
+                                                                gpu_time_used,
+                                                                hpr_gflop_count<T>(N),
+                                                                hpr_gbyte_count<T>(N),
+                                                                hipblas_error_host,
+                                                                hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hpr_batched.hpp
+++ b/clients/include/testing_hpr_batched.hpp
@@ -136,13 +136,13 @@ hipblasStatus_t testing_hpr_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_batch_count>{}.log_args<T>(std::cout,
-                                                                argus,
-                                                                gpu_time_used,
-                                                                hpr_gflop_count<T>(N),
-                                                                hpr_gbyte_count<T>(N),
-                                                                hipblas_error_host,
-                                                                hipblas_error_device);
+        ArgumentModel<e_N, e_alpha, e_incx, e_batch_count>{}.log_args<U>(std::cout,
+                                                                         argus,
+                                                                         gpu_time_used,
+                                                                         hpr_gflop_count<T>(N),
+                                                                         hpr_gbyte_count<T>(N),
+                                                                         hipblas_error_host,
+                                                                         hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_hpr_strided_batched.hpp
+++ b/clients/include/testing_hpr_strided_batched.hpp
@@ -138,7 +138,7 @@ hipblasStatus_t testing_hpr_strided_batched(const Arguments& argus)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_stride_x, e_stride_a, e_batch_count>{}.log_args<T>(
+        ArgumentModel<e_N, e_alpha, e_incx, e_stride_x, e_stride_a, e_batch_count>{}.log_args<U>(
             std::cout,
             argus,
             gpu_time_used,


### PR DESCRIPTION
This PR adds hemv, her, her2, hpmv, hpr, and hpr2 to hipblas bench. It also adds device_mode tests, updates to use the new handle, and updates to use more recent batched arrays, along with any other cleanup I noticed.