### PR TITLE
Updating *_ex tests and aux tests

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -451,20 +451,21 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same
             {"trtri", testing_trtri<T>},
             {"trtri_batched", testing_trtri_batched<T>},
             {"trtri_strided_batched", testing_trtri_strided_batched<T>},
-            /*{"set_get_vector", testing_set_get_vector<T>},
-                {"set_get_matrix", testing_set_get_matrix<T>},
-                {"set_get_matrix_async", testing_set_get_matrix_async<T>},
-*/
             {"syrkx", testing_syrkx<T>},
             {"syrkx_batched", testing_syrkx_batched<T>},
             {"syrkx_strided_batched", testing_syrkx_strided_batched<T>},
-
             {"trsm", testing_trsm<T>},
             {"trsm_ex", testing_trsm_ex<T>},
             {"trsm_batched", testing_trsm_batched<T>},
             {"trsm_batched_ex", testing_trsm_batched_ex<T>},
             {"trsm_strided_batched", testing_trsm_strided_batched<T>},
             {"trsm_strided_batched_ex", testing_trsm_strided_batched_ex<T>},
+
+            // Aux
+            {"set_get_vector", testing_set_get_vector<T>},
+            {"set_get_vector_async", testing_set_get_vector_async<T>},
+            {"set_get_matrix", testing_set_get_matrix<T>},
+            {"set_get_matrix_async", testing_set_get_matrix_async<T>},
         };
         run_function(fmap, arg);
     }

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -460,11 +460,11 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same
             {"syrkx_strided_batched", testing_syrkx_strided_batched<T>},
 
             {"trsm", testing_trsm<T>},
-            //{"trsm_ex", testing_trsm_ex<T>},
+            {"trsm_ex", testing_trsm_ex<T>},
             {"trsm_batched", testing_trsm_batched<T>},
-            //{"trsm_batched_ex", testing_trsm_batched_ex<T>},
+            {"trsm_batched_ex", testing_trsm_batched_ex<T>},
             {"trsm_strided_batched", testing_trsm_strided_batched<T>},
-            //{"trsm_strided_batched_ex", testing_trsm_strided_batched_ex<T>},
+            {"trsm_strided_batched_ex", testing_trsm_strided_batched_ex<T>},
         };
         run_function(fmap, arg);
     }
@@ -653,11 +653,11 @@ struct perf_blas<
             {"syrkx_batched", testing_syrkx_batched<T>},
             {"syrkx_strided_batched", testing_syrkx_strided_batched<T>},
             {"trsm", testing_trsm<T>},
-            //{"trsm_ex", testing_trsm_ex<T>},
+            {"trsm_ex", testing_trsm_ex<T>},
             {"trsm_batched", testing_trsm_batched<T>},
-            //{"trsm_batched_ex", testing_trsm_batched_ex<T>},
+            {"trsm_batched_ex", testing_trsm_batched_ex<T>},
             {"trsm_strided_batched", testing_trsm_strided_batched<T>},
-            //{"trsm_strided_batched_ex", testing_trsm_strided_batched_ex<T>},
+            {"trsm_strided_batched_ex", testing_trsm_strided_batched_ex<T>},
 
             {"trmm", testing_trmm<T>},
             {"trmm_batched", testing_trmm_batched<T>},

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -32,10 +32,10 @@
 #include "testing_asum_strided_batched.hpp"
 #include "testing_axpy.hpp"
 #include "testing_axpy_batched.hpp"
-//#include "testing_axpy_batched_ex.hpp"
-//#include "testing_axpy_ex.hpp"
+#include "testing_axpy_batched_ex.hpp"
+#include "testing_axpy_ex.hpp"
 #include "testing_axpy_strided_batched.hpp"
-//#include "testing_axpy_strided_batched_ex.hpp"
+#include "testing_axpy_strided_batched_ex.hpp"
 #include "testing_copy.hpp"
 #include "testing_copy_batched.hpp"
 #include "testing_copy_strided_batched.hpp"
@@ -669,26 +669,26 @@ struct perf_blas_axpy_ex<
     Tx,
     Ty,
     Tex,
-    std::enable_if_t<(std::is_same<Ta, float>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Ty>{}
-                      && std::is_same<Ty, Tex>{})
-                     || (std::is_same<Ta, double>{} && std::is_same<Ta, Tx>{}
-                         && std::is_same<Tx, Ty>{} && std::is_same<Ty, Tex>{})
-                     || (std::is_same<Ta, hipblasHalf>{} && std::is_same<Ta, Tx>{}
-                         && std::is_same<Tx, Ty>{} && std::is_same<Ty, Tex>{})
-                     || (std::is_same<Ta, hipblasComplex>{} && std::is_same<Ta, Tx>{}
-                         && std::is_same<Tx, Ty>{} && std::is_same<Ty, Tex>{})
-                     || (std::is_same<Ta, hipblasDoubleComplex>{} && std::is_same<Ta, Tx>{}
-                         && std::is_same<Tx, Ty>{} && std::is_same<Ty, Tex>{})
-                     || (std::is_same<Ta, hipblasHalf>{} && std::is_same<Ta, Tx>{}
-                         && std::is_same<Tx, Ty>{} && std::is_same<Tex, float>{})>>
+    std::enable_if_t<((std::is_same<Ta, float>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Ty>{}
+                       && std::is_same<Ty, Tex>{})
+                      || (std::is_same<Ta, double>{} && std::is_same<Ta, Tx>{}
+                          && std::is_same<Tx, Ty>{} && std::is_same<Ty, Tex>{})
+                      || (std::is_same<Ta, hipblasHalf>{} && std::is_same<Ta, Tx>{}
+                          && std::is_same<Tx, Ty>{} && std::is_same<Ty, Tex>{})
+                      || (std::is_same<Ta, hipblasComplex>{} && std::is_same<Ta, Tx>{}
+                          && std::is_same<Tx, Ty>{} && std::is_same<Ty, Tex>{})
+                      || (std::is_same<Ta, hipblasDoubleComplex>{} && std::is_same<Ta, Tx>{}
+                          && std::is_same<Tx, Ty>{} && std::is_same<Ty, Tex>{})
+                      || (std::is_same<Ta, hipblasHalf>{} && std::is_same<Ta, Tx>{}
+                          && std::is_same<Tx, Ty>{} && std::is_same<Tex, float>{}))>>
     : hipblas_test_valid
 {
     void operator()(const Arguments& arg)
     {
         static const func_map map = {
-            // {"axpy_ex", testing_axpy_ex<Ta, Tx, Ty, Tex>},
-            // {"axpy_batched_ex", testing_axpy_batched_ex<Ta, Tx, Ty, Tex>},
-            // {"axpy_strided_batched_ex", testing_axpy_strided_batched_ex<Ta, Tx, Ty, Tex>},
+            {"axpy_ex", testing_axpy_ex_template<Ta, Tx, Ty>},
+            {"axpy_batched_ex", testing_axpy_batched_ex_template<Ta, Tx, Ty>},
+            {"axpy_strided_batched_ex", testing_axpy_strided_batched_ex_template<Ta, Tx, Ty>},
         };
         run_function(map, arg);
     }
@@ -963,10 +963,9 @@ int run_bench_test(Arguments& arg)
         else if(!strcmp(function, "rot") || !strcmp(function, "rot_batched")
                 || !strcmp(function, "rot_strided_batched"))
             hipblas_rot_dispatch<perf_blas_rot>(arg);
-        /*
         else if(!strcmp(function, "axpy_ex") || !strcmp(function, "axpy_batched_ex")
                 || !strcmp(function, "axpy_strided_batched_ex"))
-            hipblas_blas1_ex_dispatch<perf_blas_axpy_ex>(arg);*/
+            hipblas_blas1_ex_dispatch<perf_blas_axpy_ex>(arg);
         else
             hipblas_simple_dispatch<perf_blas>(arg);
     }

--- a/clients/gtest/geam_gtest.cpp
+++ b/clients/gtest/geam_gtest.cpp
@@ -177,6 +177,8 @@ TEST_P(geam_gtest, geam_gtest_double_complex)
     }
 }
 
+#ifndef __HIP_PLATFORM_NVCC__
+
 TEST_P(geam_gtest, geam_batched_gtest_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -296,6 +298,8 @@ TEST_P(geam_gtest, geam_strided_batched_gtest_double_complex)
         }
     }
 }
+
+#endif
 
 // This function mainly test the scope of alpha_beta, transA_transB,.the scope of matrix_size_range
 // is small

--- a/clients/gtest/trsm_ex_gtest.cpp
+++ b/clients/gtest/trsm_ex_gtest.cpp
@@ -113,7 +113,7 @@ Arguments setup_trsm_ex_arguments(trsm_ex_tuple tup)
     arg.transA_option = side_uplo_transA_diag[2];
     arg.diag_option   = side_uplo_transA_diag[3];
 
-    arg.timing = 1;
+    arg.timing = 0;
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;

--- a/clients/include/bytes.hpp
+++ b/clients/include/bytes.hpp
@@ -27,6 +27,14 @@ constexpr double set_get_matrix_gbyte_count(int m, int n)
     return (sizeof(T) * m * n * 2.0) / 1e9;
 }
 
+/* \brief byte counts of SET/GET_VECTOR/_ASYNC */
+template <typename T>
+constexpr double set_get_vector_gbyte_count(int n)
+{
+    // calls done in pairs for timing so x 2.0
+    return (sizeof(T) * n * 2.0) / 1e9;
+}
+
 /*
  * ===========================================================================
  *    level 1 BLAS

--- a/clients/include/norm.h
+++ b/clients/include/norm.h
@@ -155,6 +155,9 @@ double vector_norm_1(int M, int incx, T* hx_gold, T* hx)
         max_err_scal += std::abs(hx_gold[i * incx]);
     }
 
+    if(std::abs(max_err_scal) < 1e6)
+        max_err_scal = 1;
+
     return max_err / max_err_scal;
 }
 

--- a/clients/include/testing_axpy_batched.hpp
+++ b/clients/include/testing_axpy_batched.hpp
@@ -110,8 +110,10 @@ hipblasStatus_t testing_axpy_batched(const Arguments& argus)
         }
         if(argus.norm_check)
         {
-            norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_host, batch_count);
-            norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_device, batch_count);
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_device, batch_count);
         }
 
     } // end of if unit check

--- a/clients/include/testing_axpy_batched_ex.hpp
+++ b/clients/include/testing_axpy_batched_ex.hpp
@@ -14,11 +14,10 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Ta, typename Tx = Ta, typename Ty = Tx>
-hipblasStatus_t testing_axpy_batched_ex_template(Arguments argus)
+hipblasStatus_t testing_axpy_batched_ex_template(const Arguments& argus)
 {
     bool FORTRAN                = argus.fortran;
     auto hipblasAxpyBatchedExFn = FORTRAN ? hipblasAxpyBatchedExFortran : hipblasAxpyBatchedEx;
-    hipblasStatus_t status      = HIPBLAS_STATUS_SUCCESS;
 
     int N           = argus.N;
     int incx        = argus.incx;
@@ -44,111 +43,136 @@ hipblasStatus_t testing_axpy_batched_ex_template(Arguments argus)
     int abs_incx = incx < 0 ? -incx : incx;
     int abs_incy = incy < 0 ? -incy : incy;
 
-    int sizeX = N * abs_incx;
-    int sizeY = N * abs_incy;
-    Ta  alpha = argus.alpha;
+    size_t sizeX   = size_t(N) * abs_incx;
+    size_t sizeY   = size_t(N) * abs_incy;
+    Ta     h_alpha = argus.alpha;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_vector<Tx> hx_array[batch_count];
-    host_vector<Ty> hy_array[batch_count];
-    host_vector<Tx> hx_cpu_array[batch_count];
-    host_vector<Ty> hy_cpu_array[batch_count];
+    host_batch_vector<Tx> hx(N, incx, batch_count);
+    host_batch_vector<Ty> hy_host(N, incy, batch_count);
+    host_batch_vector<Ty> hy_device(N, incy, batch_count);
+    host_batch_vector<Ty> hy_cpu(N, incy, batch_count);
 
-    device_batch_vector<Tx> bx_array(batch_count, sizeX);
-    device_batch_vector<Ty> by_array(batch_count, sizeY);
+    device_batch_vector<Tx> dx(N, incx, batch_count);
+    device_batch_vector<Ty> dy(N, incy, batch_count);
+    device_vector<Ta>       d_alpha(1);
 
-    device_vector<Tx*, 0, Tx> dx_array(batch_count);
-    device_vector<Ty*, 0, Ty> dy_array(batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dy.memcheck());
 
-    int last = batch_count - 1;
-    if(!dx_array || !dy_array || (!bx_array[last] && sizeX) || (!by_array[last] && sizeY))
-    {
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
-
-    double gpu_time_used, cpu_time_used;
-    double rocblas_error = 0.0;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hx_array[b]     = host_vector<Tx>(sizeX);
-        hy_array[b]     = host_vector<Ty>(sizeY);
-        hx_cpu_array[b] = host_vector<Tx>(sizeX);
-        hy_cpu_array[b] = host_vector<Ty>(sizeY);
+    hipblas_init(hx, true);
+    hipblas_init(hy_host);
 
-        srand(1);
-        hipblas_init(hx_array[b], 1, N, abs_incx);
-        hipblas_init(hy_array[b], 1, N, abs_incy);
+    hy_device.copy_from(hy_host);
+    hy_cpu.copy_from(hy_host);
 
-        hx_cpu_array[b] = hx_array[b];
-        hy_cpu_array[b] = hy_array[b];
-
-        CHECK_HIP_ERROR(
-            hipMemcpy(bx_array[b], hx_array[b], sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(
-            hipMemcpy(by_array[b], hy_array[b], sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(
-        hipMemcpy(dx_array, bx_array, sizeof(Tx*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(
-        hipMemcpy(dy_array, by_array, sizeof(Ty*) * batch_count, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(dy.transfer_from(hy_host));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(Ta), hipMemcpyHostToDevice));
 
     /* =====================================================================
-         ROCBLAS
+         HIPBLAS
     =================================================================== */
-    status = hipblasAxpyBatchedExFn(handle,
-                                    N,
-                                    &alpha,
-                                    alphaType,
-                                    dx_array,
-                                    xType,
-                                    incx,
-                                    dy_array,
-                                    yType,
-                                    incy,
-                                    batch_count,
-                                    executionType);
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasAxpyBatchedExFn(handle,
+                                               N,
+                                               &h_alpha,
+                                               alphaType,
+                                               dx.ptr_on_device(),
+                                               xType,
+                                               incx,
+                                               dy.ptr_on_device(),
+                                               yType,
+                                               incy,
+                                               batch_count,
+                                               executionType));
 
-    for(int b = 0; b < batch_count; b++)
-    {
-        // copy output from device to CPU
-        CHECK_HIP_ERROR(
-            hipMemcpy(hx_array[b], bx_array[b], sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(
-            hipMemcpy(hy_array[b], by_array[b], sizeof(Ty) * sizeY, hipMemcpyDeviceToHost));
-    }
+    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+    CHECK_HIP_ERROR(dy.transfer_from(hy_device));
 
-    if(argus.unit_check)
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasAxpyBatchedExFn(handle,
+                                               N,
+                                               d_alpha,
+                                               alphaType,
+                                               dx.ptr_on_device(),
+                                               xType,
+                                               incx,
+                                               dy.ptr_on_device(),
+                                               yType,
+                                               incy,
+                                               batch_count,
+                                               executionType));
+
+    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_axpy(N, alpha, hx_cpu_array[b].data(), incx, hy_cpu_array[b].data(), incy);
+            cblas_axpy(N, h_alpha, hx[b], incx, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<Tx>(1, N, batch_count, abs_incx, hx_cpu_array, hx_array);
-            unit_check_general<Ty>(1, N, batch_count, abs_incy, hy_cpu_array, hy_array);
+            unit_check_general<Ty>(1, N, batch_count, abs_incx, hy_cpu, hy_host);
+            unit_check_general<Ty>(1, N, batch_count, abs_incy, hy_cpu, hy_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<Ty>('F', 1, N, abs_incy, hy_cpu, hy_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<Ty>('F', 1, N, abs_incy, hy_cpu, hy_device, batch_count);
         }
 
     } // end of if unit check
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasAxpyBatchedExFn(handle,
+                                                       N,
+                                                       d_alpha,
+                                                       alphaType,
+                                                       dx.ptr_on_device(),
+                                                       xType,
+                                                       incx,
+                                                       dy.ptr_on_device(),
+                                                       yType,
+                                                       incy,
+                                                       batch_count,
+                                                       executionType));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<Ta>(std::cout,
+                                                                         argus,
+                                                                         gpu_time_used,
+                                                                         axpy_gflop_count<Ta>(N),
+                                                                         axpy_gbyte_count<Ta>(N),
+                                                                         hipblas_error_host,
+                                                                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_axpy_ex.hpp
+++ b/clients/include/testing_axpy_ex.hpp
@@ -14,11 +14,10 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Ta, typename Tx = Ta, typename Ty = Tx>
-hipblasStatus_t testing_axpy_ex_template(Arguments argus)
+hipblasStatus_t testing_axpy_ex_template(const Arguments& argus)
 {
-    bool            FORTRAN         = argus.fortran;
-    auto            hipblasAxpyExFn = FORTRAN ? hipblasAxpyExFortran : hipblasAxpyEx;
-    hipblasStatus_t status          = HIPBLAS_STATUS_SUCCESS;
+    bool FORTRAN         = argus.fortran;
+    auto hipblasAxpyExFn = FORTRAN ? hipblasAxpyExFortran : hipblasAxpyEx;
 
     int N    = argus.N;
     int incx = argus.incx;
@@ -39,70 +38,99 @@ hipblasStatus_t testing_axpy_ex_template(Arguments argus)
     int abs_incx = incx < 0 ? -incx : incx;
     int abs_incy = incy < 0 ? -incy : incy;
 
-    int sizeX = N * abs_incx;
-    int sizeY = N * abs_incy;
-    Ta  alpha = argus.alpha;
+    size_t sizeX   = size_t(N) * abs_incx;
+    size_t sizeY   = size_t(N) * abs_incy;
+    Ta     h_alpha = argus.alpha;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx(sizeX);
-    host_vector<Ty> hy(sizeY);
-    host_vector<Tx> hx_cpu(sizeX);
+    host_vector<Ty> hy_host(sizeY);
+    host_vector<Tx> hy_device(sizeX);
     host_vector<Ty> hy_cpu(sizeY);
 
     device_vector<Tx> dx(sizeX);
     device_vector<Ty> dy(sizeX);
+    device_vector<Ta> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double rocblas_error = 0.0;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<Tx>(hx, 1, N, abs_incx);
-    hipblas_init<Ty>(hy, 1, N, abs_incy);
+    hipblas_init<Ty>(hy_host, 1, N, abs_incy);
 
-    // copy vector is easy in STL; hx_cpu = hx: save a copy in hx_cpu which will be output of CPU BLAS
-    hx_cpu = hx;
-    hy_cpu = hy;
+    hy_device = hy_host;
+    hy_cpu    = hy_host;
 
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy_host, sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(Ta), hipMemcpyHostToDevice));
 
     /* =====================================================================
-         ROCBLAS
+         HIPBLAS
     =================================================================== */
-    status = hipblasAxpyExFn(
-        handle, N, &alpha, alphaType, dx, xType, incx, dy, yType, incy, executionType);
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasAxpyExFn(
+        handle, N, &h_alpha, alphaType, dx, xType, incx, dy, yType, incy, executionType));
 
     // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(Ty) * sizeY, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy_host, dy, sizeof(Ty) * sizeY, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy_device, sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
 
-    if(argus.unit_check)
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasAxpyExFn(
+        handle, N, d_alpha, alphaType, dx, xType, incx, dy, yType, incy, executionType));
+    CHECK_HIP_ERROR(hipMemcpy(hy_device, dy, sizeof(Ty) * sizeY, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_axpy(N, alpha, hx_cpu.data(), incx, hy_cpu.data(), incy);
+        cblas_axpy(N, h_alpha, hx.data(), incx, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<Tx>(1, N, abs_incx, hx_cpu.data(), hx.data());
-            unit_check_general<Ty>(1, N, abs_incy, hy_cpu.data(), hy.data());
+            unit_check_general<Ty>(1, N, abs_incx, hy_cpu, hy_host);
+            unit_check_general<Ty>(1, N, abs_incy, hy_cpu, hy_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = norm_check_general<Ty>('F', 1, N, abs_incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<Ty>('F', 1, N, abs_incy, hy_cpu, hy_device);
         }
 
     } // end of if unit check
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasAxpyExFn(
+                handle, N, d_alpha, alphaType, dx, xType, incx, dy, yType, incy, executionType));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy>{}.log_args<Ta>(std::cout,
+                                                          argus,
+                                                          gpu_time_used,
+                                                          axpy_gflop_count<Ta>(N),
+                                                          axpy_gbyte_count<Ta>(N),
+                                                          hipblas_error_host,
+                                                          hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -31,8 +31,8 @@ hipblasStatus_t testing_dot(const Arguments& argus)
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    int sizeX = N * incx;
-    int sizeY = N * incy;
+    size_t sizeX = size_t(N) * incx;
+    size_t sizeY = size_t(N) * incy;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(sizeX);

--- a/clients/include/testing_dot_batched_ex.hpp
+++ b/clients/include/testing_dot_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,7 +14,7 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Tx, typename Ty = Tx, typename Tr = Ty, typename Tex = Tr, bool CONJ = false>
-hipblasStatus_t testing_dot_batched_ex_template(Arguments argus)
+hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
 {
     bool FORTRAN = argus.fortran;
     auto hipblasDotBatchedExFn
@@ -42,108 +42,64 @@ hipblasStatus_t testing_dot_batched_ex_template(Arguments argus)
     hipblasDatatype_t resultType    = argus.c_type;
     hipblasDatatype_t executionType = argus.compute_type;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-
-    int sizeX = N * incx;
-    int sizeY = N * incy;
-
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_vector<Tx> hx[batch_count];
-    host_vector<Ty> hy[batch_count];
-    host_vector<Tr> h_cpu_result(batch_count);
-    host_vector<Tr> h_rocblas_result1(batch_count);
-    host_vector<Tr> h_rocblas_result2(batch_count);
+    host_batch_vector<Tx> hx(N, incx, batch_count);
+    host_batch_vector<Ty> hy(N, incy, batch_count);
+    host_vector<Tr>       h_cpu_result(batch_count);
+    host_vector<Tr>       h_hipblas_result_host(batch_count);
+    host_vector<Tr>       h_hipblas_result_device(batch_count);
 
-    device_batch_vector<Tx> bx(batch_count, sizeX);
-    device_batch_vector<Ty> by(batch_count, sizeY);
+    device_batch_vector<Tx> dx(N, incx, batch_count);
+    device_batch_vector<Ty> dy(N, incy, batch_count);
+    device_vector<Tr>       d_hipblas_result(batch_count);
 
-    device_vector<Tx*, 0, Tx> dx(batch_count);
-    device_vector<Ty*, 0, Ty> dy(batch_count);
-    device_vector<Tr>         d_rocblas_result(batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
+    CHECK_HIP_ERROR(dy.memcheck());
 
-    int last = batch_count - 1;
-    if(!dx || !dy || !d_rocblas_result || (!bx[last] && sizeX) || (!by[last] && sizeY))
-    {
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
-
-    int device_pointer = 1;
-    int host_pointer   = 1;
-
-    double gpu_time_used, cpu_time_used;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hx[b] = host_vector<Tx>(sizeX);
-        hy[b] = host_vector<Ty>(sizeY);
-
-        srand(1);
-        hipblas_init_alternating_sign<Tx>(hx[b], 1, N, incx);
-        hipblas_init<Ty>(hy[b], 1, N, incy);
-
-        CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(by[b], hy[b], sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dx, bx, batch_count * sizeof(Tx*), hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, by, batch_count * sizeof(Ty*), hipMemcpyHostToDevice));
+    hipblas_init(hy, true);
+    hipblas_init_alternating_sign(hx);
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
+    CHECK_HIP_ERROR(dy.transfer_from(hy));
 
     /* =====================================================================
-         ROCBLAS
+         HIPBLAS
     =================================================================== */
-    // hipblasDot accept both dev/host pointer for the scalar
-    if(host_pointer)
-    {
-        hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-        status_1 = (hipblasDotBatchedExFn)(handle,
-                                           N,
-                                           dx,
-                                           xType,
-                                           incx,
-                                           dy,
-                                           yType,
-                                           incy,
-                                           batch_count,
-                                           d_rocblas_result,
-                                           resultType,
-                                           executionType);
-    }
-    if(device_pointer)
-    {
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasDotBatchedExFn(handle,
+                                              N,
+                                              dx.ptr_on_device(),
+                                              xType,
+                                              incx,
+                                              dy.ptr_on_device(),
+                                              yType,
+                                              incy,
+                                              batch_count,
+                                              h_hipblas_result_host,
+                                              resultType,
+                                              executionType));
 
-        hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        status_2 = (hipblasDotBatchedExFn)(handle,
-                                           N,
-                                           dx,
-                                           xType,
-                                           incx,
-                                           dy,
-                                           yType,
-                                           incy,
-                                           batch_count,
-                                           h_rocblas_result2,
-                                           resultType,
-                                           executionType);
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasDotBatchedExFn(handle,
+                                              N,
+                                              dx.ptr_on_device(),
+                                              xType,
+                                              incx,
+                                              dy.ptr_on_device(),
+                                              yType,
+                                              incy,
+                                              batch_count,
+                                              d_hipblas_result,
+                                              resultType,
+                                              executionType));
 
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS))
-    {
-        hipblasDestroy(handle);
-        if(status_1 != HIPBLAS_STATUS_SUCCESS)
-            return status_1;
-        if(status_2 != HIPBLAS_STATUS_SUCCESS)
-            return status_2;
-    }
-
-    if(device_pointer)
-        CHECK_HIP_ERROR(hipMemcpy(
-            h_rocblas_result1, d_rocblas_result, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                              d_hipblas_result,
+                              sizeof(Tr) * batch_count,
+                              hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {
@@ -158,13 +114,56 @@ hipblasStatus_t testing_dot_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_rocblas_result1);
-            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_rocblas_result2);
+            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_host);
+            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host = norm_check_general<Tr>(
+                'F', 1, batch_count, 1, h_cpu_result, h_hipblas_result_host);
+            hipblas_error_device = norm_check_general<Tr>(
+                'F', 1, batch_count, 1, h_cpu_result, h_hipblas_result_device);
         }
 
     } // end of if unit/norm check
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasDotBatchedExFn(handle,
+                                                      N,
+                                                      dx.ptr_on_device(),
+                                                      xType,
+                                                      incx,
+                                                      dy.ptr_on_device(),
+                                                      yType,
+                                                      incy,
+                                                      batch_count,
+                                                      d_hipblas_result,
+                                                      resultType,
+                                                      executionType));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy, e_batch_count>{}.log_args<Tx>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            dot_gflop_count<CONJ, Tx>(N),
+            dot_gbyte_count<Tx>(N),
+            hipblas_error_host,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_dot_strided_batched_ex.hpp
+++ b/clients/include/testing_dot_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,7 +14,7 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Tx, typename Ty = Tx, typename Tr = Ty, typename Tex = Tr, bool CONJ = false>
-hipblasStatus_t testing_dot_strided_batched_ex_template(Arguments argus)
+hipblasStatus_t testing_dot_strided_batched_ex_template(const Arguments& argus)
 {
     bool FORTRAN = argus.fortran;
     auto hipblasDotStridedBatchedExFn
@@ -27,10 +27,10 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(Arguments argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stridex = N * incx * stride_scale;
-    hipblasStride stridey = N * incy * stride_scale;
-    int           sizeX   = stridex * batch_count;
-    int           sizeY   = stridey * batch_count;
+    hipblasStride stridex = size_t(N) * incx * stride_scale;
+    hipblasStride stridey = size_t(N) * incy * stride_scale;
+    size_t        sizeX   = stridex * batch_count;
+    size_t        sizeY   = stridey * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -48,25 +48,19 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(Arguments argus)
     hipblasDatatype_t resultType    = argus.c_type;
     hipblasDatatype_t executionType = argus.compute_type;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx(sizeX);
     host_vector<Ty> hy(sizeY);
-    host_vector<Tr> h_rocblas_result1(batch_count);
-    host_vector<Tr> h_rocblas_result2(batch_count);
+    host_vector<Tr> h_hipblas_result_host(batch_count);
+    host_vector<Tr> h_hipblas_result_device(batch_count);
     host_vector<Tr> h_cpu_result(batch_count);
 
     device_vector<Tx> dx(sizeX);
     device_vector<Ty> dy(sizeY);
-    device_vector<Tr> d_rocblas_result(batch_count);
+    device_vector<Tr> d_hipblas_result(batch_count);
 
-    double gpu_time_used, cpu_time_used;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
@@ -74,64 +68,48 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(Arguments argus)
     hipblas_init<Ty>(hy, 1, N, incy, stridey, batch_count);
 
     // copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
 
     /* =====================================================================
-         ROCBLAS
+         HIPBLAS
     =================================================================== */
-    /* =====================================================================
-                CPU BLAS
-    =================================================================== */
-    // hipblasDot accept both dev/host pointer for the scalar
-    {
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedExFn(handle,
+                                                     N,
+                                                     dx,
+                                                     xType,
+                                                     incx,
+                                                     stridex,
+                                                     dy,
+                                                     yType,
+                                                     incy,
+                                                     stridey,
+                                                     batch_count,
+                                                     h_hipblas_result_host,
+                                                     resultType,
+                                                     executionType));
 
-        hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-        status_1 = (hipblasDotStridedBatchedExFn)(handle,
-                                                  N,
-                                                  dx,
-                                                  xType,
-                                                  incx,
-                                                  stridex,
-                                                  dy,
-                                                  yType,
-                                                  incy,
-                                                  stridey,
-                                                  batch_count,
-                                                  d_rocblas_result,
-                                                  resultType,
-                                                  executionType);
-    }
-    {
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedExFn(handle,
+                                                     N,
+                                                     dx,
+                                                     xType,
+                                                     incx,
+                                                     stridex,
+                                                     dy,
+                                                     yType,
+                                                     incy,
+                                                     stridey,
+                                                     batch_count,
+                                                     d_hipblas_result,
+                                                     resultType,
+                                                     executionType));
 
-        hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        status_2 = (hipblasDotStridedBatchedExFn)(handle,
-                                                  N,
-                                                  dx,
-                                                  xType,
-                                                  incx,
-                                                  stridex,
-                                                  dy,
-                                                  yType,
-                                                  incy,
-                                                  stridey,
-                                                  batch_count,
-                                                  h_rocblas_result2,
-                                                  resultType,
-                                                  executionType);
-    }
-
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS))
-    {
-        hipblasDestroy(handle);
-        if(status_1 != HIPBLAS_STATUS_SUCCESS)
-            return status_1;
-        if(status_2 != HIPBLAS_STATUS_SUCCESS)
-            return status_2;
-    }
-
-    CHECK_HIP_ERROR(hipMemcpy(
-        h_rocblas_result1, d_rocblas_result, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                              d_hipblas_result,
+                              sizeof(Tr) * batch_count,
+                              hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {
@@ -150,13 +128,58 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_rocblas_result1);
-            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_rocblas_result2);
+            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_host);
+            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_device);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error_host = norm_check_general<Tr>(
+                'F', 1, batch_count, 1, h_cpu_result, h_hipblas_result_host);
+            hipblas_error_device = norm_check_general<Tr>(
+                'F', 1, batch_count, 1, h_cpu_result, h_hipblas_result_device);
         }
 
     } // end of if unit/norm check
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedExFn(handle,
+                                                             N,
+                                                             dx,
+                                                             xType,
+                                                             incx,
+                                                             stridex,
+                                                             dy,
+                                                             yType,
+                                                             incy,
+                                                             stridey,
+                                                             batch_count,
+                                                             d_hipblas_result,
+                                                             resultType,
+                                                             executionType));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_stride_x, e_incy, e_stride_y, e_batch_count>{}.log_args<Tx>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            dot_gflop_count<CONJ, Tx>(N),
+            dot_gbyte_count<Tx>(N),
+            hipblas_error_host,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -104,164 +104,161 @@ hipblasStatus_t testing_gemm_batched_ex_template(const Arguments& argus)
     const size_t size_B = static_cast<size_t>(ldb) * static_cast<size_t>(B_col);
     const size_t size_C = static_cast<size_t>(ldc) * static_cast<size_t>(N);
 
-    device_vector<Ta*, 0, Ta> dA(batch_count);
-    device_vector<Tb*, 0, Tb> dB(batch_count);
-    device_vector<Tc*, 0, Tc> dC(batch_count);
-    device_vector<Tex>        d_alpha_Tc(1);
-    device_vector<Tex>        d_beta_Tc(1);
+    device_batch_vector<Ta> dA(size_A, 1, batch_count);
+    device_batch_vector<Tb> dB(size_B, 1, batch_count);
+    device_batch_vector<Tc> dC(size_C, 1, batch_count);
+    device_vector<Tex>      d_alpha(1);
+    device_vector<Tex>      d_beta(1);
 
-    device_batch_vector<Ta> bA(batch_count, size_A);
-    device_batch_vector<Tb> bB(batch_count, size_B);
-    device_batch_vector<Tc> bC(batch_count, size_C);
+    CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dB.memcheck());
+    CHECK_HIP_ERROR(dC.memcheck());
 
-    int last = batch_count - 1;
-    if(!dA || !dB || !dC || !bA[last] || !bB[last] || !bC[last])
-    {
-        PRINT_IF_HIP_ERROR(hipErrorOutOfMemory);
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
+    host_batch_vector<Ta> hA(size_A, 1, batch_count);
+    host_batch_vector<Tb> hB(size_B, 1, batch_count);
+    host_batch_vector<Tc> hC_host(size_C, 1, batch_count);
+    host_batch_vector<Tc> hC_device(size_C, 1, batch_count);
+    host_batch_vector<Tc> hC_gold(size_C, 1, batch_count);
 
-    hipblasHandle_t handle;
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
-    // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<Ta> hA[batch_count];
-    host_vector<Tb> hB[batch_count];
-    host_vector<Tc> hC[batch_count];
-    host_vector<Tc> hC_gold[batch_count];
+    hipblas_init(hA, true);
+    hipblas_init_alternating_sign(hB);
+    hipblas_init(hC_host);
+
+    hC_device.copy_from(hC_host);
+    hC_gold.copy_from(hC_host);
 
     // Initial Data on CPU
     srand(1);
     for(int b = 0; b < batch_count; b++)
     {
-        hA[b]      = host_vector<Ta>(size_A);
-        hB[b]      = host_vector<Tb>(size_B);
-        hC[b]      = host_vector<Tc>(size_C);
-        hC_gold[b] = host_vector<Tc>(size_C);
-
-        hipblas_init<Ta>(hA[b], A_row, A_col, lda);
-        hipblas_init_alternating_sign<Tb>(hB[b], B_row, B_col, ldb);
-        hipblas_init<Tc>(hC[b], M, N, ldc);
-
-        hC_gold[b] = hC[b];
 #ifdef __HIP_PLATFORM_NVCC__
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b].data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(bB[b], hB[b].data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+        CHECK_HIP_ERROR(dB.transfer_from(hB));
 #else
         if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N && layout_pack_int8())
         {
-            vector<Ta> hA_packed(hA[b]);
-            hipblas_packInt8(hA_packed, M, K, lda);
-            CHECK_HIP_ERROR(
-                hipMemcpy(bA[b], hA_packed.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+            host_batch_vector<Ta> hA_packed(size_A, 1, batch_count);
+            hA_packed.copy_from(hA);
+            for(int b = 0; b < batch_count; b++)
+                hipblas_packInt8(hA_packed[b], hA[b], M, K, lda);
+            CHECK_HIP_ERROR(dA.transfer_from(hA_packed));
         }
         else
         {
-            CHECK_HIP_ERROR(
-                hipMemcpy(bA[b], hA[b].data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+            CHECK_HIP_ERROR(dA.transfer_from(hA));
         }
 
         if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N && layout_pack_int8())
         {
-            vector<Tb> hB_packed(hB[b]);
-            hipblas_packInt8(hB_packed, N, K, ldb);
-            CHECK_HIP_ERROR(
-                hipMemcpy(bB[b], hB_packed.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+            host_batch_vector<Tb> hB_packed(size_B, 1, batch_count);
+            hB_packed.copy_from(hB);
+            for(int b = 0; b < batch_count; b++)
+                hipblas_packInt8(hB_packed[b], hB[b], N, K, ldb);
+            CHECK_HIP_ERROR(dB.transfer_from(hB_packed));
         }
         else
         {
-            CHECK_HIP_ERROR(
-                hipMemcpy(bB[b], hB[b].data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+            CHECK_HIP_ERROR(dB.transfer_from(hB));
         }
 #endif
-        CHECK_HIP_ERROR(hipMemcpy(bC[b], hC[b].data(), sizeof(Tc) * size_C, hipMemcpyHostToDevice));
     }
 
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, sizeof(Ta*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, bB, sizeof(Tb*) * batch_count, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, bC, sizeof(Tc*) * batch_count, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dC.transfer_from(hC_host));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha_Tc, sizeof(Tex), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta_Tc, sizeof(Tex), hipMemcpyHostToDevice));
 
-    status = hipblasGemmBatchedExFn(handle,
-                                    transA,
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasGemmBatchedExFn(handle,
+                                               transA,
+                                               transB,
+                                               M,
+                                               N,
+                                               K,
+                                               &h_alpha_Tc,
+                                               (const void**)(Ta**)dA.ptr_on_device(),
+                                               a_type,
+                                               lda,
+                                               (const void**)(Tb**)dB.ptr_on_device(),
+                                               b_type,
+                                               ldb,
+                                               &h_beta_Tc,
+                                               (void**)(Tc**)dC.ptr_on_device(),
+                                               c_type,
+                                               ldc,
+                                               batch_count,
+                                               compute_type,
+                                               algo));
+
+    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasGemmBatchedExFn(handle,
+                                               transA,
+                                               transB,
+                                               M,
+                                               N,
+                                               K,
+                                               d_alpha,
+                                               (const void**)(Ta**)dA.ptr_on_device(),
+                                               a_type,
+                                               lda,
+                                               (const void**)(Tb**)dB.ptr_on_device(),
+                                               b_type,
+                                               ldb,
+                                               d_beta,
+                                               (void**)(Tc**)dC.ptr_on_device(),
+                                               c_type,
+                                               ldc,
+                                               batch_count,
+                                               compute_type,
+                                               algo));
+
+    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
+    if(unit_check || norm_check)
+    {
+        // CPU BLAS
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_gemm<Ta, Tc, Tex>(transA,
                                     transB,
                                     M,
                                     N,
                                     K,
-                                    &h_alpha_Tc,
-                                    (const void**)(Ta**)dA,
-                                    a_type,
+                                    h_alpha_Tc,
+                                    hA[b],
                                     lda,
-                                    (const void**)(Tb**)dB,
-                                    b_type,
+                                    hB[b],
                                     ldb,
-                                    &h_beta_Tc,
-                                    (void**)(Tc**)dC,
-                                    c_type,
-                                    ldc,
-                                    batch_count,
-                                    compute_type,
-                                    algo);
+                                    h_beta_Tc,
+                                    hC_gold[b],
+                                    ldc);
+        }
 
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
+        if(unit_check)
+        {
+            unit_check_general<Tc>(M, N, batch_count, ldc, hC_gold, hC_host);
+            unit_check_general<Tc>(M, N, batch_count, ldc, hC_gold, hC_device);
+        }
 
-        return status;
-    }
-
-    for(int b = 0; b < batch_count; b++)
-    {
-        CHECK_HIP_ERROR(hipMemcpy(hC[b].data(), bC[b], sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
-    }
-
-    // CPU BLAS
-    for(int b = 0; b < batch_count; b++)
-    {
-        cblas_gemm<Ta, Tc, Tex>(transA,
-                                transB,
-                                M,
-                                N,
-                                K,
-                                h_alpha_Tc,
-                                hA[b].data(),
-                                lda,
-                                hB[b].data(),
-                                ldb,
-                                h_beta_Tc,
-                                hC_gold[b].data(),
-                                ldc);
-    }
-
-    double hipblas_error = 0.0;
-    double gpu_time_used = 0.0;
-    // enable unit check, notice unit check is not invasive, but norm check is,
-    // unit check and norm check can not be interchanged their order
-    if(unit_check)
-    {
-        for(int b = 0; b < batch_count; b++)
-            unit_check_general<Tc>(M, N, ldc, hC_gold[b].data(), hC[b].data());
-    }
-    if(norm_check)
-    {
-        hipblas_error = std::abs(norm_check_general<Tc>('F', M, N, lda, hC_gold, hC, batch_count));
+        if(norm_check)
+        {
+            hipblas_error_host
+                = norm_check_general<Tc>('F', M, N, ldc, hC_gold, hC_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<Tc>('F', M, N, ldc, hC_gold, hC_device, batch_count);
+        }
     }
 
     if(timing)
     {
         hipStream_t stream;
-        status = hipblasGetStream(handle, &stream);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
 
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)
@@ -269,32 +266,26 @@ hipblasStatus_t testing_gemm_batched_ex_template(const Arguments& argus)
             if(iter == argus.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            status = hipblasGemmBatchedExFn(handle,
-                                            transA,
-                                            transB,
-                                            M,
-                                            N,
-                                            K,
-                                            &h_alpha_Tc,
-                                            (const void**)(Ta**)dA,
-                                            a_type,
-                                            lda,
-                                            (const void**)(Tb**)dB,
-                                            b_type,
-                                            ldb,
-                                            &h_beta_Tc,
-                                            (void**)(Tc**)dC,
-                                            c_type,
-                                            ldc,
-                                            batch_count,
-                                            compute_type,
-                                            algo);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(hipblasGemmBatchedExFn(handle,
+                                                       transA,
+                                                       transB,
+                                                       M,
+                                                       N,
+                                                       K,
+                                                       &h_alpha_Tc,
+                                                       (const void**)(Ta**)dA.ptr_on_device(),
+                                                       a_type,
+                                                       lda,
+                                                       (const void**)(Tb**)dB.ptr_on_device(),
+                                                       b_type,
+                                                       ldb,
+                                                       &h_beta_Tc,
+                                                       (void**)(Tc**)dC.ptr_on_device(),
+                                                       c_type,
+                                                       ldc,
+                                                       batch_count,
+                                                       compute_type,
+                                                       algo));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
@@ -312,12 +303,11 @@ hipblasStatus_t testing_gemm_batched_ex_template(const Arguments& argus)
                           gpu_time_used,
                           gemm_gflop_count<Tex>(M, N, K),
                           gemm_gbyte_count<Tex>(M, N, K),
-                          hipblas_error);
+                          hipblas_error_host,
+                          hipblas_error_device);
     }
 
-    hipblasDestroy(handle);
-
-    return status;
+    return HIPBLAS_STATUS_SUCCESS;
 }
 
 hipblasStatus_t testing_gemm_batched_ex(const Arguments& argus)

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -104,131 +104,143 @@ hipblasStatus_t testing_gemm_ex_template(const Arguments& argus)
     const size_t size_C = static_cast<size_t>(ldc) * static_cast<size_t>(N);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
-    vector<Ta> hA(size_A);
-    vector<Tb> hB(size_B);
-    vector<Tc> hC(size_C);
-    vector<Tc> hC_gold(size_C);
+    host_vector<Ta> hA(size_A);
+    host_vector<Tb> hB(size_B);
+    host_vector<Tc> hC_host(size_C);
+    host_vector<Tc> hC_device(size_C);
+    host_vector<Tc> hC_gold(size_C);
 
-    device_vector<Ta> dA(size_A);
-    device_vector<Tb> dB(size_B);
-    device_vector<Tc> dC(size_C);
+    device_vector<Ta>  dA(size_A);
+    device_vector<Tb>  dB(size_B);
+    device_vector<Tc>  dC(size_C);
+    device_vector<Tex> d_alpha(1);
+    device_vector<Tex> d_beta(1);
 
-    hipblasHandle_t handle;
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<Ta>(hA, A_row, A_col, lda);
     hipblas_init_alternating_sign<Tb>(hB, B_row, B_col, ldb);
-    hipblas_init<Tc>(hC, M, N, ldc);
+    hipblas_init<Tc>(hC_host, M, N, ldc);
 
-    hC_gold = hC;
+    hC_gold = hC_device = hC_host;
 
     // copy data from CPU to device
 
     // CUDA doesn't do packing
 #ifdef __HIP_PLATFORM_NVCC__
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
 #else
     if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N && layout_pack_int8())
     {
-        vector<Ta> hA_packed(hA);
+        host_vector<Ta> hA_packed(hA);
         hipblas_packInt8(hA_packed, M, K, lda);
-        CHECK_HIP_ERROR(
-            hipMemcpy(dA, hA_packed.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA_packed, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
     }
     else
     {
-        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
     }
 
     if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N && layout_pack_int8())
     {
-        vector<Tb> hB_packed(hB);
+        host_vector<Tb> hB_packed(hB);
         hipblas_packInt8(hB_packed, N, K, ldb);
-        CHECK_HIP_ERROR(
-            hipMemcpy(dB, hB_packed.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dB, hB_packed, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
     }
     else
     {
-        CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
     }
 #endif
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(Tc) * size_C, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha_Tc, sizeof(Tex), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta_Tc, sizeof(Tex), hipMemcpyHostToDevice));
 
-    status = hipblasGemmExFn(handle,
-                             transA,
-                             transB,
-                             M,
-                             N,
-                             K,
-                             &h_alpha_Tc,
-                             dA,
-                             a_type,
-                             lda,
-                             dB,
-                             b_type,
-                             ldb,
-                             &h_beta_Tc,
-                             dC,
-                             c_type,
-                             ldc,
-                             compute_type,
-                             algo);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
+                                        transA,
+                                        transB,
+                                        M,
+                                        N,
+                                        K,
+                                        &h_alpha_Tc,
+                                        dA,
+                                        a_type,
+                                        lda,
+                                        dB,
+                                        b_type,
+                                        ldb,
+                                        &h_beta_Tc,
+                                        dC,
+                                        c_type,
+                                        ldc,
+                                        compute_type,
+                                        algo));
 
-    if(status != HIPBLAS_STATUS_SUCCESS)
+    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
+
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
+                                        transA,
+                                        transB,
+                                        M,
+                                        N,
+                                        K,
+                                        d_alpha,
+                                        dA,
+                                        a_type,
+                                        lda,
+                                        dB,
+                                        b_type,
+                                        ldb,
+                                        d_beta,
+                                        dC,
+                                        c_type,
+                                        ldc,
+                                        compute_type,
+                                        algo));
+
+    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
+
+    if(unit_check || norm_check)
     {
-        hipblasDestroy(handle);
-        return status;
-    }
+        cblas_gemm<Ta, Tc, Tex>(transA,
+                                transB,
+                                M,
+                                N,
+                                K,
+                                h_alpha_Tc,
+                                hA.data(),
+                                lda,
+                                hB.data(),
+                                ldb,
+                                h_beta_Tc,
+                                hC_gold.data(),
+                                ldc);
 
-    CHECK_HIP_ERROR(hipMemcpy(hC.data(), dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
-
-    // CPU BLAS
-    cblas_gemm<Ta, Tc, Tex>(transA,
-                            transB,
-                            M,
-                            N,
-                            K,
-                            h_alpha_Tc,
-                            hA.data(),
-                            lda,
-                            hB.data(),
-                            ldb,
-                            h_beta_Tc,
-                            hC_gold.data(),
-                            ldc);
-
-    double hipblas_error = 0.0;
-    double gpu_time_used = 0.0;
-    // enable unit check, notice unit check is not invasive, but norm check is,
-    // unit check and norm check can not be interchanged their order
-    if(unit_check)
-    {
-        unit_check_general<Tc>(M, N, ldc, hC_gold.data(), hC.data());
-    }
-    if(norm_check)
-    {
-        hipblas_error = std::abs(norm_check_general<Tc>('F', M, N, ldc, hC_gold.data(), hC.data()));
+        if(unit_check)
+        {
+            unit_check_general<Tc>(M, N, ldc, hC_gold, hC_host);
+            unit_check_general<Tc>(M, N, ldc, hC_gold, hC_device);
+        }
+        if(norm_check)
+        {
+            hipblas_error_host = std::abs(norm_check_general<Tc>('F', M, N, ldc, hC_gold, hC_host));
+            hipblas_error_device
+                = std::abs(norm_check_general<Tc>('F', M, N, ldc, hC_gold, hC_device));
+        }
     }
 
     if(timing)
     {
         hipStream_t stream;
-        status = hipblasGetStream(handle, &stream);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
-        status = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
 
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)
@@ -236,31 +248,25 @@ hipblasStatus_t testing_gemm_ex_template(const Arguments& argus)
             if(iter == argus.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            status = hipblasGemmExFn(handle,
-                                     transA,
-                                     transB,
-                                     M,
-                                     N,
-                                     K,
-                                     &h_alpha_Tc,
-                                     dA,
-                                     a_type,
-                                     lda,
-                                     dB,
-                                     b_type,
-                                     ldb,
-                                     &h_beta_Tc,
-                                     dC,
-                                     c_type,
-                                     ldc,
-                                     compute_type,
-                                     algo);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
+                                                transA,
+                                                transB,
+                                                M,
+                                                N,
+                                                K,
+                                                &h_alpha_Tc,
+                                                dA,
+                                                a_type,
+                                                lda,
+                                                dB,
+                                                b_type,
+                                                ldb,
+                                                &h_beta_Tc,
+                                                dC,
+                                                c_type,
+                                                ldc,
+                                                compute_type,
+                                                algo));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
@@ -270,12 +276,11 @@ hipblasStatus_t testing_gemm_ex_template(const Arguments& argus)
                           gpu_time_used,
                           gemm_gflop_count<Tex>(M, N, K),
                           gemm_gbyte_count<Tex>(M, N, K),
-                          hipblas_error);
+                          hipblas_error_host,
+                          hipblas_error_device);
     }
 
-    hipblasDestroy(handle);
-
-    return status;
+    return HIPBLAS_STATUS_SUCCESS;
 }
 
 hipblasStatus_t testing_gemm_ex(const Arguments& argus)

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -75,8 +75,8 @@ hipblasStatus_t testing_nrm2(const Arguments& argus)
 
         if(argus.norm_check)
         {
-            hipblas_error_host   = std::abs((cpu_result - hipblas_result_host) / cpu_result);
-            hipblas_error_device = std::abs((cpu_result - hipblas_result_device) / cpu_result);
+            hipblas_error_host   = vector_norm_1(1, 1, &cpu_result, &hipblas_result_host);
+            hipblas_error_device = vector_norm_1(1, 1, &cpu_result, &hipblas_result_device);
         }
     } // end of if unit/norm check
 

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -89,12 +89,12 @@ hipblasStatus_t testing_nrm2_batched(const Arguments& argus)
         {
             for(int b = 0; b < batch_count; b++)
             {
-                hipblas_error_host = std::max(
-                    Tr(hipblas_error_host),
-                    std::abs((h_cpu_result[b] - h_hipblas_result_host[b]) / h_cpu_result[b]));
+                hipblas_error_host
+                    = std::max(vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_host[b])),
+                               hipblas_error_host);
                 hipblas_error_device = std::max(
-                    Tr(hipblas_error_device),
-                    std::abs((h_cpu_result[b] - h_hipblas_result_device[b]) / h_cpu_result[b]));
+                    vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_device[b])),
+                    hipblas_error_device);
             }
         }
 

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,7 +14,7 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Tx, typename Tr = Tx, typename Tex = Tr>
-hipblasStatus_t testing_nrm2_batched_ex_template(Arguments argus)
+hipblasStatus_t testing_nrm2_batched_ex_template(const Arguments& argus)
 {
     bool FORTRAN                = argus.fortran;
     auto hipblasNrm2BatchedExFn = FORTRAN ? hipblasNrm2BatchedExFortran : hipblasNrm2BatchedEx;
@@ -37,74 +37,51 @@ hipblasStatus_t testing_nrm2_batched_ex_template(Arguments argus)
     hipblasDatatype_t resultType    = argus.b_type;
     hipblasDatatype_t executionType = argus.compute_type;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
-
-    int sizeX = N * incx;
-
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_vector<Tx> hx[batch_count];
-    host_vector<Tr> h_cpu_result(batch_count);
-    host_vector<Tr> h_rocblas_result1(batch_count);
-    host_vector<Tr> h_rocblas_result2(batch_count);
+    host_batch_vector<Tx> hx(N, incx, batch_count);
+    host_vector<Tr>       h_cpu_result(batch_count);
+    host_vector<Tr>       h_hipblas_result_host(batch_count);
+    host_vector<Tr>       h_hipblas_result_device(batch_count);
 
-    device_batch_vector<Tx> bx(batch_count, sizeX);
+    device_batch_vector<Tx> dx(N, incx, batch_count);
+    device_vector<Tr>       d_hipblas_result(batch_count);
 
-    device_vector<Tx*, 0, Tx> dx(batch_count);
-    device_vector<Tr>         d_rocblas_result(batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
 
-    int last = batch_count - 1;
-    if(!dx || !d_rocblas_result || (!bx[last] && sizeX))
-    {
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
-
-    double gpu_time_used, cpu_time_used;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hx[b] = host_vector<Tx>(sizeX);
-
-        srand(1);
-        hipblas_init<Tx>(hx[b], 1, N, incx);
-
-        CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dx, bx, sizeof(Tx*) * batch_count, hipMemcpyHostToDevice));
+    hipblas_init(hx, true);
+    CHECK_HIP_ERROR(dx.transfer_from(hx));
 
     // hipblasNrm2 accept both dev/host pointer for the scalar
-    status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-    status_2 = hipblasNrm2BatchedExFn(
-        handle, N, dx, xType, incx, batch_count, d_rocblas_result, resultType, executionType);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedExFn(handle,
+                                               N,
+                                               dx.ptr_on_device(),
+                                               xType,
+                                               incx,
+                                               batch_count,
+                                               d_hipblas_result,
+                                               resultType,
+                                               executionType));
 
-    status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-    status_4 = hipblasNrm2BatchedExFn(
-        handle, N, dx, xType, incx, batch_count, h_rocblas_result2, resultType, executionType);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedExFn(handle,
+                                               N,
+                                               dx.ptr_on_device(),
+                                               xType,
+                                               incx,
+                                               batch_count,
+                                               h_hipblas_result_host,
+                                               resultType,
+                                               executionType));
 
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
-       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-    {
-        hipblasDestroy(handle);
-        if(status_1 != HIPBLAS_STATUS_SUCCESS)
-            return status_1;
-        if(status_2 != HIPBLAS_STATUS_SUCCESS)
-            return status_2;
-        if(status_3 != HIPBLAS_STATUS_SUCCESS)
-            return status_3;
-        if(status_4 != HIPBLAS_STATUS_SUCCESS)
-            return status_4;
-    }
-
-    CHECK_HIP_ERROR(hipMemcpy(
-        h_rocblas_result1, d_rocblas_result, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                              d_hipblas_result,
+                              sizeof(Tr) * batch_count,
+                              hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {
@@ -119,13 +96,57 @@ hipblasStatus_t testing_nrm2_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, N);
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, N);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_hipblas_result_host, N);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_hipblas_result_device, N);
+        }
+        if(argus.norm_check)
+        {
+            for(int b = 0; b < batch_count; b++)
+            {
+                hipblas_error_host = std::max(
+                    Tr(hipblas_error_host),
+                    Tr(std::abs((h_cpu_result[b] - h_hipblas_result_host[b]) / h_cpu_result[b])));
+                hipblas_error_device = std::max(
+                    Tr(hipblas_error_device),
+                    Tr(std::abs((h_cpu_result[b] - h_hipblas_result_device[b]) / h_cpu_result[b])));
+            }
         }
 
     } // end of if unit/norm check
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedExFn(handle,
+                                                       N,
+                                                       dx.ptr_on_device(),
+                                                       xType,
+                                                       incx,
+                                                       batch_count,
+                                                       d_hipblas_result,
+                                                       resultType,
+                                                       executionType));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_batch_count>{}.log_args<Tx>(std::cout,
+                                                                 argus,
+                                                                 gpu_time_used,
+                                                                 nrm2_gflop_count<Tx>(N),
+                                                                 nrm2_gbyte_count<Tx>(N),
+                                                                 hipblas_error_host,
+                                                                 hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -103,12 +103,12 @@ hipblasStatus_t testing_nrm2_batched_ex_template(const Arguments& argus)
         {
             for(int b = 0; b < batch_count; b++)
             {
-                hipblas_error_host = std::max(
-                    Tr(hipblas_error_host),
-                    Tr(std::abs((h_cpu_result[b] - h_hipblas_result_host[b]) / h_cpu_result[b])));
+                hipblas_error_host
+                    = std::max(vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_host[b])),
+                               hipblas_error_host);
                 hipblas_error_device = std::max(
-                    Tr(hipblas_error_device),
-                    Tr(std::abs((h_cpu_result[b] - h_hipblas_result_device[b]) / h_cpu_result[b])));
+                    vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_device[b])),
+                    hipblas_error_device);
             }
         }
 

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -96,8 +96,8 @@ hipblasStatus_t testing_nrm2_batched_ex_template(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_rocblas_result1, N);
-            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_rocblas_result2, N);
+            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_hipblas_result_host, N);
+            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_hipblas_result_device, N);
         }
         if(argus.norm_check)
         {

--- a/clients/include/testing_nrm2_ex.hpp
+++ b/clients/include/testing_nrm2_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,7 +14,7 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Tx, typename Tr = Tx, typename Tex = Tr>
-hipblasStatus_t testing_nrm2_ex_template(Arguments argus)
+hipblasStatus_t testing_nrm2_ex_template(const Arguments& argus)
 {
     bool FORTRAN         = argus.fortran;
     auto hipblasNrm2ExFn = FORTRAN ? hipblasNrm2ExFortran : hipblasNrm2Ex;
@@ -32,59 +32,37 @@ hipblasStatus_t testing_nrm2_ex_template(Arguments argus)
     hipblasDatatype_t resultType    = argus.b_type;
     hipblasDatatype_t executionType = argus.compute_type;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
-
-    int sizeX = N * incx;
+    size_t sizeX = size_t(N) * incx;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx(sizeX);
 
     device_vector<Tx> dx(sizeX);
-    device_vector<Tr> d_rocblas_result(1);
+    device_vector<Tr> d_hipblas_result(1);
 
-    Tr cpu_result, rocblas_result_1, rocblas_result_2;
+    Tr cpu_result, hipblas_result_host, hipblas_result_device;
 
-    double gpu_time_used, cpu_time_used;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<Tx>(hx, 1, N, incx);
 
     // copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
 
     // hipblasNrm2 accept both dev/host pointer for the scalar
-    status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-    status_2
-        = hipblasNrm2ExFn(handle, N, dx, xType, incx, d_rocblas_result, resultType, executionType);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(
+        hipblasNrm2ExFn(handle, N, dx, xType, incx, d_hipblas_result, resultType, executionType));
 
-    status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-    status_4
-        = hipblasNrm2ExFn(handle, N, dx, xType, incx, &rocblas_result_1, resultType, executionType);
-
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
-       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-    {
-        hipblasDestroy(handle);
-        if(status_1 != HIPBLAS_STATUS_SUCCESS)
-            return status_1;
-        if(status_2 != HIPBLAS_STATUS_SUCCESS)
-            return status_2;
-        if(status_3 != HIPBLAS_STATUS_SUCCESS)
-            return status_3;
-        if(status_4 != HIPBLAS_STATUS_SUCCESS)
-            return status_4;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasNrm2ExFn(
+        handle, N, dx, xType, incx, &hipblas_result_host, resultType, executionType));
 
     CHECK_HIP_ERROR(
-        hipMemcpy(&rocblas_result_2, d_rocblas_result, sizeof(Tr), hipMemcpyDeviceToHost));
+        hipMemcpy(&hipblas_result_device, d_hipblas_result, sizeof(Tr), hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {
@@ -97,13 +75,42 @@ hipblasStatus_t testing_nrm2_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr>(cpu_result, rocblas_result_1, N);
-            unit_check_nrm2<Tr>(cpu_result, rocblas_result_2, N);
+            unit_check_nrm2<Tr>(cpu_result, hipblas_result_host, N);
+            unit_check_nrm2<Tr>(cpu_result, hipblas_result_device, N);
         }
-
+        if(argus.norm_check)
+        {
+            hipblas_error_host   = std::abs((cpu_result - hipblas_result_host) / cpu_result);
+            hipblas_error_device = std::abs((cpu_result - hipblas_result_device) / cpu_result);
+        }
     } // end of if unit/norm check
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasNrm2ExFn(
+                handle, N, dx, xType, incx, d_hipblas_result, resultType, executionType));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx>{}.log_args<Tx>(std::cout,
+                                                  argus,
+                                                  gpu_time_used,
+                                                  nrm2_gflop_count<Tx>(N),
+                                                  nrm2_gbyte_count<Tx>(N),
+                                                  hipblas_error_host,
+                                                  hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_nrm2_ex.hpp
+++ b/clients/include/testing_nrm2_ex.hpp
@@ -75,8 +75,8 @@ hipblasStatus_t testing_nrm2_ex_template(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr, Tex>(cpu_result, rocblas_result_1, N);
-            unit_check_nrm2<Tr, Tex>(cpu_result, rocblas_result_2, N);
+            unit_check_nrm2<Tr, Tex>(cpu_result, hipblas_result_host, N);
+            unit_check_nrm2<Tr, Tex>(cpu_result, hipblas_result_device, N);
         }
         if(argus.norm_check)
         {

--- a/clients/include/testing_nrm2_ex.hpp
+++ b/clients/include/testing_nrm2_ex.hpp
@@ -80,8 +80,8 @@ hipblasStatus_t testing_nrm2_ex_template(const Arguments& argus)
         }
         if(argus.norm_check)
         {
-            hipblas_error_host   = std::abs((cpu_result - hipblas_result_host) / cpu_result);
-            hipblas_error_device = std::abs((cpu_result - hipblas_result_device) / cpu_result);
+            hipblas_error_host   = vector_norm_1(1, 1, &cpu_result, &hipblas_result_host);
+            hipblas_error_device = vector_norm_1(1, 1, &cpu_result, &hipblas_result_device);
         }
     } // end of if unit/norm check
 

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -93,12 +93,12 @@ hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
         {
             for(int b = 0; b < batch_count; b++)
             {
-                hipblas_error_host = std::max(
-                    Tr(hipblas_error_host),
-                    std::abs((h_cpu_result[b] - h_hipblas_result_host[b]) / h_cpu_result[b]));
+                hipblas_error_host
+                    = std::max(vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_host[b])),
+                               hipblas_error_host);
                 hipblas_error_device = std::max(
-                    Tr(hipblas_error_device),
-                    std::abs((h_cpu_result[b] - h_hipblas_result_device[b]) / h_cpu_result[b]));
+                    vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_device[b])),
+                    hipblas_error_device);
             }
         }
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -111,12 +111,12 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
         {
             for(int b = 0; b < batch_count; b++)
             {
-                hipblas_error_host = std::max(
-                    Tr(hipblas_error_host),
-                    Tr(std::abs((h_cpu_result[b] - h_hipblas_result_host[b]) / h_cpu_result[b])));
+                hipblas_error_host
+                    = std::max(vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_host[b])),
+                               hipblas_error_host);
                 hipblas_error_device = std::max(
-                    Tr(hipblas_error_device),
-                    Tr(std::abs((h_cpu_result[b] - h_hipblas_result_device[b]) / h_cpu_result[b])));
+                    vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_device[b])),
+                    hipblas_error_device);
             }
         }
 

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,7 +14,7 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Tx, typename Tr = Tx, typename Tex = Tr>
-hipblasStatus_t testing_nrm2_strided_batched_ex_template(Arguments argus)
+hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
 {
     bool FORTRAN = argus.fortran;
     auto hipblasNrm2StridedBatchedExFn
@@ -25,8 +25,8 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(Arguments argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stridex = N * incx * stride_scale;
-    int           sizeX   = stridex * batch_count;
+    hipblasStride stridex = size_t(N) * incx * stride_scale;
+    size_t        sizeX   = stridex * batch_count;
 
     // check to prevent undefined memory allocation error
     if(N < 0 || incx < 0 || batch_count < 0)
@@ -42,74 +42,54 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(Arguments argus)
     hipblasDatatype_t resultType    = argus.b_type;
     hipblasDatatype_t executionType = argus.compute_type;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
-
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx(sizeX);
-    host_vector<Tr> h_rocblas_result1(batch_count);
-    host_vector<Tr> h_rocblas_result2(batch_count);
+    host_vector<Tr> h_hipblas_result_host(batch_count);
+    host_vector<Tr> h_hipblas_result_device(batch_count);
     host_vector<Tr> h_cpu_result(batch_count);
 
     device_vector<Tx> dx(sizeX);
-    device_vector<Tr> d_rocblas_result(batch_count);
+    device_vector<Tr> d_hipblas_result(batch_count);
 
-    double gpu_time_used, cpu_time_used;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<Tx>(hx, 1, N, incx, stridex, batch_count);
 
     // copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
 
     // hipblasNrm2 accept both dev/host pointer for the scalar
-    status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-    status_2 = hipblasNrm2StridedBatchedExFn(handle,
-                                             N,
-                                             dx,
-                                             xType,
-                                             incx,
-                                             stridex,
-                                             batch_count,
-                                             d_rocblas_result,
-                                             resultType,
-                                             executionType);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedExFn(handle,
+                                                      N,
+                                                      dx,
+                                                      xType,
+                                                      incx,
+                                                      stridex,
+                                                      batch_count,
+                                                      d_hipblas_result,
+                                                      resultType,
+                                                      executionType));
 
-    status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-    status_4 = hipblasNrm2StridedBatchedExFn(handle,
-                                             N,
-                                             dx,
-                                             xType,
-                                             incx,
-                                             stridex,
-                                             batch_count,
-                                             h_rocblas_result2,
-                                             resultType,
-                                             executionType);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedExFn(handle,
+                                                      N,
+                                                      dx,
+                                                      xType,
+                                                      incx,
+                                                      stridex,
+                                                      batch_count,
+                                                      h_hipblas_result_host,
+                                                      resultType,
+                                                      executionType));
 
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
-       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-    {
-        hipblasDestroy(handle);
-        if(status_1 != HIPBLAS_STATUS_SUCCESS)
-            return status_1;
-        if(status_2 != HIPBLAS_STATUS_SUCCESS)
-            return status_2;
-        if(status_3 != HIPBLAS_STATUS_SUCCESS)
-            return status_3;
-        if(status_4 != HIPBLAS_STATUS_SUCCESS)
-            return status_4;
-    }
-
-    CHECK_HIP_ERROR(hipMemcpy(
-        h_rocblas_result1, d_rocblas_result, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                              d_hipblas_result,
+                              sizeof(Tr) * batch_count,
+                              hipMemcpyDeviceToHost));
 
     if(argus.unit_check || argus.norm_check)
     {
@@ -124,13 +104,59 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, N);
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, N);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_hipblas_result_host, N);
+            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_hipblas_result_device, N);
+        }
+        if(argus.norm_check)
+        {
+            for(int b = 0; b < batch_count; b++)
+            {
+                hipblas_error_host = std::max(
+                    Tr(hipblas_error_host),
+                    Tr(std::abs((h_cpu_result[b] - h_hipblas_result_host[b]) / h_cpu_result[b])));
+                hipblas_error_device = std::max(
+                    Tr(hipblas_error_device),
+                    Tr(std::abs((h_cpu_result[b] - h_hipblas_result_device[b]) / h_cpu_result[b])));
+            }
         }
 
     } // end of if unit/norm check
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedExFn(handle,
+                                                              N,
+                                                              dx,
+                                                              xType,
+                                                              incx,
+                                                              stridex,
+                                                              batch_count,
+                                                              d_hipblas_result,
+                                                              resultType,
+                                                              executionType));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_stride_x, e_batch_count>{}.log_args<Tx>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            nrm2_gflop_count<Tx>(N),
+            nrm2_gbyte_count<Tx>(N),
+            hipblas_error_host,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -104,8 +104,8 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_rocblas_result1, N);
-            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_rocblas_result2, N);
+            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_hipblas_result_host, N);
+            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_hipblas_result_device, N);
         }
         if(argus.norm_check)
         {

--- a/clients/include/testing_rot_ex.hpp
+++ b/clients/include/testing_rot_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,8 +14,9 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Tex, typename Tx = Tex, typename Tcs = Tx>
-hipblasStatus_t testing_rot_ex_template(Arguments arg)
+hipblasStatus_t testing_rot_ex_template(const Arguments& arg)
 {
+    using Ty            = Tx;
     bool FORTRAN        = arg.fortran;
     auto hipblasRotExFn = FORTRAN ? hipblasRotExFortran : hipblasRotEx;
 
@@ -34,32 +35,30 @@ hipblasStatus_t testing_rot_ex_template(Arguments arg)
     hipblasDatatype_t csType        = arg.c_type;
     hipblasDatatype_t executionType = arg.compute_type;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
-
-    // const Tcs rel_error = std::numeric_limits<Tcs>::epsilon() * 1000;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(arg);
 
     size_t size_x = N * size_t(incx);
     size_t size_y = N * size_t(incy);
 
     device_vector<Tx>  dx(size_x);
-    device_vector<Tx>  dy(size_y);
+    device_vector<Ty>  dy(size_y);
     device_vector<Tcs> dc(1);
     device_vector<Tcs> ds(1);
 
     // Initial Data on CPU
-    host_vector<Tx>  hx(size_x);
-    host_vector<Tx>  hy(size_y);
+    host_vector<Tx>  hx_host(size_x);
+    host_vector<Ty>  hy_host(size_y);
+    host_vector<Tx>  hx_device(size_x);
+    host_vector<Ty>  hy_device(size_y);
+    host_vector<Tx>  hx_cpu(size_x);
+    host_vector<Ty>  hy_cpu(size_y);
     host_vector<Tcs> hc(1);
     host_vector<Tcs> hs(1);
+
     srand(1);
-    hipblas_init<Tx>(hx, 1, N, incx);
-    hipblas_init<Tx>(hy, 1, N, incy);
+    hipblas_init<Tx>(hx_host, 1, N, incx);
+    hipblas_init<Ty>(hy_host, 1, N, incy);
 
     // Random alpha (0 - 10)
     host_vector<int> alpha(1);
@@ -72,67 +71,77 @@ hipblasStatus_t testing_rot_ex_template(Arguments arg)
     // hs[0] = sin(alpha[0]);
 
     // CPU BLAS reference data
-    host_vector<Tx> cx = hx;
-    host_vector<Tx> cy = hy;
+    hx_cpu = hx_device = hx_host;
+    hy_cpu = hy_device = hy_host;
 
-    cblas_rot<Tx, Tcs, Tcs>(N, cx.data(), incx, cy.data(), incy, *hc, *hs);
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx_host, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy_host, sizeof(Ty) * size_y, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(Tcs), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(Tcs), hipMemcpyHostToDevice));
 
-    if(arg.unit_check)
+    // HIPBLAS
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasRotExFn(handle, N, dx, xType, incx, dy, yType, incy, hc, hs, csType, executionType));
+
+    CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy_host, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy_device, sizeof(Ty) * size_y, hipMemcpyHostToDevice));
+
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(
+        hipblasRotExFn(handle, N, dx, xType, incx, dy, yType, incy, dc, ds, csType, executionType));
+
+    CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy_device, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
+
+    if(arg.unit_check || arg.norm_check)
     {
-        // Test host
-        {
-            status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-            CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(Tx) * size_y, hipMemcpyHostToDevice));
-            status_2 = (hipblasRotExFn(
-                handle, N, dx, xType, incx, dy, yType, incy, hc, hs, csType, executionType));
+        cblas_rot<Tx, Tcs, Tcs>(N, hx_cpu.data(), incx, hy_cpu.data(), incy, *hc, *hs);
 
-            host_vector<Tx> rx(size_x);
-            host_vector<Tx> ry(size_y);
-            CHECK_HIP_ERROR(hipMemcpy(rx, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
-            CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(Tx) * size_y, hipMemcpyDeviceToHost));
-            if(arg.unit_check)
-            {
-                unit_check_general(1, N, incx, cx.data(), rx.data());
-                unit_check_general(1, N, incy, cy.data(), ry.data());
-            }
+        if(arg.unit_check)
+        {
+            unit_check_general<Tx>(1, N, incx, hx_cpu, hx_host);
+            unit_check_general<Ty>(1, N, incy, hy_cpu, hy_host);
+            unit_check_general<Tx>(1, N, incx, hx_cpu, hx_device);
+            unit_check_general<Ty>(1, N, incy, hy_cpu, hy_device);
         }
-
-        // Test device
+        if(arg.norm_check)
         {
-            status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-            CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(Tx) * size_y, hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(Tcs), hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(Tcs), hipMemcpyHostToDevice));
-            status_3 = (hipblasRotExFn(
+            hipblas_error_host = norm_check_general<Tx>('F', 1, N, incx, hx_cpu, hx_host);
+            hipblas_error_host += norm_check_general<Ty>('F', 1, N, incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<Tx>('F', 1, N, incx, hx_cpu, hx_device);
+            hipblas_error_device += norm_check_general<Ty>('F', 1, N, incy, hy_cpu, hy_device);
+        }
+    }
+
+    if(arg.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasRotExFn(
                 handle, N, dx, xType, incx, dy, yType, incy, dc, ds, csType, executionType));
-            host_vector<Tx> rx(size_x);
-            host_vector<Tx> ry(size_y);
-            CHECK_HIP_ERROR(hipMemcpy(rx, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
-            CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(Tx) * size_y, hipMemcpyDeviceToHost));
-            if(arg.unit_check)
-            {
-                unit_check_general(1, N, incx, cx.data(), rx.data());
-                unit_check_general(1, N, incy, cy.data(), ry.data());
-            }
         }
-    }
-    if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS)
-       || (status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-    {
-        hipblasDestroy(handle);
-        if(status_1 != HIPBLAS_STATUS_SUCCESS)
-            return status_1;
-        if(status_2 != HIPBLAS_STATUS_SUCCESS)
-            return status_2;
-        if(status_3 != HIPBLAS_STATUS_SUCCESS)
-            return status_3;
-        if(status_4 != HIPBLAS_STATUS_SUCCESS)
-            return status_4;
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_incy>{}.log_args<Tx>(std::cout,
+                                                          arg,
+                                                          gpu_time_used,
+                                                          rot_gflop_count<Tx, Ty, Tcs, Tcs>(N),
+                                                          rot_gbyte_count<Tx>(N),
+                                                          hipblas_error_host,
+                                                          hipblas_error_device);
     }
 
-    hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_rot_strided_batched_ex.hpp
+++ b/clients/include/testing_rot_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -14,8 +14,9 @@ using namespace std;
 /* ============================================================================================ */
 
 template <typename Tex, typename Tx = Tex, typename Tcs = Tx>
-hipblasStatus_t testing_rot_strided_batched_ex_template(Arguments arg)
+hipblasStatus_t testing_rot_strided_batched_ex_template(const Arguments& arg)
 {
+    using Ty     = Tx;
     bool FORTRAN = arg.fortran;
     auto hipblasRotStridedBatchedExFn
         = FORTRAN ? hipblasRotStridedBatchedExFortran : hipblasRotStridedBatchedEx;
@@ -47,51 +48,40 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(Arguments arg)
     hipblasDatatype_t csType        = arg.c_type;
     hipblasDatatype_t executionType = arg.compute_type;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_3 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_4 = HIPBLAS_STATUS_SUCCESS;
-
-    // const Tcs rel_error = std::numeric_limits<Tcs>::epsilon() * 1000;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(arg);
 
     device_vector<Tx>  dx(size_x);
-    device_vector<Tx>  dy(size_y);
+    device_vector<Ty>  dy(size_y);
     device_vector<Tcs> dc(1);
     device_vector<Tcs> ds(1);
 
     // Initial Data on CPU
-    host_vector<Tx>  hx(size_x);
-    host_vector<Tx>  hy(size_y);
+    host_vector<Tx>  hx_host(size_x);
+    host_vector<Ty>  hy_host(size_y);
+    host_vector<Tx>  hx_device(size_x);
+    host_vector<Ty>  hy_device(size_y);
+    host_vector<Tx>  hx_cpu(size_x);
+    host_vector<Ty>  hy_cpu(size_y);
     host_vector<Tcs> hc(1);
     host_vector<Tcs> hs(1);
     srand(1);
-    hipblas_init<Tx>(hx, 1, N, incx, stridex, batch_count);
-    hipblas_init<Tx>(hy, 1, N, incy, stridey, batch_count);
+    hipblas_init<Tx>(hx_host, 1, N, incx, stridex, batch_count);
+    hipblas_init<Tx>(hy_host, 1, N, incy, stridey, batch_count);
 
     hipblas_init<Tcs>(hc, 1, 1, 1);
     hipblas_init<Tcs>(hs, 1, 1, 1);
 
-    // CPU BLAS reference data
-    host_vector<Tx> hx_cpu = hx;
-    host_vector<Tx> hy_cpu = hy;
+    hx_cpu = hx_device = hx_host;
+    hy_cpu = hy_device = hy_host;
 
-    if(arg.unit_check)
-    {
-        for(int b = 0; b < batch_count; b++)
-        {
-            cblas_rot<Tx, Tcs, Tcs>(
-                N, hx_cpu.data() + b * stridex, incx, hy_cpu.data() + b * stridey, incy, *hc, *hs);
-        }
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx_host, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy_host, sizeof(Ty) * size_y, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(Tcs), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(Tcs), hipMemcpyHostToDevice));
 
-        // Test host
-        {
-            status_1 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST);
-            CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(Tx) * size_y, hipMemcpyHostToDevice));
-            status_2 = (hipblasRotStridedBatchedExFn(handle,
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasRotStridedBatchedExFn(handle,
                                                      N,
                                                      dx,
                                                      xType,
@@ -107,44 +97,13 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(Arguments arg)
                                                      batch_count,
                                                      executionType));
 
-            if((status_1 != HIPBLAS_STATUS_SUCCESS) || (status_2 != HIPBLAS_STATUS_SUCCESS))
-            {
-                hipblasDestroy(handle);
-                if(status_1 != HIPBLAS_STATUS_SUCCESS)
-                    return status_1;
-                if(status_2 != HIPBLAS_STATUS_SUCCESS)
-                    return status_2;
-            }
+    CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy_host, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy_device, sizeof(Ty) * size_y, hipMemcpyHostToDevice));
 
-            host_vector<Tx> rx(size_x);
-            host_vector<Tx> ry(size_y);
-            CHECK_HIP_ERROR(hipMemcpy(rx, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
-            CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(Tx) * size_y, hipMemcpyDeviceToHost));
-            if(arg.unit_check)
-            {
-                unit_check_general(1, N, batch_count, incx, stridex, hx_cpu.data(), rx.data());
-                unit_check_general(1, N, batch_count, incy, stridey, hy_cpu.data(), ry.data());
-            }
-        }
-
-        // Test device
-        {
-            status_3 = hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE);
-            CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(Tx) * size_y, hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(Tcs), hipMemcpyHostToDevice));
-            CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(Tcs), hipMemcpyHostToDevice));
-
-            if((status_3 != HIPBLAS_STATUS_SUCCESS) || (status_4 != HIPBLAS_STATUS_SUCCESS))
-            {
-                hipblasDestroy(handle);
-                if(status_3 != HIPBLAS_STATUS_SUCCESS)
-                    return status_3;
-                if(status_4 != HIPBLAS_STATUS_SUCCESS)
-                    return status_4;
-            }
-
-            status_3 = (hipblasRotStridedBatchedExFn(handle,
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasRotStridedBatchedExFn(handle,
                                                      N,
                                                      dx,
                                                      xType,
@@ -159,19 +118,79 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(Arguments arg)
                                                      csType,
                                                      batch_count,
                                                      executionType));
-            host_vector<Tx> rx(size_x);
-            host_vector<Tx> ry(size_y);
-            CHECK_HIP_ERROR(hipMemcpy(rx, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
-            CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(Tx) * size_y, hipMemcpyDeviceToHost));
-            if(arg.unit_check)
-            {
-                unit_check_general(1, N, batch_count, incx, stridex, hx_cpu.data(), rx.data());
-                unit_check_general(1, N, batch_count, incy, stridey, hy_cpu.data(), ry.data());
-            }
+
+    CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hy_device, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
+
+    if(arg.unit_check || arg.norm_check)
+    {
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_rot<Tx, Tcs, Tcs>(
+                N, hx_cpu.data() + b * stridex, incx, hy_cpu.data() + b * stridey, incy, *hc, *hs);
+        }
+
+        if(arg.unit_check)
+        {
+            unit_check_general<Tx>(1, N, batch_count, incx, stridex, hx_cpu, hx_host);
+            unit_check_general<Tx>(1, N, batch_count, incy, stridey, hy_cpu, hy_host);
+            unit_check_general<Ty>(1, N, batch_count, incx, stridex, hx_cpu, hx_device);
+            unit_check_general<Ty>(1, N, batch_count, incy, stridey, hy_cpu, hy_device);
+        }
+
+        if(arg.unit_check)
+        {
+            hipblas_error_host
+                = norm_check_general<Tx>('F', 1, N, incx, stridex, hx_cpu, hx_host, batch_count);
+            hipblas_error_host
+                += norm_check_general<Ty>('F', 1, N, incy, stridey, hy_cpu, hy_host, batch_count);
+            hipblas_error_device
+                = norm_check_general<Tx>('F', 1, N, incx, stridex, hx_cpu, hx_device, batch_count);
+            hipblas_error_device
+                += norm_check_general<Ty>('F', 1, N, incy, stridey, hy_cpu, hy_device, batch_count);
         }
     }
 
-    hipblasDestroy(handle);
+    if(arg.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = arg.cold_iters + arg.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == arg.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasRotStridedBatchedExFn(handle,
+                                                             N,
+                                                             dx,
+                                                             xType,
+                                                             incx,
+                                                             stridex,
+                                                             dy,
+                                                             yType,
+                                                             incy,
+                                                             stridey,
+                                                             dc,
+                                                             ds,
+                                                             csType,
+                                                             batch_count,
+                                                             executionType));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_incx, e_stride_x, e_incy, e_stride_y>{}.log_args<Tx>(
+            std::cout,
+            arg,
+            gpu_time_used,
+            rot_gflop_count<Tx, Ty, Tcs, Tcs>(N),
+            rot_gbyte_count<Tx>(N),
+            hipblas_error_host,
+            hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }
 

--- a/clients/include/testing_rot_strided_batched_ex.hpp
+++ b/clients/include/testing_rot_strided_batched_ex.hpp
@@ -67,7 +67,7 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(const Arguments& arg)
     host_vector<Tcs> hs(1);
     srand(1);
     hipblas_init<Tx>(hx_host, 1, N, incx, stridex, batch_count);
-    hipblas_init<Tx>(hy_host, 1, N, incy, stridey, batch_count);
+    hipblas_init<Ty>(hy_host, 1, N, incy, stridey, batch_count);
 
     hipblas_init<Tcs>(hc, 1, 1, 1);
     hipblas_init<Tcs>(hs, 1, 1, 1);

--- a/clients/include/testing_scal_batched_ex.hpp
+++ b/clients/include/testing_scal_batched_ex.hpp
@@ -26,10 +26,7 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
     int timing      = argus.timing;
     int norm_check  = argus.norm_check;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
-    int sizeX = N * incx;
-    Ta  alpha = argus.get_alpha<Ta>();
+    Ta h_alpha = argus.get_alpha<Ta>();
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -47,59 +44,56 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
     hipblasDatatype_t executionType = argus.compute_type;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_vector<Tx> hx[batch_count];
-    host_vector<Tx> hz[batch_count];
+    host_batch_vector<Tx> hx_host(N, incx, batch_count);
+    host_batch_vector<Tx> hx_device(N, incx, batch_count);
+    host_batch_vector<Tx> hx_cpu(N, incx, batch_count);
 
-    device_batch_vector<Tx> bx(batch_count, sizeX);
-    device_batch_vector<Tx> bz(batch_count, sizeX);
+    device_batch_vector<Tx> dx(N, incx, batch_count);
+    device_vector<Ta>       d_alpha(1);
 
-    device_vector<Tx*, 0, Tx> dx(batch_count);
-    device_vector<Tx*, 0, Tx> dz(batch_count);
+    CHECK_HIP_ERROR(dx.memcheck());
 
-    int last = batch_count - 1;
-    if(!dx || !dz || (!bx[last] && sizeX) || (!bz[last] && sizeX))
-    {
-        return HIPBLAS_STATUS_ALLOC_FAILED;
-    }
-
-    double gpu_time_used = 0.0, cpu_time_used = 0.0;
-    double hipblas_error = 0.0;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        hx[b] = host_vector<Tx>(sizeX);
-        hz[b] = host_vector<Tx>(sizeX);
+    hipblas_init(hx_host, true);
 
-        srand(1);
-        hipblas_init<Tx>(hx[b], 1, N, incx);
-        hz[b] = hx[b];
+    hx_device.copy_from(hx_host);
+    hx_cpu.copy_from(hx_host);
 
-        CHECK_HIP_ERROR(hipMemcpy(bx[b], hx[b], sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
-    }
-    CHECK_HIP_ERROR(hipMemcpy(dx, bx, batch_count * sizeof(Tx*), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dx.transfer_from(hx_host));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(Ta), hipMemcpyHostToDevice));
 
     /* =====================================================================
-         ROCBLAS
+         HIPBLAS
     =================================================================== */
-    status = hipblasScalBatchedExFn(
-        handle, N, &alpha, alphaType, dx, xType, incx, batch_count, executionType);
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasScalBatchedExFn(handle,
+                                               N,
+                                               &h_alpha,
+                                               alphaType,
+                                               dx.ptr_on_device(),
+                                               xType,
+                                               incx,
+                                               batch_count,
+                                               executionType));
 
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIP_ERROR(hx_host.transfer_from(dx));
+    CHECK_HIP_ERROR(dx.transfer_from(hx_device));
 
-    // copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-    {
-        CHECK_HIP_ERROR(hipMemcpy(hx[b], bx[b], sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasScalBatchedExFn(handle,
+                                               N,
+                                               d_alpha,
+                                               alphaType,
+                                               dx.ptr_on_device(),
+                                               xType,
+                                               incx,
+                                               batch_count,
+                                               executionType));
+
+    CHECK_HIP_ERROR(hx_device.transfer_from(dx));
 
     if(unit_check || norm_check)
     {
@@ -108,32 +102,31 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_scal<Tx, Ta>(N, alpha, hz[b], incx);
+            cblas_scal<Tx, Ta>(N, h_alpha, hx_cpu[b], incx);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(unit_check)
         {
-            unit_check_general<Tx>(1, N, batch_count, incx, hz, hx);
+            unit_check_general<Tx>(1, N, batch_count, incx, hx_cpu, hx_host);
+            unit_check_general<Tx>(1, N, batch_count, incx, hx_cpu, hx_device);
         }
 
         if(norm_check)
         {
-            hipblas_error = norm_check_general<Tx>('F', 1, N, incx, hz, hx, batch_count);
+            hipblas_error_host
+                = norm_check_general<Tx>('F', 1, N, incx, hx_cpu, hx_host, batch_count);
+            hipblas_error_host
+                = norm_check_general<Tx>('F', 1, N, incx, hx_cpu, hx_device, batch_count);
         }
-
     } // end of if unit check
 
     if(timing)
     {
         hipStream_t stream;
-        status = hipblasGetStream(handle, &stream);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
 
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)
@@ -141,14 +134,15 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
             if(iter == argus.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            status = hipblasScalBatchedExFn(
-                handle, N, &alpha, alphaType, dx, xType, incx, batch_count, executionType);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(hipblasScalBatchedExFn(handle,
+                                                       N,
+                                                       d_alpha,
+                                                       alphaType,
+                                                       dx.ptr_on_device(),
+                                                       xType,
+                                                       incx,
+                                                       batch_count,
+                                                       executionType));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
@@ -158,10 +152,11 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
             gpu_time_used,
             scal_gflop_count<Tx, Ta>(N),
             scal_gbyte_count<Tx>(N),
-            hipblas_error);
+            hipblas_error_host,
+            hipblas_error_device);
     }
-    hipblasDestroy(handle);
-    return status;
+
+    return HIPBLAS_STATUS_SUCCESS;
 }
 
 hipblasStatus_t testing_scal_batched_ex(const Arguments& argus)

--- a/clients/include/testing_scal_ex.hpp
+++ b/clients/include/testing_scal_ex.hpp
@@ -25,10 +25,8 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
     int timing     = argus.timing;
     int norm_check = argus.norm_check;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
-    int sizeX = N * incx;
-    Ta  alpha = argus.get_alpha<Ta>();
+    size_t sizeX   = size_t(N) * incx;
+    Ta     h_alpha = argus.get_alpha<Ta>();
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -42,56 +40,63 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
     hipblasDatatype_t executionType = argus.compute_type;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_vector<Tx>   hx(sizeX);
-    host_vector<Tx>   hz(sizeX);
+    host_vector<Tx> hx_host(sizeX);
+    host_vector<Tx> hx_device(sizeX);
+    host_vector<Tx> hx_cpu(sizeX);
+
     device_vector<Tx> dx(sizeX);
+    device_vector<Ta> d_alpha(1);
 
-    double gpu_time_used = 0.0, cpu_time_used = 0.0;
-    double hipblas_error = 0.0;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init<Tx>(hx, 1, N, incx);
+    hipblas_init<Tx>(hx_host, 1, N, incx);
 
     // copy vector is easy in STL; hz = hx: save a copy in hz which will be output of CPU BLAS
-    hz = hx;
+    hx_device = hx_cpu = hx_host;
 
     // copy data from CPU to device, does not work for incx != 1
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(Tx) * N * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx_host, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(Ta), hipMemcpyHostToDevice));
 
     /* =====================================================================
-         ROCBLAS
+         HIPBLAS
     =================================================================== */
-    status = hipblasScalExFn(handle, N, &alpha, alphaType, dx, xType, incx, executionType);
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(
+        hipblasScalExFn(handle, N, &h_alpha, alphaType, dx, xType, incx, executionType));
 
     // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(Tx) * N * incx, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
+
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(
+        hipblasScalExFn(handle, N, d_alpha, alphaType, dx, xType, incx, executionType));
+
+    CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
 
     if(unit_check || norm_check)
     {
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_scal<Tx, Ta>(N, alpha, hz.data(), incx);
+        cblas_scal<Tx, Ta>(N, h_alpha, hx_cpu, incx);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order
         if(unit_check)
         {
-            unit_check_general<Tx>(1, N, incx, hz.data(), hx.data());
+            unit_check_general<Tx>(1, N, incx, hx_cpu, hx_host);
+            unit_check_general<Tx>(1, N, incx, hx_cpu, hx_device);
         }
 
         if(norm_check)
         {
-            hipblas_error = norm_check_general<Tx>('F', 1, N, incx, hz.data(), hx.data());
+            hipblas_error_host = norm_check_general<Tx>('F', 1, N, incx, hx_cpu, hx_host);
+            hipblas_error_host = norm_check_general<Tx>('F', 1, N, incx, hx_cpu, hx_device);
         }
 
     } // end of if unit check
@@ -99,12 +104,8 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
     if(timing)
     {
         hipStream_t stream;
-        status = hipblasGetStream(handle, &stream);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
 
         int runs = argus.cold_iters + argus.iters;
         for(int iter = 0; iter < runs; iter++)
@@ -112,13 +113,8 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
             if(iter == argus.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            status = hipblasScalExFn(handle, N, &alpha, alphaType, dx, xType, incx, executionType);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(
+                hipblasScalExFn(handle, N, d_alpha, alphaType, dx, xType, incx, executionType));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 
@@ -127,10 +123,11 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
                                                            gpu_time_used,
                                                            scal_gflop_count<Tx, Ta>(N),
                                                            scal_gbyte_count<Tx>(N),
-                                                           hipblas_error);
+                                                           hipblas_error_host,
+                                                           hipblas_error_device);
     }
-    hipblasDestroy(handle);
-    return status;
+
+    return HIPBLAS_STATUS_SUCCESS;
 }
 
 hipblasStatus_t testing_scal_ex(const Arguments& argus)

--- a/clients/include/testing_set_get_atomics_mode.hpp
+++ b/clients/include/testing_set_get_atomics_mode.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -20,46 +20,25 @@ hipblasStatus_t testing_set_get_atomics_mode(const Arguments& argus)
     auto hipblasSetAtomicsModeFn = FORTRAN ? hipblasSetAtomicsModeFortran : hipblasSetAtomicsMode;
     auto hipblasGetAtomicsModeFn = FORTRAN ? hipblasGetAtomicsModeFortran : hipblasGetAtomicsMode;
 
-    hipblasStatus_t status     = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_set = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_get = HIPBLAS_STATUS_SUCCESS;
-
     hipblasAtomicsMode_t mode;
-    hipblasHandle_t      handle;
-    hipblasCreate(&handle);
+    hipblasLocalHandle   handle(argus);
 
     // Not checking default as rocBLAS defaults to allowed
     // and cuBLAS defaults to not allowed.
-    // status = hipblasGetAtomicsModeFn(handle, &mode);
-    // if(status != HIPBLAS_STATUS_SUCCESS)
-    // {
-    //     hipblasDestroy(handle);
-    //     return status;
-    // }
+    // CHECK_HIPBLAS_ERROR(hipblasGetAtomicsModeFn(handle, &mode));
 
     // EXPECT_EQ(HIPBLAS_ATOMICS_ALLOWED, mode);
 
     // Make sure set()/get() functions work
-    status_set = hipblasSetAtomicsModeFn(handle, HIPBLAS_ATOMICS_NOT_ALLOWED);
-    status_get = hipblasGetAtomicsModeFn(handle, &mode);
-    if(status_set != HIPBLAS_STATUS_SUCCESS || status_get != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status_set != HIPBLAS_STATUS_SUCCESS ? status_set : status_get;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetAtomicsModeFn(handle, HIPBLAS_ATOMICS_NOT_ALLOWED));
+    CHECK_HIPBLAS_ERROR(hipblasGetAtomicsModeFn(handle, &mode));
 
     EXPECT_EQ(HIPBLAS_ATOMICS_NOT_ALLOWED, mode);
 
-    status_set = hipblasSetAtomicsModeFn(handle, HIPBLAS_ATOMICS_ALLOWED);
-    status_get = hipblasGetAtomicsModeFn(handle, &mode);
-    if(status_set != HIPBLAS_STATUS_SUCCESS || status_get != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status_set != HIPBLAS_STATUS_SUCCESS ? status_set : status_get;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetAtomicsModeFn(handle, HIPBLAS_ATOMICS_ALLOWED));
+    CHECK_HIPBLAS_ERROR(hipblasGetAtomicsModeFn(handle, &mode));
 
     EXPECT_EQ(HIPBLAS_ATOMICS_ALLOWED, mode);
 
-    hipblasDestroy(handle);
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_set_get_matrix_async.hpp
+++ b/clients/include/testing_set_get_matrix_async.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -27,16 +27,11 @@ hipblasStatus_t testing_set_get_matrix_async(const Arguments& argus)
     int ldb  = argus.ldb;
     int ldc  = argus.ldc;
 
-    hipblasStatus_t status     = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_set = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_get = HIPBLAS_STATUS_SUCCESS;
-
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(rows < 0 || cols < 0 || lda <= 0 || ldb <= 0 || ldc <= 0)
     {
-        status = HIPBLAS_STATUS_INVALID_VALUE;
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -47,12 +42,8 @@ hipblasStatus_t testing_set_get_matrix_async(const Arguments& argus)
 
     device_vector<T> dc(cols * ldc);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasBandwidth, cpu_bandwidth;
-    double rocblas_error = 0.0;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             hipblas_error = 0.0, gpu_time_used = 0.0;
+    hipblasLocalHandle handle(argus);
 
     hipStream_t stream;
     hipblasGetStream(handle, &stream);
@@ -73,29 +64,16 @@ hipblasStatus_t testing_set_get_matrix_async(const Arguments& argus)
     };
 
     /* =====================================================================
-           ROCBLAS
+           HIPBLAS
     =================================================================== */
-
-    status_set = hipblasSetMatrixAsyncFn(
-        rows, cols, sizeof(T), (void*)ha.data(), lda, (void*)dc, ldc, stream);
-    status_get = hipblasGetMatrixAsyncFn(
-        rows, cols, sizeof(T), (void*)dc, ldc, (void*)hb.data(), ldb, stream);
+    CHECK_HIPBLAS_ERROR(
+        hipblasSetMatrixAsyncFn(rows, cols, sizeof(T), (void*)ha, lda, (void*)dc, ldc, stream));
+    CHECK_HIPBLAS_ERROR(
+        hipblasGetMatrixAsyncFn(rows, cols, sizeof(T), (void*)dc, ldc, (void*)hb, ldb, stream));
 
     hipStreamSynchronize(stream);
 
-    if(status_set != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status_set;
-    }
-
-    if(status_get != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status_get;
-    }
-
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -114,10 +92,40 @@ hipblasStatus_t testing_set_get_matrix_async(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(rows, cols, ldb, hb.data(), hb_ref.data());
+            unit_check_general<T>(rows, cols, ldb, hb, hb_ref);
+        }
+        if(argus.norm_check)
+        {
+            hipblas_error = norm_check_general<T>('F', rows, cols, ldb, hb, hb_ref);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasSetMatrixAsyncFn(
+                rows, cols, sizeof(T), (void*)ha, lda, (void*)dc, ldc, stream));
+            CHECK_HIPBLAS_ERROR(hipblasGetMatrixAsyncFn(
+                rows, cols, sizeof(T), (void*)dc, ldc, (void*)hb, ldb, stream));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_M, e_N, e_lda, e_ldb, e_ldc>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            ArgumentLogging::NA_value,
+            set_get_matrix_gbyte_count<T>(rows, cols),
+            hipblas_error);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_trsm_ex.hpp
+++ b/clients/include/testing_trsm_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -31,18 +31,16 @@ hipblasStatus_t testing_trsm_ex(const Arguments& argus)
     char char_uplo   = argus.uplo_option;
     char char_transA = argus.transA_option;
     char char_diag   = argus.diag_option;
-    T    alpha       = argus.alpha;
+    T    h_alpha     = argus.alpha;
 
     hipblasSideMode_t  side   = char2hipblas_side(char_side);
     hipblasFillMode_t  uplo   = char2hipblas_fill(char_uplo);
     hipblasOperation_t transA = char2hipblas_operation(char_transA);
     hipblasDiagType_t  diag   = char2hipblas_diagonal(char_diag);
 
-    int K      = (side == HIPBLAS_SIDE_LEFT ? M : N);
-    int A_size = lda * K;
-    int B_size = ldb * N;
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    int    K      = (side == HIPBLAS_SIDE_LEFT ? M : N);
+    size_t A_size = size_t(lda) * K;
+    size_t B_size = size_t(ldb) * N;
 
     // check here to prevent undefined memory allocation error
     if(M < 0 || N < 0 || lda < K || ldb < M)
@@ -51,24 +49,21 @@ hipblasStatus_t testing_trsm_ex(const Arguments& argus)
     }
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(B_size);
-    host_vector<T> hB_copy(B_size);
-    host_vector<T> hX(B_size);
+    host_vector<T> hB_host(B_size);
+    host_vector<T> hB_device(B_size);
+    host_vector<T> hB_cpu(B_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dinvA(TRSM_BLOCK * K);
+    device_vector<T> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial hA on CPU
     srand(1);
-    hipblas_init_symmetric<T>(hA, K, lda);
+    hipblas_init(hA, K, K, lda);
     // pad untouched area into zero
     for(int i = K; i < lda; i++)
     {
@@ -78,7 +73,7 @@ hipblasStatus_t testing_trsm_ex(const Arguments& argus)
         }
     }
     // proprocess the matrix to avoid ill-conditioned matrix
-    vector<int> ipiv(K);
+    host_vector<int> ipiv(K);
     cblas_getrf(K, K, hA.data(), lda, ipiv.data());
     for(int i = 0; i < K; i++)
     {
@@ -94,26 +89,35 @@ hipblasStatus_t testing_trsm_ex(const Arguments& argus)
     }
 
     // Initial hB, hX on CPU
-    hipblas_init<T>(hB, M, N, ldb);
+    hipblas_init<T>(hB_host, M, N, ldb);
     // pad untouched area into zero
     for(int i = M; i < ldb; i++)
     {
         for(int j = 0; j < N; j++)
         {
-            hB[i + j * ldb] = 0.0;
+            hB_host[i + j * ldb] = 0.0;
         }
     }
-    hX = hB; // original solution hX
 
     // Calculate hB = hA*hX;
-    cblas_trmm<T>(
-        side, uplo, transA, diag, M, N, T(1.0) / alpha, (const T*)hA.data(), lda, hB.data(), ldb);
+    cblas_trmm<T>(side,
+                  uplo,
+                  transA,
+                  diag,
+                  M,
+                  N,
+                  T(1.0) / h_alpha,
+                  (const T*)hA.data(),
+                  lda,
+                  hB_host.data(),
+                  ldb);
 
-    hB_copy = hB;
+    hB_cpu = hB_device = hB_host;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB_host, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     hipblasStride stride_A    = TRSM_BLOCK * lda + TRSM_BLOCK;
     hipblasStride stride_invA = TRSM_BLOCK * TRSM_BLOCK;
@@ -125,91 +129,144 @@ hipblasStatus_t testing_trsm_ex(const Arguments& argus)
     // Calculate invA
     if(blocks > 0)
     {
-        status = hipblasTrtriStridedBatched<T>(handle,
-                                               uplo,
-                                               diag,
-                                               TRSM_BLOCK,
-                                               dA,
-                                               lda,
-                                               stride_A,
-                                               dinvA,
-                                               TRSM_BLOCK,
-                                               stride_invA,
-                                               blocks);
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasTrtriStridedBatched<T>(handle,
+                                                          uplo,
+                                                          diag,
+                                                          TRSM_BLOCK,
+                                                          dA,
+                                                          lda,
+                                                          stride_A,
+                                                          dinvA,
+                                                          TRSM_BLOCK,
+                                                          stride_invA,
+                                                          blocks));
     }
 
     if(K % TRSM_BLOCK != 0 || blocks == 0)
     {
-        status = hipblasTrtriStridedBatched<T>(handle,
-                                               uplo,
-                                               diag,
-                                               K - TRSM_BLOCK * blocks,
-                                               dA + stride_A * blocks,
-                                               lda,
-                                               stride_A,
-                                               dinvA + stride_invA * blocks,
-                                               TRSM_BLOCK,
-                                               stride_invA,
-                                               1);
-
-        if(blocks > 0)
-        {
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
-        }
+        CHECK_HIPBLAS_ERROR(hipblasTrtriStridedBatched<T>(handle,
+                                                          uplo,
+                                                          diag,
+                                                          K - TRSM_BLOCK * blocks,
+                                                          dA + stride_A * blocks,
+                                                          lda,
+                                                          stride_A,
+                                                          dinvA + stride_invA * blocks,
+                                                          TRSM_BLOCK,
+                                                          stride_invA,
+                                                          1));
     }
 
-    status = hipblasTrsmExFn(handle,
-                             side,
-                             uplo,
-                             transA,
-                             diag,
-                             M,
-                             N,
-                             &alpha,
-                             dA,
-                             lda,
-                             dB,
-                             ldb,
-                             dinvA,
-                             TRSM_BLOCK * K,
-                             argus.compute_type);
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasTrsmExFn(handle,
+                                        side,
+                                        uplo,
+                                        transA,
+                                        diag,
+                                        M,
+                                        N,
+                                        &h_alpha,
+                                        dA,
+                                        lda,
+                                        dB,
+                                        ldb,
+                                        dinvA,
+                                        TRSM_BLOCK * K,
+                                        argus.compute_type));
 
     // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hB.data(), dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hB_host, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB_device, sizeof(T) * B_size, hipMemcpyHostToDevice));
 
-    if(argus.unit_check)
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasTrsmExFn(handle,
+                                        side,
+                                        uplo,
+                                        transA,
+                                        diag,
+                                        M,
+                                        N,
+                                        d_alpha,
+                                        dA,
+                                        lda,
+                                        dB,
+                                        ldb,
+                                        dinvA,
+                                        TRSM_BLOCK * K,
+                                        argus.compute_type));
+
+    CHECK_HIP_ERROR(hipMemcpy(hB_device, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
         =================================================================== */
 
         cblas_trsm<T>(
-            side, uplo, transA, diag, M, N, alpha, (const T*)hA.data(), lda, hB_copy.data(), ldb);
-
-        //      print_matrix(hB_copy, hB, min(M, 3), min(N,3), ldb);
+            side, uplo, transA, diag, M, N, h_alpha, (const T*)hA.data(), lda, hB_cpu.data(), ldb);
 
         // if enable norm check, norm check is invasive
         real_t<T> eps       = std::numeric_limits<real_t<T>>::epsilon();
         double    tolerance = eps * 40 * M;
 
-        double error = norm_check_general<T>('F', M, N, ldb, hB_copy.data(), hB.data());
-        unit_check_error(error, tolerance);
+        hipblas_error_host   = norm_check_general<T>('F', M, N, ldb, hB_cpu, hB_host);
+        hipblas_error_device = norm_check_general<T>('F', M, N, ldb, hB_cpu, hB_device);
+
+        if(argus.unit_check)
+        {
+            unit_check_error(hipblas_error_host, tolerance);
+            unit_check_error(hipblas_error_device, tolerance);
+        }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasTrsmExFn(handle,
+                                                side,
+                                                uplo,
+                                                transA,
+                                                diag,
+                                                M,
+                                                N,
+                                                d_alpha,
+                                                dA,
+                                                lda,
+                                                dB,
+                                                ldb,
+                                                dinvA,
+                                                TRSM_BLOCK * K,
+                                                argus.compute_type));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_side_option,
+                      e_uplo_option,
+                      e_transA_option,
+                      e_diag_option,
+                      e_M,
+                      e_N,
+                      e_alpha,
+                      e_lda,
+                      e_ldb>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         trsm_gflop_count<T>(M, N, K),
+                         trsm_gbyte_count<T>(M, N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_trsm_ex.hpp
+++ b/clients/include/testing_trsm_ex.hpp
@@ -119,7 +119,7 @@ hipblasStatus_t testing_trsm_ex(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dB, hB_host, sizeof(T) * B_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    hipblasStride stride_A    = TRSM_BLOCK * lda + TRSM_BLOCK;
+    hipblasStride stride_A    = TRSM_BLOCK * size_t(lda) + TRSM_BLOCK;
     hipblasStride stride_invA = TRSM_BLOCK * TRSM_BLOCK;
     int           blocks      = K / TRSM_BLOCK;
 

--- a/clients/include/testing_trsm_strided_batched_ex.hpp
+++ b/clients/include/testing_trsm_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -32,7 +32,7 @@ hipblasStatus_t testing_trsm_strided_batched_ex(const Arguments& argus)
     char   char_uplo    = argus.uplo_option;
     char   char_transA  = argus.transA_option;
     char   char_diag    = argus.diag_option;
-    T      alpha        = argus.alpha;
+    T      h_alpha      = argus.alpha;
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
@@ -43,14 +43,12 @@ hipblasStatus_t testing_trsm_strided_batched_ex(const Arguments& argus)
 
     int K = (side == HIPBLAS_SIDE_LEFT ? M : N);
 
-    hipblasStride strideA     = lda * K * stride_scale;
-    hipblasStride strideB     = ldb * N * stride_scale;
-    hipblasStride stride_invA = TRSM_BLOCK * K;
-    int           A_size      = strideA * batch_count;
-    int           B_size      = strideB * batch_count;
-    int           invA_size   = stride_invA * batch_count;
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasStride strideA     = size_t(lda) * K * stride_scale;
+    hipblasStride strideB     = size_t(ldb) * N * stride_scale;
+    hipblasStride stride_invA = TRSM_BLOCK * size_t(K);
+    size_t        A_size      = strideA * batch_count;
+    size_t        B_size      = strideB * batch_count;
+    size_t        invA_size   = stride_invA * batch_count;
 
     // check here to prevent undefined memory allocation error
     // TODO: Workaround for cuda tests, not actually testing return values
@@ -64,27 +62,25 @@ hipblasStatus_t testing_trsm_strided_batched_ex(const Arguments& argus)
     }
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hB(B_size);
-    host_vector<T> hB_copy(B_size);
-    host_vector<T> hX(B_size);
+    host_vector<T> hB_host(B_size);
+    host_vector<T> hB_device(B_size);
+    host_vector<T> hB_cpu(B_size);
 
     device_vector<T> dA(A_size);
     device_vector<T> dB(B_size);
     device_vector<T> dinvA(invA_size);
+    device_vector<T> d_alpha(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // Initial hA on CPU
     srand(1);
-    hipblas_init_symmetric<T>(hA, K, lda, strideA, batch_count);
+    hipblas_init(hA, K, K, lda, strideA, batch_count);
     for(int b = 0; b < batch_count; b++)
     {
         T* hAb = hA.data() + b * strideA;
-        T* hBb = hB.data() + b * strideB;
+        T* hBb = hB_host.data() + b * strideB;
 
         // pad ountouched area into zero
         for(int i = K; i < lda; i++)
@@ -96,7 +92,7 @@ hipblasStatus_t testing_trsm_strided_batched_ex(const Arguments& argus)
         }
 
         // proprocess the matrix to avoid ill-conditioned matrix
-        vector<int> ipiv(K);
+        host_vector<int> ipiv(K);
         cblas_getrf(K, K, hAb, lda, ipiv.data());
         for(int i = 0; i < K; i++)
         {
@@ -123,14 +119,16 @@ hipblasStatus_t testing_trsm_strided_batched_ex(const Arguments& argus)
         }
 
         // Calculate hB = hA*hX;
-        cblas_trmm<T>(side, uplo, transA, diag, M, N, T(1.0) / alpha, (const T*)hAb, lda, hBb, ldb);
+        cblas_trmm<T>(
+            side, uplo, transA, diag, M, N, T(1.0) / h_alpha, (const T*)hAb, lda, hBb, ldb);
     }
-    hX      = hB; // original solutions hX
-    hB_copy = hB;
+
+    hB_device = hB_cpu = hB_host;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB.data(), sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB_host, sizeof(T) * B_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     /* =====================================================================
            HIPBLAS
@@ -143,78 +141,85 @@ hipblasStatus_t testing_trsm_strided_batched_ex(const Arguments& argus)
     {
         if(blocks > 0)
         {
-            status = hipblasTrtriStridedBatched<T>(handle,
-                                                   uplo,
-                                                   diag,
-                                                   TRSM_BLOCK,
-                                                   dA + b * strideA,
-                                                   lda,
-                                                   sub_stride_A,
-                                                   dinvA + b * stride_invA,
-                                                   TRSM_BLOCK,
-                                                   sub_stride_invA,
-                                                   blocks);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(hipblasTrtriStridedBatched<T>(handle,
+                                                              uplo,
+                                                              diag,
+                                                              TRSM_BLOCK,
+                                                              dA + b * strideA,
+                                                              lda,
+                                                              sub_stride_A,
+                                                              dinvA + b * stride_invA,
+                                                              TRSM_BLOCK,
+                                                              sub_stride_invA,
+                                                              blocks));
         }
 
         if(K % TRSM_BLOCK != 0 || blocks == 0)
         {
-            status
-                = hipblasTrtriStridedBatched<T>(handle,
-                                                uplo,
-                                                diag,
-                                                K - TRSM_BLOCK * blocks,
-                                                dA + sub_stride_A * blocks + b * strideA,
-                                                lda,
-                                                sub_stride_A,
-                                                dinvA + sub_stride_invA * blocks + b * stride_invA,
-                                                TRSM_BLOCK,
-                                                sub_stride_invA,
-                                                1);
-
-            if(status != HIPBLAS_STATUS_SUCCESS)
-            {
-                hipblasDestroy(handle);
-                return status;
-            }
+            CHECK_HIPBLAS_ERROR(
+                hipblasTrtriStridedBatched<T>(handle,
+                                              uplo,
+                                              diag,
+                                              K - TRSM_BLOCK * blocks,
+                                              dA + sub_stride_A * blocks + b * strideA,
+                                              lda,
+                                              sub_stride_A,
+                                              dinvA + sub_stride_invA * blocks + b * stride_invA,
+                                              TRSM_BLOCK,
+                                              sub_stride_invA,
+                                              1));
         }
     }
 
-    status = hipblasTrsmStridedBatchedExFn(handle,
-                                           side,
-                                           uplo,
-                                           transA,
-                                           diag,
-                                           M,
-                                           N,
-                                           &alpha,
-                                           dA,
-                                           lda,
-                                           strideA,
-                                           dB,
-                                           ldb,
-                                           strideB,
-                                           batch_count,
-                                           dinvA,
-                                           invA_size,
-                                           stride_invA,
-                                           argus.compute_type);
-
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+    CHECK_HIPBLAS_ERROR(hipblasTrsmStridedBatchedExFn(handle,
+                                                      side,
+                                                      uplo,
+                                                      transA,
+                                                      diag,
+                                                      M,
+                                                      N,
+                                                      &h_alpha,
+                                                      dA,
+                                                      lda,
+                                                      strideA,
+                                                      dB,
+                                                      ldb,
+                                                      strideB,
+                                                      batch_count,
+                                                      dinvA,
+                                                      invA_size,
+                                                      stride_invA,
+                                                      argus.compute_type));
 
     // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hB.data(), dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hB_host, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB_device, sizeof(T) * B_size, hipMemcpyHostToDevice));
 
-    if(argus.unit_check)
+    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+    CHECK_HIPBLAS_ERROR(hipblasTrsmStridedBatchedExFn(handle,
+                                                      side,
+                                                      uplo,
+                                                      transA,
+                                                      diag,
+                                                      M,
+                                                      N,
+                                                      d_alpha,
+                                                      dA,
+                                                      lda,
+                                                      strideA,
+                                                      dB,
+                                                      ldb,
+                                                      strideB,
+                                                      batch_count,
+                                                      dinvA,
+                                                      invA_size,
+                                                      stride_invA,
+                                                      argus.compute_type));
+
+    CHECK_HIP_ERROR(hipMemcpy(hB_device, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
            CPU BLAS
@@ -228,10 +233,10 @@ hipblasStatus_t testing_trsm_strided_batched_ex(const Arguments& argus)
                           diag,
                           M,
                           N,
-                          alpha,
+                          h_alpha,
                           (const T*)hA.data() + b * strideA,
                           lda,
-                          hB_copy.data() + b * strideB,
+                          hB_cpu.data() + b * strideB,
                           ldb);
         }
 
@@ -239,14 +244,73 @@ hipblasStatus_t testing_trsm_strided_batched_ex(const Arguments& argus)
         real_t<T> eps       = std::numeric_limits<real_t<T>>::epsilon();
         double    tolerance = eps * 40 * M;
 
-        for(int b = 0; b < batch_count; b++)
+        hipblas_error_host
+            = norm_check_general<T>('F', M, N, ldb, strideB, hB_cpu, hB_host, batch_count);
+        hipblas_error_device
+            = norm_check_general<T>('F', M, N, ldb, strideB, hB_cpu, hB_device, batch_count);
+        if(argus.unit_check)
         {
-            double error = norm_check_general<T>(
-                'F', M, N, ldb, hB_copy.data() + b * strideB, hB.data() + b * strideB);
-            unit_check_error(error, tolerance);
+            unit_check_error(hipblas_error_host, tolerance);
+            unit_check_error(hipblas_error_device, tolerance);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+            {
+                gpu_time_used = get_time_us_sync(stream);
+            }
+
+            CHECK_HIPBLAS_ERROR(hipblasTrsmStridedBatchedExFn(handle,
+                                                              side,
+                                                              uplo,
+                                                              transA,
+                                                              diag,
+                                                              M,
+                                                              N,
+                                                              d_alpha,
+                                                              dA,
+                                                              lda,
+                                                              strideA,
+                                                              dB,
+                                                              ldb,
+                                                              strideB,
+                                                              batch_count,
+                                                              dinvA,
+                                                              invA_size,
+                                                              stride_invA,
+                                                              argus.compute_type));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_side_option,
+                      e_uplo_option,
+                      e_transA_option,
+                      e_diag_option,
+                      e_M,
+                      e_N,
+                      e_alpha,
+                      e_lda,
+                      e_stride_a,
+                      e_ldb,
+                      e_stride_b,
+                      e_batch_count>{}
+            .log_args<T>(std::cout,
+                         argus,
+                         gpu_time_used,
+                         trsm_gflop_count<T>(M, N, K),
+                         trsm_gbyte_count<T>(M, N, K),
+                         hipblas_error_host,
+                         hipblas_error_device);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -79,53 +79,98 @@ auto hipblas_blas1_dispatch(const Arguments& arg)
 template <template <typename...> class TEST>
 auto hipblas_blas1_ex_dispatch(const Arguments& arg)
 {
-    // For axpy there are 4 types, alpha_type, x_type, y_type, and execution_type.
-    // these currently correspond as follows:
-    // alpha_type = arg.a_type
-    // x_type     = arg.b_type
-    // y_type     = arg.c_type
-    // ex_type    = arg.compute_type
-    //
-    // Currently for axpy we're only supporting a limited number of variants,
-    // specifically alpha_type == x_type == y_type, however I'm trying to leave
-    // this open to expansion.
     const auto        Ta = arg.a_type, Tx = arg.b_type, Ty = arg.c_type, Tex = arg.compute_type;
     const std::string function = arg.function;
-    const bool        is_scal  = function == "scal_ex" || function == "scal_batched_ex"
+    const bool        is_axpy  = function == "axpy_ex" || function == "axpy_batched_ex"
+                         || function == "axpy_strided_batched_ex";
+    const bool is_dot = function == "dot_ex" || function == "dot_batched_ex"
+                        || function == "dot_strided_batched_ex" || function == "dotc_ex"
+                        || function == "dotc_batched_ex" || function == "dotc_strided_batched_ex";
+    const bool is_nrm2 = function == "nrm2_ex" || function == "nrm2_batched_ex"
+                         || function == "nrm2_strided_batched_ex";
+    const bool is_rot = function == "rot_ex" || function == "rot_batched_ex"
+                        || function == "rot_strided_batched_ex";
+    const bool is_scal = function == "scal_ex" || function == "scal_batched_ex"
                          || function == "scal_strided_batched_ex";
 
     if(Ta == Tx && Tx == Ty && Ty == Tex)
     {
         return hipblas_simple_dispatch<TEST>(arg); // Ta == Tx == Ty == Tex
     }
-    else if(Ta == Tx && Tx == Tex && is_scal)
+    else if(is_scal && Ta == Tx && Tx == Tex)
     {
         // hscal with f16_r compute (scal doesn't care about Ty)
         return hipblas_simple_dispatch<TEST>(arg);
     }
-    else if(Ta == Tx && Tx == Ty && Ta == HIPBLAS_R_16F && Tex == HIPBLAS_R_32F)
+    else if((is_rot || is_dot || is_axpy) && Ta == Tx && Tx == Ty && Ta == HIPBLAS_R_16F
+            && Tex == HIPBLAS_R_32F)
     {
         return TEST<hipblasHalf, hipblasHalf, hipblasHalf, float>{}(arg);
     }
-    else if(Ta == Tx && Ta == HIPBLAS_R_16F && Tex == HIPBLAS_R_32F)
+    else if((is_rot || is_dot) && Ta == Tx && Tx == Ty && Ta == HIPBLAS_R_16B
+            && Tex == HIPBLAS_R_32F)
     {
-        // scal half
+        return TEST<hipblasBfloat16, hipblasBfloat16, hipblasBfloat16, float>{}(arg);
+    }
+    else if(is_axpy && Ta == Tex && Tx == Ty && Tx == HIPBLAS_R_16F && Tex == HIPBLAS_R_32F)
+    {
+        return TEST<float, hipblasHalf, hipblasHalf, float>{}(arg);
+    }
+    else if((is_scal || is_nrm2 || is_axpy) && Ta == Tx && Ta == HIPBLAS_R_16F
+            && Tex == HIPBLAS_R_32F)
+    {
+        // half scal, nrm2, axpy
         return TEST<hipblasHalf, hipblasHalf, float>{}(arg);
     }
-    else if(Ta == HIPBLAS_R_32F && Tx == HIPBLAS_R_16F && Tex == HIPBLAS_R_32F && is_scal)
+    // exclusive functions cases
+    else if(is_scal)
     {
-        // scal half with float alpha
-        return TEST<float, hipblasHalf, float>{}(arg);
+        // scal_ex ordering: <alphaType, dataType, exType> opposite order of scal test
+
+        if(Ta == HIPBLAS_R_32F && Tx == HIPBLAS_R_16F && Tex == HIPBLAS_R_32F)
+        {
+            // scal half with float alpha
+            return TEST<float, hipblasHalf, float>{}(arg);
+        }
+        else if(Ta == HIPBLAS_R_32F && Tx == HIPBLAS_C_32F && Tex == HIPBLAS_C_32F)
+        {
+            // csscal-like
+            return TEST<float, hipblasComplex, hipblasComplex>{}(arg);
+        }
+        else if(Ta == HIPBLAS_R_64F && Tx == HIPBLAS_C_64F && Tex == HIPBLAS_C_64F)
+        {
+            // zdscal-like
+            return TEST<double, hipblasDoubleComplex, hipblasDoubleComplex>{}(arg);
+        }
     }
-    else if(Ta == HIPBLAS_R_32F && Tx == HIPBLAS_C_32F && Tex == HIPBLAS_C_32F)
+    else if(is_nrm2)
     {
-        // csscal
-        return TEST<float, hipblasComplex, hipblasComplex>{}(arg);
+        if(Ta == HIPBLAS_C_32F && Tx == HIPBLAS_R_32F && Tex == HIPBLAS_R_32F)
+        {
+            // scnrm2
+            return TEST<hipblasComplex, float, float>{}(arg);
+        }
+        else if(Ta == HIPBLAS_C_64F && Tx == HIPBLAS_R_64F && Tex == HIPBLAS_R_64F)
+        {
+            // dznrm2
+            return TEST<hipblasDoubleComplex, double, double>{}(arg);
+        }
     }
-    else if(Ta == HIPBLAS_R_64F && Tx == HIPBLAS_C_64F && Tex == HIPBLAS_C_64F)
+    else if(is_rot)
     {
-        // zdscal
-        return TEST<double, hipblasDoubleComplex, hipblasDoubleComplex>{}(arg);
+        if(Ta == HIPBLAS_C_32F && Tx == HIPBLAS_C_32F && Ty == HIPBLAS_R_32F
+           && Tex == HIPBLAS_C_32F)
+        {
+            // rot with complex x/y/compute and real cs
+            return TEST<hipblasComplex, hipblasComplex, float, hipblasComplex>{}(arg);
+        }
+        else if(Ta == HIPBLAS_C_64F && Tx == HIPBLAS_C_64F && Ty == HIPBLAS_R_64F
+                && Tex == HIPBLAS_C_64F)
+        {
+            // rot with complex x/y/compute and real cs
+            return TEST<hipblasDoubleComplex, hipblasDoubleComplex, double, hipblasDoubleComplex>{}(
+                arg);
+        }
     }
 
     return TEST<void>{}(arg);

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -378,6 +378,15 @@ void hipblas_packInt8(
                         = temp[(colBase + colOffset) * lda + row + (stride_a * b)];
 }
 
+template <typename T>
+void hipblas_packInt8(T* A, const T* temp, size_t M, size_t N, size_t lda)
+{
+    for(size_t colBase = 0; colBase < N; colBase += 4)
+        for(size_t row = 0; row < lda; row++)
+            for(size_t colOffset = 0; colOffset < 4; colOffset++)
+                A[(colBase * lda + 4 * row) + colOffset] = temp[(colBase + colOffset) * lda + row];
+}
+
 /* ============================================================================================ */
 
 /* ============================================================================================ */

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -15,6 +15,7 @@
 #include "hipblas_datatype2string.hpp"
 #include <cmath>
 #include <immintrin.h>
+#include <iostream>
 #include <random>
 #include <type_traits>
 #include <vector>

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -369,6 +369,9 @@ template <typename T>
 void hipblas_packInt8(
     std::vector<T>& A, size_t M, size_t N, size_t lda, size_t batch_count = 1, size_t stride_a = 0)
 {
+    if(N % 4 != 0)
+        std::cerr << "ERROR: dimension must be a multiple of 4 in order to pack" << std::endl;
+
     std::vector<T> temp(A);
     for(size_t b = 0; b < batch_count; b++)
         for(size_t colBase = 0; colBase < N; colBase += 4)
@@ -381,6 +384,9 @@ void hipblas_packInt8(
 template <typename T>
 void hipblas_packInt8(T* A, const T* temp, size_t M, size_t N, size_t lda)
 {
+    if(N % 4 != 0)
+        std::cerr << "ERROR: dimension must be a multiple of 4 in order to pack" << std::endl;
+
     for(size_t colBase = 0; colBase < N; colBase += 4)
         for(size_t row = 0; row < lda; row++)
             for(size_t colOffset = 0; colOffset < 4; colOffset++)


### PR DESCRIPTION
Adding functions to hipblas-bench, along with some cleanup (size_t changes, using host/device_batch_vector, using new handle, using CHECK_HIPBLAS_ERROR, adding device-mode tests, etc.)

- axpy_ex
- dot_ex
- nrm2_ex
- rot_ex
- scal_ex
- gemm_ex
- trsm_ex
- set_get_vector(_async)
- set_get_matrix(_async)
- set_get_atomics

Next steps:
- need to make these changes to geqrf, getrf, getri, and getrs, then hipblas-bench should have full support!
- There are some more changes in [LWPMLSE-122](https://ontrack-internal.amd.com/browse/LWPMLSE-122) that can be done (moving calls in/out of `if(unit_check)`, allow negative incx/incy, add bad enum test
- Add complex alpha/beta to gemm tests (and others?) [LWPMLSE-106](https://ontrack-internal.amd.com/browse/LWPMLSE-106)