### PR TITLE
Updating L3 tests (1)

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -152,6 +152,9 @@
 #include "testing_herk.hpp"
 #include "testing_herk_batched.hpp"
 #include "testing_herk_strided_batched.hpp"
+#include "testing_herkx.hpp"
+#include "testing_herkx_batched.hpp"
+#include "testing_herkx_strided_batched.hpp"
 #include "testing_syr2k.hpp"
 #include "testing_syr2k_batched.hpp"
 #include "testing_syr2k_strided_batched.hpp"
@@ -612,9 +615,15 @@ struct perf_blas<
             {"hemm", testing_hemm<T>},
             {"hemm_batched", testing_hemm_batched<T>},
             {"hemm_strided_batched", testing_hemm_strided_batched<T>},
-            // {"herk", testing_herk<T>},
-            // {"herk_batched", testing_herk_batched<T>},
-            // {"herk_strided_batched", testing_herk_strided_batched<T>},
+            {"herk", testing_herk<T>},
+            {"herk_batched", testing_herk_batched<T>},
+            {"herk_strided_batched", testing_herk_strided_batched<T>},
+            {"her2k", testing_her2k<T>},
+            {"her2k_batched", testing_her2k_batched<T>},
+            {"her2k_strided_batched", testing_her2k_strided_batched<T>},
+            {"herkx", testing_herkx<T>},
+            {"herkx_batched", testing_herkx_batched<T>},
+            {"herkx_strided_batched", testing_herkx_strided_batched<T>},
             /*
                 // L3
                 {"syrk", testing_syrk<T>},
@@ -629,12 +638,7 @@ struct perf_blas<
                 {"symm", testing_symm_hemm<T, false>},
                 {"symm_batched", testing_symm_hemm_batched<T, false>},
                 {"symm_strided_batched", testing_symm_hemm_strided_batched<T, false>},
-                {"her2k", testing_her2k<T>},
-                {"her2k_batched", testing_her2k_batched<T>},
-                {"her2k_strided_batched", testing_her2k_strided_batched<T>},
-                {"herkx", testing_her2k<T, false>},
-                {"herkx_batched", testing_her2k_batched<T, false>},
-                {"herkx_strided_batched", testing_her2k_strided_batched<T, false>},
+
             {"trtri", testing_trtri<T>},
             {"trtri_batched", testing_trtri_batched<T>},
             {"trtri_strided_batched", testing_trtri_strided_batched<T>},

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -143,15 +143,15 @@
 #include "testing_geam.hpp"
 #include "testing_geam_batched.hpp"
 #include "testing_geam_strided_batched.hpp"
+#include "testing_hemm.hpp"
+#include "testing_hemm_batched.hpp"
+#include "testing_hemm_strided_batched.hpp"
 #include "testing_her2k.hpp"
 #include "testing_her2k_batched.hpp"
 #include "testing_her2k_strided_batched.hpp"
 #include "testing_herk.hpp"
 #include "testing_herk_batched.hpp"
 #include "testing_herk_strided_batched.hpp"
-// #include "testing_symm_hemm.hpp"
-// #include "testing_symm_hemm_batched.hpp"
-// #include "testing_symm_hemm_strided_batched.hpp"
 #include "testing_syr2k.hpp"
 #include "testing_syr2k_batched.hpp"
 #include "testing_syr2k_strided_batched.hpp"
@@ -391,26 +391,44 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same
             {"tbmv", testing_tbmv<T>},
             {"tbmv_batched", testing_tbmv_batched<T>},
             {"tbmv_strided_batched", testing_tbmv_strided_batched<T>},
+            {"tbsv", testing_tbsv<T>},
+            {"tbsv_batched", testing_tbsv_batched<T>},
+            {"tbsv_strided_batched", testing_tbsv_strided_batched<T>},
             {"tpmv", testing_tpmv<T>},
             {"tpmv_batched", testing_tpmv_batched<T>},
             {"tpmv_strided_batched", testing_tpmv_strided_batched<T>},
+            {"tpsv", testing_tpsv<T>},
+            {"tpsv_batched", testing_tpsv_batched<T>},
+            {"tpsv_strided_batched", testing_tpsv_strided_batched<T>},
             {"trmv", testing_trmv<T>},
             {"trmv_batched", testing_trmv_batched<T>},
             {"trmv_strided_batched", testing_trmv_strided_batched<T>},
+            {"trsv", testing_trsv<T>},
+            {"trsv_batched", testing_trsv_batched<T>},
+            {"trsv_strided_batched", testing_trsv_strided_batched<T>},
+
+            // L3
+            {"geam", testing_geam<T>},
+            {"geam_batched", testing_geam_batched<T>},
+            {"geam_strided_batched", testing_geam_strided_batched<T>},
+            {"dgmm", testing_dgmm<T>},
+            {"dgmm_batched", testing_dgmm_batched<T>},
+            {"dgmm_strided_batched", testing_dgmm_strided_batched<T>},
+            {"trmm", testing_trmm<T>},
+            {"trmm_batched", testing_trmm_batched<T>},
+            {"trmm_strided_batched", testing_trmm_strided_batched<T>},
+            {"gemm", testing_gemm<T>},
+            {"gemm_batched", testing_gemm_batched<T>},
+            {"gemm_strided_batched", testing_gemm_strided_batched<T>},
             /*{"set_get_vector", testing_set_get_vector<T>},
                 {"set_get_matrix", testing_set_get_matrix<T>},
                 {"set_get_matrix_async", testing_set_get_matrix_async<T>},
 
                 // L3
-                {"geam", testing_geam<T>},
-                {"geam_batched", testing_geam_batched<T>},
-                {"geam_strided_batched", testing_geam_strided_batched<T>},
-                {"dgmm", testing_dgmm<T>},
-                {"dgmm_batched", testing_dgmm_batched<T>},
-                {"dgmm_strided_batched", testing_dgmm_strided_batched<T>},
-                {"symm", testing_symm_hemm<T, false>},
-                {"symm_batched", testing_symm_hemm_batched<T, false>},
-                {"symm_strided_batched", testing_symm_hemm_strided_batched<T, false>},
+
+                {"symm", testing_symm<T>},
+                {"symm_batched", testing_symm_batched<T>},
+                {"symm_strided_batched", testing_symm_strided_batched<T>},
                 {"syrk", testing_syrk<T>},
                 {"syrk_batched", testing_syrk_batched<T>},
                 {"syrk_strided_batched", testing_syrk_strided_batched<T>},
@@ -425,28 +443,12 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same
                 {"trtri_batched", testing_trtri_batched<T>},
                 {"trtri_strided_batched", testing_trtri_strided_batched<T>},
 */
-            {"trmm", testing_trmm<T>},
-            {"trmm_batched", testing_trmm_batched<T>},
-            {"trmm_strided_batched", testing_trmm_strided_batched<T>},
-            {"gemm", testing_gemm<T>},
-            {"gemm_batched", testing_gemm_batched<T>},
-            {"gemm_strided_batched", testing_gemm_strided_batched<T>},
-
             {"trsm", testing_trsm<T>},
             //{"trsm_ex", testing_trsm_ex<T>},
             {"trsm_batched", testing_trsm_batched<T>},
             //{"trsm_batched_ex", testing_trsm_batched_ex<T>},
             {"trsm_strided_batched", testing_trsm_strided_batched<T>},
             //{"trsm_strided_batched_ex", testing_trsm_strided_batched_ex<T>},
-            {"tbsv", testing_tbsv<T>},
-            {"tbsv_batched", testing_tbsv_batched<T>},
-            {"tbsv_strided_batched", testing_tbsv_strided_batched<T>},
-            {"tpsv", testing_tpsv<T>},
-            {"tpsv_batched", testing_tpsv_batched<T>},
-            {"tpsv_strided_batched", testing_tpsv_strided_batched<T>},
-            {"trsv", testing_trsv<T>},
-            {"trsv_batched", testing_trsv_batched<T>},
-            {"trsv_strided_batched", testing_trsv_strided_batched<T>},
         };
         run_function(fmap, arg);
     }
@@ -581,21 +583,40 @@ struct perf_blas<
             {"tbmv", testing_tbmv<T>},
             {"tbmv_batched", testing_tbmv_batched<T>},
             {"tbmv_strided_batched", testing_tbmv_strided_batched<T>},
+            {"tbsv", testing_tbsv<T>},
+            {"tbsv_batched", testing_tbsv_batched<T>},
+            {"tbsv_strided_batched", testing_tbsv_strided_batched<T>},
             {"tpmv", testing_tpmv<T>},
             {"tpmv_batched", testing_tpmv_batched<T>},
             {"tpmv_strided_batched", testing_tpmv_strided_batched<T>},
+            {"tpsv", testing_tpsv<T>},
+            {"tpsv_batched", testing_tpsv_batched<T>},
+            {"tpsv_strided_batched", testing_tpsv_strided_batched<T>},
             {"trmv", testing_trmv<T>},
             {"trmv_batched", testing_trmv_batched<T>},
             {"trmv_strided_batched", testing_trmv_strided_batched<T>},
+            {"trsv", testing_trsv<T>},
+            {"trsv_batched", testing_trsv_batched<T>},
+            {"trsv_strided_batched", testing_trsv_strided_batched<T>},
 
+            // L3
+            {"dgmm", testing_dgmm<T>},
+            {"dgmm_batched", testing_dgmm_batched<T>},
+            {"dgmm_strided_batched", testing_dgmm_strided_batched<T>},
+            {"geam", testing_geam<T>},
+            {"geam_batched", testing_geam_batched<T>},
+            {"geam_strided_batched", testing_geam_strided_batched<T>},
+            {"gemm", testing_gemm<T>},
+            {"gemm_batched", testing_gemm_batched<T>},
+            {"gemm_strided_batched", testing_gemm_strided_batched<T>},
+            {"hemm", testing_hemm<T>},
+            {"hemm_batched", testing_hemm_batched<T>},
+            {"hemm_strided_batched", testing_hemm_strided_batched<T>},
+            // {"herk", testing_herk<T>},
+            // {"herk_batched", testing_herk_batched<T>},
+            // {"herk_strided_batched", testing_herk_strided_batched<T>},
             /*
                 // L3
-                {"dgmm", testing_dgmm<T>},
-                {"dgmm_batched", testing_dgmm_batched<T>},
-                {"dgmm_strided_batched", testing_dgmm_strided_batched<T>},
-                {"geam", testing_geam<T>},
-                {"geam_batched", testing_geam_batched<T>},
-                {"geam_strided_batched", testing_geam_strided_batched<T>},
                 {"syrk", testing_syrk<T>},
                 {"syrk_batched", testing_syrk_batched<T>},
                 {"syrk_strided_batched", testing_syrk_strided_batched<T>},
@@ -608,12 +629,6 @@ struct perf_blas<
                 {"symm", testing_symm_hemm<T, false>},
                 {"symm_batched", testing_symm_hemm_batched<T, false>},
                 {"symm_strided_batched", testing_symm_hemm_strided_batched<T, false>},
-                {"hemm", testing_symm_hemm<T, true>},
-                {"hemm_batched", testing_symm_hemm_batched<T, true>},
-                {"hemm_strided_batched", testing_symm_hemm_strided_batched<T, true>},
-                {"herk", testing_herk<T>},
-                {"herk_batched", testing_herk_batched<T>},
-                {"herk_strided_batched", testing_herk_strided_batched<T>},
                 {"her2k", testing_her2k<T>},
                 {"her2k_batched", testing_her2k_batched<T>},
                 {"her2k_strided_batched", testing_her2k_strided_batched<T>},
@@ -624,24 +639,14 @@ struct perf_blas<
             {"trtri_batched", testing_trtri_batched<T>},
             {"trtri_strided_batched", testing_trtri_strided_batched<T>},
           */
-            {"gemm", testing_gemm<T>},
-            {"gemm_batched", testing_gemm_batched<T>},
-            {"gemm_strided_batched", testing_gemm_strided_batched<T>},
+
             {"trsm", testing_trsm<T>},
             //{"trsm_ex", testing_trsm_ex<T>},
             {"trsm_batched", testing_trsm_batched<T>},
             //{"trsm_batched_ex", testing_trsm_batched_ex<T>},
             {"trsm_strided_batched", testing_trsm_strided_batched<T>},
             //{"trsm_strided_batched_ex", testing_trsm_strided_batched_ex<T>},
-            {"tbsv", testing_tbsv<T>},
-            {"tbsv_batched", testing_tbsv_batched<T>},
-            {"tbsv_strided_batched", testing_tbsv_strided_batched<T>},
-            {"tpsv", testing_tpsv<T>},
-            {"tpsv_batched", testing_tpsv_batched<T>},
-            {"tpsv_strided_batched", testing_tpsv_strided_batched<T>},
-            {"trsv", testing_trsv<T>},
-            {"trsv_batched", testing_trsv_batched<T>},
-            {"trsv_strided_batched", testing_trsv_strided_batched<T>},
+
             {"trmm", testing_trmm<T>},
             {"trmm_batched", testing_trmm_batched<T>},
             {"trmm_strided_batched", testing_trmm_strided_batched<T>},

--- a/clients/gtest/hemm_gtest.cpp
+++ b/clients/gtest/hemm_gtest.cpp
@@ -120,7 +120,7 @@ Arguments setup_hemm_arguments(hemm_tuple tup)
     arg.side_option = side_uplo[0];
     arg.uplo_option = side_uplo[1];
 
-    arg.timing = 1;
+    arg.timing = 0;
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;

--- a/clients/gtest/her2k_gtest.cpp
+++ b/clients/gtest/her2k_gtest.cpp
@@ -137,7 +137,7 @@ TEST_P(blas2_her2k_gtest, her2k_gtest_float)
 
     Arguments arg = setup_her2k_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her2k<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_her2k<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -164,7 +164,7 @@ TEST_P(blas2_her2k_gtest, her2k_gtest_double)
 
     Arguments arg = setup_her2k_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her2k<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_her2k<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -194,7 +194,7 @@ TEST_P(blas2_her2k_gtest, her2k_batched_gtest_float)
 
     Arguments arg = setup_her2k_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her2k_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_her2k_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -222,7 +222,7 @@ TEST_P(blas2_her2k_gtest, her2k_batched_gtest_double)
 
     Arguments arg = setup_her2k_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her2k_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_her2k_batched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -251,7 +251,7 @@ TEST_P(blas2_her2k_gtest, her2k_strided_batched_gtest_float)
 
     Arguments arg = setup_her2k_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her2k_strided_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_her2k_strided_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -279,7 +279,7 @@ TEST_P(blas2_her2k_gtest, her2k_strided_batched_gtest_double)
 
     Arguments arg = setup_her2k_arguments(GetParam());
 
-    hipblasStatus_t status = testing_her2k_strided_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_her2k_strided_batched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/herk_gtest.cpp
+++ b/clients/gtest/herk_gtest.cpp
@@ -133,7 +133,7 @@ TEST_P(blas2_herk_gtest, herk_gtest_float)
 
     Arguments arg = setup_herk_arguments(GetParam());
 
-    hipblasStatus_t status = testing_herk<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_herk<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -160,7 +160,7 @@ TEST_P(blas2_herk_gtest, herk_gtest_double)
 
     Arguments arg = setup_herk_arguments(GetParam());
 
-    hipblasStatus_t status = testing_herk<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_herk<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -190,7 +190,7 @@ TEST_P(blas2_herk_gtest, herk_batched_gtest_float)
 
     Arguments arg = setup_herk_arguments(GetParam());
 
-    hipblasStatus_t status = testing_herk_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_herk_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -217,7 +217,7 @@ TEST_P(blas2_herk_gtest, herk_batched_gtest_double)
 
     Arguments arg = setup_herk_arguments(GetParam());
 
-    hipblasStatus_t status = testing_herk_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_herk_batched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -245,7 +245,7 @@ TEST_P(blas2_herk_gtest, herk_strided_batched_gtest_float)
 
     Arguments arg = setup_herk_arguments(GetParam());
 
-    hipblasStatus_t status = testing_herk_strided_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_herk_strided_batched<hipblasComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -272,7 +272,7 @@ TEST_P(blas2_herk_gtest, herk_strided_batched_gtest_double)
 
     Arguments arg = setup_herk_arguments(GetParam());
 
-    hipblasStatus_t status = testing_herk_strided_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_herk_strided_batched<hipblasDoubleComplex>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)

--- a/clients/gtest/herkx_gtest.cpp
+++ b/clients/gtest/herkx_gtest.cpp
@@ -126,9 +126,7 @@ protected:
     virtual void SetUp() {}
     virtual void TearDown() {}
 };
-////////////////////////////////////////////////////////////////
-// TODO: Temporarily not testing as there's a bug in rocBLAS. //
-////////////////////////////////////////////////////////////////
+
 // herkx
 TEST_P(blas2_herkx_gtest, herkx_gtest_float)
 {
@@ -137,24 +135,24 @@ TEST_P(blas2_herkx_gtest, herkx_gtest_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    // Arguments arg = setup_herkx_arguments(GetParam());
+    Arguments arg = setup_herkx_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_herkx<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_herkx<hipblasComplex>(arg);
 
-    // // if not success, then the input argument is problematic, so detect the error message
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
-    //        || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
-    //        || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K)))
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-    //     }
-    //     else
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
-    //     }
-    // }
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
+           || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
+           || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K)))
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
 }
 
 TEST_P(blas2_herkx_gtest, herkx_gtest_double)
@@ -164,24 +162,24 @@ TEST_P(blas2_herkx_gtest, herkx_gtest_double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    // Arguments arg = setup_herkx_arguments(GetParam());
+    Arguments arg = setup_herkx_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_herkx<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_herkx<hipblasDoubleComplex>(arg);
 
-    // // if not success, then the input argument is problematic, so detect the error message
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
-    //        || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
-    //        || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K)))
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-    //     }
-    //     else
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
-    //     }
-    // }
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
+           || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
+           || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K)))
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
 }
 
 #ifndef __HIP_PLATFORM_NVCC__
@@ -194,25 +192,25 @@ TEST_P(blas2_herkx_gtest, herkx_batched_gtest_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    // Arguments arg = setup_herkx_arguments(GetParam());
+    Arguments arg = setup_herkx_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_herkx_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_herkx_batched<hipblasComplex>(arg);
 
-    // // if not success, then the input argument is problematic, so detect the error message
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
-    //        || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
-    //        || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K))
-    //        || arg.batch_count < 0)
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-    //     }
-    //     else
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
-    //     }
-    // }
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
+           || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
+           || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K))
+           || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
 }
 
 TEST_P(blas2_herkx_gtest, herkx_batched_gtest_double)
@@ -222,25 +220,25 @@ TEST_P(blas2_herkx_gtest, herkx_batched_gtest_double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    // Arguments arg = setup_herkx_arguments(GetParam());
+    Arguments arg = setup_herkx_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_herkx_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_herkx_batched<hipblasDoubleComplex>(arg);
 
-    // // if not success, then the input argument is problematic, so detect the error message
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
-    //        || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
-    //        || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K))
-    //        || arg.batch_count < 0)
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-    //     }
-    //     else
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
-    //     }
-    // }
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
+           || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
+           || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K))
+           || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
 }
 
 // herkx_strided_batched
@@ -251,25 +249,25 @@ TEST_P(blas2_herkx_gtest, herkx_strided_batched_gtest_float)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    // Arguments arg = setup_herkx_arguments(GetParam());
+    Arguments arg = setup_herkx_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_herkx_strided_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_herkx_strided_batched<hipblasComplex>(arg);
 
-    // // if not success, then the input argument is problematic, so detect the error message
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
-    //        || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
-    //        || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K))
-    //        || arg.batch_count < 0)
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-    //     }
-    //     else
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
-    //     }
-    // }
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
+           || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
+           || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K))
+           || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
 }
 
 TEST_P(blas2_herkx_gtest, herkx_strided_batched_gtest_double)
@@ -279,25 +277,25 @@ TEST_P(blas2_herkx_gtest, herkx_strided_batched_gtest_double)
     // The Arguments data struture have physical meaning associated.
     // while the tuple is non-intuitive.
 
-    // Arguments arg = setup_herkx_arguments(GetParam());
+    Arguments arg = setup_herkx_arguments(GetParam());
 
-    // hipblasStatus_t status = testing_herkx_strided_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_herkx_strided_batched<hipblasDoubleComplex>(arg);
 
-    // // if not success, then the input argument is problematic, so detect the error message
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
-    //        || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
-    //        || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K))
-    //        || arg.batch_count < 0)
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-    //     }
-    //     else
-    //     {
-    //         EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
-    //     }
-    // }
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.K < 0 || arg.ldc < arg.N
+           || (arg.transA_option == 'N' && (arg.lda < arg.N || arg.ldb < arg.N))
+           || (arg.transA_option != 'N' && (arg.lda < arg.K || arg.ldb < arg.K))
+           || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
 }
 
 #endif

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -340,4 +340,11 @@ constexpr double herk_gbyte_count(int n, int k)
     return syrk_gbyte_count<T>(n, k);
 }
 
+/* \brief byte counts of DGMM */
+template <typename T>
+constexpr double dgmm_gbyte_count(int n, int m, int k)
+{
+    return (sizeof(T) * (2 * m * n) + (k));
+}
+
 #endif /* _HIPBLAS_BYTES_H_ */

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -344,7 +344,16 @@ constexpr double herk_gbyte_count(int n, int k)
 template <typename T>
 constexpr double dgmm_gbyte_count(int n, int m, int k)
 {
+    // read A, read x, write C
     return (sizeof(T) * (2 * m * n) + (k));
+}
+
+/* \brief byte counts of GEAM */
+template <typename T>
+constexpr double geam_gbyte_count(int n, int m)
+{
+    // read A, read B, write to C
+    return (sizeof(T) * 3 * m * n);
 }
 
 #endif /* _HIPBLAS_BYTES_H_ */

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -356,4 +356,12 @@ constexpr double geam_gbyte_count(int n, int m)
     return (sizeof(T) * 3 * m * n);
 }
 
+/* \brief byte counts of HEMM */
+template <typename T>
+constexpr double hemm_gbyte_count(int n, int m, int k)
+{
+    // read A, B, C, write C
+    return (sizeof(T) * (3 * m * n + tri_count(k)));
+}
+
 #endif /* _HIPBLAS_BYTES_H_ */

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -333,11 +333,40 @@ constexpr double syrk_gbyte_count(int n, int k)
     return (sizeof(T) * (tri_count(n) + n * k)) / 1e9;
 }
 
+/* \brief byte counts of SYR2K */
+template <typename T>
+constexpr double syr2k_gbyte_count(int n, int k)
+{
+    // Read A, B, C, write C
+    return (sizeof(T) * (2 * n * k + 2 * tri_count(n)));
+}
+
+/* \brief byte counts of SYRKX */
+template <typename T>
+constexpr double syrkx_gbyte_count(int n, int k)
+{
+    return syr2k_gbyte_count<T>(n, k);
+}
+
 /* \brief byte counts of HERK */
 template <typename T>
 constexpr double herk_gbyte_count(int n, int k)
 {
     return syrk_gbyte_count<T>(n, k);
+}
+
+/* \brief byte counts of HER2K */
+template <typename T>
+constexpr double her2k_gbyte_count(int n, int k)
+{
+    return syr2k_gbyte_count<T>(n, k);
+}
+
+/* \brief byte counts of HERKX */
+template <typename T>
+constexpr double herkx_gbyte_count(int n, int k)
+{
+    return syrkx_gbyte_count<T>(n, k);
 }
 
 /* \brief byte counts of DGMM */

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -620,22 +620,21 @@ constexpr double dgmm_gflop_count<hipblasDoubleComplex>(int m, int n)
 
 /* \brief floating point counts of HEMM */
 template <typename T>
-constexpr double hemm_gflop_count(hipblasSideMode_t side, int m, int n)
+constexpr double hemm_gflop_count(int m, int n, int k)
 {
-    int k = side == HIPBLAS_SIDE_LEFT ? m : n;
     return ((2 * k - 1.0) * m * n + 2.0 * m * n) / 1e9;
 }
 
 template <>
-constexpr double hemm_gflop_count<hipblasComplex>(hipblasSideMode_t side, int m, int n)
+constexpr double hemm_gflop_count<hipblasComplex>(int m, int n, int k)
 {
-    return 4.0 * hemm_gflop_count<float>(side, m, n);
+    return 4.0 * hemm_gflop_count<float>(m, n, k);
 }
 
 template <>
-constexpr double hemm_gflop_count<hipblasDoubleComplex>(hipblasSideMode_t side, int m, int n)
+constexpr double hemm_gflop_count<hipblasDoubleComplex>(int m, int n, int k)
 {
-    return hemm_gflop_count<hipblasComplex>(side, m, n);
+    return hemm_gflop_count<hipblasComplex>(m, n, k);
 }
 
 /* \brief floating point counts of HERK */

--- a/clients/include/testing_dgmm.hpp
+++ b/clients/include/testing_dgmm.hpp
@@ -28,10 +28,10 @@ hipblasStatus_t testing_dgmm(const Arguments& argus)
     int incx = argus.incx;
     int ldc  = argus.ldc;
 
-    int A_size = size_t(lda) * N;
-    int C_size = size_t(ldc) * N;
-    int k      = (side == HIPBLAS_SIDE_RIGHT ? N : M);
-    int X_size = size_t(incx) * k;
+    size_t A_size = size_t(lda) * N;
+    size_t C_size = size_t(ldc) * N;
+    int    k      = (side == HIPBLAS_SIDE_RIGHT ? N : M);
+    size_t X_size = size_t(incx) * k;
     if(!X_size)
         X_size = 1;
 

--- a/clients/include/testing_dgmm.hpp
+++ b/clients/include/testing_dgmm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -35,14 +35,11 @@ hipblasStatus_t testing_dgmm(const Arguments& argus)
     if(!X_size)
         X_size = 1;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(M < 0 || N < 0 || lda < M || ldc < M)
     {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -58,12 +55,8 @@ hipblasStatus_t testing_dgmm(const Arguments& argus)
     device_vector<T> dx(X_size);
     device_vector<T> dC(C_size);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -76,25 +69,19 @@ hipblasStatus_t testing_dgmm(const Arguments& argus)
     hC_gold = hC;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    status = hipblasDgmmFn(handle, side, M, N, dA, lda, dx, incx, dC, ldc);
-
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasDgmmFn(handle, side, M, N, dA, lda, dx, incx, dC, ldc));
 
     // copy output from device to CPU
-    hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -122,8 +109,36 @@ hipblasStatus_t testing_dgmm(const Arguments& argus)
         {
             unit_check_general<T>(M, N, ldc, hC_gold, hC_1);
         }
+
+        if(argus.norm_check)
+        {
+            hipblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold, hC_1);
+        }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasDgmmFn(handle, side, M, N, dA, lda, dx, incx, dC, ldc));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_side_option, e_M, e_N, e_lda, e_incx, e_ldc>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            dgmm_gflop_count<T>(M, N),
+            dgmm_gbyte_count<T>(M, N, k),
+            hipblas_error);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_dgmm_batched.hpp
+++ b/clients/include/testing_dgmm_batched.hpp
@@ -30,12 +30,9 @@ hipblasStatus_t testing_dgmm_batched(const Arguments& argus)
     int ldc         = argus.ldc;
     int batch_count = argus.batch_count;
 
-    int A_size = size_t(lda) * N;
-    int C_size = size_t(ldc) * N;
-    int k      = (side == HIPBLAS_SIDE_RIGHT ? N : M);
-    int X_size = size_t(incx) * k;
-    if(!X_size)
-        X_size = 1;
+    size_t A_size = size_t(lda) * N;
+    size_t C_size = size_t(ldc) * N;
+    int    k      = (side == HIPBLAS_SIDE_RIGHT ? N : M);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory

--- a/clients/include/testing_dgmm_batched.hpp
+++ b/clients/include/testing_dgmm_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -37,93 +37,64 @@ hipblasStatus_t testing_dgmm_batched(const Arguments& argus)
     if(!X_size)
         X_size = 1;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(M < 0 || N < 0 || lda < M || ldc < M || batch_count < 0)
     {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> hA_copy[batch_count];
-    host_vector<T> hx[batch_count];
-    host_vector<T> hx_copy[batch_count];
-    host_vector<T> hC[batch_count];
-    host_vector<T> hC_1[batch_count];
-    host_vector<T> hC_gold[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hA_copy(A_size, 1, batch_count);
+    host_batch_vector<T> hx(k, incx, batch_count);
+    host_batch_vector<T> hx_copy(k, incx, batch_count);
+    host_batch_vector<T> hC(C_size, 1, batch_count);
+    host_batch_vector<T> hC_1(C_size, 1, batch_count);
+    host_batch_vector<T> hC_gold(C_size, 1, batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bx(batch_count, X_size);
-    device_batch_vector<T> bC(batch_count, C_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dx(k, incx, batch_count);
+    device_batch_vector<T> dC(C_size, 1, batch_count);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dx(batch_count);
-    device_vector<T*, 0, T> dC(batch_count);
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dC.memcheck());
 
-    int last = batch_count - 1;
-    if(!dA || !dx || !dC || !bA[last] || !bx[last] || !bC[last])
-    {
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
-
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA[b]      = host_vector<T>(A_size);
-        hA_copy[b] = host_vector<T>(A_size);
-        hx[b]      = host_vector<T>(X_size);
-        hx_copy[b] = host_vector<T>(X_size);
-        hC[b]      = host_vector<T>(C_size);
-        hC_1[b]    = host_vector<T>(C_size);
-        hC_gold[b] = host_vector<T>(C_size);
+    hipblas_init(hA, true);
+    hipblas_init(hx);
+    hipblas_init(hC);
 
-        srand(1);
-        hipblas_init<T>(hA[b], M, N, lda);
-        hipblas_init<T>(hx[b], 1, k, incx);
-        hipblas_init<T>(hC[b], M, N, ldc);
+    hA_copy.copy_from(hA);
+    hx_copy.copy_from(hx);
+    hC_1.copy_from(hC);
+    hC_gold.copy_from(hC_gold);
 
-        hA_copy[b] = hA[b];
-        hx_copy[b] = hx[b];
-        hC_1[b]    = hC[b];
-        hC_gold[b] = hC[b];
-
-        hipMemcpy(bA[b], hA[b].data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-        hipMemcpy(bx[b], hx[b].data(), sizeof(T) * X_size, hipMemcpyHostToDevice);
-        hipMemcpy(bC[b], hC[b].data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
-    }
-
-    hipMemcpy(dA, bA, sizeof(T*) * batch_count, hipMemcpyHostToDevice);
-    hipMemcpy(dx, bx, sizeof(T*) * batch_count, hipMemcpyHostToDevice);
-    hipMemcpy(dC, bC, sizeof(T*) * batch_count, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(dC.transfer_from(hC));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    status = hipblasDgmmBatchedFn(handle, side, M, N, dA, lda, dx, incx, dC, ldc, batch_count);
+    CHECK_HIPBLAS_ERROR(hipblasDgmmBatchedFn(handle,
+                                             side,
+                                             M,
+                                             N,
+                                             dA.ptr_on_device(),
+                                             lda,
+                                             dx.ptr_on_device(),
+                                             incx,
+                                             dC.ptr_on_device(),
+                                             ldc,
+                                             batch_count));
+    CHECK_HIP_ERROR(hC_1.transfer_from(dC));
 
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
-
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-        hipMemcpy(hC_1[b].data(), bC[b], sizeof(T) * C_size, hipMemcpyDeviceToHost);
-
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -156,8 +127,46 @@ hipblasStatus_t testing_dgmm_batched(const Arguments& argus)
         {
             unit_check_general<T>(M, N, batch_count, ldc, hC_gold, hC_1);
         }
+
+        if(argus.norm_check)
+        {
+            hipblas_error = norm_check_general<T>('F', M, N, ldc, hC_gold, hC_1, batch_count);
+        }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasDgmmBatchedFn(handle,
+                                                     side,
+                                                     M,
+                                                     N,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     dx.ptr_on_device(),
+                                                     incx,
+                                                     dC.ptr_on_device(),
+                                                     ldc,
+                                                     batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_side_option, e_M, e_N, e_lda, e_incx, e_ldc, e_batch_count>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            dgmm_gflop_count<T>(M, N),
+            dgmm_gbyte_count<T>(M, N, k),
+            hipblas_error);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_dgmm_strided_batched.hpp
+++ b/clients/include/testing_dgmm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -42,14 +42,11 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
     int C_size = stride_C * batch_count;
     int X_size = stride_x * batch_count;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(M < 0 || N < 0 || lda < M || ldc < M || batch_count < 0)
     {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -65,12 +62,8 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
     device_vector<T> dx(X_size);
     device_vector<T> dC(C_size);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -83,26 +76,20 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
     hC_gold = hC;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    status = hipblasDgmmStridedBatchedFn(
-        handle, side, M, N, dA, lda, stride_A, dx, incx, stride_x, dC, ldc, stride_C, batch_count);
-
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasDgmmStridedBatchedFn(
+        handle, side, M, N, dA, lda, stride_A, dx, incx, stride_x, dC, ldc, stride_C, batch_count));
 
     // copy output from device to CPU
-    hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -136,8 +123,59 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
         {
             unit_check_general<T>(M, N, batch_count, ldc, stride_C, hC_gold, hC_1);
         }
+
+        if(argus.norm_check)
+        {
+            hipblas_error
+                = norm_check_general<T>('F', M, N, ldc, stride_C, hC_gold, hC_1, batch_count);
+        }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasDgmmStridedBatchedFn(handle,
+                                                            side,
+                                                            M,
+                                                            N,
+                                                            dA,
+                                                            lda,
+                                                            stride_A,
+                                                            dx,
+                                                            incx,
+                                                            stride_x,
+                                                            dC,
+                                                            ldc,
+                                                            stride_C,
+                                                            batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_side_option,
+                      e_M,
+                      e_N,
+                      e_lda,
+                      e_stride_a,
+                      e_incx,
+                      e_stride_x,
+                      e_ldc,
+                      e_stride_c,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         dgmm_gflop_count<T>(M, N),
+                         dgmm_gbyte_count<T>(M, N, k),
+                         hipblas_error);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_dgmm_strided_batched.hpp
+++ b/clients/include/testing_dgmm_strided_batched.hpp
@@ -38,9 +38,9 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
     if(!stride_x)
         stride_x = 1;
 
-    int A_size = stride_A * batch_count;
-    int C_size = stride_C * batch_count;
-    int X_size = stride_x * batch_count;
+    size_t A_size = size_t(stride_A) * batch_count;
+    size_t C_size = size_t(stride_C) * batch_count;
+    size_t X_size = size_t(stride_x) * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory

--- a/clients/include/testing_geam_batched.hpp
+++ b/clients/include/testing_geam_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include <fstream>
@@ -38,46 +38,32 @@ hipblasStatus_t testing_geam_batched(const Arguments& argus)
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
 
-    int A_size, B_size, C_size, A_row, A_col, B_row, B_col;
-    int inc1_A, inc2_A, inc1_B, inc2_B;
-
-    T hipblas_error = 0.0;
-
-    hipblasStatus_t status1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status2 = HIPBLAS_STATUS_SUCCESS;
+    int A_row, A_col, B_row, B_col;
 
     if(transA == HIPBLAS_OP_N)
     {
-        A_row  = M;
-        A_col  = N;
-        inc1_A = 1;
-        inc2_A = lda;
+        A_row = M;
+        A_col = N;
     }
     else
     {
-        A_row  = N;
-        A_col  = M;
-        inc1_A = lda;
-        inc2_A = 1;
+        A_row = N;
+        A_col = M;
     }
     if(transB == HIPBLAS_OP_N)
     {
-        B_row  = M;
-        B_col  = N;
-        inc1_B = 1;
-        inc2_B = ldb;
+        B_row = M;
+        B_col = N;
     }
     else
     {
-        B_row  = N;
-        B_col  = M;
-        inc1_B = ldb;
-        inc2_B = 1;
+        B_row = N;
+        B_col = M;
     }
 
-    A_size = lda * A_col;
-    B_size = ldb * B_col;
-    C_size = ldc * N;
+    size_t A_size = size_t(lda) * A_col;
+    size_t B_size = size_t(ldb) * B_col;
+    size_t C_size = size_t(ldc) * N;
 
     // check here to prevent undefined memory allocation error
     if(M <= 0 || N <= 0 || lda < A_row || ldb < B_row || ldc < M || batch_count < 0)
@@ -89,138 +75,89 @@ hipblasStatus_t testing_geam_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // allocate memory on device
-    device_batch_vector<T> bA_array(batch_count, A_size);
-    device_batch_vector<T> bB_array(batch_count, B_size);
-    device_batch_vector<T> bC_array(batch_count, C_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dB(B_size, 1, batch_count);
+    device_batch_vector<T> dC(C_size, 1, batch_count);
+    device_vector<T>       d_alpha(1);
+    device_vector<T>       d_beta(1);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dB(batch_count);
-    device_vector<T*, 0, T> dC(batch_count);
-    device_vector<T>        d_alpha(1);
-    device_vector<T>        d_beta(1);
-
-    int last = batch_count - 1;
-    if(!dA || !dB || !dC || !d_alpha || !d_beta || (!bA_array[last] && A_size)
-       || (!bB_array[last] && B_size) || (!bC_array[last] && C_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dB.memcheck());
+    CHECK_HIP_ERROR(dC.memcheck());
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> hB[batch_count];
-    host_vector<T> hC1[batch_count];
-    host_vector<T> hC2[batch_count];
-    host_vector<T> hC_copy[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hB(B_size, 1, batch_count);
+    host_batch_vector<T> hC1(C_size, 1, batch_count);
+    host_batch_vector<T> hC2(C_size, 1, batch_count);
+    host_batch_vector<T> hC_copy(C_size, 1, batch_count);
 
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA[b]      = host_vector<T>(A_size);
-        hB[b]      = host_vector<T>(B_size);
-        hC1[b]     = host_vector<T>(C_size);
-        hC2[b]     = host_vector<T>(C_size);
-        hC_copy[b] = host_vector<T>(C_size);
+    hipblas_init(hA, true);
+    hipblas_init(hB);
+    hipblas_init(hC1);
+    hC2.copy_from(hC1);
+    hC_copy.copy_from(hC1);
 
-        hipblas_init<T>(hA[b], A_row, A_col, lda);
-        hipblas_init<T>(hB[b], B_row, B_col, ldb);
-        hipblas_init<T>(hC1[b], M, N, ldc);
-        hC2[b]     = hC1[b];
-        hC_copy[b] = hC1[b];
-
-        CHECK_HIP_ERROR(hipMemcpy(bA_array[b], hA[b], sizeof(T) * A_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bB_array[b], hB[b], sizeof(T) * B_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bC_array[b], hC1[b], sizeof(T) * C_size, hipMemcpyHostToDevice));
-    }
-
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, bB_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, bC_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dB.transfer_from(hB));
+    CHECK_HIP_ERROR(dC.transfer_from(hC1));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-         ROCBLAS
+         HIPBLAS
     =================================================================== */
     {
         // &h_alpha and &h_beta are host pointers
-        status1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGeamBatchedFn(handle,
+                                                 transA,
+                                                 transB,
+                                                 M,
+                                                 N,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 &h_beta,
+                                                 dB.ptr_on_device(),
+                                                 ldb,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
 
-        if(status1 != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status1;
-        }
-
-        status2 = hipblasGeamBatchedFn(handle,
-                                       transA,
-                                       transB,
-                                       M,
-                                       N,
-                                       &h_alpha,
-                                       dA,
-                                       lda,
-                                       &h_beta,
-                                       dB,
-                                       ldb,
-                                       dC,
-                                       ldc,
-                                       batch_count);
-
-        if(status2 != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status2;
-        }
-
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(
-                hipMemcpy(hC1[b], bC_array[b], sizeof(T) * C_size, hipMemcpyDeviceToHost));
-        }
+        CHECK_HIP_ERROR(hC1.transfer_from(dC));
     }
     {
+        CHECK_HIP_ERROR(dC.transfer_from(hC2));
+
         // d_alpha and d_beta are device pointers
-        status1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGeamBatchedFn(handle,
+                                                 transA,
+                                                 transB,
+                                                 M,
+                                                 N,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 d_beta,
+                                                 dB.ptr_on_device(),
+                                                 ldb,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
 
-        if(status1 != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status1;
-        }
-
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(
-                hipMemcpy(bC_array[b], hC2[b], sizeof(T) * C_size, hipMemcpyHostToDevice));
-        }
-        CHECK_HIP_ERROR(hipMemcpy(dC, bC_array, batch_count * sizeof(T*), hipMemcpyHostToDevice));
-
-        status2 = hipblasGeamBatchedFn(
-            handle, transA, transB, M, N, d_alpha, dA, lda, d_beta, dB, ldb, dC, ldc, batch_count);
-
-        if(status2 != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status2;
-        }
-
-        for(int b = 0; b < batch_count; b++)
-        {
-            CHECK_HIP_ERROR(
-                hipMemcpy(hC2[b], bC_array[b], sizeof(T) * C_size, hipMemcpyDeviceToHost));
-        }
+        CHECK_HIP_ERROR(hC2.transfer_from(dC));
     }
 
     /* =====================================================================
             CPU BLAS
     =================================================================== */
-    if(status2 != HIPBLAS_STATUS_INVALID_VALUE) // only valid size compare with cblas
+    if(argus.norm_check || argus.unit_check)
     {
         // reference calculation
         for(int b = 0; b < batch_count; b++)
@@ -238,16 +175,69 @@ hipblasStatus_t testing_geam_batched(const Arguments& argus)
                        (T*)hC_copy[b],
                        ldc);
         }
+
+        // enable unit check, notice unit check is not invasive, but norm check is,
+        // unit check and norm check can not be interchanged their order
+        if(argus.unit_check)
+        {
+            unit_check_general<T>(M, N, batch_count, ldc, hC_copy, hC1);
+            unit_check_general<T>(M, N, batch_count, ldc, hC_copy, hC2);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', M, N, ldc, hC_copy, hC1, batch_count);
+            hipblas_error_device = norm_check_general<T>('F', M, N, ldc, hC_copy, hC2, batch_count);
+        }
     }
 
-    // enable unit check, notice unit check is not invasive, but norm check is,
-    // unit check and norm check can not be interchanged their order
-    if(argus.unit_check)
+    if(argus.timing)
     {
-        unit_check_general<T>(M, N, batch_count, ldc, hC_copy, hC1);
-        unit_check_general<T>(M, N, batch_count, ldc, hC_copy, hC2);
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasGeamBatchedFn(handle,
+                                                     transA,
+                                                     transB,
+                                                     M,
+                                                     N,
+                                                     d_alpha,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     d_beta,
+                                                     dB.ptr_on_device(),
+                                                     ldb,
+                                                     dC.ptr_on_device(),
+                                                     ldc,
+                                                     batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_transA_option,
+                      e_transB_option,
+                      e_M,
+                      e_N,
+                      e_alpha,
+                      e_lda,
+                      e_beta,
+                      e_ldb,
+                      e_ldc,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         geam_gflop_count<T>(M, N),
+                         geam_gbyte_count<T>(M, N),
+                         hipblas_error_host,
+                         hipblas_error_device);
     }
 
-    hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -82,12 +82,12 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
         B_col = K;
     }
 
-    hipblasStride stride_A = lda * A_col * stride_scale;
-    hipblasStride stride_B = ldb * B_col * stride_scale;
-    hipblasStride stride_C = ldc * N * stride_scale;
-    size_t        A_size   = size_t(stride_A) * batch_count;
-    size_t        B_size   = size_t(stride_B) * batch_count;
-    size_t        C_size   = size_t(stride_C) * batch_count;
+    hipblasStride stride_A = size_t(lda) * A_col * stride_scale;
+    hipblasStride stride_B = size_t(ldb) * B_col * stride_scale;
+    hipblasStride stride_C = size_t(ldc) * N * stride_scale;
+    size_t        A_size   = stride_A * batch_count;
+    size_t        B_size   = stride_B * batch_count;
+    size_t        C_size   = stride_C * batch_count;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hA(A_size);
@@ -155,7 +155,7 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
 
         // device mode
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
         CHECK_HIPBLAS_ERROR(hipblasGemmStridedBatchedFn(handle,
                                                         transA,
                                                         transB,

--- a/clients/include/testing_gemm_strided_batched.hpp
+++ b/clients/include/testing_gemm_strided_batched.hpp
@@ -27,10 +27,11 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
     int N = argus.N;
     int K = argus.K;
 
-    int lda         = argus.lda;
-    int ldb         = argus.ldb;
-    int ldc         = argus.ldc;
-    int batch_count = argus.batch_count;
+    int    lda          = argus.lda;
+    int    ldb          = argus.ldb;
+    int    ldc          = argus.ldc;
+    int    batch_count  = argus.batch_count;
+    double stride_scale = argus.stride_scale;
 
     // check here to prevent undefined memory allocation error
     if(M < 0 || N < 0 || K < 0 || lda < 0 || ldb < 0 || ldc < 0 || batch_count < 0)
@@ -41,32 +42,23 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasOperation_t transB = char2hipblas_operation(argus.transB_option);
 
-    int A_size, B_size, C_size, A_row, A_col, B_row, B_col;
-    int bsa, bsb, bsc; // batch size A, B, C
+    int A_row, A_col, B_row, B_col;
 
     float alpha_float = argus.alpha;
     float beta_float  = argus.beta;
 
-    T alpha, beta;
+    T h_alpha, h_beta;
 
     if(is_same<T, hipblasHalf>::value)
     {
-        alpha = float_to_half(alpha_float);
-        beta  = float_to_half(beta_float);
+        h_alpha = float_to_half(alpha_float);
+        h_beta  = float_to_half(beta_float);
     }
     else
     {
-        alpha = static_cast<T>(alpha_float);
-        beta  = static_cast<T>(beta_float);
+        h_alpha = static_cast<T>(alpha_float);
+        h_beta  = static_cast<T>(beta_float);
     }
-
-    double hipblas_error;
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops;
-
-    hipblasHandle_t handle;
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-    hipblasCreate(&handle);
 
     if(transA == HIPBLAS_OP_N)
     {
@@ -90,81 +82,103 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
         B_col = K;
     }
 
-    bsa    = lda * A_col * 2;
-    bsb    = ldb * B_col * 2;
-    bsc    = ldc * N;
-    A_size = bsa * batch_count;
-    B_size = bsb * batch_count;
-    C_size = bsc * batch_count;
+    hipblasStride stride_A = lda * A_col * stride_scale;
+    hipblasStride stride_B = ldb * B_col * stride_scale;
+    hipblasStride stride_C = ldc * N * stride_scale;
+    size_t        A_size   = size_t(stride_A) * batch_count;
+    size_t        B_size   = size_t(stride_B) * batch_count;
+    size_t        C_size   = size_t(stride_C) * batch_count;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    vector<T> hA(A_size);
-    vector<T> hB(B_size);
-    vector<T> hC(C_size);
-    vector<T> hC_copy(C_size);
+    host_vector<T> hA(A_size);
+    host_vector<T> hB(B_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
+    host_vector<T> hC_copy(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dC(C_size);
+    device_vector<T> d_alpha(1);
+    device_vector<T> d_beta(1);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, A_row, A_col * batch_count, lda);
     hipblas_init<T>(hB, B_row, B_col * batch_count, ldb);
-    hipblas_init<T>(hC, M, N * batch_count, ldc);
+    hipblas_init<T>(hC_host, M, N * batch_count, ldc);
 
     // copy vector is easy in STL; hz = hx: save a copy in hC_copy which will be output of CPU BLAS
-    hC_copy = hC;
+    hC_copy   = hC_host;
+    hC_device = hC_host;
 
     // copy data from CPU to device, does not work for lda != A_row
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
+
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     /* =====================================================================
          HIPBLAS
     =================================================================== */
     if(argus.unit_check || argus.norm_check)
     {
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        // host mode
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
 
         // library interface
-        status = hipblasGemmStridedBatchedFn(handle,
-                                             transA,
-                                             transB,
-                                             M,
-                                             N,
-                                             K,
-                                             &alpha,
-                                             dA,
-                                             lda,
-                                             bsa,
-                                             dB,
-                                             ldb,
-                                             bsb,
-                                             &beta,
-                                             dC,
-                                             ldc,
-                                             bsc,
-                                             batch_count);
+        CHECK_HIPBLAS_ERROR(hipblasGemmStridedBatchedFn(handle,
+                                                        transA,
+                                                        transB,
+                                                        M,
+                                                        N,
+                                                        K,
+                                                        &h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dB,
+                                                        ldb,
+                                                        stride_B,
+                                                        &h_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
         // copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        // device mode
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIPBLAS_ERROR(hipblasGemmStridedBatchedFn(handle,
+                                                        transA,
+                                                        transB,
+                                                        M,
+                                                        N,
+                                                        K,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dB,
+                                                        ldb,
+                                                        stride_B,
+                                                        d_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-
         for(int i = 0; i < batch_count; i++)
         {
             cblas_gemm<T>(transA,
@@ -172,13 +186,13 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
                           M,
                           N,
                           K,
-                          alpha,
-                          hA.data() + bsa * i,
+                          h_alpha,
+                          hA.data() + stride_A * i,
                           lda,
-                          hB.data() + bsb * i,
+                          hB.data() + stride_B * i,
                           ldb,
-                          beta,
-                          hC_copy.data() + bsc * i,
+                          h_beta,
+                          hC_copy.data() + stride_C * i,
                           ldc);
         }
 
@@ -186,30 +200,23 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(M, N * batch_count, lda, hC_copy.data(), hC.data());
+            unit_check_general<T>(M, N, batch_count, ldc, stride_C, hC_copy, hC_host);
+            unit_check_general<T>(M, N, batch_count, ldc, stride_C, hC_copy, hC_device);
         }
         if(argus.norm_check)
         {
-            hipblas_error = norm_check_general<T>(
-                'F', M, N, lda, bsc, hC_copy.data(), hC.data(), batch_count);
+            hipblas_error_host
+                = norm_check_general<T>('F', M, N, ldc, stride_C, hC_copy, hC_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', M, N, ldc, stride_C, hC_copy, hC_device, batch_count);
         }
-    } // end of if unit/norm check
+    }
 
     if(argus.timing)
     {
         hipStream_t stream;
-        status = hipblasGetStream(handle, &stream);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
 
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)
@@ -217,30 +224,24 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
             if(iter == argus.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            status = hipblasGemmStridedBatchedFn(handle,
-                                                 transA,
-                                                 transB,
-                                                 M,
-                                                 N,
-                                                 K,
-                                                 &alpha,
-                                                 dA,
-                                                 lda,
-                                                 bsa,
-                                                 dB,
-                                                 ldb,
-                                                 bsb,
-                                                 &beta,
-                                                 dC,
-                                                 ldc,
-                                                 bsc,
-                                                 batch_count);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(hipblasGemmStridedBatchedFn(handle,
+                                                            transA,
+                                                            transB,
+                                                            M,
+                                                            N,
+                                                            K,
+                                                            d_alpha,
+                                                            dA,
+                                                            lda,
+                                                            stride_A,
+                                                            dB,
+                                                            ldb,
+                                                            stride_B,
+                                                            d_beta,
+                                                            dC,
+                                                            ldc,
+                                                            stride_C,
+                                                            batch_count));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
@@ -251,18 +252,21 @@ hipblasStatus_t testing_gemm_strided_batched(const Arguments& argus)
                       e_K,
                       e_alpha,
                       e_lda,
+                      e_stride_a,
                       e_ldb,
+                      e_stride_b,
                       e_beta,
                       e_ldc,
+                      e_stride_c,
                       e_batch_count>{}
             .log_args<T>(std::cout,
                          argus,
                          gpu_time_used,
                          gemm_gflop_count<T>(M, N, K),
                          gemm_gbyte_count<T>(M, N, K),
-                         hipblas_error);
+                         hipblas_error_host,
+                         hipblas_error_device);
     }
 
-    hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hemm.hpp
+++ b/clients/include/testing_hemm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -28,15 +28,13 @@ hipblasStatus_t testing_hemm(const Arguments& argus)
 
     char char_side = argus.side_option;
     char char_uplo = argus.uplo_option;
-    T    alpha     = argus.get_alpha<T>();
-    T    beta      = argus.get_beta<T>();
+    T    h_alpha   = argus.get_alpha<T>();
+    T    h_beta    = argus.get_beta<T>();
 
     hipblasSideMode_t side = char2hipblas_side(char_side);
     hipblasFillMode_t uplo = char2hipblas_fill(char_uplo);
 
     int K = (side == HIPBLAS_SIDE_LEFT ? M : N);
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
     // check here to prevent undefined memory allocation error
     if(M < 0 || N < 0 || ldc < M || ldb < M || lda < K)
@@ -45,68 +43,114 @@ hipblasStatus_t testing_hemm(const Arguments& argus)
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    int A_size = size_t(lda) * K;
-    int B_size = size_t(ldb) * N;
-    int C_size = size_t(ldc) * N;
+    size_t A_size = size_t(lda) * K;
+    size_t B_size = size_t(ldb) * N;
+    size_t C_size = size_t(ldc) * N;
 
     host_vector<T> hA(A_size);
     host_vector<T> hB(B_size);
-    host_vector<T> hC_1(C_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
     host_vector<T> hC_gold(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dC(C_size);
+    device_vector<T> d_alpha(1);
+    device_vector<T> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda);
     hipblas_init<T>(hB, M, N, ldb);
-    hipblas_init<T>(hC_1, M, N, ldc);
-    hC_gold = hC_1;
+    hipblas_init<T>(hC_host, M, N, ldc);
+    hC_gold   = hC_host;
+    hC_device = hC_host;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_1.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    status = hipblasHemmFn(handle, side, uplo, M, N, &alpha, dA, lda, dB, ldb, &beta, dC, ldc);
-
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHemmFn(handle, side, uplo, M, N, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
 
     // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHemmFn(handle, side, uplo, M, N, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_hemm<T>(
-            side, uplo, M, N, alpha, hA.data(), lda, hB.data(), ldb, beta, hC_gold.data(), ldc);
+            side, uplo, M, N, h_alpha, hA.data(), lda, hB.data(), ldb, h_beta, hC_gold.data(), ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(M, N, ldc, hC_gold.data(), hC_1.data());
+            unit_check_general<T>(M, N, ldc, hC_gold, hC_host);
+            unit_check_general<T>(M, N, ldc, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', M, N, ldc, hC_gold, hC_host);
+            hipblas_error_device = norm_check_general<T>('F', M, N, ldc, hC_gold, hC_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHemmFn(
+                handle, side, uplo, M, N, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_side_option,
+                      e_uplo_option,
+                      e_M,
+                      e_N,
+                      e_alpha,
+                      e_lda,
+                      e_ldb,
+                      e_beta,
+                      e_ldc>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         hemm_gflop_count<T>(M, N, K),
+                         hemm_gbyte_count<T>(M, N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_hemm.hpp
+++ b/clients/include/testing_hemm.hpp
@@ -87,7 +87,7 @@ hipblasStatus_t testing_hemm(const Arguments& argus)
     // copy output from device to CPU
     CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
     CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
     CHECK_HIPBLAS_ERROR(
         hipblasHemmFn(handle, side, uplo, M, N, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));

--- a/clients/include/testing_hemm_strided_batched.hpp
+++ b/clients/include/testing_hemm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -32,16 +32,14 @@ hipblasStatus_t testing_hemm_strided_batched(const Arguments& argus)
     hipblasSideMode_t side = char2hipblas_side(argus.side_option);
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     int           K        = (side == HIPBLAS_SIDE_LEFT ? M : N);
-    hipblasStride stride_A = lda * K * stride_scale;
-    hipblasStride stride_B = ldb * N * stride_scale;
-    hipblasStride stride_C = ldc * N * stride_scale;
+    hipblasStride stride_A = size_t(lda) * K * stride_scale;
+    hipblasStride stride_B = size_t(ldb) * N * stride_scale;
+    hipblasStride stride_C = size_t(ldc) * N * stride_scale;
 
-    int A_size = stride_A * batch_count;
-    int B_size = stride_B * batch_count;
-    int C_size = stride_C * batch_count;
+    size_t A_size = size_t(stride_A) * batch_count;
+    size_t B_size = size_t(stride_B) * batch_count;
+    size_t C_size = size_t(stride_C) * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -53,87 +51,101 @@ hipblasStatus_t testing_hemm_strided_batched(const Arguments& argus)
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
     host_vector<T> hB(B_size);
-    host_vector<T> hC_1(C_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
     host_vector<T> hC_gold(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dC(C_size);
+    device_vector<T> d_alpha(1);
+    device_vector<T> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
-    T alpha = argus.get_alpha<T>();
-    T beta  = argus.get_beta<T>();
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    T h_alpha = argus.get_alpha<T>();
+    T h_beta  = argus.get_beta<T>();
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda, stride_A, batch_count);
     hipblas_init<T>(hB, M, N, ldb, stride_B, batch_count);
-    hipblas_init<T>(hC_1, M, N, ldc, stride_C, batch_count);
-    hC_gold = hC_1;
+    hipblas_init<T>(hC_host, M, N, ldc, stride_C, batch_count);
+    hC_gold   = hC_host;
+    hC_device = hC_host;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC_1.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHemmStridedBatchedFn(handle,
-                                             side,
-                                             uplo,
-                                             M,
-                                             N,
-                                             &alpha,
-                                             dA,
-                                             lda,
-                                             stride_A,
-                                             dB,
-                                             ldb,
-                                             stride_B,
-                                             &beta,
-                                             dC,
-                                             ldc,
-                                             stride_C,
-                                             batch_count);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            // here in cuda
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHemmStridedBatchedFn(handle,
+                                                    side,
+                                                    uplo,
+                                                    M,
+                                                    N,
+                                                    &h_alpha,
+                                                    dA,
+                                                    lda,
+                                                    stride_A,
+                                                    dB,
+                                                    ldb,
+                                                    stride_B,
+                                                    &h_beta,
+                                                    dC,
+                                                    ldc,
+                                                    stride_C,
+                                                    batch_count));
 
     // copy output from device to CPU
-    hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHemmStridedBatchedFn(handle,
+                                                    side,
+                                                    uplo,
+                                                    M,
+                                                    N,
+                                                    d_alpha,
+                                                    dA,
+                                                    lda,
+                                                    stride_A,
+                                                    dB,
+                                                    ldb,
+                                                    stride_B,
+                                                    d_beta,
+                                                    dC,
+                                                    ldc,
+                                                    stride_C,
+                                                    batch_count));
+
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_hemm<T>(side,
                           uplo,
                           M,
                           N,
-                          alpha,
+                          h_alpha,
                           hA.data() + b * stride_A,
                           lda,
                           hB.data() + b * stride_B,
                           ldb,
-                          beta,
+                          h_beta,
                           hC_gold.data() + b * stride_C,
                           ldc);
         }
@@ -142,10 +154,72 @@ hipblasStatus_t testing_hemm_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(M, N, batch_count, ldc, stride_C, hC_gold, hC_1);
+            unit_check_general<T>(M, N, batch_count, ldc, stride_C, hC_gold, hC_host);
+            unit_check_general<T>(M, N, batch_count, ldc, stride_C, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', M, N, ldc, stride_C, hC_gold, hC_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', M, N, ldc, stride_C, hC_gold, hC_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHemmStridedBatchedFn(handle,
+                                                            side,
+                                                            uplo,
+                                                            M,
+                                                            N,
+                                                            d_alpha,
+                                                            dA,
+                                                            lda,
+                                                            stride_A,
+                                                            dB,
+                                                            ldb,
+                                                            stride_B,
+                                                            d_beta,
+                                                            dC,
+                                                            ldc,
+                                                            stride_C,
+                                                            batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_side_option,
+                      e_uplo_option,
+                      e_M,
+                      e_N,
+                      e_alpha,
+                      e_lda,
+                      e_stride_a,
+                      e_ldb,
+                      e_stride_b,
+                      e_beta,
+                      e_ldc,
+                      e_stride_c,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         hemm_gflop_count<T>(M, N, K),
+                         hemm_gbyte_count<T>(M, N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_her2k.hpp
+++ b/clients/include/testing_her2k.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_her2k(const Arguments& argus)
 {
+    using U             = real_t<T>;
     bool FORTRAN        = argus.fortran;
     auto hipblasHer2kFn = FORTRAN ? hipblasHer2k<T, U, true> : hipblasHer2k<T, U, false>;
 
@@ -39,84 +40,120 @@ hipblasStatus_t testing_her2k(const Arguments& argus)
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    int K1     = (transA == HIPBLAS_OP_N ? K : N);
-    int A_size = lda * K1;
-    int B_size = lda * K1;
-    int C_size = ldc * N;
+    int    K1     = (transA == HIPBLAS_OP_N ? K : N);
+    size_t A_size = size_t(lda) * K1;
+    size_t B_size = size_t(ldb) * K1;
+    size_t C_size = size_t(ldc) * N;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
     host_vector<T> hB(B_size);
-    host_vector<T> hC(C_size);
-    host_vector<T> hC2(C_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
+    host_vector<T> hC_gold(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dC(C_size);
+    device_vector<T> d_alpha(1);
+    device_vector<U> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    T h_alpha = argus.get_alpha<T>();
+    U h_beta  = argus.get_beta<U>();
 
-    T alpha = argus.get_alpha<T>();
-    U beta  = argus.get_beta<U>();
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, K1, lda);
     hipblas_init<T>(hB, N, K1, ldb);
-    hipblas_init<T>(hC, N, N, ldc);
+    hipblas_init<T>(hC_host, N, N, ldc);
 
     // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    // hB = hA;
+    hC_device = hC_host;
+    hC_gold   = hC_host;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
-
-    for(int iter = 0; iter < 1; iter++)
-    {
-
-        status = hipblasHer2kFn(
-            handle, uplo, transA, N, K, (T*)&alpha, dA, lda, dB, ldb, (U*)&beta, dC, ldc);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHer2kFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
 
     // copy output from device to CPU
-    hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHer2kFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_her2k<T>(uplo, transA, N, K, alpha, hA.data(), lda, hB.data(), ldb, beta, hC, ldc);
+        cblas_her2k<T>(uplo, transA, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, ldc, hC2.data(), hC.data());
+            unit_check_general<T>(N, N, ldc, hC_gold, hC_host);
+            unit_check_general<T>(N, N, ldc, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_host);
+            hipblas_error_device = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHer2kFn(
+                handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_uplo_option,
+                      e_transA_option,
+                      e_N,
+                      e_K,
+                      e_alpha,
+                      e_lda,
+                      e_ldb,
+                      e_beta,
+                      e_ldc>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         her2k_gflop_count<T>(N, K),
+                         her2k_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_her2k.hpp
+++ b/clients/include/testing_her2k.hpp
@@ -91,8 +91,8 @@ hipblasStatus_t testing_her2k(const Arguments& argus)
     // copy output from device to CPU
     CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
     CHECK_HIPBLAS_ERROR(
         hipblasHer2kFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
 

--- a/clients/include/testing_her2k_strided_batched.hpp
+++ b/clients/include/testing_her2k_strided_batched.hpp
@@ -131,6 +131,8 @@ hipblasStatus_t testing_her2k_strided_batched(const Arguments& argus)
                                                      stride_C,
                                                      batch_count));
 
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================

--- a/clients/include/testing_her2k_strided_batched.hpp
+++ b/clients/include/testing_her2k_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_her2k_strided_batched(const Arguments& argus)
 {
+    using U                           = real_t<T>;
     bool FORTRAN                      = argus.fortran;
     auto hipblasHer2kStridedBatchedFn = FORTRAN ? hipblasHer2kStridedBatched<T, U, true>
                                                 : hipblasHer2kStridedBatched<T, U, false>;
@@ -32,14 +33,12 @@ hipblasStatus_t testing_her2k_strided_batched(const Arguments& argus)
     hipblasFillMode_t  uplo     = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA   = char2hipblas_operation(argus.transA_option);
     int                K1       = (transA == HIPBLAS_OP_N ? K : N);
-    hipblasStride      stride_A = lda * K1 * stride_scale;
-    hipblasStride      stride_B = ldb * K1 * stride_scale;
-    hipblasStride      stride_C = ldc * N * stride_scale;
-    int                A_size   = stride_A * batch_count;
-    int                B_size   = stride_B * batch_count;
-    int                C_size   = stride_C * batch_count;
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasStride      stride_A = size_t(lda) * K1 * stride_scale;
+    hipblasStride      stride_B = size_t(ldb) * K1 * stride_scale;
+    hipblasStride      stride_C = size_t(ldc) * N * stride_scale;
+    size_t             A_size   = stride_A * batch_count;
+    size_t             B_size   = stride_B * batch_count;
+    size_t             C_size   = stride_C * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -56,73 +55,83 @@ hipblasStatus_t testing_her2k_strided_batched(const Arguments& argus)
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
     host_vector<T> hB(B_size);
-    host_vector<T> hC(C_size);
-    host_vector<T> hC2(C_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
+    host_vector<T> hC_gold(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dC(C_size);
+    device_vector<T> d_alpha(1);
+    device_vector<U> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    T h_alpha = argus.get_alpha<T>();
+    U h_beta  = argus.get_beta<U>();
 
-    T alpha = argus.get_alpha<T>();
-    U beta  = argus.get_beta<U>();
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, K1, lda, stride_A, batch_count);
     hipblas_init<T>(hB, N, K1, ldb, stride_B, batch_count);
-    hipblas_init<T>(hC, N, N, ldc, stride_C, batch_count);
+    hipblas_init<T>(hC_host, N, N, ldc, stride_C, batch_count);
+    hC_device = hC_host;
+    hC_gold   = hC_host;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
-
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHer2kStridedBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              (T*)&alpha,
-                                              dA,
-                                              lda,
-                                              stride_A,
-                                              dB,
-                                              ldb,
-                                              stride_B,
-                                              (U*)&beta,
-                                              dC,
-                                              ldc,
-                                              stride_C,
-                                              batch_count);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHer2kStridedBatchedFn(handle,
+                                                     uplo,
+                                                     transA,
+                                                     N,
+                                                     K,
+                                                     &h_alpha,
+                                                     dA,
+                                                     lda,
+                                                     stride_A,
+                                                     dB,
+                                                     ldb,
+                                                     stride_B,
+                                                     &h_beta,
+                                                     dC,
+                                                     ldc,
+                                                     stride_C,
+                                                     batch_count));
 
     // copy output from device to CPU
-    hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHer2kStridedBatchedFn(handle,
+                                                     uplo,
+                                                     transA,
+                                                     N,
+                                                     K,
+                                                     d_alpha,
+                                                     dA,
+                                                     lda,
+                                                     stride_A,
+                                                     dB,
+                                                     ldb,
+                                                     stride_B,
+                                                     d_beta,
+                                                     dC,
+                                                     ldc,
+                                                     stride_C,
+                                                     batch_count));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -133,13 +142,13 @@ hipblasStatus_t testing_her2k_strided_batched(const Arguments& argus)
                            transA,
                            N,
                            K,
-                           alpha,
+                           h_alpha,
                            hA.data() + b * stride_A,
                            lda,
                            hB.data() + b * stride_B,
                            ldb,
-                           beta,
-                           hC.data() + b * stride_C,
+                           h_beta,
+                           hC_gold.data() + b * stride_C,
                            ldc);
         }
 
@@ -147,10 +156,72 @@ hipblasStatus_t testing_her2k_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC2.data(), hC.data());
+            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC_gold, hC_host);
+            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', N, N, ldc, stride_C, hC_gold, hC_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', N, N, ldc, stride_C, hC_gold, hC_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHer2kStridedBatchedFn(handle,
+                                                             uplo,
+                                                             transA,
+                                                             N,
+                                                             K,
+                                                             d_alpha,
+                                                             dA,
+                                                             lda,
+                                                             stride_A,
+                                                             dB,
+                                                             ldb,
+                                                             stride_B,
+                                                             d_beta,
+                                                             dC,
+                                                             ldc,
+                                                             stride_C,
+                                                             batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_uplo_option,
+                      e_transA_option,
+                      e_N,
+                      e_K,
+                      e_alpha,
+                      e_lda,
+                      e_stride_a,
+                      e_ldb,
+                      e_stride_b,
+                      e_beta,
+                      e_ldc,
+                      e_stride_c,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         her2k_gflop_count<T>(N, K),
+                         her2k_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_herk.hpp
+++ b/clients/include/testing_herk.hpp
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_herk(const Arguments& argus)
 {
+    using U            = real_t<T>;
     bool FORTRAN       = argus.fortran;
     auto hipblasHerkFn = FORTRAN ? hipblasHerk<T, U, true> : hipblasHerk<T, U, false>;
 

--- a/clients/include/testing_herk.hpp
+++ b/clients/include/testing_herk.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -28,8 +28,6 @@ hipblasStatus_t testing_herk(const Arguments& argus)
     hipblasFillMode_t  uplo   = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N < 0 || K < 0 || ldc < N || (transA == HIPBLAS_OP_N && lda < N)
@@ -38,78 +36,107 @@ hipblasStatus_t testing_herk(const Arguments& argus)
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    int K1     = (transA == HIPBLAS_OP_N ? K : N);
-    int A_size = lda * K1;
-    int C_size = ldc * N;
+    int    K1     = (transA == HIPBLAS_OP_N ? K : N);
+    size_t A_size = size_t(lda) * K1;
+    size_t C_size = size_t(ldc) * N;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hC(C_size);
-    host_vector<T> hC2(C_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
+    host_vector<T> hC_gold(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dC(C_size);
+    device_vector<U> d_alpha(1);
+    device_vector<U> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    U h_alpha = argus.get_alpha<U>();
+    U h_beta  = argus.get_beta<U>();
 
-    U alpha = argus.get_alpha<U>();
-    U beta  = argus.get_beta<U>();
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, K1, lda);
-    hipblas_init<T>(hC, N, N, ldc);
+    hipblas_init<T>(hC_host, N, N, ldc);
 
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
-    // hB = hA;
+    hC_device = hC_host;
+    hC_gold   = hC_host;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
-
-    for(int iter = 0; iter < 1; iter++)
-    {
-
-        status = hipblasHerkFn(handle, uplo, transA, N, K, (U*)&alpha, dA, lda, (U*)&beta, dC, ldc);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHerkFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, &h_beta, dC, ldc));
 
     // copy output from device to CPU
-    hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHerkFn(handle, uplo, transA, N, K, d_alpha, dA, lda, d_beta, dC, ldc));
+
+    // copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_herk<T>(uplo, transA, N, K, alpha, hA.data(), lda, beta, hC, ldc);
+        cblas_herk<T>(uplo, transA, N, K, h_alpha, hA, lda, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, ldc, hC2.data(), hC.data());
+            unit_check_general<T>(N, N, ldc, hC_gold, hC_host);
+            unit_check_general<T>(N, N, ldc, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_host);
+            hipblas_error_device = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(
+                hipblasHerkFn(handle, uplo, transA, N, K, d_alpha, dA, lda, d_beta, dC, ldc));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_uplo_option, e_transA_option, e_N, e_K, e_alpha, e_lda, e_beta, e_ldc>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         herk_gflop_count<T>(N, K),
+                         herk_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_herk_batched.hpp
+++ b/clients/include/testing_herk_batched.hpp
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_herk_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasHerkBatchedFn
         = FORTRAN ? hipblasHerkBatched<T, U, true> : hipblasHerkBatched<T, U, false>;

--- a/clients/include/testing_herk_batched.hpp
+++ b/clients/include/testing_herk_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -30,14 +30,8 @@ hipblasStatus_t testing_herk_batched(const Arguments& argus)
     hipblasFillMode_t  uplo   = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
-
-    U alpha = argus.get_alpha<U>();
-    U beta  = argus.get_beta<U>();
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    U h_alpha = argus.get_alpha<U>();
+    U h_beta  = argus.get_beta<U>();
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -51,93 +45,145 @@ hipblasStatus_t testing_herk_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
-    int K1     = (transA == HIPBLAS_OP_N ? K : N);
-    int A_size = lda * K1;
-    int C_size = ldc * N;
+    int    K1     = (transA == HIPBLAS_OP_N ? K : N);
+    size_t A_size = size_t(lda) * K1;
+    size_t C_size = size_t(ldc) * N;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> hC[batch_count];
-    host_vector<T> hC2[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hC_host(C_size, 1, batch_count);
+    host_batch_vector<T> hC_device(C_size, 1, batch_count);
+    host_batch_vector<T> hC_gold(C_size, 1, batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bC(batch_count, C_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dC(A_size, 1, batch_count);
+    device_vector<U>       d_alpha(1);
+    device_vector<U>       d_beta(1);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dC(batch_count);
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dC.memcheck());
 
-    int last = batch_count - 1;
-    if(!dA || !dC || (!bA[last] && A_size) || (!bC[last] && C_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    hipblas_init(hA, true);
+    hipblas_init(hC_host);
 
-    // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA[b]  = host_vector<T>(A_size);
-        hC[b]  = host_vector<T>(C_size);
-        hC2[b] = host_vector<T>(C_size);
+    hC_device.copy_from(hC_host);
+    hC_gold.copy_from(hC_host);
 
-        srand(1);
-        hipblas_init<T>(hA[b], N, K1, lda);
-        hipblas_init<T>(hC[b], N, N, ldc);
-
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b], sizeof(T) * A_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bC[b], hC[b], sizeof(T) * C_size, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, bC, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dC.transfer_from(hC_host));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHerkBatchedFn(handle,
+                                             uplo,
+                                             transA,
+                                             N,
+                                             K,
+                                             &h_alpha,
+                                             dA.ptr_on_device(),
+                                             lda,
+                                             &h_beta,
+                                             dC.ptr_on_device(),
+                                             ldc,
+                                             batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHerkBatchedFn(
-            handle, uplo, transA, N, K, (U*)&alpha, dA, lda, (U*)&beta, dC, ldc, batch_count);
+    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHerkBatchedFn(handle,
+                                             uplo,
+                                             transA,
+                                             N,
+                                             K,
+                                             d_alpha,
+                                             dA.ptr_on_device(),
+                                             lda,
+                                             d_beta,
+                                             dC.ptr_on_device(),
+                                             ldc,
+                                             batch_count));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipMemcpy(hC2[b], bC[b], sizeof(T) * C_size, hipMemcpyDeviceToHost);
-    }
+    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_herk<T>(uplo, transA, N, K, alpha, hA[b], lda, beta, hC[b], ldc);
+            cblas_herk<T>(uplo, transA, N, K, h_alpha, hA[b], lda, h_beta, hC_gold[b], ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, ldc, hC2, hC);
+            unit_check_general<T>(N, N, batch_count, ldc, hC_gold, hC_host);
+            unit_check_general<T>(N, N, batch_count, ldc, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHerkBatchedFn(handle,
+                                                     uplo,
+                                                     transA,
+                                                     N,
+                                                     K,
+                                                     d_alpha,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     d_beta,
+                                                     dC.ptr_on_device(),
+                                                     ldc,
+                                                     batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_uplo_option,
+                      e_transA_option,
+                      e_N,
+                      e_K,
+                      e_alpha,
+                      e_lda,
+                      e_beta,
+                      e_ldc,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         herk_gflop_count<T>(N, K),
+                         herk_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_herk_batched.hpp
+++ b/clients/include/testing_herk_batched.hpp
@@ -60,7 +60,7 @@ hipblasStatus_t testing_herk_batched(const Arguments& argus)
     host_batch_vector<T> hC_gold(C_size, 1, batch_count);
 
     device_batch_vector<T> dA(A_size, 1, batch_count);
-    device_batch_vector<T> dC(A_size, 1, batch_count);
+    device_batch_vector<T> dC(C_size, 1, batch_count);
     device_vector<U>       d_alpha(1);
     device_vector<U>       d_beta(1);
 

--- a/clients/include/testing_herk_strided_batched.hpp
+++ b/clients/include/testing_herk_strided_batched.hpp
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_herk_strided_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasHerkStridedBatchedFn
         = FORTRAN ? hipblasHerkStridedBatched<T, U, true> : hipblasHerkStridedBatched<T, U, false>;

--- a/clients/include/testing_herk_strided_batched.hpp
+++ b/clients/include/testing_herk_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -31,12 +31,10 @@ hipblasStatus_t testing_herk_strided_batched(const Arguments& argus)
     hipblasFillMode_t  uplo     = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA   = char2hipblas_operation(argus.transA_option);
     int                K1       = (transA == HIPBLAS_OP_N ? K : N);
-    hipblasStride      stride_A = lda * K1 * stride_scale;
-    hipblasStride      stride_C = ldc * N * stride_scale;
-    int                A_size   = stride_A * batch_count;
-    int                C_size   = stride_C * batch_count;
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasStride      stride_A = size_t(lda) * K1 * stride_scale;
+    hipblasStride      stride_C = size_t(ldc) * N * stride_scale;
+    size_t             A_size   = stride_A * batch_count;
+    size_t             C_size   = stride_C * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -52,67 +50,76 @@ hipblasStatus_t testing_herk_strided_batched(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hC(C_size);
-    host_vector<T> hC2(C_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
+    host_vector<T> hC_gold(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dC(C_size);
+    device_vector<U> d_alpha(1);
+    device_vector<U> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    U h_alpha = argus.get_alpha<U>();
+    U h_beta  = argus.get_beta<U>();
 
-    U alpha = argus.get_alpha<U>();
-    U beta  = argus.get_beta<U>();
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, K1, lda, stride_A, batch_count);
-    hipblas_init<T>(hC, N, N, ldc, stride_C, batch_count);
+    hipblas_init<T>(hC_host, N, N, ldc, stride_C, batch_count);
+    hC_device = hC_host;
+    hC_gold   = hC_host;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
-
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHerkStridedBatchedFn(handle,
-                                             uplo,
-                                             transA,
-                                             N,
-                                             K,
-                                             (U*)&alpha,
-                                             dA,
-                                             lda,
-                                             stride_A,
-                                             (U*)&beta,
-                                             dC,
-                                             ldc,
-                                             stride_C,
-                                             batch_count);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHerkStridedBatchedFn(handle,
+                                                    uplo,
+                                                    transA,
+                                                    N,
+                                                    K,
+                                                    &h_alpha,
+                                                    dA,
+                                                    lda,
+                                                    stride_A,
+                                                    &h_beta,
+                                                    dC,
+                                                    ldc,
+                                                    stride_C,
+                                                    batch_count));
 
     // copy output from device to CPU
-    hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+    CHECK_HIPBLAS_ERROR(hipblasHerkStridedBatchedFn(handle,
+                                                    uplo,
+                                                    transA,
+                                                    N,
+                                                    K,
+                                                    d_alpha,
+                                                    dA,
+                                                    lda,
+                                                    stride_A,
+                                                    d_beta,
+                                                    dC,
+                                                    ldc,
+                                                    stride_C,
+                                                    batch_count));
+
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -123,11 +130,11 @@ hipblasStatus_t testing_herk_strided_batched(const Arguments& argus)
                           transA,
                           N,
                           K,
-                          alpha,
+                          h_alpha,
                           hA.data() + b * stride_A,
                           lda,
-                          beta,
-                          hC.data() + b * stride_C,
+                          h_beta,
+                          hC_gold.data() + b * stride_C,
                           ldc);
         }
 
@@ -135,10 +142,67 @@ hipblasStatus_t testing_herk_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC2.data(), hC.data());
+            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC_gold, hC_host);
+            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', N, N, ldc, stride_C, hC_gold, hC_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', N, N, ldc, stride_C, hC_gold, hC_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHerkStridedBatchedFn(handle,
+                                                            uplo,
+                                                            transA,
+                                                            N,
+                                                            K,
+                                                            d_alpha,
+                                                            dA,
+                                                            lda,
+                                                            stride_A,
+                                                            d_beta,
+                                                            dC,
+                                                            ldc,
+                                                            stride_C,
+                                                            batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_uplo_option,
+                      e_transA_option,
+                      e_N,
+                      e_K,
+                      e_alpha,
+                      e_lda,
+                      e_stride_a,
+                      e_beta,
+                      e_ldc,
+                      e_stride_c,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         herk_gflop_count<T>(N, K),
+                         herk_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_herkx.hpp
+++ b/clients/include/testing_herkx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_herkx(const Arguments& argus)
 {
+    using U             = real_t<T>;
     bool FORTRAN        = argus.fortran;
     auto hipblasHerkxFn = FORTRAN ? hipblasHerkx<T, U, true> : hipblasHerkx<T, U, false>;
 
@@ -39,85 +40,119 @@ hipblasStatus_t testing_herkx(const Arguments& argus)
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    int K1     = (transA == HIPBLAS_OP_N ? K : N);
-    int A_size = lda * K1;
-    int B_size = lda * K1;
-    int C_size = ldc * N;
+    int    K1     = (transA == HIPBLAS_OP_N ? K : N);
+    size_t A_size = size_t(lda) * K1;
+    size_t B_size = size_t(ldb) * K1;
+    size_t C_size = size_t(ldc) * N;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
     host_vector<T> hB(B_size);
-    host_vector<T> hC(C_size);
-    host_vector<T> hC2(C_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
+    host_vector<T> hC_gold(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dC(C_size);
+    device_vector<T> d_alpha(1);
+    device_vector<U> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    T h_alpha = argus.get_alpha<T>();
+    U h_beta  = argus.get_beta<U>();
 
-    T alpha = argus.get_alpha<T>();
-    U beta  = argus.get_beta<U>();
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, K1, lda);
-    // hipblas_init<T>(hB, N, K1, ldb);
-    hipblas_init<T>(hC, N, N, ldc);
-    hB = hA;
-
-    // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
+    hipblas_init<T>(hB, N, K1, ldb);
+    hipblas_init<T>(hC_host, N, N, ldc);
     // hB = hA;
+    hC_device = hC_host;
+    hC_gold   = hC_host;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
-
-    for(int iter = 0; iter < 1; iter++)
-    {
-
-        status = hipblasHerkxFn(
-            handle, uplo, transA, N, K, (T*)&alpha, dA, lda, dB, ldb, (U*)&beta, dC, ldc);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHerkxFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
 
     // copy output from device to CPU
-    hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
-    if(argus.unit_check)
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasHerkxFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_herkx<T>(uplo, transA, N, K, alpha, hA.data(), lda, hB.data(), ldb, beta, hC, ldc);
+        cblas_herkx<T>(uplo, transA, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, ldc, hC2.data(), hC.data());
+            unit_check_general<T>(N, N, ldc, hC_gold, hC_host);
+            unit_check_general<T>(N, N, ldc, hC_gold, hC_host);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_host);
+            hipblas_error_device = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_device);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHerkxFn(
+                handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_uplo_option,
+                      e_transA_option,
+                      e_N,
+                      e_K,
+                      e_alpha,
+                      e_lda,
+                      e_ldb,
+                      e_beta,
+                      e_ldc>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         herkx_gflop_count<T>(N, K),
+                         herkx_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_herkx.hpp
+++ b/clients/include/testing_herkx.hpp
@@ -91,7 +91,7 @@ hipblasStatus_t testing_herkx(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
 
     CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
     CHECK_HIPBLAS_ERROR(
         hipblasHerkxFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
 

--- a/clients/include/testing_herkx_batched.hpp
+++ b/clients/include/testing_herkx_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_herkx_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasHerkxBatchedFn
         = FORTRAN ? hipblasHerkxBatched<T, U, true> : hipblasHerkxBatched<T, U, false>;
@@ -31,14 +32,8 @@ hipblasStatus_t testing_herkx_batched(const Arguments& argus)
     hipblasFillMode_t  uplo   = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
-
-    T alpha = argus.get_alpha<T>();
-    U beta  = argus.get_beta<U>();
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    T h_alpha = argus.get_alpha<T>();
+    U h_beta  = argus.get_beta<U>();
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -52,113 +47,159 @@ hipblasStatus_t testing_herkx_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
-    int K1     = (transA == HIPBLAS_OP_N ? K : N);
-    int A_size = lda * K1;
-    int B_size = ldb * K1;
-    int C_size = ldc * N;
+    int    K1     = (transA == HIPBLAS_OP_N ? K : N);
+    size_t A_size = size_t(lda) * K1;
+    size_t B_size = size_t(ldb) * K1;
+    size_t C_size = size_t(ldc) * N;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> hB[batch_count];
-    host_vector<T> hC[batch_count];
-    host_vector<T> hC2[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hB(B_size, 1, batch_count);
+    host_batch_vector<T> hC_host(C_size, 1, batch_count);
+    host_batch_vector<T> hC_device(C_size, 1, batch_count);
+    host_batch_vector<T> hC_gold(C_size, 1, batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bB(batch_count, B_size);
-    device_batch_vector<T> bC(batch_count, C_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dB(B_size, 1, batch_count);
+    device_batch_vector<T> dC(C_size, 1, batch_count);
+    device_vector<T>       d_alpha(1);
+    device_vector<U>       d_beta(1);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dB(batch_count);
-    device_vector<T*, 0, T> dC(batch_count);
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dB.memcheck());
+    CHECK_HIP_ERROR(dC.memcheck());
 
-    int last = batch_count - 1;
-    if(!dA || !dB || !dC || (!bA[last] && A_size) || (!bB[last] && B_size) || (!bC[last] && C_size))
-    {
-        hipblasDestroy(handle);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    hipblas_init(hA, true);
+    hipblas_init(hB);
+    hipblas_init(hC_host);
 
-    // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hA[b]  = host_vector<T>(A_size);
-        hB[b]  = host_vector<T>(B_size);
-        hC[b]  = host_vector<T>(C_size);
-        hC2[b] = host_vector<T>(C_size);
+    hC_device.copy_from(hC_host);
+    hC_gold.copy_from(hC_host);
 
-        srand(1);
-        hipblas_init<T>(hA[b], N, K1, lda);
-        hipblas_init<T>(hB[b], N, K1, ldb);
-        hipblas_init<T>(hC[b], N, N, ldc);
-
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b], sizeof(T) * A_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bB[b], hB[b], sizeof(T) * B_size, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bC[b], hC[b], sizeof(T) * C_size, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, bB, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, bC, sizeof(T*) * batch_count, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dB.transfer_from(hB));
+    CHECK_HIP_ERROR(dC.transfer_from(hC_host));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHerkxBatchedFn(handle,
+                                              uplo,
+                                              transA,
+                                              N,
+                                              K,
+                                              &h_alpha,
+                                              dA.ptr_on_device(),
+                                              lda,
+                                              dB.ptr_on_device(),
+                                              ldb,
+                                              &h_beta,
+                                              dC.ptr_on_device(),
+                                              ldc,
+                                              batch_count));
 
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHerkxBatchedFn(handle,
-                                       uplo,
-                                       transA,
-                                       N,
-                                       K,
-                                       (T*)&alpha,
-                                       dA,
-                                       lda,
-                                       dB,
-                                       ldb,
-                                       (U*)&beta,
-                                       dC,
-                                       ldc,
-                                       batch_count);
+    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
 
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHerkxBatchedFn(handle,
+                                              uplo,
+                                              transA,
+                                              N,
+                                              K,
+                                              d_alpha,
+                                              dA.ptr_on_device(),
+                                              lda,
+                                              dB.ptr_on_device(),
+                                              ldb,
+                                              d_beta,
+                                              dC.ptr_on_device(),
+                                              ldc,
+                                              batch_count));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        hipMemcpy(hC2[b], bC[b], sizeof(T) * C_size, hipMemcpyDeviceToHost);
-    }
+    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_herkx<T>(uplo, transA, N, K, alpha, hA[b], lda, hB[b], ldb, beta, hC[b], ldc);
+            cblas_herkx<T>(
+                uplo, transA, N, K, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, ldc, hC2, hC);
+            unit_check_general<T>(N, N, batch_count, ldc, hC_gold, hC_host);
+            unit_check_general<T>(N, N, batch_count, ldc, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', N, N, ldc, hC_gold, hC_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHerkxBatchedFn(handle,
+                                                      uplo,
+                                                      transA,
+                                                      N,
+                                                      K,
+                                                      d_alpha,
+                                                      dA.ptr_on_device(),
+                                                      lda,
+                                                      dB.ptr_on_device(),
+                                                      ldb,
+                                                      d_beta,
+                                                      dC.ptr_on_device(),
+                                                      ldc,
+                                                      batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_uplo_option,
+                      e_transA_option,
+                      e_N,
+                      e_K,
+                      e_alpha,
+                      e_lda,
+                      e_ldb,
+                      e_beta,
+                      e_ldc,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         herkx_gflop_count<T>(N, K),
+                         herkx_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_herkx_strided_batched.hpp
+++ b/clients/include/testing_herkx_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,9 +14,10 @@ using namespace std;
 
 /* ============================================================================================ */
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_herkx_strided_batched(const Arguments& argus)
 {
+    using U                           = real_t<T>;
     bool FORTRAN                      = argus.fortran;
     auto hipblasHerkxStridedBatchedFn = FORTRAN ? hipblasHerkxStridedBatched<T, U, true>
                                                 : hipblasHerkxStridedBatched<T, U, false>;
@@ -32,14 +33,12 @@ hipblasStatus_t testing_herkx_strided_batched(const Arguments& argus)
     hipblasFillMode_t  uplo     = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA   = char2hipblas_operation(argus.transA_option);
     int                K1       = (transA == HIPBLAS_OP_N ? K : N);
-    hipblasStride      stride_A = lda * K1 * stride_scale;
-    hipblasStride      stride_B = ldb * K1 * stride_scale;
-    hipblasStride      stride_C = ldc * N * stride_scale;
-    int                A_size   = stride_A * batch_count;
-    int                B_size   = stride_B * batch_count;
-    int                C_size   = stride_C * batch_count;
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasStride      stride_A = size_t(lda) * K1 * stride_scale;
+    hipblasStride      stride_B = size_t(ldb) * K1 * stride_scale;
+    hipblasStride      stride_C = size_t(ldc) * N * stride_scale;
+    size_t             A_size   = stride_A * batch_count;
+    size_t             B_size   = stride_B * batch_count;
+    size_t             C_size   = stride_C * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -56,73 +55,85 @@ hipblasStatus_t testing_herkx_strided_batched(const Arguments& argus)
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
     host_vector<T> hB(B_size);
-    host_vector<T> hC(C_size);
-    host_vector<T> hC2(C_size);
+    host_vector<T> hC_host(C_size);
+    host_vector<T> hC_device(C_size);
+    host_vector<T> hC_gold(C_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dC(C_size);
+    device_vector<T> d_alpha(1);
+    device_vector<U> d_beta(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-    double rocblas_error;
+    T h_alpha = argus.get_alpha<T>();
+    U h_beta  = argus.get_beta<U>();
 
-    T alpha = argus.get_alpha<T>();
-    U beta  = argus.get_beta<U>();
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, K1, lda, stride_A, batch_count);
     hipblas_init<T>(hB, N, K1, ldb, stride_B, batch_count);
-    hipblas_init<T>(hC, N, N, ldc, stride_C, batch_count);
+    hipblas_init<T>(hC_host, N, N, ldc, stride_C, batch_count);
+    hC_device = hC_host;
+    hC_gold   = hC_host;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice);
-    hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice);
-    hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(T) * C_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-    if(argus.timing)
-    {
-        gpu_time_used = get_time_us(); // in microseconds
-    }
-
-    for(int iter = 0; iter < 1; iter++)
-    {
-        status = hipblasHerkxStridedBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              (T*)&alpha,
-                                              dA,
-                                              lda,
-                                              stride_A,
-                                              dB,
-                                              ldb,
-                                              stride_B,
-                                              (U*)&beta,
-                                              dC,
-                                              ldc,
-                                              stride_C,
-                                              batch_count);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasHerkxStridedBatchedFn(handle,
+                                                     uplo,
+                                                     transA,
+                                                     N,
+                                                     K,
+                                                     &h_alpha,
+                                                     dA,
+                                                     lda,
+                                                     stride_A,
+                                                     dB,
+                                                     ldb,
+                                                     stride_B,
+                                                     &h_beta,
+                                                     dC,
+                                                     ldc,
+                                                     stride_C,
+                                                     batch_count));
 
     // copy output from device to CPU
-    hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost);
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
 
-    if(argus.unit_check)
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasHerkxStridedBatchedFn(handle,
+                                                     uplo,
+                                                     transA,
+                                                     N,
+                                                     K,
+                                                     d_alpha,
+                                                     dA,
+                                                     lda,
+                                                     stride_A,
+                                                     dB,
+                                                     ldb,
+                                                     stride_B,
+                                                     d_beta,
+                                                     dC,
+                                                     ldc,
+                                                     stride_C,
+                                                     batch_count));
+
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -133,13 +144,13 @@ hipblasStatus_t testing_herkx_strided_batched(const Arguments& argus)
                            transA,
                            N,
                            K,
-                           alpha,
+                           h_alpha,
                            hA.data() + b * stride_A,
                            lda,
                            hB.data() + b * stride_B,
                            ldb,
-                           beta,
-                           hC.data() + b * stride_C,
+                           h_beta,
+                           hC_gold.data() + b * stride_C,
                            ldc);
         }
 
@@ -147,10 +158,72 @@ hipblasStatus_t testing_herkx_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC2.data(), hC.data());
+            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC_gold, hC_host);
+            unit_check_general<T>(N, N, batch_count, ldc, stride_C, hC_gold, hC_device);
+        }
+
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<T>('F', N, N, ldc, stride_C, hC_gold, hC_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', N, N, ldc, stride_C, hC_gold, hC_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasHerkxStridedBatchedFn(handle,
+                                                             uplo,
+                                                             transA,
+                                                             N,
+                                                             K,
+                                                             d_alpha,
+                                                             dA,
+                                                             lda,
+                                                             stride_A,
+                                                             dB,
+                                                             ldb,
+                                                             stride_B,
+                                                             d_beta,
+                                                             dC,
+                                                             ldc,
+                                                             stride_C,
+                                                             batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
+
+        ArgumentModel<e_uplo_option,
+                      e_transA_option,
+                      e_N,
+                      e_K,
+                      e_alpha,
+                      e_lda,
+                      e_stride_a,
+                      e_ldb,
+                      e_stride_b,
+                      e_beta,
+                      e_ldc,
+                      e_stride_c,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         herkx_gflop_count<T>(N, K),
+                         herkx_gbyte_count<T>(N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_trsv.hpp
+++ b/clients/include/testing_trsv.hpp
@@ -30,9 +30,9 @@ hipblasStatus_t testing_trsv(const Arguments& argus)
     hipblasDiagType_t  diag        = char2hipblas_diagonal(char_diag);
     hipblasOperation_t transA      = char2hipblas_operation(char_transA);
 
-    int abs_incx = incx < 0 ? -incx : incx;
-    int size_A   = lda * M;
-    int size_x   = abs_incx * M;
+    int    abs_incx = incx < 0 ? -incx : incx;
+    size_t size_A   = size_t(lda) * M;
+    size_t size_x   = abs_incx * size_t(M);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory

--- a/clients/include/testing_trsv.hpp
+++ b/clients/include/testing_trsv.hpp
@@ -34,24 +34,11 @@ hipblasStatus_t testing_trsv(const Arguments& argus)
     int size_A   = lda * M;
     int size_x   = abs_incx * M;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0)
+    if(M < 0 || lda < 0 || incx == 0)
     {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
-    }
-    else if(lda < 0)
-    {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
-    }
-    else if(incx == 0)
-    {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -60,18 +47,12 @@ hipblasStatus_t testing_trsv(const Arguments& argus)
     host_vector<T> hb(size_x);
     host_vector<T> hx(size_x);
     host_vector<T> hx_or_b_1(size_x);
-    host_vector<T> hx_or_b_2(size_x);
-    host_vector<T> cpu_x_or_b(size_x);
 
     device_vector<T> dA(size_A);
     device_vector<T> dx_or_b(size_x);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblas_error;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -130,34 +111,24 @@ hipblasStatus_t testing_trsv(const Arguments& argus)
 
     // Calculate hb = hA*hx;
     cblas_trmv<T>(uplo, transA, diag, M, hA.data(), lda, hb.data(), incx);
-    cpu_x_or_b = hb; // cpuXorB <- B
-    hx_or_b_1  = hb;
-    hx_or_b_2  = hb;
+    hx_or_b_1 = hb;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice);
-    hipMemcpy(dx_or_b, hx_or_b_1.data(), sizeof(T) * size_x, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(
+        hipMemcpy(dx_or_b, hx_or_b_1.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
 
     /* =====================================================================
            HIPBLAS
     =================================================================== */
     if(argus.unit_check || argus.norm_check)
     {
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasTrsvFn(handle, uplo, transA, diag, M, dA, lda, dx_or_b, incx);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasTrsvFn(handle, uplo, transA, diag, M, dA, lda, dx_or_b, incx));
 
         // copy output from device to CPU
-        hipMemcpy(hx_or_b_1.data(), dx_or_b, sizeof(T) * size_x, hipMemcpyDeviceToHost);
+        CHECK_HIP_ERROR(
+            hipMemcpy(hx_or_b_1.data(), dx_or_b, sizeof(T) * size_x, hipMemcpyDeviceToHost));
 
         // Calculating error
         hipblas_error = std::abs(vector_norm_1<T>(M, abs_incx, hx.data(), hx_or_b_1.data()));
@@ -172,31 +143,17 @@ hipblasStatus_t testing_trsv(const Arguments& argus)
     if(argus.timing)
     {
         hipStream_t stream;
-        status = hipblasGetStream(handle, &stream);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)
         {
             if(iter == argus.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            status = hipblasTrsvFn(handle, uplo, transA, diag, M, dA, lda, dx_or_b, incx);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(
+                hipblasTrsvFn(handle, uplo, transA, diag, M, dA, lda, dx_or_b, incx));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
 
@@ -209,6 +166,5 @@ hipblasStatus_t testing_trsv(const Arguments& argus)
                          hipblas_error);
     }
 
-    hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_trsv_batched.hpp
+++ b/clients/include/testing_trsv_batched.hpp
@@ -32,9 +32,8 @@ hipblasStatus_t testing_trsv_batched(const Arguments& argus)
     hipblasOperation_t transA      = char2hipblas_operation(char_transA);
     int                batch_count = argus.batch_count;
 
-    int abs_incx = incx < 0 ? -incx : incx;
-    int size_A   = lda * M;
-    int size_x   = abs_incx * M;
+    int    abs_incx = incx < 0 ? -incx : incx;
+    size_t size_A   = size_t(lda) * M;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory

--- a/clients/include/testing_trsv_batched.hpp
+++ b/clients/include/testing_trsv_batched.hpp
@@ -36,8 +36,6 @@ hipblasStatus_t testing_trsv_batched(const Arguments& argus)
     int size_A   = lda * M;
     int size_x   = abs_incx * M;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(M < 0 || lda < M || incx == 0 || batch_count < 0)
@@ -50,45 +48,25 @@ hipblasStatus_t testing_trsv_batched(const Arguments& argus)
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T> hA[batch_count];
-    host_vector<T> AAT[batch_count];
-    host_vector<T> hb[batch_count];
-    host_vector<T> hx[batch_count];
-    host_vector<T> hx_or_b_1[batch_count];
-    host_vector<T> hx_or_b_2[batch_count];
-    host_vector<T> cpu_x_or_b[batch_count];
+    host_batch_vector<T> hA(size_A, 1, batch_count);
+    host_batch_vector<T> AAT(size_A, 1, batch_count);
+    host_batch_vector<T> hb(M, incx, batch_count);
+    host_batch_vector<T> hx(M, incx, batch_count);
+    host_batch_vector<T> hx_or_b_1(M, incx, batch_count);
 
-    device_batch_vector<T> bA(batch_count, size_A);
-    device_batch_vector<T> bx_or_b(batch_count, size_x);
+    device_batch_vector<T> dA(size_A, 1, batch_count);
+    device_batch_vector<T> dx_or_b(M, incx, batch_count);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dx_or_b(batch_count);
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dx_or_b.memcheck());
 
-    int last = batch_count - 1;
-    if(!dA || !dx_or_b || (!bA[last] && size_A) || (!bx_or_b[last] && size_x))
-    {
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
-
-    double gpu_time_used, cpu_time_used;
-    double hipblas_error, cumulative_hipblas_error = 0;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error, cumulative_hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     for(int b = 0; b < batch_count; b++)
     {
-        hA[b]         = host_vector<T>(size_A);
-        AAT[b]        = host_vector<T>(size_A);
-        hb[b]         = host_vector<T>(size_x);
-        hx[b]         = host_vector<T>(size_x);
-        hx_or_b_1[b]  = host_vector<T>(size_x);
-        hx_or_b_2[b]  = host_vector<T>(size_x);
-        cpu_x_or_b[b] = host_vector<T>(size_x);
-
         srand(1);
         hipblas_init<T>(hA[b], M, M, lda);
 
@@ -140,54 +118,46 @@ hipblasStatus_t testing_trsv_batched(const Arguments& argus)
                         hA[b][i + j * lda] = hA[b][i + j * lda] / diag;
                 }
         }
+    }
 
-        hipblas_init<T>(hx[b], 1, M, abs_incx);
-        hb[b] = hx[b];
+    hipblas_init(hx, false);
+    hb.copy_from(hx);
 
+    for(int b = 0; b < batch_count; b++)
+    {
         // Calculate hb = hA*hx;
         cblas_trmv<T>(uplo, transA, diag, M, hA[b], lda, hb[b], incx);
-        cpu_x_or_b[b] = hb[b]; // cpuXorB <- B
-        hx_or_b_1[b]  = hb[b];
-        hx_or_b_2[b]  = hb[b];
-
-        // copy data from CPU to device
-        hipMemcpy(bA[b], hA[b], sizeof(T) * size_A, hipMemcpyHostToDevice);
-        hipMemcpy(bx_or_b[b], hx_or_b_1[b], sizeof(T) * size_x, hipMemcpyHostToDevice);
     }
-    hipMemcpy(dA, bA, sizeof(T*) * batch_count, hipMemcpyHostToDevice);
-    hipMemcpy(dx_or_b, bx_or_b, sizeof(T*) * batch_count, hipMemcpyHostToDevice);
+
+    hx_or_b_1.copy_from(hb);
+
+    CHECK_HIP_ERROR(dx_or_b.transfer_from(hx_or_b_1));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
 
     /* =====================================================================
            HIPBLAS
     =================================================================== */
     if(argus.unit_check || argus.norm_check)
     {
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasTrsvBatchedFn(
-            handle, uplo, transA, diag, M, dA, lda, dx_or_b, incx, batch_count);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasTrsvBatchedFn(handle,
+                                                 uplo,
+                                                 transA,
+                                                 diag,
+                                                 M,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx_or_b.ptr_on_device(),
+                                                 incx,
+                                                 batch_count));
 
-        // copy output from device to CPU
-        for(int b = 0; b < batch_count; b++)
-        {
-            hipMemcpy(hx_or_b_1[b], bx_or_b[b], sizeof(T) * size_x, hipMemcpyDeviceToHost);
-        }
+        CHECK_HIP_ERROR(hx_or_b_1.transfer_from(dx_or_b));
 
         // Calculating error
         // For norm_check/bench, currently taking the cumulative sum of errors over all batches
         for(int b = 0; b < batch_count; b++)
         {
-            hipblas_error
-                = std::abs(vector_norm_1<T>(M, abs_incx, hx[b].data(), hx_or_b_1[b].data()));
+            hipblas_error = std::abs(vector_norm_1<T>(M, abs_incx, hx[b], hx_or_b_1[b]));
             if(argus.unit_check)
             {
                 double tolerance = std::numeric_limits<real_t<T>>::epsilon() * 40 * M;
@@ -201,32 +171,25 @@ hipblasStatus_t testing_trsv_batched(const Arguments& argus)
     if(argus.timing)
     {
         hipStream_t stream;
-        status = hipblasGetStream(handle, &stream);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)
         {
             if(iter == argus.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            status = hipblasTrsvBatchedFn(
-                handle, uplo, transA, diag, M, dA, lda, dx_or_b, incx, batch_count);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(hipblasTrsvBatchedFn(handle,
+                                                     uplo,
+                                                     transA,
+                                                     diag,
+                                                     M,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     dx_or_b.ptr_on_device(),
+                                                     incx,
+                                                     batch_count));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
 
@@ -245,6 +208,5 @@ hipblasStatus_t testing_trsv_batched(const Arguments& argus)
                          cumulative_hipblas_error);
     }
 
-    hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_trsv_strided_batched.hpp
+++ b/clients/include/testing_trsv_strided_batched.hpp
@@ -36,8 +36,8 @@ hipblasStatus_t testing_trsv_strided_batched(const Arguments& argus)
     int           abs_incx = incx < 0 ? -incx : incx;
     hipblasStride strideA  = lda * M * stride_scale;
     hipblasStride stridex  = abs_incx * M * stride_scale;
-    int           size_A   = strideA * batch_count;
-    int           size_x   = stridex * batch_count;
+    size_t        size_A   = size_t(strideA) * batch_count;
+    size_t        size_x   = size_t(stridex) * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory

--- a/clients/include/testing_trsv_strided_batched.hpp
+++ b/clients/include/testing_trsv_strided_batched.hpp
@@ -39,8 +39,6 @@ hipblasStatus_t testing_trsv_strided_batched(const Arguments& argus)
     int           size_A   = strideA * batch_count;
     int           size_x   = stridex * batch_count;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(M < 0 || lda < M || !incx || batch_count < 0)
@@ -58,18 +56,12 @@ hipblasStatus_t testing_trsv_strided_batched(const Arguments& argus)
     host_vector<T> hb(size_x);
     host_vector<T> hx(size_x);
     host_vector<T> hx_or_b_1(size_x);
-    host_vector<T> hx_or_b_2(size_x);
-    host_vector<T> cpu_x_or_b(size_x);
 
     device_vector<T> dA(size_A);
     device_vector<T> dx_or_b(size_x);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblas_error, cumulative_hipblas_error = 0;
-    double hipblasGflops, cblas_gflops, hipblasBandwidth;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error, cumulative_hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -123,35 +115,25 @@ hipblasStatus_t testing_trsv_strided_batched(const Arguments& argus)
         cblas_trmv<T>(uplo, transA, diag, M, hAb, lda, hbb, incx);
     }
 
-    cpu_x_or_b = hb; // cpuXorB <- B
-    hx_or_b_1  = hb;
-    hx_or_b_2  = hb;
+    hx_or_b_1 = hb;
 
     // copy data from CPU to device
-    hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice);
-    hipMemcpy(dx_or_b, hx_or_b_1.data(), sizeof(T) * size_x, hipMemcpyHostToDevice);
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(
+        hipMemcpy(dx_or_b, hx_or_b_1.data(), sizeof(T) * size_x, hipMemcpyHostToDevice));
 
     /* =====================================================================
            HIPBLAS
     =================================================================== */
     if(argus.unit_check || argus.norm_check)
     {
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasTrsvStridedBatchedFn(
-            handle, uplo, transA, diag, M, dA, lda, strideA, dx_or_b, incx, stridex, batch_count);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasTrsvStridedBatchedFn(
+            handle, uplo, transA, diag, M, dA, lda, strideA, dx_or_b, incx, stridex, batch_count));
 
         // copy output from device to CPU
-        hipMemcpy(hx_or_b_1.data(), dx_or_b, sizeof(T) * size_x, hipMemcpyDeviceToHost);
+        CHECK_HIP_ERROR(
+            hipMemcpy(hx_or_b_1.data(), dx_or_b, sizeof(T) * size_x, hipMemcpyDeviceToHost));
 
         // Calculating error
         // For norm_check/bench, currently taking the cumulative sum of errors over all batches
@@ -172,42 +154,27 @@ hipblasStatus_t testing_trsv_strided_batched(const Arguments& argus)
     if(argus.timing)
     {
         hipStream_t stream;
-        status = hipblasGetStream(handle, &stream);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)
         {
             if(iter == argus.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            status = hipblasTrsvStridedBatchedFn(handle,
-                                                 uplo,
-                                                 transA,
-                                                 diag,
-                                                 M,
-                                                 dA,
-                                                 lda,
-                                                 strideA,
-                                                 dx_or_b,
-                                                 incx,
-                                                 stridex,
-                                                 batch_count);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(hipblasTrsvStridedBatchedFn(handle,
+                                                            uplo,
+                                                            transA,
+                                                            diag,
+                                                            M,
+                                                            dA,
+                                                            lda,
+                                                            strideA,
+                                                            dx_or_b,
+                                                            incx,
+                                                            stridex,
+                                                            batch_count));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used; // in microseconds
 
@@ -227,6 +194,5 @@ hipblasStatus_t testing_trsv_strided_batched(const Arguments& argus)
                          cumulative_hipblas_error);
     }
 
-    hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Updating trsv, dgmm, geam, gemm, gemm, herk, her2k, and herkx tests.

- Adding `HIPBLAS_POINTER_MODE_DEVICE` tests
- Adding `host_batched_vector`s
- Adding functions to hipblas-bench
- `size_t` updates
- Using updated `hipblasLocalHandle`
- Added back previously removed herkx tests
