### PR TITLE
Nrm2_ex windows failures

### DIFF
--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -472,59 +472,69 @@ TEST_P(parameterized_gemm_batched_ex, standard_strided_batched)
     }
 }
 
-class parameterized_chunk_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
-{
-protected:
-    parameterized_chunk_gemm_ex() {}
-    virtual ~parameterized_chunk_gemm_ex() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
-};
+// TODO: Disabling some gemm int8 tests as not supported by rocBLAS for all architectures
+// class parameterized_chunk_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
+// {
+// protected:
+//     parameterized_chunk_gemm_ex() {}
+//     virtual ~parameterized_chunk_gemm_ex() {}
+//     virtual void SetUp() {}
+//     virtual void TearDown() {}
+// };
 
-TEST_P(parameterized_chunk_gemm_ex, float)
-{
-    // GetParam return a tuple. Tee setup routine unpack the tuple
-    // and initializes arg(Arguments) which will be passed to testing routine
-    // The Arguments data struture have physical meaning associated.
-    // while the tuple is non-intuitive.
+// TEST_P(parameterized_chunk_gemm_ex, float)
+// {
+//     // GetParam return a tuple. Tee setup routine unpack the tuple
+//     // and initializes arg(Arguments) which will be passed to testing routine
+//     // The Arguments data struture have physical meaning associated.
+//     // while the tuple is non-intuitive.
 
-    Arguments arg = setup_gemm_ex_arguments(GetParam());
+//     Arguments arg = setup_gemm_ex_arguments(GetParam());
 
-    hipblasStatus_t status = testing_gemm_ex(arg);
+//     hipblasStatus_t status = testing_gemm_ex(arg);
 
-    // if not success, then the input argument is problematic, so detect the error message
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        if(arg.M < 0 || arg.N < 0 || arg.K < 0)
-        {
-            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-        }
-        else if(arg.transA_option == 'N' ? arg.lda < arg.M : arg.lda < arg.K)
-        {
-            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-        }
-        else if(arg.transB_option == 'N' ? arg.ldb < arg.K : arg.ldb < arg.N)
-        {
-            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-        }
-        else
-        {
-            // Only available in cuda cc >= 5.0.
-            // If we want we can change this to call query_device_property() and
-            // call this only if cc < 5.0 on a CUDA device, else fail.
-            EXPECT_EQ(HIPBLAS_STATUS_ARCH_MISMATCH, status);
-        }
-    }
-}
+//     // if not success, then the input argument is problematic, so detect the error message
+//     if(status != HIPBLAS_STATUS_SUCCESS)
+//     {
+//         if(arg.M < 0 || arg.N < 0 || arg.K < 0)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else if(arg.transA_option == 'N' ? arg.lda < arg.M : arg.lda < arg.K)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else if(arg.transB_option == 'N' ? arg.ldb < arg.K : arg.ldb < arg.N)
+//         {
+//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+//         }
+//         else
+//         {
+//             // Only available in cuda cc >= 5.0.
+//             // If we want we can change this to call query_device_property() and
+//             // call this only if cc < 5.0 on a CUDA device, else fail.
+//             EXPECT_EQ(HIPBLAS_STATUS_ARCH_MISMATCH, status);
+//         }
+//     }
+// }
 
-class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
-{
-protected:
-    parameterized_half_gemm_ex() {}
-    virtual ~parameterized_half_gemm_ex() {}
-    virtual void SetUp() {}
-    virtual void TearDown() {}
-};
+// class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
+// {
+// protected:
+//     parameterized_half_gemm_ex() {}
+//     virtual ~parameterized_half_gemm_ex() {}
+//     virtual void SetUp() {}
+//     virtual void TearDown() {}
+// };
+
+// INSTANTIATE_TEST_SUITE_P(quick_blas_ex_small_int8,
+//                          parameterized_gemm_ex,
+//                          Combine(ValuesIn(int8_matrix_size_range),
+//                                  ValuesIn(alpha_beta_range_int8),
+//                                  ValuesIn(transA_transB_range),
+//                                  ValuesIn(precision_int8),
+//                                  ValuesIn(batch_count_range_small),
+//                                  ValuesIn(is_fortran)));
 
 // TEST(pre_checkin_blas_ex_bad_arg, float) { testing_gemm_ex_bad_arg(); }
 
@@ -582,16 +592,6 @@ INSTANTIATE_TEST_SUITE_P(quick_blas_ex_small_double_complex,
                                  ValuesIn(precision_double_complex),
                                  ValuesIn(batch_count_range_small),
                                  ValuesIn(is_fortran)));
-
-// TODO: Disabling some gemm int8 tests as not supported by rocBLAS for all architectures
-// INSTANTIATE_TEST_SUITE_P(quick_blas_ex_small_int8,
-//                          parameterized_gemm_ex,
-//                          Combine(ValuesIn(int8_matrix_size_range),
-//                                  ValuesIn(alpha_beta_range_int8),
-//                                  ValuesIn(transA_transB_range),
-//                                  ValuesIn(precision_int8),
-//                                  ValuesIn(batch_count_range_small),
-//                                  ValuesIn(is_fortran)));
 
 //----medium
 INSTANTIATE_TEST_SUITE_P(pre_checkin_blas_ex_medium_hpa_half,

--- a/clients/gtest/nrm2_ex_gtest.cpp
+++ b/clients/gtest/nrm2_ex_gtest.cpp
@@ -57,7 +57,7 @@ const int incx_range[] = {1, -1};
 
 const double stride_scale_range[] = {1.0, 2.5};
 
-const int batch_count_range[] = {-1, 0, 1, 2, 10};
+const int batch_count_range[] = {-1, 0, 1, 2, 5}; // ,10};
 
 // All configs supported in rocBLAS and cuBLAS
 const vector<vector<hipblasDatatype_t>> precisions{

--- a/clients/gtest/nrm2_ex_gtest.cpp
+++ b/clients/gtest/nrm2_ex_gtest.cpp
@@ -57,7 +57,7 @@ const int incx_range[] = {1, -1};
 
 const double stride_scale_range[] = {1.0, 2.5};
 
-const int batch_count_range[] = {-1, 0, 1, 2, 5}; // ,10};
+const int batch_count_range[] = {-1, 0, 1, 2, 10};
 
 // All configs supported in rocBLAS and cuBLAS
 const vector<vector<hipblasDatatype_t>> precisions{

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -119,8 +119,8 @@ hipblasStatus_t testing_nrm2_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, N);
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, N);
+            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_rocblas_result1, N);
+            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_rocblas_result2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_ex.hpp
+++ b/clients/include/testing_nrm2_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -97,8 +97,8 @@ hipblasStatus_t testing_nrm2_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr>(cpu_result, rocblas_result_1, N);
-            unit_check_nrm2<Tr>(cpu_result, rocblas_result_2, N);
+            unit_check_nrm2<Tr, Tex>(cpu_result, rocblas_result_1, N);
+            unit_check_nrm2<Tr, Tex>(cpu_result, rocblas_result_2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  *
  * ************************************************************************ */
 
@@ -124,8 +124,8 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(Arguments argus)
 
         if(argus.unit_check)
         {
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result1, N);
-            unit_check_nrm2<Tr>(batch_count, h_cpu_result, h_rocblas_result2, N);
+            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_rocblas_result1, N);
+            unit_check_nrm2<Tr, Tex>(batch_count, h_cpu_result, h_rocblas_result2, N);
         }
 
     } // end of if unit/norm check

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -53,18 +53,18 @@ void unit_check_error(T error, T tolerance)
 #endif
 }
 
-template <typename T>
+template <typename T, typename Tex = T>
 void unit_check_nrm2(T cpu_result, T gpu_result, int vector_length)
 {
-    T allowable_error = vector_length * std::numeric_limits<T>::epsilon() * cpu_result;
+    T allowable_error = vector_length * std::numeric_limits<Tex>::epsilon() * cpu_result;
     if(allowable_error == 0)
-        allowable_error = vector_length * std::numeric_limits<T>::epsilon();
+        allowable_error = vector_length * std::numeric_limits<Tex>::epsilon();
 #ifdef GOOGLE_TEST
     ASSERT_NEAR(cpu_result, gpu_result, allowable_error);
 #endif
 }
 
-template <typename T>
+template <typename T, typename Tex = T>
 void unit_check_nrm2(int            batch_count,
                      host_vector<T> cpu_result,
                      host_vector<T> gpu_result,
@@ -72,9 +72,9 @@ void unit_check_nrm2(int            batch_count,
 {
     for(int b = 0; b < batch_count; b++)
     {
-        T allowable_error = vector_length * std::numeric_limits<T>::epsilon() * cpu_result[b];
+        T allowable_error = vector_length * std::numeric_limits<Tex>::epsilon() * cpu_result[b];
         if(allowable_error == 0)
-            allowable_error = vector_length * std::numeric_limits<T>::epsilon();
+            allowable_error = vector_length * std::numeric_limits<Tex>::epsilon();
 #ifdef GOOGLE_TEST
         ASSERT_NEAR(cpu_result[b], gpu_result[b], allowable_error);
 #endif


### PR DESCRIPTION
Seeing if this will remove the failures from [SWDEV-300988](https://ontrack-internal.amd.com/browse/SWDEV-300988).

It appears that the cpu result on windows is off by 1 from the cpu result we are getting on linux for this specific half-precision test case. I believe this is due to the conversion from hipblasHalf -> float -> hipblasHalf during the cpu calculations. This differs from the rocBLAS implementation as rocBLAS uses _Float16, which apparently isn't defined for g++ (see [here](https://github.com/ROCmSoftwarePlatform/rocBLAS-internal/commit/5c144635b237cd0e0f96e2895a835317ce52e68c#diff-972107ba5a8a0ad89499e64ffa0d015ffc0d59e9379b265d947904b13f4181a2R49)).

If anyone has any ideas for a better solution, I'm all ears! I can work on getting _Float16 to work with hipcc in the meantime.