### PR TITLE
Add size_t to gemv and hemv

### DIFF
--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -135,7 +135,7 @@ hipblasStatus_t testing_gemv(const Arguments& argus)
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-        hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice);
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
 
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)

--- a/clients/include/testing_gemv_batched.hpp
+++ b/clients/include/testing_gemv_batched.hpp
@@ -71,16 +71,16 @@ hipblasStatus_t testing_gemv_batched(const Arguments& argus)
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);
-    host_batch_vector<T> hx(X_size, 1, batch_count);
-    host_batch_vector<T> hy(Y_size, 1, batch_count);
-    host_batch_vector<T> hy_cpu(Y_size, 1, batch_count);
-    host_batch_vector<T> hy_host(Y_size, 1, batch_count);
-    host_batch_vector<T> hy_device(Y_size, 1, batch_count);
+    host_batch_vector<T> hx(dim_x, incx, batch_count);
+    host_batch_vector<T> hy(dim_y, incy, batch_count);
+    host_batch_vector<T> hy_cpu(dim_y, incy, batch_count);
+    host_batch_vector<T> hy_host(dim_y, incy, batch_count);
+    host_batch_vector<T> hy_device(dim_y, incy, batch_count);
 
     // device pointers
     device_batch_vector<T> dA(A_size, 1, batch_count);
-    device_batch_vector<T> dx(X_size, 1, batch_count);
-    device_batch_vector<T> dy(Y_size, 1, batch_count);
+    device_batch_vector<T> dx(dim_x, incx, batch_count);
+    device_batch_vector<T> dy(dim_y, incy, batch_count);
     device_vector<T>       d_alpha(1);
     device_vector<T>       d_beta(1);
 

--- a/clients/include/testing_gemv_strided_batched.hpp
+++ b/clients/include/testing_gemv_strided_batched.hpp
@@ -33,28 +33,25 @@ hipblasStatus_t testing_gemv_strided_batched(const Arguments& argus)
     hipblasStride stride_x;
     hipblasStride stride_y;
 
-    int A_size = stride_A * batch_count;
-    int X_size;
-    int Y_size;
-
-    int x_els;
-    int y_els;
+    size_t A_size = stride_A * batch_count;
+    size_t X_size, dim_x;
+    size_t Y_size, dim_y;
 
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
 
     if(transA == HIPBLAS_OP_N)
     {
-        x_els = N;
-        y_els = M;
+        dim_x = N;
+        dim_y = M;
     }
     else
     {
-        x_els = M;
-        y_els = N;
+        dim_x = M;
+        dim_y = N;
     }
 
-    stride_x = x_els * incx * stride_scale;
-    stride_y = y_els * incy * stride_scale;
+    stride_x = dim_x * incx * stride_scale;
+    stride_y = dim_y * incy * stride_scale;
     X_size   = stride_x * batch_count;
     Y_size   = stride_y * batch_count;
 
@@ -91,8 +88,8 @@ hipblasStatus_t testing_gemv_strided_batched(const Arguments& argus)
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, x_els, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, y_els, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, dim_x, incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, dim_y, incy, stride_y, batch_count);
 
     // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
     hy_cpu = hy;
@@ -173,15 +170,15 @@ hipblasStatus_t testing_gemv_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, y_els, batch_count, incy, stride_y, hy_cpu, hy_host);
-            unit_check_general<T>(1, y_els, batch_count, incy, stride_y, hy_cpu, hy_device);
+            unit_check_general<T>(1, dim_y, batch_count, incy, stride_y, hy_cpu, hy_host);
+            unit_check_general<T>(1, dim_y, batch_count, incy, stride_y, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host = norm_check_general<T>(
-                'F', 1, y_els, incy, stride_y, hy_cpu, hy_host, batch_count);
+                'F', 1, dim_y, incy, stride_y, hy_cpu, hy_host, batch_count);
             hipblas_error_device = norm_check_general<T>(
-                'F', 1, y_els, incy, stride_y, hy_cpu, hy_device, batch_count);
+                'F', 1, dim_y, incy, stride_y, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_gemv_strided_batched.hpp
+++ b/clients/include/testing_gemv_strided_batched.hpp
@@ -185,7 +185,7 @@ hipblasStatus_t testing_gemv_strided_batched(const Arguments& argus)
     if(argus.timing)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-        hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice);
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
 

--- a/clients/include/testing_hemv_batched.hpp
+++ b/clients/include/testing_hemv_batched.hpp
@@ -26,15 +26,13 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    int A_size = lda * N;
-    int X_size;
-    int Y_size;
+    size_t A_size = size_t(lda) * N;
+    size_t X_size = size_t(incx) * N;
+    size_t Y_size = size_t(incy) * N;
 
     int batch_count = argus.batch_count;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
-    X_size                 = N * incx;
-    Y_size                 = N * incy;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -56,16 +54,16 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);
-    host_batch_vector<T> hx(N, incx, batch_count);
-    host_batch_vector<T> hy(N, incy, batch_count);
-    host_batch_vector<T> hy_host(N, incy, batch_count);
-    host_batch_vector<T> hy_device(N, incy, batch_count);
-    host_batch_vector<T> hy_cpu(N, incy, batch_count);
+    host_batch_vector<T> hx(X_size, 1, batch_count);
+    host_batch_vector<T> hy(Y_size, 1, batch_count);
+    host_batch_vector<T> hy_host(Y_size, 1, batch_count);
+    host_batch_vector<T> hy_device(Y_size, 1, batch_count);
+    host_batch_vector<T> hy_cpu(Y_size, 1, batch_count);
 
     // device arrays
     device_batch_vector<T> dA(A_size, 1, batch_count);
-    device_batch_vector<T> dx(N, incx, batch_count);
-    device_batch_vector<T> dy(N, incy, batch_count);
+    device_batch_vector<T> dx(X_size, 1, batch_count);
+    device_batch_vector<T> dy(Y_size, 1, batch_count);
     device_vector<T>       d_alpha(1);
     device_vector<T>       d_beta(1);
 
@@ -136,8 +134,8 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, N, batch_count, incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {

--- a/clients/include/testing_hemv_strided_batched.hpp
+++ b/clients/include/testing_hemv_strided_batched.hpp
@@ -29,18 +29,14 @@ hipblasStatus_t testing_hemv_strided_batched(const Arguments& argus)
     int    batch_count  = argus.batch_count;
 
     hipblasStride stride_A = lda * N * stride_scale;
-    hipblasStride stride_x;
-    hipblasStride stride_y;
+    hipblasStride stride_x = N * incx * stride_scale;
+    hipblasStride stride_y = N * incy * stride_scale;
 
-    int               A_size = stride_A * batch_count;
-    int               X_size;
-    int               Y_size;
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
-    stride_x = N * incx * stride_scale;
-    stride_y = N * incy * stride_scale;
-    X_size   = stride_x * batch_count;
-    Y_size   = stride_y * batch_count;
+    size_t A_size = stride_A * batch_count;
+    size_t X_size = stride_x * batch_count;
+    size_t Y_size = stride_y * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory


### PR DESCRIPTION
In large matrices `int index = n*lda` exceeds `int` 31 bit datatype capacity which results in a `std::bad_alloc` error. Therefore, change to use `size_t` in place of `int` for index in Level 2 BLAS gemv and hemv.
