### PR TITLE
Improving exception handling

### DIFF
--- a/library/include/exceptions.hpp
+++ b/library/include/exceptions.hpp
@@ -6,7 +6,7 @@
 
 // Convert the current C++ exception to hiblasStatus_t
 // This allows extern "C" functions to return this function in a catch(...) block
-// while converting all C++ exceptions to an equivalent rocblas_status here
+// while converting all C++ exceptions to an equivalent hipblasStatus_t here
 inline hipblasStatus_t exception_to_hipblas_status(std::exception_ptr e = std::current_exception())
 try
 {

--- a/library/include/exceptions.hpp
+++ b/library/include/exceptions.hpp
@@ -1,0 +1,28 @@
+/* ************************************************************************
+ * Copyright 2021 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+
+// Convert the current C++ exception to hiblasStatus_t
+// This allows extern "C" functions to return this function in a catch(...) block
+// while converting all C++ exceptions to an equivalent rocblas_status here
+inline hipblasStatus_t exception_to_hipblas_status(std::exception_ptr e = std::current_exception())
+try
+{
+    if(e)
+        std::rethrow_exception(e);
+    return HIPBLAS_STATUS_SUCCESS;
+}
+catch(const hipblasStatus_t& status)
+{
+    return status;
+}
+catch(const std::bad_alloc&)
+{
+    return HIPBLAS_STATUS_ALLOC_FAILED;
+}
+catch(...)
+{
+    return HIPBLAS_STATUS_INTERNAL_ERROR;
+}

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -213,6 +213,7 @@ typedef enum
     HIPBLAS_STATUS_NOT_SUPPORTED     = 7, // function not implemented
     HIPBLAS_STATUS_ARCH_MISMATCH     = 8,
     HIPBLAS_STATUS_HANDLE_IS_NULLPTR = 9, // hipBLAS handle is null pointer
+    HIPBLAS_STATUS_INVALID_ENUM      = 10, // unsupported enum value was passed to function
 } hipblasStatus_t;
 
 // set the values of enum constants to be the same as those used in cblas

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -2,6 +2,7 @@
  * Copyright 2016-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 #include "hipblas.h"
+#include "exceptions.hpp"
 #include "limits.h"
 #include "rocblas.h"
 #ifdef __HIP_PLATFORM_SOLVER__
@@ -63,7 +64,7 @@ rocblas_operation_ hipOperationToHCCOperation(hipblasOperation_t op)
     case HIPBLAS_OP_C:
         return rocblas_operation_conjugate_transpose;
     }
-    throw "Non existent OP";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasOperation_t HCCOperationToHIPOperation(rocblas_operation_ op)
@@ -77,7 +78,7 @@ hipblasOperation_t HCCOperationToHIPOperation(rocblas_operation_ op)
     case rocblas_operation_conjugate_transpose:
         return HIPBLAS_OP_C;
     }
-    throw "Non existent OP";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_fill_ hipFillToHCCFill(hipblasFillMode_t fill)
@@ -91,7 +92,7 @@ rocblas_fill_ hipFillToHCCFill(hipblasFillMode_t fill)
     case HIPBLAS_FILL_MODE_FULL:
         return rocblas_fill_full;
     }
-    throw "Non existent FILL";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasFillMode_t HCCFillToHIPFill(rocblas_fill_ fill)
@@ -105,7 +106,7 @@ hipblasFillMode_t HCCFillToHIPFill(rocblas_fill_ fill)
     case rocblas_fill_full:
         return HIPBLAS_FILL_MODE_FULL;
     }
-    throw "Non existent FILL";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_diagonal_ hipDiagonalToHCCDiagonal(hipblasDiagType_t diagonal)
@@ -117,7 +118,7 @@ rocblas_diagonal_ hipDiagonalToHCCDiagonal(hipblasDiagType_t diagonal)
     case HIPBLAS_DIAG_UNIT:
         return rocblas_diagonal_unit;
     }
-    throw "Non existent DIAGONAL";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasDiagType_t HCCDiagonalToHIPDiagonal(rocblas_diagonal_ diagonal)
@@ -129,7 +130,7 @@ hipblasDiagType_t HCCDiagonalToHIPDiagonal(rocblas_diagonal_ diagonal)
     case rocblas_diagonal_unit:
         return HIPBLAS_DIAG_UNIT;
     }
-    throw "Non existent DIAGONAL";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_side_ hipSideToHCCSide(hipblasSideMode_t side)
@@ -143,7 +144,7 @@ rocblas_side_ hipSideToHCCSide(hipblasSideMode_t side)
     case HIPBLAS_SIDE_BOTH:
         return rocblas_side_both;
     }
-    throw "Non existent SIDE";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasSideMode_t HCCSideToHIPSide(rocblas_side_ side)
@@ -157,7 +158,7 @@ hipblasSideMode_t HCCSideToHIPSide(rocblas_side_ side)
     case rocblas_side_both:
         return HIPBLAS_SIDE_BOTH;
     }
-    throw "Non existent SIDE";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_pointer_mode HIPPointerModeToRocblasPointerMode(hipblasPointerMode_t mode)
@@ -170,7 +171,7 @@ rocblas_pointer_mode HIPPointerModeToRocblasPointerMode(hipblasPointerMode_t mod
     case HIPBLAS_POINTER_MODE_DEVICE:
         return rocblas_pointer_mode_device;
     }
-    throw "Non existent PointerMode";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasPointerMode_t RocblasPointerModeToHIPPointerMode(rocblas_pointer_mode mode)
@@ -183,7 +184,7 @@ hipblasPointerMode_t RocblasPointerModeToHIPPointerMode(rocblas_pointer_mode mod
     case rocblas_pointer_mode_device:
         return HIPBLAS_POINTER_MODE_DEVICE;
     }
-    throw "Non existent PointerMode";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_datatype HIPDatatypeToRocblasDatatype(hipblasDatatype_t type)
@@ -217,7 +218,7 @@ rocblas_datatype HIPDatatypeToRocblasDatatype(hipblasDatatype_t type)
     case HIPBLAS_C_64F:
         return rocblas_datatype_f64_c;
     }
-    throw "Non existent DataType";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasDatatype_t RocblasDatatypeToHIPDatatype(rocblas_datatype type)
@@ -248,7 +249,7 @@ hipblasDatatype_t RocblasDatatypeToHIPDatatype(rocblas_datatype type)
     case rocblas_datatype_f64_c:
         return HIPBLAS_C_64F;
     }
-    throw "Non existent DataType";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_gemm_algo HIPGemmAlgoToRocblasGemmAlgo(hipblasGemmAlgo_t algo)
@@ -258,7 +259,7 @@ rocblas_gemm_algo HIPGemmAlgoToRocblasGemmAlgo(hipblasGemmAlgo_t algo)
     case HIPBLAS_GEMM_DEFAULT:
         return rocblas_gemm_algo_standard;
     }
-    throw "Non existent GemmAlgo";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasGemmAlgo_t RocblasGemmAlgoToHIPGemmAlgo(rocblas_gemm_algo algo)
@@ -268,7 +269,7 @@ hipblasGemmAlgo_t RocblasGemmAlgoToHIPGemmAlgo(rocblas_gemm_algo algo)
     case rocblas_gemm_algo_standard:
         return HIPBLAS_GEMM_DEFAULT;
     }
-    throw "Non existent GemmAlgo";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_atomics_mode HIPAtomicsModeToRocblasAtomicsMode(hipblasAtomicsMode_t mode)
@@ -280,7 +281,7 @@ rocblas_atomics_mode HIPAtomicsModeToRocblasAtomicsMode(hipblasAtomicsMode_t mod
     case HIPBLAS_ATOMICS_ALLOWED:
         return rocblas_atomics_allowed;
     }
-    throw "Non existent AtomicsMode";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasAtomicsMode_t RocblasAtomicsModeToHIPAtomicsMode(rocblas_atomics_mode mode)
@@ -292,7 +293,7 @@ hipblasAtomicsMode_t RocblasAtomicsModeToHIPAtomicsMode(rocblas_atomics_mode mod
     case rocblas_atomics_allowed:
         return HIPBLAS_ATOMICS_ALLOWED;
     }
-    throw "Non existent AtomicsMode";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasStatus_t rocBLASStatusToHIPStatus(rocblas_status_ error)
@@ -2811,6 +2812,7 @@ hipblasStatus_t hipblasSgbmv(hipblasHandle_t    handle,
                              const float*       beta,
                              float*             y,
                              int                incy)
+try
 {
     return rocBLASStatusToHIPStatus(rocblas_sgbmv((rocblas_handle)handle,
                                                   hipOperationToHCCOperation(trans),
@@ -2827,6 +2829,10 @@ hipblasStatus_t hipblasSgbmv(hipblasHandle_t    handle,
                                                   y,
                                                   incy));
 }
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
 
 hipblasStatus_t hipblasDgbmv(hipblasHandle_t    handle,
                              hipblasOperation_t trans,
@@ -2842,6 +2848,7 @@ hipblasStatus_t hipblasDgbmv(hipblasHandle_t    handle,
                              const double*      beta,
                              double*            y,
                              int                incy)
+try
 {
     return rocBLASStatusToHIPStatus(rocblas_dgbmv((rocblas_handle)handle,
                                                   hipOperationToHCCOperation(trans),
@@ -2858,6 +2865,10 @@ hipblasStatus_t hipblasDgbmv(hipblasHandle_t    handle,
                                                   y,
                                                   incy));
 }
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
 
 hipblasStatus_t hipblasCgbmv(hipblasHandle_t       handle,
                              hipblasOperation_t    trans,
@@ -2873,6 +2884,7 @@ hipblasStatus_t hipblasCgbmv(hipblasHandle_t       handle,
                              const hipblasComplex* beta,
                              hipblasComplex*       y,
                              int                   incy)
+try
 {
     return rocBLASStatusToHIPStatus(rocblas_cgbmv((rocblas_handle)handle,
                                                   hipOperationToHCCOperation(trans),
@@ -2889,6 +2901,10 @@ hipblasStatus_t hipblasCgbmv(hipblasHandle_t       handle,
                                                   (rocblas_float_complex*)y,
                                                   incy));
 }
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
 
 hipblasStatus_t hipblasZgbmv(hipblasHandle_t             handle,
                              hipblasOperation_t          trans,
@@ -2904,6 +2920,7 @@ hipblasStatus_t hipblasZgbmv(hipblasHandle_t             handle,
                              const hipblasDoubleComplex* beta,
                              hipblasDoubleComplex*       y,
                              int                         incy)
+try
 {
     return rocBLASStatusToHIPStatus(rocblas_zgbmv((rocblas_handle)handle,
                                                   hipOperationToHCCOperation(trans),
@@ -2919,6 +2936,10 @@ hipblasStatus_t hipblasZgbmv(hipblasHandle_t             handle,
                                                   (rocblas_double_complex*)beta,
                                                   (rocblas_double_complex*)y,
                                                   incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
 }
 
 // gbmv_batched

--- a/library/src/hipblas_auxiliary.cpp
+++ b/library/src/hipblas_auxiliary.cpp
@@ -21,6 +21,7 @@ extern "C" const char* hipblasStatusToString(hipblasStatus_t status)
         CASE(HIPBLAS_STATUS_NOT_SUPPORTED);
         CASE(HIPBLAS_STATUS_ARCH_MISMATCH);
         CASE(HIPBLAS_STATUS_HANDLE_IS_NULLPTR);
+        CASE(HIPBLAS_STATUS_INVALID_ENUM);
     }
 #undef CASE
     // We don't use default: so that the compiler warns us if any valid enums are missing

--- a/library/src/hipblas_module.f90
+++ b/library/src/hipblas_module.f90
@@ -42,6 +42,7 @@ module hipblas_enums
         enumerator :: HIPBLAS_STATUS_NOT_SUPPORTED     = 7
         enumerator :: HIPBLAS_STATUS_ARCH_MISMATCH     = 8
         enumerator :: HIPBLAS_STATUS_HANDLE_IS_NULLPTR = 9
+        enumerator :: HIPBLAS_STATUS_INVALID_ENUM      = 10
     end enum
 
     enum, bind(c)

--- a/library/src/nvcc_detail/hipblas.cpp
+++ b/library/src/nvcc_detail/hipblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "hipblas.h"
@@ -26,7 +26,7 @@ cublasOperation_t hipOperationToCudaOperation(hipblasOperation_t op)
         return CUBLAS_OP_C;
 
     default:
-        throw "Non existent OP";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -44,7 +44,7 @@ hipblasOperation_t CudaOperationToHIPOperation(cublasOperation_t op)
         return HIPBLAS_OP_C;
 
     default:
-        throw "Non existent OP";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -57,7 +57,7 @@ cublasFillMode_t hipFillToCudaFill(hipblasFillMode_t fill)
     case HIPBLAS_FILL_MODE_LOWER:
         return CUBLAS_FILL_MODE_LOWER;
     default:
-        throw "Non existent FILL";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -70,7 +70,7 @@ hipblasFillMode_t CudaFillToHIPFill(cublasFillMode_t fill)
     case CUBLAS_FILL_MODE_LOWER:
         return HIPBLAS_FILL_MODE_LOWER;
     default:
-        throw "Non existent FILL";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -83,7 +83,7 @@ cublasDiagType_t hipDiagonalToCudaDiagonal(hipblasDiagType_t diagonal)
     case HIPBLAS_DIAG_UNIT:
         return CUBLAS_DIAG_UNIT;
     default:
-        throw "Non existent DIAGONAL";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -96,7 +96,7 @@ hipblasDiagType_t CudaDiagonalToHIPDiagonal(cublasDiagType_t diagonal)
     case CUBLAS_DIAG_UNIT:
         return HIPBLAS_DIAG_UNIT;
     default:
-        throw "Non existent DIAGONAL";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -109,7 +109,7 @@ cublasSideMode_t hipSideToCudaSide(hipblasSideMode_t side)
     case HIPBLAS_SIDE_RIGHT:
         return CUBLAS_SIDE_RIGHT;
     default:
-        throw "Non existent SIDE";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -122,7 +122,7 @@ hipblasSideMode_t CudaSideToHIPSide(cublasSideMode_t side)
     case CUBLAS_SIDE_RIGHT:
         return HIPBLAS_SIDE_RIGHT;
     default:
-        throw "Non existent SIDE";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -137,7 +137,7 @@ cublasPointerMode_t HIPPointerModeToCudaPointerMode(hipblasPointerMode_t mode)
         return CUBLAS_POINTER_MODE_DEVICE;
 
     default:
-        throw "Non existent PointerMode";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -152,7 +152,7 @@ hipblasPointerMode_t CudaPointerModeToHIPPointerMode(cublasPointerMode_t mode)
         return HIPBLAS_POINTER_MODE_DEVICE;
 
     default:
-        throw "Non existent PointerMode";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -191,7 +191,7 @@ cudaDataType_t HIPDatatypeToCudaDatatype(hipblasDatatype_t type)
         return CUDA_C_8I;
 
     default:
-        throw "Non existent DataType";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -204,7 +204,7 @@ cublasGemmAlgo_t HIPGemmAlgoToCudaGemmAlgo(hipblasGemmAlgo_t algo)
         return CUBLAS_GEMM_DEFAULT;
 
     default:
-        throw "Non existent GemmAlgo";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 
@@ -217,7 +217,7 @@ cublasAtomicsMode_t HIPAtomicsModeToCudaAtomicsMode(hipblasAtomicsMode_t mode)
     case HIPBLAS_ATOMICS_ALLOWED:
         return CUBLAS_ATOMICS_ALLOWED;
     }
-    throw "Non existent AtomicsMode";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasAtomicsMode_t CudaAtomicsModeToHIPAtomicsMode(cublasAtomicsMode_t mode)
@@ -229,7 +229,7 @@ hipblasAtomicsMode_t CudaAtomicsModeToHIPAtomicsMode(cublasAtomicsMode_t mode)
     case CUBLAS_ATOMICS_ALLOWED:
         return HIPBLAS_ATOMICS_ALLOWED;
     }
-    throw "Non existent AtomicsMode";
+    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasStatus_t hipCUBLASStatusToHIPStatus(cublasStatus_t cuStatus)
@@ -255,7 +255,7 @@ hipblasStatus_t hipCUBLASStatusToHIPStatus(cublasStatus_t cuStatus)
     case CUBLAS_STATUS_ARCH_MISMATCH:
         return HIPBLAS_STATUS_ARCH_MISMATCH;
     default:
-        throw "Unimplemented status";
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
 }
 


### PR DESCRIPTION
Adding `catch`s to hipBLAS as discussed.
- introduces `HIPBLAS_STATUS_INVALID_ENUM`. If we don't want this, we can expand the definition of `HIPBLAS_STATUS_INVALID_VALUE`, but I prefer adding this additional status
- Instead of throwing strings in failed conversions, we now throw this status.
- Adding `exception_to_hipblas_status` (same as in rocBLAS)
- Added `try` `catch` blocks to hcc gbmv. Tested this out in hipblas-bench with a non-existent transpose type, seemed to work as expected.

The `try` `catch` blocks will have to be added to all hcc and nvcc functions. I'll see if I can do a simple find & replace to avoid some tedious work :)