### PR TITLE
Call npvt routines from hipBLAS

### DIFF
--- a/clients/gtest/getrf_batched_gtest.cpp
+++ b/clients/gtest/getrf_batched_gtest.cpp
@@ -4,6 +4,7 @@
  * ************************************************************************ */
 
 #include "testing_getrf_batched.hpp"
+#include "testing_getrf_npvt_batched.hpp"
 #include "utility.h"
 #include <math.h>
 #include <stdexcept>
@@ -134,6 +135,94 @@ TEST_P(getrf_batched_gtest, getrf_batched_gtest_double_complex)
     Arguments arg = setup_getrf_batched_arguments(GetParam());
 
     hipblasStatus_t status = testing_getrf_batched<hipblasDoubleComplex, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getrf_batched_gtest, getrf_npvt_batched_gtest_float)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt_batched<float, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getrf_batched_gtest, getrf_npvt_batched_gtest_double)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getrf_batched_gtest, getrf_npvt_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getrf_batched_gtest, getrf_npvt_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrf_gtest.cpp
+++ b/clients/gtest/getrf_gtest.cpp
@@ -4,6 +4,7 @@
  * ************************************************************************ */
 
 #include "testing_getrf.hpp"
+#include "testing_getrf_npvt.hpp"
 #include "utility.h"
 #include <math.h>
 #include <stdexcept>
@@ -136,6 +137,94 @@ TEST_P(getrf_gtest, getrf_gtest_double_complex)
     Arguments arg = setup_getrf_arguments(GetParam());
 
     hipblasStatus_t status = testing_getrf<hipblasDoubleComplex, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(getrf_gtest, getrf_npvt_gtest_float)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt<float, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(getrf_gtest, getrf_npvt_gtest_double)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(getrf_gtest, getrf_npvt_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(getrf_gtest, getrf_npvt_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrf_strided_batched_gtest.cpp
+++ b/clients/gtest/getrf_strided_batched_gtest.cpp
@@ -3,6 +3,7 @@
  *
  * ************************************************************************ */
 
+#include "testing_getrf_npvt_strided_batched.hpp"
 #include "testing_getrf_strided_batched.hpp"
 #include "utility.h"
 #include <math.h>
@@ -136,6 +137,94 @@ TEST_P(getrf_strided_batched_gtest, getrf_strided_batched_gtest_double_complex)
     Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
 
     hipblasStatus_t status = testing_getrf_strided_batched<hipblasDoubleComplex, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(getrf_strided_batched_gtest, getrf_npvt_strided_batched_gtest_float)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt_strided_batched<float, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(getrf_strided_batched_gtest, getrf_npvt_strided_batched_gtest_double)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt_strided_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(getrf_strided_batched_gtest, getrf_npvt_strided_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt_strided_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(getrf_strided_batched_gtest, getrf_npvt_strided_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getrf_npvt_strided_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getri_batched_gtest.cpp
+++ b/clients/gtest/getri_batched_gtest.cpp
@@ -4,6 +4,7 @@
  * ************************************************************************ */
 
 #include "testing_getri_batched.hpp"
+#include "testing_getri_npvt_batched.hpp"
 #include "utility.h"
 #include <math.h>
 #include <stdexcept>
@@ -129,6 +130,94 @@ TEST_P(getri_batched_gtest, getri_batched_gtest_double_complex)
     Arguments arg = setup_getri_batched_arguments(GetParam());
 
     hipblasStatus_t status = testing_getri_batched<hipblasDoubleComplex, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getri_batched_gtest, getri_npvt_batched_gtest_float)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getri_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getri_npvt_batched<float, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getri_batched_gtest, getri_npvt_batched_gtest_double)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getri_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getri_npvt_batched<double, double>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getri_batched_gtest, getri_npvt_batched_gtest_float_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getri_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getri_npvt_batched<hipblasComplex, float>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0 || arg.lda < arg.N || arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(getri_batched_gtest, getri_npvt_batched_gtest_double_complex)
+{
+    // GetParam returns a tuple. The setup routine unpacks the tuple
+    // and initializes arg(Arguments), which will be passed to testing routine.
+
+    Arguments arg = setup_getri_batched_arguments(GetParam());
+
+    hipblasStatus_t status = testing_getri_npvt_batched<hipblasDoubleComplex, double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_getrf_npvt.hpp
+++ b/clients/include/testing_getrf_npvt.hpp
@@ -1,0 +1,109 @@
+/* ************************************************************************
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
+ *
+ * ************************************************************************ */
+
+#include <fstream>
+#include <iostream>
+#include <stdlib.h>
+#include <vector>
+
+#include "testing_common.hpp"
+
+using namespace std;
+
+template <typename T, typename U>
+hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
+{
+    bool FORTRAN        = argus.fortran;
+    auto hipblasGetrfFn = FORTRAN ? hipblasGetrf<T, true> : hipblasGetrf<T, false>;
+
+    int M   = argus.N;
+    int N   = argus.N;
+    int lda = argus.lda;
+
+    int A_size    = lda * N;
+    int Ipiv_size = min(M, N);
+
+    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+
+    // Check to prevent memory allocation error
+    if(M < 0 || N < 0 || lda < M)
+    {
+        return HIPBLAS_STATUS_INVALID_VALUE;
+    }
+
+    // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
+    host_vector<T>   hA(A_size);
+    host_vector<T>   hA1(A_size);
+    host_vector<int> hIpiv(Ipiv_size);
+    host_vector<int> hInfo(1);
+    host_vector<int> hInfo1(1);
+
+    device_vector<T>   dA(A_size);
+    device_vector<int> dInfo(1);
+
+    double gpu_time_used, cpu_time_used;
+    double hipblasGflops, cblas_gflops;
+    double rocblas_error;
+
+    hipblasHandle_t handle;
+    hipblasCreate(&handle);
+
+    // Initial hA on CPU
+    srand(1);
+    hipblas_init<T>(hA, M, N, lda);
+
+    // scale A to avoid singularities
+    for(int i = 0; i < M; i++)
+    {
+        for(int j = 0; j < N; j++)
+        {
+            if(i == j)
+                hA[i + j * lda] += 400;
+            else
+                hA[i + j * lda] -= 4;
+        }
+    }
+
+    // Copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), A_size * sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemset(dInfo, 0, sizeof(int)));
+
+    /* =====================================================================
+           HIPBLAS
+    =================================================================== */
+
+    status = hipblasGetrfFn(handle, N, dA, lda, nullptr, dInfo);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        hipblasDestroy(handle);
+        return status;
+    }
+
+    // Copy output from device to CPU
+    CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hInfo1.data(), dInfo, sizeof(int), hipMemcpyDeviceToHost));
+
+    if(argus.unit_check)
+    {
+        /* =====================================================================
+           CPU LAPACK
+        =================================================================== */
+
+        hInfo[0] = cblas_getrf(M, N, hA.data(), lda, hIpiv.data());
+
+        if(argus.unit_check)
+        {
+            U      eps       = std::numeric_limits<U>::epsilon();
+            double tolerance = eps * 2000;
+
+            double e = norm_check_general<T>('F', M, N, lda, hA.data(), hA1.data());
+            unit_check_error(e, tolerance);
+        }
+    }
+
+    hipblasDestroy(handle);
+    return HIPBLAS_STATUS_SUCCESS;
+}

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -15123,8 +15123,12 @@ hipblasStatus_t hipblasSgetrf(
     hipblasHandle_t handle, const int n, float* A, const int lda, int* ipiv, int* info)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
-        rocsolver_sgetrf((rocblas_handle)handle, n, n, A, lda, ipiv, info)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_sgetrf((rocblas_handle)handle, n, n, A, lda, ipiv, info)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_sgetrf_npvt((rocblas_handle)handle, n, n, A, lda, info)));
 }
 catch(...)
 {
@@ -15135,8 +15139,12 @@ hipblasStatus_t hipblasDgetrf(
     hipblasHandle_t handle, const int n, double* A, const int lda, int* ipiv, int* info)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
-        rocsolver_dgetrf((rocblas_handle)handle, n, n, A, lda, ipiv, info)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_dgetrf((rocblas_handle)handle, n, n, A, lda, ipiv, info)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_dgetrf_npvt((rocblas_handle)handle, n, n, A, lda, info)));
 }
 catch(...)
 {
@@ -15147,8 +15155,12 @@ hipblasStatus_t hipblasCgetrf(
     hipblasHandle_t handle, const int n, hipblasComplex* A, const int lda, int* ipiv, int* info)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_cgetrf(
-        (rocblas_handle)handle, n, n, (rocblas_float_complex*)A, lda, ipiv, info)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_cgetrf(
+            (rocblas_handle)handle, n, n, (rocblas_float_complex*)A, lda, ipiv, info)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_cgetrf_npvt(
+            (rocblas_handle)handle, n, n, (rocblas_float_complex*)A, lda, info)));
 }
 catch(...)
 {
@@ -15163,8 +15175,12 @@ hipblasStatus_t hipblasZgetrf(hipblasHandle_t       handle,
                               int*                  info)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_zgetrf(
-        (rocblas_handle)handle, n, n, (rocblas_double_complex*)A, lda, ipiv, info)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_zgetrf(
+            (rocblas_handle)handle, n, n, (rocblas_double_complex*)A, lda, ipiv, info)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_zgetrf_npvt(
+            (rocblas_handle)handle, n, n, (rocblas_double_complex*)A, lda, info)));
 }
 catch(...)
 {
@@ -15181,8 +15197,12 @@ hipblasStatus_t hipblasSgetrfBatched(hipblasHandle_t handle,
                                      const int       batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_sgetrf_batched(
-        (rocblas_handle)handle, n, n, A, lda, ipiv, n, info, batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_sgetrf_batched(
+            (rocblas_handle)handle, n, n, A, lda, ipiv, n, info, batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_sgetrf_npvt_batched(
+            (rocblas_handle)handle, n, n, A, lda, info, batch_count)));
 }
 catch(...)
 {
@@ -15198,8 +15218,12 @@ hipblasStatus_t hipblasDgetrfBatched(hipblasHandle_t handle,
                                      const int       batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_dgetrf_batched(
-        (rocblas_handle)handle, n, n, A, lda, ipiv, n, info, batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_dgetrf_batched(
+            (rocblas_handle)handle, n, n, A, lda, ipiv, n, info, batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_dgetrf_npvt_batched(
+            (rocblas_handle)handle, n, n, A, lda, info, batch_count)));
 }
 catch(...)
 {
@@ -15215,16 +15239,20 @@ hipblasStatus_t hipblasCgetrfBatched(hipblasHandle_t       handle,
                                      const int             batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(
-        rocBLASStatusToHIPStatus(rocsolver_cgetrf_batched((rocblas_handle)handle,
-                                                          n,
-                                                          n,
-                                                          (rocblas_float_complex**)A,
-                                                          lda,
-                                                          ipiv,
-                                                          n,
-                                                          info,
-                                                          batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(
+            rocBLASStatusToHIPStatus(rocsolver_cgetrf_batched((rocblas_handle)handle,
+                                                              n,
+                                                              n,
+                                                              (rocblas_float_complex**)A,
+                                                              lda,
+                                                              ipiv,
+                                                              n,
+                                                              info,
+                                                              batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_cgetrf_npvt_batched(
+            (rocblas_handle)handle, n, n, (rocblas_float_complex**)A, lda, info, batch_count)));
 }
 catch(...)
 {
@@ -15240,16 +15268,20 @@ hipblasStatus_t hipblasZgetrfBatched(hipblasHandle_t             handle,
                                      const int                   batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(
-        rocBLASStatusToHIPStatus(rocsolver_zgetrf_batched((rocblas_handle)handle,
-                                                          n,
-                                                          n,
-                                                          (rocblas_double_complex**)A,
-                                                          lda,
-                                                          ipiv,
-                                                          n,
-                                                          info,
-                                                          batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(
+            rocBLASStatusToHIPStatus(rocsolver_zgetrf_batched((rocblas_handle)handle,
+                                                              n,
+                                                              n,
+                                                              (rocblas_double_complex**)A,
+                                                              lda,
+                                                              ipiv,
+                                                              n,
+                                                              info,
+                                                              batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_zgetrf_npvt_batched(
+            (rocblas_handle)handle, n, n, (rocblas_double_complex**)A, lda, info, batch_count)));
 }
 catch(...)
 {
@@ -15268,8 +15300,12 @@ hipblasStatus_t hipblasSgetrfStridedBatched(hipblasHandle_t     handle,
                                             const int           batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_sgetrf_strided_batched(
-        (rocblas_handle)handle, n, n, A, lda, strideA, ipiv, strideP, info, batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_sgetrf_strided_batched(
+            (rocblas_handle)handle, n, n, A, lda, strideA, ipiv, strideP, info, batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_sgetrf_npvt_strided_batched(
+            (rocblas_handle)handle, n, n, A, lda, strideA, info, batch_count)));
 }
 catch(...)
 {
@@ -15287,8 +15323,12 @@ hipblasStatus_t hipblasDgetrfStridedBatched(hipblasHandle_t     handle,
                                             const int           batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_dgetrf_strided_batched(
-        (rocblas_handle)handle, n, n, A, lda, strideA, ipiv, strideP, info, batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_dgetrf_strided_batched(
+            (rocblas_handle)handle, n, n, A, lda, strideA, ipiv, strideP, info, batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_dgetrf_npvt_strided_batched(
+            (rocblas_handle)handle, n, n, A, lda, strideA, info, batch_count)));
 }
 catch(...)
 {
@@ -15306,17 +15346,28 @@ hipblasStatus_t hipblasCgetrfStridedBatched(hipblasHandle_t     handle,
                                             const int           batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(
-        rocBLASStatusToHIPStatus(rocsolver_cgetrf_strided_batched((rocblas_handle)handle,
-                                                                  n,
-                                                                  n,
-                                                                  (rocblas_float_complex*)A,
-                                                                  lda,
-                                                                  strideA,
-                                                                  ipiv,
-                                                                  strideP,
-                                                                  info,
-                                                                  batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(
+            rocBLASStatusToHIPStatus(rocsolver_cgetrf_strided_batched((rocblas_handle)handle,
+                                                                      n,
+                                                                      n,
+                                                                      (rocblas_float_complex*)A,
+                                                                      lda,
+                                                                      strideA,
+                                                                      ipiv,
+                                                                      strideP,
+                                                                      info,
+                                                                      batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_cgetrf_npvt_strided_batched((rocblas_handle)handle,
+                                                  n,
+                                                  n,
+                                                  (rocblas_float_complex*)A,
+                                                  lda,
+                                                  strideA,
+                                                  info,
+                                                  batch_count)));
 }
 catch(...)
 {
@@ -15334,17 +15385,28 @@ hipblasStatus_t hipblasZgetrfStridedBatched(hipblasHandle_t       handle,
                                             const int             batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(
-        rocBLASStatusToHIPStatus(rocsolver_zgetrf_strided_batched((rocblas_handle)handle,
-                                                                  n,
-                                                                  n,
-                                                                  (rocblas_double_complex*)A,
-                                                                  lda,
-                                                                  strideA,
-                                                                  ipiv,
-                                                                  strideP,
-                                                                  info,
-                                                                  batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(
+            rocBLASStatusToHIPStatus(rocsolver_zgetrf_strided_batched((rocblas_handle)handle,
+                                                                      n,
+                                                                      n,
+                                                                      (rocblas_double_complex*)A,
+                                                                      lda,
+                                                                      strideA,
+                                                                      ipiv,
+                                                                      strideP,
+                                                                      info,
+                                                                      batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_zgetrf_npvt_strided_batched((rocblas_handle)handle,
+                                                  n,
+                                                  n,
+                                                  (rocblas_double_complex*)A,
+                                                  lda,
+                                                  strideA,
+                                                  info,
+                                                  batch_count)));
 }
 catch(...)
 {
@@ -15974,8 +16036,13 @@ hipblasStatus_t hipblasSgetriBatched(hipblasHandle_t handle,
                                      const int       batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_sgetri_outofplace_batched(
-        (rocblas_handle)handle, n, A, lda, ipiv, n, C, ldc, info, batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_sgetri_outofplace_batched(
+            (rocblas_handle)handle, n, A, lda, ipiv, n, C, ldc, info, batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(
+            rocBLASStatusToHIPStatus(rocsolver_sgetri_npvt_outofplace_batched(
+                (rocblas_handle)handle, n, A, lda, C, ldc, info, batch_count)));
 }
 catch(...)
 {
@@ -15993,8 +16060,13 @@ hipblasStatus_t hipblasDgetriBatched(hipblasHandle_t handle,
                                      const int       batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_dgetri_outofplace_batched(
-        (rocblas_handle)handle, n, A, lda, ipiv, n, C, ldc, info, batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(rocsolver_dgetri_outofplace_batched(
+            (rocblas_handle)handle, n, A, lda, ipiv, n, C, ldc, info, batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(
+            rocBLASStatusToHIPStatus(rocsolver_dgetri_npvt_outofplace_batched(
+                (rocblas_handle)handle, n, A, lda, C, ldc, info, batch_count)));
 }
 catch(...)
 {
@@ -16012,17 +16084,28 @@ hipblasStatus_t hipblasCgetriBatched(hipblasHandle_t       handle,
                                      const int             batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(
-        rocBLASStatusToHIPStatus(rocsolver_cgetri_outofplace_batched((rocblas_handle)handle,
-                                                                     n,
-                                                                     (rocblas_float_complex**)A,
-                                                                     lda,
-                                                                     ipiv,
-                                                                     n,
-                                                                     (rocblas_float_complex**)C,
-                                                                     ldc,
-                                                                     info,
-                                                                     batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(
+            rocBLASStatusToHIPStatus(rocsolver_cgetri_outofplace_batched((rocblas_handle)handle,
+                                                                         n,
+                                                                         (rocblas_float_complex**)A,
+                                                                         lda,
+                                                                         ipiv,
+                                                                         n,
+                                                                         (rocblas_float_complex**)C,
+                                                                         ldc,
+                                                                         info,
+                                                                         batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_cgetri_npvt_outofplace_batched((rocblas_handle)handle,
+                                                     n,
+                                                     (rocblas_float_complex**)A,
+                                                     lda,
+                                                     (rocblas_float_complex**)C,
+                                                     ldc,
+                                                     info,
+                                                     batch_count)));
 }
 catch(...)
 {
@@ -16040,17 +16123,28 @@ hipblasStatus_t hipblasZgetriBatched(hipblasHandle_t             handle,
                                      const int                   batch_count)
 try
 {
-    return HIPBLAS_DEMAND_ALLOC(
-        rocBLASStatusToHIPStatus(rocsolver_zgetri_outofplace_batched((rocblas_handle)handle,
-                                                                     n,
-                                                                     (rocblas_double_complex**)A,
-                                                                     lda,
-                                                                     ipiv,
-                                                                     n,
-                                                                     (rocblas_double_complex**)C,
-                                                                     ldc,
-                                                                     info,
-                                                                     batch_count)));
+    if(ipiv != nullptr)
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_zgetri_outofplace_batched((rocblas_handle)handle,
+                                                n,
+                                                (rocblas_double_complex**)A,
+                                                lda,
+                                                ipiv,
+                                                n,
+                                                (rocblas_double_complex**)C,
+                                                ldc,
+                                                info,
+                                                batch_count)));
+    else
+        return HIPBLAS_DEMAND_ALLOC(rocBLASStatusToHIPStatus(
+            rocsolver_zgetri_npvt_outofplace_batched((rocblas_handle)handle,
+                                                     n,
+                                                     (rocblas_double_complex**)A,
+                                                     lda,
+                                                     (rocblas_double_complex**)C,
+                                                     ldc,
+                                                     info,
+                                                     batch_count)));
 }
 catch(...)
 {


### PR DESCRIPTION
Addresses SWDEV-297252.

This PR allows the getrf and getri routines in hipBLAS to receive null ipiv arrays, disabling pivoting in these routines similarly to cuBLAS.