### PR TITLE
Updating rot(m)(g) tests

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -339,6 +339,15 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same
             {"nrm2", testing_nrm2<T>},
             {"nrm2_batched", testing_nrm2_batched<T>},
             {"nrm2_strided_batched", testing_nrm2_strided_batched<T>},
+            {"rotg", testing_rotg<T>},
+            {"rotg_batched", testing_rotg_batched<T>},
+            {"rotg_strided_batched", testing_rotg_strided_batched<T>},
+            {"rotm", testing_rotm<T>},
+            {"rotm_batched", testing_rotm_batched<T>},
+            {"rotm_strided_batched", testing_rotm_strided_batched<T>},
+            {"rotmg", testing_rotmg<T>},
+            {"rotmg_batched", testing_rotmg_batched<T>},
+            {"rotmg_strided_batched", testing_rotmg_strided_batched<T>},
             {"swap", testing_swap<T>},
             {"swap_batched", testing_swap_batched<T>},
             {"swap_strided_batched", testing_swap_strided_batched<T>},
@@ -348,13 +357,6 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same
             /*{"set_get_vector", testing_set_get_vector<T>},
                 {"set_get_matrix", testing_set_get_matrix<T>},
                 {"set_get_matrix_async", testing_set_get_matrix_async<T>},
-                // L1
-                {"rotm", testing_rotm<T>},
-                {"rotm_batched", testing_rotm_batched<T>},
-                {"rotm_strided_batched", testing_rotm_strided_batched<T>},
-                {"rotmg", testing_rotmg<T>},
-                {"rotmg_batched", testing_rotmg_batched<T>},
-                {"rotmg_strided_batched", testing_rotmg_strided_batched<T>},
                 // L2
                 {"gbmv", testing_gbmv<T>},
                 {"gbmv_batched", testing_gbmv_batched<T>},
@@ -517,6 +519,9 @@ struct perf_blas<
             {"nrm2", testing_nrm2<T>},
             {"nrm2_batched", testing_nrm2_batched<T>},
             {"nrm2_strided_batched", testing_nrm2_strided_batched<T>},
+            {"rotg", testing_rotg<T>},
+            {"rotg_batched", testing_rotg_batched<T>},
+            {"rotg_strided_batched", testing_rotg_strided_batched<T>},
             {"swap", testing_swap<T>},
             {"swap_batched", testing_swap_batched<T>},
             {"swap_strided_batched", testing_swap_strided_batched<T>},
@@ -773,32 +778,6 @@ struct perf_blas_scal_ex<
     }
 };
 
-template <typename Ta, typename Tb = Ta, typename = void>
-struct perf_blas_rotg : hipblas_test_invalid
-{
-};
-
-template <typename Ta, typename Tb>
-struct perf_blas_rotg<
-    Ta,
-    Tb,
-    std::enable_if_t<(std::is_same<Ta, hipblasDoubleComplex>{} && std::is_same<Tb, double>{})
-                     || (std::is_same<Ta, hipblasComplex>{} && std::is_same<Tb, float>{})
-                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, float>{})
-                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, double>{})>>
-    : hipblas_test_valid
-{
-    void operator()(const Arguments& arg)
-    {
-        static const func_map map = {
-            {"rotg", testing_rotg<Ta, Tb>},
-            {"rotg_batched", testing_rotg_batched<Ta, Tb>},
-            {"rotg_strided_batched", testing_rotg_strided_batched<Ta, Tb>},
-        };
-        run_function(map, arg, " --b_type "s + hipblas_datatype2string(arg.b_type));
-    }
-};
-
 int run_bench_test(Arguments& arg)
 {
     //hipblas_initialize(); // Initialize rocBLAS
@@ -968,10 +947,7 @@ int run_bench_test(Arguments& arg)
         if(!strcmp(function, "scal") || !strcmp(function, "scal_batched")
            || !strcmp(function, "scal_strided_batched"))
             hipblas_blas1_dispatch<perf_blas_scal>(arg);
-
-        else if(!strcmp(function, "rotg") || !strcmp(function, "rotg_batched")
-                || !strcmp(function, "rotg_strided_batched"))
-            hipblas_blas1_dispatch<perf_blas_rotg>(arg);*/
+        */
         else if(!strcmp(function, "rot") || !strcmp(function, "rot_batched")
                 || !strcmp(function, "rot_strided_batched"))
             hipblas_rot_dispatch<perf_blas_rot>(arg);

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -702,9 +702,9 @@ struct perf_blas_rot<
     void operator()(const Arguments& arg)
     {
         static const func_map map = {
-            // {"rot", testing_rot<Ti, To, Tc>},
-            // {"rot_batched", testing_rot_batched<Ti, To, Tc>},
-            // {"rot_strided_batched", testing_rot_strided_batched<Ti, To, Tc>},
+            {"rot", testing_rot<Ti, To, Tc>},
+            {"rot_batched", testing_rot_batched<Ti, To, Tc>},
+            {"rot_strided_batched", testing_rot_strided_batched<Ti, To, Tc>},
         };
         run_function(map, arg);
     }
@@ -971,13 +971,14 @@ int run_bench_test(Arguments& arg)
         else if(!strcmp(function, "rotg") || !strcmp(function, "rotg_batched")
                 || !strcmp(function, "rotg_strided_batched"))
             hipblas_blas1_dispatch<perf_blas_rotg>(arg);
+        */
         else if(!strcmp(function, "rot") || !strcmp(function, "rot_batched")
                 || !strcmp(function, "rot_strided_batched"))
-            hipblas_blas1_dispatch<perf_blas_rot>(arg);
+            hipblas_rot_dispatch<perf_blas_rot>(arg);
+        /*
         else if(!strcmp(function, "axpy_ex") || !strcmp(function, "axpy_batched_ex")
                 || !strcmp(function, "axpy_strided_batched_ex"))
             hipblas_blas1_ex_dispatch<perf_blas_axpy_ex>(arg);*/
-
         else
             hipblas_simple_dispatch<perf_blas>(arg);
     }

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -968,10 +968,10 @@ int run_bench_test(Arguments& arg)
         if(!strcmp(function, "scal") || !strcmp(function, "scal_batched")
            || !strcmp(function, "scal_strided_batched"))
             hipblas_blas1_dispatch<perf_blas_scal>(arg);
+
         else if(!strcmp(function, "rotg") || !strcmp(function, "rotg_batched")
                 || !strcmp(function, "rotg_strided_batched"))
-            hipblas_blas1_dispatch<perf_blas_rotg>(arg);
-        */
+            hipblas_blas1_dispatch<perf_blas_rotg>(arg);*/
         else if(!strcmp(function, "rot") || !strcmp(function, "rot_batched")
                 || !strcmp(function, "rot_strided_batched"))
             hipblas_rot_dispatch<perf_blas_rot>(arg);

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -567,6 +567,7 @@ void zdrot_(const int*            n,
             const double*         s);
 
 void crotg_(hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s);
+void zrotg_(hipblasDoubleComplex* a, hipblasDoubleComplex* b, double* c, hipblasDoubleComplex* s);
 }
 
 // rot
@@ -732,6 +733,15 @@ void cblas_rotg<hipblasComplex, float>(hipblasComplex* a,
                                        hipblasComplex* s)
 {
     crotg_(a, b, c, s);
+}
+
+template <>
+void cblas_rotg<hipblasDoubleComplex, double>(hipblasDoubleComplex* a,
+                                              hipblasDoubleComplex* b,
+                                              double*               c,
+                                              hipblasDoubleComplex* s)
+{
+    zrotg_(a, b, c, s);
 }
 
 // rotm

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -1733,7 +1733,7 @@ TEST_P(blas1_gtest, rot_strided_batched_float_complex_float)
 TEST_P(blas1_gtest, rotg_float)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg<float, float>(arg);
+    hipblasStatus_t status = testing_rotg<float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1744,7 +1744,7 @@ TEST_P(blas1_gtest, rotg_float)
 TEST_P(blas1_gtest, rotg_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_rotg<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1756,7 +1756,7 @@ TEST_P(blas1_gtest, rotg_float_complex)
 TEST_P(blas1_gtest, rotg_batched_float)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg_batched<float, float>(arg);
+    hipblasStatus_t status = testing_rotg_batched<float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1774,7 +1774,7 @@ TEST_P(blas1_gtest, rotg_batched_float)
 TEST_P(blas1_gtest, rotg_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_rotg_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1793,7 +1793,7 @@ TEST_P(blas1_gtest, rotg_batched_float_complex)
 TEST_P(blas1_gtest, rotg_strided_batched_float)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg_strided_batched<float, float>(arg);
+    hipblasStatus_t status = testing_rotg_strided_batched<float>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -1811,7 +1811,7 @@ TEST_P(blas1_gtest, rotg_strided_batched_float)
 TEST_P(blas1_gtest, rotg_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
-    hipblasStatus_t status = testing_rotg_strided_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_rotg_strided_batched<hipblasComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/argument_model.hpp
+++ b/clients/include/argument_model.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #ifndef _ARGUMENT_MODEL_HPP_
@@ -8,6 +8,11 @@
 #include "hipblas_arguments.hpp"
 #include <iostream>
 #include <sstream>
+
+namespace ArgumentLogging
+{
+    const double NA_value = -1.0; // invalid for time, GFlop, GB
+}
 
 // ArgumentModel template has a variadic list of argument enums
 template <hipblas_argument... Args>

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -82,14 +82,6 @@ constexpr double rot_gbyte_count(int n)
     return (sizeof(T) * 4.0 * n) / 1e9; // 2 loads and 2 stores
 }
 
-/* \brief byte counts of ROTG */
-template <typename T, typename U>
-constexpr double rotg_gbyte_count()
-{
-    // 1 load and 1 store for each element
-    return sizeof(T) * 3 * 2 + sizeof(U) * 2;
-}
-
 /* \brief byte counts of ROTM */
 template <typename T>
 constexpr double rotm_gbyte_count(int n, T flag)
@@ -103,14 +95,6 @@ constexpr double rotm_gbyte_count(int n, T flag)
     {
         return 0;
     }
-}
-
-/* \brief byte counts of ROTMG */
-template <typename T>
-constexpr double rotmg_gbyte_count()
-{
-    // TODO
-    return 0;
 }
 
 /* \brief byte counts of SCAL */

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -75,6 +75,13 @@ constexpr double nrm2_gbyte_count(int n)
     return (sizeof(T) * n) / 1e9;
 }
 
+/* \brief byte counts of ROT */
+template <typename T>
+constexpr double rot_gbyte_count(int n)
+{
+    return (sizeof(T) * 4.0 * n) / 1e9; // 2 loads and 2 stores
+}
+
 /* \brief byte counts of SCAL */
 template <typename T>
 constexpr double scal_gbyte_count(int n)

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -82,6 +82,37 @@ constexpr double rot_gbyte_count(int n)
     return (sizeof(T) * 4.0 * n) / 1e9; // 2 loads and 2 stores
 }
 
+/* \brief byte counts of ROTG */
+template <typename T, typename U>
+constexpr double rotg_gbyte_count()
+{
+    // 1 load and 1 store for each element
+    return sizeof(T) * 3 * 2 + sizeof(U) * 2;
+}
+
+/* \brief byte counts of ROTM */
+template <typename T>
+constexpr double rotm_gbyte_count(int n, T flag)
+{
+    //No load and store operations when flag is set to -2.0
+    if(flag != -2.0)
+    {
+        return (sizeof(T) * 4.0 * n) / 1e9; //2 loads and 2 stores
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+/* \brief byte counts of ROTMG */
+template <typename T>
+constexpr double rotmg_gbyte_count()
+{
+    // TODO
+    return 0;
+}
+
 /* \brief byte counts of SCAL */
 template <typename T>
 constexpr double scal_gbyte_count(int n)

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -119,6 +119,35 @@ constexpr double nrm2_gflop_count<hipblasDoubleComplex>(int n)
     return nrm2_gflop_count<hipblasComplex>(n);
 }
 
+// rot
+template <typename Tx, typename Ty, typename Tc, typename Ts>
+constexpr double rot_gflop_count(int n)
+{
+    return (6.0 * n) / 1e9; //4 real multiplication, 1 addition , 1 subtraction
+}
+template <>
+constexpr double rot_gflop_count<hipblasComplex, hipblasComplex, float, hipblasComplex>(int n)
+{
+    return (20.0 * n)
+           / 1e9; // (6*2 n for c-c multiply)+(2*2 n for real-complex multiply) + 2n for c-c add + 2n for c-c sub
+}
+template <>
+constexpr double rot_gflop_count<hipblasComplex, hipblasComplex, float, float>(int n)
+{
+    return (12.0 * n) / 1e9; // (2*4 n for real-complex multiply) + 2n for c-c add + 2n for c-c sub
+}
+template <>
+constexpr double
+    rot_gflop_count<hipblasDoubleComplex, hipblasDoubleComplex, double, hipblasDoubleComplex>(int n)
+{
+    return (20.0 * n) / 1e9;
+}
+template <>
+constexpr double rot_gflop_count<hipblasDoubleComplex, hipblasDoubleComplex, double, double>(int n)
+{
+    return (12.0 * n) / 1e9;
+}
+
 // scal
 template <typename T, typename U>
 constexpr double scal_gflop_count(int n)

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -148,13 +148,6 @@ constexpr double rot_gflop_count<hipblasDoubleComplex, hipblasDoubleComplex, dou
     return (12.0 * n) / 1e9;
 }
 
-// rotg
-template <typename T, typename U>
-constexpr double rotg_gflop_count()
-{
-    return 12;
-}
-
 // rotm
 template <typename Tx>
 constexpr double rotm_gflop_count(int n, Tx flag)
@@ -171,14 +164,6 @@ constexpr double rotm_gflop_count(int n, Tx flag)
     {
         return 0;
     }
-}
-
-// rotmg
-template <typename T>
-constexpr double rotmg_gflop_count()
-{
-    // TODO
-    return 0;
 }
 
 // scal

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -148,6 +148,39 @@ constexpr double rot_gflop_count<hipblasDoubleComplex, hipblasDoubleComplex, dou
     return (12.0 * n) / 1e9;
 }
 
+// rotg
+template <typename T, typename U>
+constexpr double rotg_gflop_count()
+{
+    return 12;
+}
+
+// rotm
+template <typename Tx>
+constexpr double rotm_gflop_count(int n, Tx flag)
+{
+    //No floating point operations when flag is set to -2.0
+    if(flag != -2.0)
+    {
+        if(flag < 0)
+            return (6.0 * n) / 1e9; // 4 real multiplication, 2 addition
+        else
+            return (4.0 * n) / 1e9; // 2 real multiplication, 2 addition
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+// rotmg
+template <typename T>
+constexpr double rotmg_gflop_count()
+{
+    // TODO
+    return 0;
+}
+
 // scal
 template <typename T, typename U>
 constexpr double scal_gflop_count(int n)

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -25,11 +25,6 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
     int incy        = arg.incy;
     int batch_count = arg.batch_count;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
-
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
@@ -42,38 +37,34 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+
+    hipblasLocalHandle handle(arg);
 
     size_t size_x = N * size_t(incx);
     size_t size_y = N * size_t(incy);
 
-    device_vector<T*, 0, T> dx(batch_count);
-    device_vector<T*, 0, T> dy(batch_count);
-    device_vector<U>        dc(1);
-    device_vector<V>        ds(1);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
+    device_vector<U>       dc(1);
+    device_vector<V>       ds(1);
 
     // Initial Data on CPU
-    host_vector<T> hx[batch_count]; //(size_x);
-    host_vector<T> hy[batch_count]; //(size_y);
-    host_vector<U> hc(1);
-    host_vector<V> hs(1);
+    host_batch_vector<T> hx_host(N, incx, batch_count);
+    host_batch_vector<T> hy_host(N, incy, batch_count);
+    host_batch_vector<T> hx_device(N, incx, batch_count);
+    host_batch_vector<T> hy_device(N, incy, batch_count);
+    host_batch_vector<T> hx_cpu(N, incx, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy, batch_count);
+    host_vector<U>       hc(1);
+    host_vector<V>       hs(1);
 
-    device_batch_vector<T> bx(batch_count, size_x);
-    device_batch_vector<T> by(batch_count, size_y);
-
-    for(int i = 0; i < batch_count; i++)
-    {
-        hx[i] = host_vector<T>(size_x);
-        hy[i] = host_vector<T>(size_y);
-    }
-
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipblas_init<T>(hx[b], 1, N, incx);
-        hipblas_init<T>(hy[b], 1, N, incy);
-    }
+    hipblas_init(hx_host, true);
+    hipblas_init(hy_host, false);
+    hx_device.copy_from(hx_host);
+    hx_cpu.copy_from(hx_host);
+    hy_device.copy_from(hy_host);
+    hy_cpu.copy_from(hy_host);
 
     // Random alpha (0 - 10)
     host_vector<int> alpha(1);
@@ -83,106 +74,87 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
     hc[0] = cos(alpha[0]);
     hs[0] = sin(alpha[0]);
 
-    // CPU BLAS reference data
-    host_vector<T> cx[batch_count];
-    host_vector<T> cy[batch_count];
+    // Test host
+    CHECK_HIP_ERROR(dx.transfer_from(hx_host));
+    CHECK_HIP_ERROR(dy.transfer_from(hy_host));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR((hipblasRotBatchedFn(
+        handle, N, dx.ptr_on_device(), incx, dy.ptr_on_device(), incy, hc, hs, batch_count)));
+    CHECK_HIP_ERROR(hx_host.transfer_from(dx));
+    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+
+    // Test device
+    CHECK_HIP_ERROR(dx.transfer_from(hx_device));
+    CHECK_HIP_ERROR(dy.transfer_from(hy_device));
+    CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(V), hipMemcpyHostToDevice));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR((hipblasRotBatchedFn(
+        handle, N, dx.ptr_on_device(), incx, dy.ptr_on_device(), incy, dc, ds, batch_count)));
+    CHECK_HIP_ERROR(hx_device.transfer_from(dx));
+    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
     for(int b = 0; b < batch_count; b++)
     {
-        cx[b] = hx[b];
-        cy[b] = hy[b];
-    }
-    // cblas_rotg<T, U>(cx, cy, hc, hs);
-    // cx[0] = hx[0];
-    // cy[0] = hy[0];
-    for(int b = 0; b < batch_count; b++)
-    {
-        cblas_rot<T, U, V>(N, cx[b].data(), incx, cy[b].data(), incy, *hc, *hs);
+        cblas_rot<T, U, V>(N, hx_cpu[b], incx, hy_cpu[b], incy, *hc, *hs);
     }
 
-    if(arg.unit_check)
+    if(arg.unit_check || arg.norm_check)
     {
-        // Test host
+        if(arg.unit_check)
         {
-            status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
             for(int b = 0; b < batch_count; b++)
             {
-                CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(T) * size_x, hipMemcpyHostToDevice));
-                CHECK_HIP_ERROR(hipMemcpy(by[b], hy[b], sizeof(T) * size_y, hipMemcpyHostToDevice));
-            }
-            CHECK_HIP_ERROR(hipMemcpy(dx, bx, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(dy, by, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-
-            status_2 = ((hipblasRotBatchedFn(handle, N, dx, incx, dy, incy, hc, hs, batch_count)));
-
-            if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS))
-            {
-                hipblasDestroy(handle);
-                if(status_1 != HIPBLAS_STATUS_SUCCESS)
-                    return status_1;
-                if(status_2 != HIPBLAS_STATUS_SUCCESS)
-                    return status_2;
-            }
-
-            host_vector<T> rx[batch_count];
-            host_vector<T> ry[batch_count];
-            for(int b = 0; b < batch_count; b++)
-            {
-                rx[b] = host_vector<T>(size_x);
-                ry[b] = host_vector<T>(size_y);
-                CHECK_HIP_ERROR(hipMemcpy(rx[b], bx[b], sizeof(T) * size_x, hipMemcpyDeviceToHost));
-                CHECK_HIP_ERROR(hipMemcpy(ry[b], by[b], sizeof(T) * size_y, hipMemcpyDeviceToHost));
-            }
-
-            if(arg.unit_check)
-            {
-                near_check_general(1, N, batch_count, incx, cx, rx, rel_error);
-                near_check_general(1, N, batch_count, incy, cy, ry, rel_error);
+                near_check_general(1, N, incx, hx_cpu[b], hx_host[b], rel_error);
+                near_check_general(1, N, incy, hy_cpu[b], hy_host[b], rel_error);
+                near_check_general(1, N, incx, hx_cpu[b], hx_device[b], rel_error);
+                near_check_general(1, N, incy, hy_cpu[b], hy_device[b], rel_error);
             }
         }
-
-        // Test device
+        if(arg.norm_check)
         {
-            status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-            for(int b = 0; b < batch_count; b++)
-            {
-                CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(T) * size_x, hipMemcpyHostToDevice));
-                CHECK_HIP_ERROR(hipMemcpy(by[b], hy[b], sizeof(T) * size_y, hipMemcpyHostToDevice));
-            }
-            CHECK_HIP_ERROR(hipMemcpy(dx, bx, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(dy, by, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-
-            CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U), hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(V), hipMemcpyHostToDevice));
-
-            status_4 = ((hipblasRotBatchedFn(handle, N, dx, incx, dy, incy, dc, ds, batch_count)));
-
-            if((status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-            {
-                hipblasDestroy(handle);
-                if(status_3 != HIPBLAS_STATUS_SUCCESS)
-                    return status_3;
-                if(status_4 != HIPBLAS_STATUS_SUCCESS)
-                    return status_4;
-            }
-
-            host_vector<T> rx[batch_count];
-            host_vector<T> ry[batch_count];
-            for(int b = 0; b < batch_count; b++)
-            {
-                rx[b] = host_vector<T>(size_x);
-                ry[b] = host_vector<T>(size_y);
-                CHECK_HIP_ERROR(hipMemcpy(rx[b], bx[b], sizeof(T) * size_x, hipMemcpyDeviceToHost));
-                CHECK_HIP_ERROR(hipMemcpy(ry[b], by[b], sizeof(T) * size_y, hipMemcpyDeviceToHost));
-            }
-
-            if(arg.unit_check)
-            {
-                near_check_general(1, N, batch_count, incx, cx, rx, rel_error);
-                near_check_general(1, N, batch_count, incy, cy, ry, rel_error);
-            }
+            hipblas_error_host
+                = std::max(norm_check_general<T>('F', 1, N, incx, hx_cpu, hx_host, batch_count),
+                           norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host, batch_count));
+            hipblas_error_device
+                = std::max(norm_check_general<T>('F', 1, N, incx, hx_cpu, hx_device, batch_count),
+                           norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device, batch_count));
         }
     }
 
-    hipblasDestroy(handle);
+    if(arg.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR((hipblasRotBatchedFn(handle,
+                                                     N,
+                                                     dx.ptr_on_device(),
+                                                     incx,
+                                                     dy.ptr_on_device(),
+                                                     incy,
+                                                     dc,
+                                                     ds,
+                                                     batch_count)));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<T>(
+            std::cout,
+            arg,
+            gpu_time_used,
+            rot_gflop_count<T, T, U, V>(N),
+            rot_gbyte_count<T>(N),
+            hipblas_error_host,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotg.hpp
+++ b/clients/include/testing_rotg.hpp
@@ -134,8 +134,8 @@ hipblasStatus_t testing_rotg(const Arguments& arg)
         ArgumentModel<e_N>{}.log_args<T>(std::cout,
                                          arg,
                                          gpu_time_used,
-                                         rotg_gflop_count<T, U>(),
-                                         rotg_gbyte_count<T, U>(),
+                                         ArgumentLogging::NA_value,
+                                         ArgumentLogging::NA_value,
                                          hipblas_error_host,
                                          hipblas_error_device);
     }

--- a/clients/include/testing_rotg.hpp
+++ b/clients/include/testing_rotg.hpp
@@ -131,13 +131,13 @@ hipblasStatus_t testing_rotg(const Arguments& arg)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N>{}.log_args<T>(std::cout,
-                                         arg,
-                                         gpu_time_used,
-                                         ArgumentLogging::NA_value,
-                                         ArgumentLogging::NA_value,
-                                         hipblas_error_host,
-                                         hipblas_error_device);
+        ArgumentModel<>{}.log_args<T>(std::cout,
+                                      arg,
+                                      gpu_time_used,
+                                      ArgumentLogging::NA_value,
+                                      ArgumentLogging::NA_value,
+                                      hipblas_error_host,
+                                      hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_rotg.hpp
+++ b/clients/include/testing_rotg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -13,19 +13,16 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U = T>
+template <typename T>
 hipblasStatus_t testing_rotg(const Arguments& arg)
 {
+    using U            = real_t<T>;
     bool FORTRAN       = arg.fortran;
     auto hipblasRotgFn = FORTRAN ? hipblasRotg<T, U, true> : hipblasRotg<T, U, false>;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle handle(arg);
 
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
@@ -54,8 +51,8 @@ hipblasStatus_t testing_rotg(const Arguments& arg)
         host_vector<T> hb = b;
         host_vector<U> hc = c;
         host_vector<T> hs = s;
-        status_1          = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        status_2          = ((hipblasRotgFn(handle, ha, hb, hc, hs)));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR((hipblasRotgFn(handle, ha, hb, hc, hs)));
 
         if(arg.unit_check)
         {
@@ -63,6 +60,13 @@ hipblasStatus_t testing_rotg(const Arguments& arg)
             near_check_general(1, 1, 1, cb.data(), hb.data(), rel_error);
             near_check_general(1, 1, 1, cc.data(), hc.data(), rel_error);
             near_check_general(1, 1, 1, cs.data(), hs.data(), rel_error);
+        }
+        if(arg.norm_check)
+        {
+            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, ca, ha);
+            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, cb, hb);
+            hipblas_error_host += norm_check_general<U>('F', 1, 1, 1, cc, hc);
+            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, cs, hs);
         }
     }
 
@@ -76,8 +80,8 @@ hipblasStatus_t testing_rotg(const Arguments& arg)
         CHECK_HIP_ERROR(hipMemcpy(db, b, sizeof(T), hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(dc, c, sizeof(U), hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(ds, s, sizeof(T), hipMemcpyHostToDevice));
-        status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-        status_4 = ((hipblasRotgFn(handle, da, db, dc, ds)));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR((hipblasRotgFn(handle, da, db, dc, ds)));
         host_vector<T> ha(1);
         host_vector<T> hb(1);
         host_vector<U> hc(1);
@@ -94,20 +98,47 @@ hipblasStatus_t testing_rotg(const Arguments& arg)
             near_check_general(1, 1, 1, cc.data(), hc.data(), rel_error);
             near_check_general(1, 1, 1, cs.data(), hs.data(), rel_error);
         }
+        if(arg.norm_check)
+        {
+            hipblas_error_device = norm_check_general<T>('F', 1, 1, 1, ca, ha);
+            hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, cb, hb);
+            hipblas_error_device += norm_check_general<U>('F', 1, 1, 1, cc, hc);
+            hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, cs, hs);
+        }
     }
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
-       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
+
+    if(arg.timing)
     {
-        hipblasDestroy(handle);
-        if(status_1 != HIPBLAS_STATUS_SUCCESS)
-            return status_1;
-        if(status_2 != HIPBLAS_STATUS_SUCCESS)
-            return status_2;
-        if(status_3 != HIPBLAS_STATUS_SUCCESS)
-            return status_3;
-        if(status_4 != HIPBLAS_STATUS_SUCCESS)
-            return status_4;
+        device_vector<T> da(1);
+        device_vector<T> db(1);
+        device_vector<U> dc(1);
+        device_vector<T> ds(1);
+        CHECK_HIP_ERROR(hipMemcpy(da, a, sizeof(T), hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(db, b, sizeof(T), hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dc, c, sizeof(U), hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(ds, s, sizeof(T), hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR((hipblasRotgFn(handle, da, db, dc, ds)));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N>{}.log_args<T>(std::cout,
+                                         arg,
+                                         gpu_time_used,
+                                         rotg_gflop_count<T, U>(),
+                                         rotg_gbyte_count<T, U>(),
+                                         hipblas_error_host,
+                                         hipblas_error_device);
     }
-    hipblasDestroy(handle);
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotg_batched.hpp
+++ b/clients/include/testing_rotg_batched.hpp
@@ -56,6 +56,10 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
     hipblas_init(hb, false);
     hipblas_init(hc, false);
     hipblas_init(hs, false);
+    ca.copy_from(ha);
+    cb.copy_from(hb);
+    cc.copy_from(hc);
+    cs.copy_from(hs);
 
     for(int b = 0; b < batch_count; b++)
     {
@@ -80,18 +84,18 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
         {
             for(int b = 0; b < batch_count; b++)
             {
-                near_check_general<T>(1, 1, 1, ra[b], ca[b], rel_error);
-                near_check_general<T>(1, 1, 1, rb[b], cb[b], rel_error);
-                near_check_general<U>(1, 1, 1, rc[b], cc[b], rel_error);
-                near_check_general<T>(1, 1, 1, rs[b], cs[b], rel_error);
+                near_check_general<T>(1, 1, 1, ca[b], ra[b], rel_error);
+                near_check_general<T>(1, 1, 1, cb[b], rb[b], rel_error);
+                near_check_general<U>(1, 1, 1, cc[b], rc[b], rel_error);
+                near_check_general<T>(1, 1, 1, cs[b], rs[b], rel_error);
             }
         }
         if(arg.norm_check)
         {
-            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, ra, ca, batch_count);
-            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, rb, cb, batch_count);
-            hipblas_error_host += norm_check_general<U>('F', 1, 1, 1, rc, cc, batch_count);
-            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, rs, cs, batch_count);
+            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, ca, ra, batch_count);
+            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, cb, rb, batch_count);
+            hipblas_error_host += norm_check_general<U>('F', 1, 1, 1, cc, rc, batch_count);
+            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, cs, rs, batch_count);
         }
     }
 
@@ -118,27 +122,27 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
         host_batch_vector<T> rb(1, 1, batch_count);
         host_batch_vector<U> rc(1, 1, batch_count);
         host_batch_vector<T> rs(1, 1, batch_count);
-        CHECK_HIP_ERROR(ha.transfer_from(da));
-        CHECK_HIP_ERROR(hb.transfer_from(db));
-        CHECK_HIP_ERROR(hc.transfer_from(dc));
-        CHECK_HIP_ERROR(hs.transfer_from(ds));
+        CHECK_HIP_ERROR(ra.transfer_from(da));
+        CHECK_HIP_ERROR(rb.transfer_from(db));
+        CHECK_HIP_ERROR(rc.transfer_from(dc));
+        CHECK_HIP_ERROR(rs.transfer_from(ds));
 
         if(arg.unit_check)
         {
             for(int b = 0; b < batch_count; b++)
             {
-                near_check_general<T>(1, 1, 1, ra[b], ca[b], rel_error);
-                near_check_general<T>(1, 1, 1, rb[b], cb[b], rel_error);
-                near_check_general<U>(1, 1, 1, rc[b], cc[b], rel_error);
-                near_check_general<T>(1, 1, 1, rs[b], cs[b], rel_error);
+                near_check_general<T>(1, 1, 1, ca[b], ra[b], rel_error);
+                near_check_general<T>(1, 1, 1, cb[b], rb[b], rel_error);
+                near_check_general<U>(1, 1, 1, cc[b], rc[b], rel_error);
+                near_check_general<T>(1, 1, 1, cs[b], rs[b], rel_error);
             }
         }
         if(arg.norm_check)
         {
-            hipblas_error_device = norm_check_general<T>('F', 1, 1, 1, ra, ca, batch_count);
-            hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, rb, cb, batch_count);
-            hipblas_error_device += norm_check_general<U>('F', 1, 1, 1, rc, cc, batch_count);
-            hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, rs, cs, batch_count);
+            hipblas_error_device = norm_check_general<T>('F', 1, 1, 1, ca, ra, batch_count);
+            hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, cb, rb, batch_count);
+            hipblas_error_device += norm_check_general<U>('F', 1, 1, 1, cc, rc, batch_count);
+            hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, cs, rs, batch_count);
         }
     }
 

--- a/clients/include/testing_rotg_batched.hpp
+++ b/clients/include/testing_rotg_batched.hpp
@@ -174,8 +174,8 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
         ArgumentModel<e_batch_count>{}.log_args<T>(std::cout,
                                                    arg,
                                                    gpu_time_used,
-                                                   rotg_gflop_count<T, U>(),
-                                                   rotg_gbyte_count<T, U>(),
+                                                   ArgumentLogging::NA_value,
+                                                   ArgumentLogging::NA_value,
                                                    hipblas_error_host,
                                                    hipblas_error_device);
     }

--- a/clients/include/testing_rotg_batched.hpp
+++ b/clients/include/testing_rotg_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -13,18 +13,15 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U = T>
+template <typename T>
 hipblasStatus_t testing_rotg_batched(const Arguments& arg)
 {
+    using U      = real_t<T>;
     bool FORTRAN = arg.fortran;
     auto hipblasRotgBatchedFn
         = FORTRAN ? hipblasRotgBatched<T, U, true> : hipblasRotgBatched<T, U, false>;
 
-    int             batch_count = arg.batch_count;
-    hipblasStatus_t status_1    = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2    = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3    = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4    = HIPBLAS_STATUS_SUCCESS;
+    int batch_count = arg.batch_count;
 
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
@@ -38,43 +35,27 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+
+    hipblasLocalHandle handle(arg);
 
     // Initial Data on CPU
-    host_vector<T> ha[batch_count];
-    host_vector<T> hb[batch_count];
-    host_vector<U> hc[batch_count];
-    host_vector<T> hs[batch_count];
+    host_batch_vector<T> ha(1, 1, batch_count);
+    host_batch_vector<T> hb(1, 1, batch_count);
+    host_batch_vector<U> hc(1, 1, batch_count);
+    host_batch_vector<T> hs(1, 1, batch_count);
+    host_batch_vector<T> ca(1, 1, batch_count);
+    host_batch_vector<T> cb(1, 1, batch_count);
+    host_batch_vector<U> cc(1, 1, batch_count);
+    host_batch_vector<T> cs(1, 1, batch_count);
 
-    device_batch_vector<T> ba(batch_count, 1);
-    device_batch_vector<T> bb(batch_count, 1);
+    device_batch_vector<T> da(1, 1, batch_count);
+    device_batch_vector<T> db(1, 1, batch_count);
 
-    for(int b = 0; b < batch_count; b++)
-    {
-        ha[b] = host_vector<T>(1);
-        hb[b] = host_vector<T>(1);
-        hc[b] = host_vector<U>(1);
-        hs[b] = host_vector<T>(1);
-    }
-
-    host_vector<T> ca[batch_count];
-    host_vector<T> cb[batch_count];
-    host_vector<U> cc[batch_count];
-    host_vector<T> cs[batch_count];
-
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipblas_init<T>(ha[b], 1, 1, 1);
-        hipblas_init<T>(hb[b], 1, 1, 1);
-        hipblas_init<U>(hc[b], 1, 1, 1);
-        hipblas_init<T>(hs[b], 1, 1, 1);
-        ca[b] = ha[b];
-        cb[b] = hb[b];
-        cc[b] = hc[b];
-        cs[b] = hs[b];
-    }
+    hipblas_init(ha, true);
+    hipblas_init(hb, false);
+    hipblas_init(hc, false);
+    hipblas_init(hs, false);
 
     for(int b = 0; b < batch_count; b++)
     {
@@ -83,102 +64,121 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
 
     // Test host
     {
-        host_vector<T> ra[batch_count];
-        host_vector<T> rb[batch_count];
-        host_vector<U> rc[batch_count];
-        host_vector<T> rs[batch_count];
-        T*             ra_in[batch_count];
-        T*             rb_in[batch_count];
-        U*             rc_in[batch_count];
-        T*             rs_in[batch_count];
-        for(int b = 0; b < batch_count; b++)
-        {
-            ra_in[b] = ra[b] = ha[b];
-            rb_in[b] = rb[b] = hb[b];
-            rc_in[b] = rc[b] = hc[b];
-            rs_in[b] = rs[b] = hs[b];
-        }
+        host_batch_vector<T> ra(1, 1, batch_count);
+        host_batch_vector<T> rb(1, 1, batch_count);
+        host_batch_vector<U> rc(1, 1, batch_count);
+        host_batch_vector<T> rs(1, 1, batch_count);
+        ra.copy_from(ha);
+        rb.copy_from(hb);
+        rc.copy_from(hc);
+        rs.copy_from(hs);
 
-        status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-
-        status_2 = (hipblasRotgBatchedFn(handle, ra_in, rb_in, rc_in, rs_in, batch_count));
-
-        if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS))
-        {
-            hipblasDestroy(handle);
-            if(status_1 != HIPBLAS_STATUS_SUCCESS)
-                return status_1;
-            if(status_2 != HIPBLAS_STATUS_SUCCESS)
-                return status_2;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasRotgBatchedFn(handle, ra, rb, rc, rs, batch_count));
 
         if(arg.unit_check)
         {
-            near_check_general<T>(1, 1, batch_count, 1, ra, ca, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, rb, cb, rel_error);
-            near_check_general<U>(1, 1, batch_count, 1, rc, cc, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, rs, cs, rel_error);
+            for(int b = 0; b < batch_count; b++)
+            {
+                near_check_general<T>(1, 1, 1, ra[b], ca[b], rel_error);
+                near_check_general<T>(1, 1, 1, rb[b], cb[b], rel_error);
+                near_check_general<U>(1, 1, 1, rc[b], cc[b], rel_error);
+                near_check_general<T>(1, 1, 1, rs[b], cs[b], rel_error);
+            }
+        }
+        if(arg.norm_check)
+        {
+            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, ra, ca, batch_count);
+            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, rb, cb, batch_count);
+            hipblas_error_host += norm_check_general<U>('F', 1, 1, 1, rc, cc, batch_count);
+            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, rs, cs, batch_count);
         }
     }
 
     // Test device
     {
-        device_vector<T*, 0, T> da(batch_count);
-        device_vector<T*, 0, T> db(batch_count);
-        device_vector<U*, 0, U> dc(batch_count);
-        device_vector<T*, 0, T> ds(batch_count);
-        device_batch_vector<T>  ba(batch_count, 1);
-        device_batch_vector<T>  bb(batch_count, 1);
-        device_batch_vector<U>  bc(batch_count, 1);
-        device_batch_vector<T>  bs(batch_count, 1);
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(hipMemcpy(ba[b], ha[b], sizeof(T), hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(bb[b], hb[b], sizeof(T), hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(bc[b], hc[b], sizeof(U), hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(bs[b], hs[b], sizeof(T), hipMemcpyHostToDevice));
-        }
-        CHECK_HIP_ERROR(hipMemcpy(da, ba, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(db, bb, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dc, bc, sizeof(U*) * batch_count, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(ds, bs, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+        device_batch_vector<T> da(1, 1, batch_count);
+        device_batch_vector<T> db(1, 1, batch_count);
+        device_batch_vector<U> dc(1, 1, batch_count);
+        device_batch_vector<T> ds(1, 1, batch_count);
+        CHECK_HIP_ERROR(da.transfer_from(ha));
+        CHECK_HIP_ERROR(db.transfer_from(hb));
+        CHECK_HIP_ERROR(dc.transfer_from(hc));
+        CHECK_HIP_ERROR(ds.transfer_from(hs));
 
-        status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-        status_4 = ((hipblasRotgBatchedFn(handle, da, db, dc, ds, batch_count)));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR((hipblasRotgBatchedFn(handle,
+                                                  da.ptr_on_device(),
+                                                  db.ptr_on_device(),
+                                                  dc.ptr_on_device(),
+                                                  ds.ptr_on_device(),
+                                                  batch_count)));
 
-        if((status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-        {
-            hipblasDestroy(handle);
-            if(status_3 != HIPBLAS_STATUS_SUCCESS)
-                return status_3;
-            if(status_4 != HIPBLAS_STATUS_SUCCESS)
-                return status_4;
-        }
-
-        host_vector<T> ra[batch_count];
-        host_vector<T> rb[batch_count];
-        host_vector<U> rc[batch_count];
-        host_vector<T> rs[batch_count];
-        for(int b = 0; b < batch_count; b++)
-        {
-            ra[b] = host_vector<T>(1);
-            rb[b] = host_vector<T>(1);
-            rc[b] = host_vector<U>(1);
-            rs[b] = host_vector<T>(1);
-            CHECK_HIP_ERROR(hipMemcpy(ra[b], ba[b], sizeof(T), hipMemcpyDeviceToHost));
-            CHECK_HIP_ERROR(hipMemcpy(rb[b], bb[b], sizeof(T), hipMemcpyDeviceToHost));
-            CHECK_HIP_ERROR(hipMemcpy(rc[b], bc[b], sizeof(U), hipMemcpyDeviceToHost));
-            CHECK_HIP_ERROR(hipMemcpy(rs[b], bs[b], sizeof(T), hipMemcpyDeviceToHost));
-        }
+        host_batch_vector<T> ra(1, 1, batch_count);
+        host_batch_vector<T> rb(1, 1, batch_count);
+        host_batch_vector<U> rc(1, 1, batch_count);
+        host_batch_vector<T> rs(1, 1, batch_count);
+        CHECK_HIP_ERROR(ha.transfer_from(da));
+        CHECK_HIP_ERROR(hb.transfer_from(db));
+        CHECK_HIP_ERROR(hc.transfer_from(dc));
+        CHECK_HIP_ERROR(hs.transfer_from(ds));
 
         if(arg.unit_check)
         {
-            near_check_general<T>(1, 1, batch_count, 1, ra, ca, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, rb, cb, rel_error);
-            near_check_general<U>(1, 1, batch_count, 1, rc, cc, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, rs, cs, rel_error);
+            for(int b = 0; b < batch_count; b++)
+            {
+                near_check_general<T>(1, 1, 1, ra[b], ca[b], rel_error);
+                near_check_general<T>(1, 1, 1, rb[b], cb[b], rel_error);
+                near_check_general<U>(1, 1, 1, rc[b], cc[b], rel_error);
+                near_check_general<T>(1, 1, 1, rs[b], cs[b], rel_error);
+            }
+        }
+        if(arg.norm_check)
+        {
+            hipblas_error_device = norm_check_general<T>('F', 1, 1, 1, ra, ca, batch_count);
+            hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, rb, cb, batch_count);
+            hipblas_error_device += norm_check_general<U>('F', 1, 1, 1, rc, cc, batch_count);
+            hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, rs, cs, batch_count);
         }
     }
-    hipblasDestroy(handle);
+
+    if(arg.timing)
+    {
+        device_batch_vector<T> da(1, 1, batch_count);
+        device_batch_vector<T> db(1, 1, batch_count);
+        device_batch_vector<U> dc(1, 1, batch_count);
+        device_batch_vector<T> ds(1, 1, batch_count);
+        CHECK_HIP_ERROR(da.transfer_from(ha));
+        CHECK_HIP_ERROR(db.transfer_from(hb));
+        CHECK_HIP_ERROR(dc.transfer_from(hc));
+        CHECK_HIP_ERROR(ds.transfer_from(hs));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR((hipblasRotgBatchedFn(handle,
+                                                      da.ptr_on_device(),
+                                                      db.ptr_on_device(),
+                                                      dc.ptr_on_device(),
+                                                      ds.ptr_on_device(),
+                                                      batch_count)));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_batch_count>{}.log_args<T>(std::cout,
+                                                   arg,
+                                                   gpu_time_used,
+                                                   rotg_gflop_count<T, U>(),
+                                                   rotg_gbyte_count<T, U>(),
+                                                   hipblas_error_host,
+                                                   hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotg_strided_batched.hpp
+++ b/clients/include/testing_rotg_strided_batched.hpp
@@ -175,8 +175,8 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
         ArgumentModel<e_batch_count>{}.log_args<T>(std::cout,
                                                    arg,
                                                    gpu_time_used,
-                                                   rotg_gflop_count<T, U>(),
-                                                   rotg_gbyte_count<T, U>(),
+                                                   ArgumentLogging::NA_value,
+                                                   ArgumentLogging::NA_value,
                                                    hipblas_error_host,
                                                    hipblas_error_device);
     }

--- a/clients/include/testing_rotg_strided_batched.hpp
+++ b/clients/include/testing_rotg_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -13,9 +13,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U = T>
+template <typename T>
 hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
 {
+    using U      = real_t<T>;
     bool FORTRAN = arg.fortran;
     auto hipblasRotgStridedBatchedFn
         = FORTRAN ? hipblasRotgStridedBatched<T, U, true> : hipblasRotgStridedBatched<T, U, false>;
@@ -26,11 +27,6 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
     hipblasStride stride_c     = stride_scale;
     hipblasStride stride_s     = stride_scale;
     int           batch_count  = arg.batch_count;
-
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
 
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
@@ -44,8 +40,9 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+
+    hipblasLocalHandle handle(arg);
 
     size_t size_a = size_t(stride_a) * size_t(batch_count);
     size_t size_b = size_t(stride_b) * size_t(batch_count);
@@ -84,18 +81,9 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
         host_vector<T> rb = hb;
         host_vector<U> rc = hc;
         host_vector<T> rs = hs;
-        status_1          = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        status_2          = ((hipblasRotgStridedBatchedFn(
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR((hipblasRotgStridedBatchedFn(
             handle, ra, stride_a, rb, stride_b, rc, stride_c, rs, stride_s, batch_count)));
-
-        if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS))
-        {
-            hipblasDestroy(handle);
-            if(status_1 != HIPBLAS_STATUS_SUCCESS)
-                return status_1;
-            if(status_2 != HIPBLAS_STATUS_SUCCESS)
-                return status_2;
-        }
 
         if(arg.unit_check)
         {
@@ -103,6 +91,16 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
             near_check_general<T>(1, 1, batch_count, 1, stride_b, cb, rb, rel_error);
             near_check_general<U>(1, 1, batch_count, 1, stride_c, cc, rc, rel_error);
             near_check_general<T>(1, 1, batch_count, 1, stride_s, cs, rs, rel_error);
+        }
+        if(arg.norm_check)
+        {
+            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, stride_a, ca, ra, batch_count);
+            hipblas_error_host
+                += norm_check_general<T>('F', 1, 1, 1, stride_b, cb, rb, batch_count);
+            hipblas_error_host
+                += norm_check_general<U>('F', 1, 1, 1, stride_c, cc, rc, batch_count);
+            hipblas_error_host
+                += norm_check_general<T>('F', 1, 1, 1, stride_s, cs, rs, batch_count);
         }
     }
 
@@ -116,18 +114,9 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
         CHECK_HIP_ERROR(hipMemcpy(db, hb, sizeof(T) * size_b, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U) * size_c, hipMemcpyHostToDevice));
         CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(T) * size_s, hipMemcpyHostToDevice));
-        status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-        status_4 = ((hipblasRotgStridedBatchedFn(
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR((hipblasRotgStridedBatchedFn(
             handle, da, stride_a, db, stride_b, dc, stride_c, ds, stride_s, batch_count)));
-
-        if((status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-        {
-            hipblasDestroy(handle);
-            if(status_3 != HIPBLAS_STATUS_SUCCESS)
-                return status_3;
-            if(status_4 != HIPBLAS_STATUS_SUCCESS)
-                return status_4;
-        }
 
         host_vector<T> ra(size_a);
         host_vector<T> rb(size_b);
@@ -145,7 +134,51 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
             near_check_general<U>(1, 1, batch_count, 1, stride_c, cc, rc, rel_error);
             near_check_general<T>(1, 1, batch_count, 1, stride_s, cs, rs, rel_error);
         }
+        if(arg.norm_check)
+        {
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, 1, 1, stride_a, ca, ra, batch_count);
+            hipblas_error_device
+                += norm_check_general<T>('F', 1, 1, 1, stride_b, cb, rb, batch_count);
+            hipblas_error_device
+                += norm_check_general<U>('F', 1, 1, 1, stride_c, cc, rc, batch_count);
+            hipblas_error_device
+                += norm_check_general<T>('F', 1, 1, 1, stride_s, cs, rs, batch_count);
+        }
     }
-    hipblasDestroy(handle);
+
+    if(arg.timing)
+    {
+        device_vector<T> da(size_a);
+        device_vector<T> db(size_b);
+        device_vector<U> dc(size_c);
+        device_vector<T> ds(size_s);
+        CHECK_HIP_ERROR(hipMemcpy(da, ha, sizeof(T) * size_a, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(db, hb, sizeof(T) * size_b, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U) * size_c, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(T) * size_s, hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR((hipblasRotgStridedBatchedFn(
+                handle, da, stride_a, db, stride_b, dc, stride_c, ds, stride_s, batch_count)));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_batch_count>{}.log_args<T>(std::cout,
+                                                   arg,
+                                                   gpu_time_used,
+                                                   rotg_gflop_count<T, U>(),
+                                                   rotg_gbyte_count<T, U>(),
+                                                   hipblas_error_host,
+                                                   hipblas_error_device);
+    }
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotm.hpp
+++ b/clients/include/testing_rotm.hpp
@@ -31,8 +31,7 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    double gpu_time_used, hipblas_error_host_x, hipblas_error_host_y, hipblas_error_device_x,
-        hipblas_error_device_y;
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     hipblasLocalHandle handle(arg);
 
@@ -83,8 +82,8 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
                 }
                 if(arg.norm_check)
                 {
-                    hipblas_error_host_x = norm_check_general<T>('F', 1, N, incx, cx, rx);
-                    hipblas_error_host_y = norm_check_general<T>('F', 1, N, incy, cy, ry);
+                    hipblas_error_host = norm_check_general<T>('F', 1, N, incx, cx, rx);
+                    hipblas_error_host += norm_check_general<T>('F', 1, N, incy, cy, ry);
                 }
             }
 
@@ -106,8 +105,8 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
                 }
                 if(arg.norm_check)
                 {
-                    hipblas_error_device_x = norm_check_general<T>('F', 1, N, incx, cx, rx);
-                    hipblas_error_device_y = norm_check_general<T>('F', 1, N, incy, cy, ry);
+                    hipblas_error_device = norm_check_general<T>('F', 1, N, incx, cx, rx);
+                    hipblas_error_device += norm_check_general<T>('F', 1, N, incy, cy, ry);
                 }
             }
         }
@@ -138,10 +137,8 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
                                                          gpu_time_used,
                                                          rotm_gflop_count<T>(N, hparam[0]),
                                                          rotm_gbyte_count<T>(N, hparam[0]),
-                                                         //  hipblas_error_host_x,
-                                                         //  hipblas_error_host_y,
-                                                         hipblas_error_device_x,
-                                                         hipblas_error_device_y);
+                                                         hipblas_error_host,
+                                                         hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_rotm.hpp
+++ b/clients/include/testing_rotm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -23,11 +23,6 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
     int incx = arg.incx;
     int incy = arg.incy;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
-
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
@@ -36,8 +31,10 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double gpu_time_used, hipblas_error_host_x, hipblas_error_host_y, hipblas_error_device_x,
+        hipblas_error_device_y;
+
+    hipblasLocalHandle handle(arg);
 
     size_t size_x = N * size_t(incx);
     size_t size_y = N * size_t(incy);
@@ -67,14 +64,14 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
         host_vector<T> cy = hy;
         cblas_rotm<T>(N, cx, incx, cy, incy, hparam);
 
-        if(arg.unit_check)
+        if(arg.unit_check || arg.norm_check)
         {
             // Test host
             {
-                status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
+                CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
                 CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
                 CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));
-                status_2 = hipblasRotmFn(handle, N, dx, incx, dy, incy, hparam);
+                CHECK_HIPBLAS_ERROR(hipblasRotmFn(handle, N, dx, incx, dy, incy, hparam));
                 host_vector<T> rx(size_x);
                 host_vector<T> ry(size_y);
                 CHECK_HIP_ERROR(hipMemcpy(rx, dx, sizeof(T) * size_x, hipMemcpyDeviceToHost));
@@ -83,16 +80,21 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
                 {
                     near_check_general(1, N, incx, cx.data(), rx.data(), rel_error);
                     near_check_general(1, N, incy, cy.data(), ry.data(), rel_error);
+                }
+                if(arg.norm_check)
+                {
+                    hipblas_error_host_x = norm_check_general<T>('F', 1, N, incx, cx, rx);
+                    hipblas_error_host_y = norm_check_general<T>('F', 1, N, incy, cy, ry);
                 }
             }
 
             // Test device
             {
-                status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+                CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
                 CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
                 CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));
                 CHECK_HIP_ERROR(hipMemcpy(dparam, hparam, sizeof(T) * 5, hipMemcpyHostToDevice));
-                status_4 = hipblasRotmFn(handle, N, dx, incx, dy, incy, dparam);
+                CHECK_HIPBLAS_ERROR(hipblasRotmFn(handle, N, dx, incx, dy, incy, dparam));
                 host_vector<T> rx(size_x);
                 host_vector<T> ry(size_y);
                 CHECK_HIP_ERROR(hipMemcpy(rx, dx, sizeof(T) * size_x, hipMemcpyDeviceToHost));
@@ -102,23 +104,45 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
                     near_check_general(1, N, incx, cx.data(), rx.data(), rel_error);
                     near_check_general(1, N, incy, cy.data(), ry.data(), rel_error);
                 }
+                if(arg.norm_check)
+                {
+                    hipblas_error_device_x = norm_check_general<T>('F', 1, N, incx, cx, rx);
+                    hipblas_error_device_y = norm_check_general<T>('F', 1, N, incy, cy, ry);
+                }
             }
         }
-
-        if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
-           || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-        {
-            hipblasDestroy(handle);
-            if(status_1 != HIPBLAS_STATUS_SUCCESS)
-                return status_1;
-            if(status_2 != HIPBLAS_STATUS_SUCCESS)
-                return status_2;
-            if(status_3 != HIPBLAS_STATUS_SUCCESS)
-                return status_3;
-            if(status_4 != HIPBLAS_STATUS_SUCCESS)
-                return status_4;
-        }
     }
-    hipblasDestroy(handle);
+
+    if(arg.timing)
+    {
+        hparam[0] = 0;
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dparam, hparam, sizeof(T) * 5, hipMemcpyHostToDevice));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasRotmFn(handle, N, dx, incx, dy, incy, dparam));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy>{}.log_args<T>(std::cout,
+                                                         arg,
+                                                         gpu_time_used,
+                                                         rotm_gflop_count<T>(N, hparam[0]),
+                                                         rotm_gbyte_count<T>(N, hparam[0]),
+                                                         //  hipblas_error_host_x,
+                                                         //  hipblas_error_host_y,
+                                                         hipblas_error_device_x,
+                                                         hipblas_error_device_y);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotm_batched.hpp
+++ b/clients/include/testing_rotm_batched.hpp
@@ -110,8 +110,9 @@ hipblasStatus_t testing_rotm_batched(const Arguments& arg)
                 if(arg.norm_check)
                 {
                     hipblas_error_device
-                        = std::max(norm_check_general<T>('F', 1, N, incx, cx, rx, batch_count),
-                                   norm_check_general<T>('F', 1, N, incy, cy, ry, batch_count));
+                        = norm_check_general<T>('F', 1, N, incx, cx, rx, batch_count);
+                    hipblas_error_device
+                        += norm_check_general<T>('F', 1, N, incy, cy, ry, batch_count);
                 }
             }
         }

--- a/clients/include/testing_rotm_strided_batched.hpp
+++ b/clients/include/testing_rotm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -30,9 +30,6 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
     hipblasStride stride_param = 5 * stride_scale;
     int           batch_count  = arg.batch_count;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
@@ -41,8 +38,9 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
         return (batch_count < 0) ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double gpu_time_used, hipblas_error_device;
+
+    hipblasLocalHandle handle(arg);
 
     size_t size_x     = N * size_t(incx) + size_t(stride_x) * size_t(batch_count - 1);
     size_t size_y     = N * size_t(incy) + size_t(stride_y) * size_t(batch_count - 1);
@@ -91,31 +89,22 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
         {
             // Test device
             {
-                status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+                CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
                 CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
                 CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));
                 CHECK_HIP_ERROR(
                     hipMemcpy(dparam, hparam, sizeof(T) * size_param, hipMemcpyHostToDevice));
-                status_2 = ((hipblasRotmStridedBatchedFn(handle,
-                                                         N,
-                                                         dx,
-                                                         incx,
-                                                         stride_x,
-                                                         dy,
-                                                         incy,
-                                                         stride_y,
-                                                         dparam,
-                                                         stride_param,
-                                                         batch_count)));
-
-                if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS))
-                {
-                    hipblasDestroy(handle);
-                    if(status_1 != HIPBLAS_STATUS_SUCCESS)
-                        return status_1;
-                    if(status_2 != HIPBLAS_STATUS_SUCCESS)
-                        return status_2;
-                }
+                CHECK_HIPBLAS_ERROR((hipblasRotmStridedBatchedFn(handle,
+                                                                 N,
+                                                                 dx,
+                                                                 incx,
+                                                                 stride_x,
+                                                                 dy,
+                                                                 incy,
+                                                                 stride_y,
+                                                                 dparam,
+                                                                 stride_param,
+                                                                 batch_count)));
 
                 host_vector<T> rx(size_x);
                 host_vector<T> ry(size_y);
@@ -126,9 +115,56 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
                     near_check_general<T>(1, N, batch_count, incx, stride_x, cx, rx, rel_error);
                     near_check_general<T>(1, N, batch_count, incy, stride_y, cy, ry, rel_error);
                 }
+                if(arg.norm_check)
+                {
+                    hipblas_error_device = std::max(
+                        norm_check_general<T>('F', 1, N, incx, stride_x, cx, rx, batch_count),
+                        norm_check_general<T>('F', 1, N, incy, stride_y, cy, ry, batch_count));
+                }
             }
         }
     }
-    hipblasDestroy(handle);
+
+    if(arg.timing)
+    {
+        for(int b = 0; b < batch_count; b++)
+            (hparam + b * stride_param)[0] = 0;
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(T) * size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(T) * size_y, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dparam, hparam, sizeof(T) * size_param, hipMemcpyHostToDevice));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR((hipblasRotmStridedBatchedFn(handle,
+                                                             N,
+                                                             dx,
+                                                             incx,
+                                                             stride_x,
+                                                             dy,
+                                                             incy,
+                                                             stride_y,
+                                                             dparam,
+                                                             stride_param,
+                                                             batch_count)));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_stride_x, e_incy, e_stride_y, e_batch_count>{}.log_args<T>(
+            std::cout,
+            arg,
+            gpu_time_used,
+            rotm_gflop_count<T>(N, 0),
+            rotm_gbyte_count<T>(N, 0),
+            0,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotm_strided_batched.hpp
+++ b/clients/include/testing_rotm_strided_batched.hpp
@@ -117,9 +117,10 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
                 }
                 if(arg.norm_check)
                 {
-                    hipblas_error_device = std::max(
-                        norm_check_general<T>('F', 1, N, incx, stride_x, cx, rx, batch_count),
-                        norm_check_general<T>('F', 1, N, incy, stride_y, cy, ry, batch_count));
+                    hipblas_error_device
+                        = norm_check_general<T>('F', 1, N, incx, stride_x, cx, rx, batch_count);
+                    hipblas_error_device
+                        += norm_check_general<T>('F', 1, N, incy, stride_y, cy, ry, batch_count);
                 }
             }
         }

--- a/clients/include/testing_rotmg.hpp
+++ b/clients/include/testing_rotmg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -19,14 +19,11 @@ hipblasStatus_t testing_rotmg(const Arguments& arg)
     bool FORTRAN        = arg.fortran;
     auto hipblasRotmgFn = FORTRAN ? hipblasRotmg<T, true> : hipblasRotmg<T, false>;
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
-    host_vector<T> params(9);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
+    hipblasLocalHandle handle(arg);
+
+    host_vector<T> params(9);
 
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
@@ -41,41 +38,59 @@ hipblasStatus_t testing_rotmg(const Arguments& arg)
     // Test host
     {
         host_vector<T> hparams = params;
-        status_1               = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        status_2               = (hipblasRotmgFn(
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasRotmgFn(
             handle, &hparams[0], &hparams[1], &hparams[2], &hparams[3], &hparams[4]));
 
         if(arg.unit_check)
             near_check_general(1, 9, 1, cparams.data(), hparams.data(), rel_error);
+        if(arg.norm_check)
+            hipblas_error_host = norm_check_general<T>('F', 1, 9, 1, cparams, hparams);
     }
 
     // Test device
     {
         device_vector<T> dparams(9);
         CHECK_HIP_ERROR(hipMemcpy(dparams, params, 9 * sizeof(T), hipMemcpyHostToDevice));
-        status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-        status_4
-            = (hipblasRotmgFn(handle, dparams, dparams + 1, dparams + 2, dparams + 3, dparams + 4));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasRotmgFn(handle, dparams, dparams + 1, dparams + 2, dparams + 3, dparams + 4));
         host_vector<T> hparams(9);
         CHECK_HIP_ERROR(hipMemcpy(hparams, dparams, 9 * sizeof(T), hipMemcpyDeviceToHost));
 
         if(arg.unit_check)
             near_check_general(1, 9, 1, cparams.data(), hparams.data(), rel_error);
+        if(arg.norm_check)
+            hipblas_error_device = norm_check_general<T>('F', 1, 9, 1, cparams, hparams);
     }
 
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
-       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
+    if(arg.timing)
     {
-        hipblasDestroy(handle);
-        if(status_1 != HIPBLAS_STATUS_SUCCESS)
-            return status_1;
-        if(status_2 != HIPBLAS_STATUS_SUCCESS)
-            return status_2;
-        if(status_3 != HIPBLAS_STATUS_SUCCESS)
-            return status_3;
-        if(status_4 != HIPBLAS_STATUS_SUCCESS)
-            return status_4;
+        device_vector<T> dparams(9);
+        CHECK_HIP_ERROR(hipMemcpy(dparams, params, 9 * sizeof(T), hipMemcpyHostToDevice));
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasRotmgFn(
+                handle, dparams, dparams + 1, dparams + 2, dparams + 3, dparams + 4));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N>{}.log_args<T>(std::cout,
+                                         arg,
+                                         gpu_time_used,
+                                         rotmg_gflop_count<T>(),
+                                         rotmg_gbyte_count<T>(),
+                                         hipblas_error_host,
+                                         hipblas_error_device);
     }
-    hipblasDestroy(handle);
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotmg.hpp
+++ b/clients/include/testing_rotmg.hpp
@@ -83,13 +83,13 @@ hipblasStatus_t testing_rotmg(const Arguments& arg)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N>{}.log_args<T>(std::cout,
-                                         arg,
-                                         gpu_time_used,
-                                         ArgumentLogging::NA_value,
-                                         ArgumentLogging::NA_value,
-                                         hipblas_error_host,
-                                         hipblas_error_device);
+        ArgumentModel<>{}.log_args<T>(std::cout,
+                                      arg,
+                                      gpu_time_used,
+                                      ArgumentLogging::NA_value,
+                                      ArgumentLogging::NA_value,
+                                      hipblas_error_host,
+                                      hipblas_error_device);
     }
 
     return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_rotmg.hpp
+++ b/clients/include/testing_rotmg.hpp
@@ -86,8 +86,8 @@ hipblasStatus_t testing_rotmg(const Arguments& arg)
         ArgumentModel<e_N>{}.log_args<T>(std::cout,
                                          arg,
                                          gpu_time_used,
-                                         rotmg_gflop_count<T>(),
-                                         rotmg_gbyte_count<T>(),
+                                         ArgumentLogging::NA_value,
+                                         ArgumentLogging::NA_value,
                                          hipblas_error_host,
                                          hipblas_error_device);
     }

--- a/clients/include/testing_rotmg_batched.hpp
+++ b/clients/include/testing_rotmg_batched.hpp
@@ -207,8 +207,8 @@ hipblasStatus_t testing_rotmg_batched(const Arguments& arg)
         ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<T>(std::cout,
                                                                         arg,
                                                                         gpu_time_used,
-                                                                        rotmg_gflop_count<T>(),
-                                                                        rotmg_gbyte_count<T>(),
+                                                                        ArgumentLogging::NA_value,
+                                                                        ArgumentLogging::NA_value,
                                                                         hipblas_error_host,
                                                                         hipblas_error_device);
     }

--- a/clients/include/testing_rotmg_batched.hpp
+++ b/clients/include/testing_rotmg_batched.hpp
@@ -204,13 +204,13 @@ hipblasStatus_t testing_rotmg_batched(const Arguments& arg)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<T>(std::cout,
-                                                                        arg,
-                                                                        gpu_time_used,
-                                                                        ArgumentLogging::NA_value,
-                                                                        ArgumentLogging::NA_value,
-                                                                        hipblas_error_host,
-                                                                        hipblas_error_device);
+        ArgumentModel<e_batch_count>{}.log_args<T>(std::cout,
+                                                   arg,
+                                                   gpu_time_used,
+                                                   ArgumentLogging::NA_value,
+                                                   ArgumentLogging::NA_value,
+                                                   hipblas_error_host,
+                                                   hipblas_error_device);
     }
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -226,13 +226,13 @@ hipblasStatus_t testing_rotmg_strided_batched(const Arguments& arg)
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
-        ArgumentModel<e_N, e_incx, e_incy>{}.log_args<T>(std::cout,
-                                                         arg,
-                                                         gpu_time_used,
-                                                         ArgumentLogging::NA_value,
-                                                         ArgumentLogging::NA_value,
-                                                         hipblas_error_host,
-                                                         hipblas_error_device);
+        ArgumentModel<e_batch_count>{}.log_args<T>(std::cout,
+                                                   arg,
+                                                   gpu_time_used,
+                                                   ArgumentLogging::NA_value,
+                                                   ArgumentLogging::NA_value,
+                                                   hipblas_error_host,
+                                                   hipblas_error_device);
     }
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -230,8 +230,8 @@ hipblasStatus_t testing_rotmg_strided_batched(const Arguments& arg)
         ArgumentModel<e_N, e_incx, e_incy>{}.log_args<T>(std::cout,
                                                          arg,
                                                          gpu_time_used,
-                                                         rotmg_gflop_count<T>(),
-                                                         rotmg_gbyte_count<T>(),
+                                                         ArgumentLogging::NA_value,
+                                                         ArgumentLogging::NA_value,
                                                          hipblas_error_host,
                                                          hipblas_error_device);
     }

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -175,7 +175,6 @@ hipblasStatus_t testing_rotmg_strided_batched(const Arguments& arg)
         }
         if(arg.norm_check)
         {
-            std::cout << "rd1[0]: " << rd1[0] << ", cd1[0]: " << cd1[0] << "\n";
             hipblas_error_device
                 = norm_check_general<T>('F', 1, 1, 1, stride_d1, cd1, rd1, batch_count);
             hipblas_error_device

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -131,6 +131,41 @@ auto hipblas_blas1_ex_dispatch(const Arguments& arg)
     return TEST<void>{}(arg);
 }
 
+// rot
+// giving rot it's own dispatch function so the code is easier to follow
+template <template <typename...> class TEST>
+auto hipblas_rot_dispatch(const Arguments& arg)
+{
+    const auto Ta = arg.a_type, Tb = arg.b_type, Tc = arg.c_type;
+    if(Ta == Tb && Tb == Tc)
+    {
+        // srot, drot
+        return hipblas_simple_dispatch<TEST>(arg);
+    }
+    else if(Ta == HIPBLAS_C_32F && Tb == HIPBLAS_R_32F && Tc == Tb)
+    {
+        // csrot
+        return TEST<hipblasComplex, float, float>{}(arg);
+    }
+    else if(Ta == HIPBLAS_C_64F && Tb == HIPBLAS_R_64F && Tc == Tb)
+    {
+        // zdrot
+        return TEST<hipblasDoubleComplex, double, double>{}(arg);
+    }
+    else if(Ta == HIPBLAS_C_32F && Tb == HIPBLAS_R_32F && Tc == Ta)
+    {
+        // crot
+        return TEST<hipblasComplex, float, hipblasComplex>{}(arg);
+    }
+    else if(Ta == HIPBLAS_C_64F && Tb == HIPBLAS_R_64F && Tc == Ta)
+    {
+        // zrot
+        return TEST<hipblasDoubleComplex, double, hipblasDoubleComplex>{}(arg);
+    }
+
+    return TEST<void>{}(arg);
+}
+
 // gemm functions
 template <template <typename...> class TEST>
 auto hipblas_gemm_dispatch(const Arguments& arg)


### PR DESCRIPTION
I've made some changes in ArgumentModel to handle rot(m)g cases where there are no arguments being passed in. It seems to work ok, but if anyone has Parameter Pack experience, they might want to weight in.