### PR TITLE
Removed getri_outofplace_batched declaration

### DIFF
--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -15113,50 +15113,6 @@ rocblas_status rocsolver_zgeqrf_ptr_batched(rocblas_handle                handle
                                             rocblas_double_complex* const ipiv[],
                                             const rocblas_int             batch_count);
 
-rocblas_status rocsolver_sgetri_outofplace_batched(rocblas_handle       handle,
-                                                   const rocblas_int    n,
-                                                   float* const         A[],
-                                                   const rocblas_int    lda,
-                                                   rocblas_int*         ipiv,
-                                                   const rocblas_stride strideP,
-                                                   float* const         C[],
-                                                   const rocblas_int    ldc,
-                                                   rocblas_int*         info,
-                                                   const rocblas_int    batch_count);
-
-rocblas_status rocsolver_dgetri_outofplace_batched(rocblas_handle       handle,
-                                                   const rocblas_int    n,
-                                                   double* const        A[],
-                                                   const rocblas_int    lda,
-                                                   rocblas_int*         ipiv,
-                                                   const rocblas_stride strideP,
-                                                   double* const        C[],
-                                                   const rocblas_int    ldc,
-                                                   rocblas_int*         info,
-                                                   const rocblas_int    batch_count);
-
-rocblas_status rocsolver_cgetri_outofplace_batched(rocblas_handle               handle,
-                                                   const rocblas_int            n,
-                                                   rocblas_float_complex* const A[],
-                                                   const rocblas_int            lda,
-                                                   rocblas_int*                 ipiv,
-                                                   const rocblas_stride         strideP,
-                                                   rocblas_float_complex* const C[],
-                                                   const rocblas_int            ldc,
-                                                   rocblas_int*                 info,
-                                                   const rocblas_int            batch_count);
-
-rocblas_status rocsolver_zgetri_outofplace_batched(rocblas_handle                handle,
-                                                   const rocblas_int             n,
-                                                   rocblas_double_complex* const A[],
-                                                   const rocblas_int             lda,
-                                                   rocblas_int*                  ipiv,
-                                                   const rocblas_stride          strideP,
-                                                   rocblas_double_complex* const C[],
-                                                   const rocblas_int             ldc,
-                                                   rocblas_int*                  info,
-                                                   const rocblas_int             batch_count);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
getri_outofplace_batched will be added to rocSOLVER's public API in 4.3 by https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/243. This PR removes the declarations that were needed because of it not being part of the public API.