### PR TITLE
Moving hipBLAS calls in tests

### DIFF
--- a/clients/include/testing_dgmm.hpp
+++ b/clients/include/testing_dgmm.hpp
@@ -73,16 +73,16 @@ hipblasStatus_t testing_dgmm(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasDgmmFn(handle, side, M, N, dA, lda, dx, incx, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasDgmmFn(handle, side, M, N, dA, lda, dx, incx, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_dgmm_batched.hpp
+++ b/clients/include/testing_dgmm_batched.hpp
@@ -75,24 +75,24 @@ hipblasStatus_t testing_dgmm_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(dC.transfer_from(hC));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasDgmmBatchedFn(handle,
-                                             side,
-                                             M,
-                                             N,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-    CHECK_HIP_ERROR(hC_1.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasDgmmBatchedFn(handle,
+                                                 side,
+                                                 M,
+                                                 N,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+        CHECK_HIP_ERROR(hC_1.transfer_from(dC));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_dgmm_strided_batched.hpp
+++ b/clients/include/testing_dgmm_strided_batched.hpp
@@ -80,17 +80,29 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dC, hC.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasDgmmStridedBatchedFn(
-        handle, side, M, N, dA, lda, stride_A, dx, incx, stride_x, dC, ldc, stride_C, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasDgmmStridedBatchedFn(handle,
+                                                        side,
+                                                        M,
+                                                        N,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -56,21 +56,21 @@ hipblasStatus_t testing_dot(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    // hipblasDot accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR((hipblasDotFn)(handle, N, dx, incx, dy, incy, d_hipblas_result));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR((hipblasDotFn)(handle, N, dx, incx, dy, incy, &h_hipblas_result_1));
-
-    CHECK_HIP_ERROR(
-        hipMemcpy(&h_hipblas_result_2, d_hipblas_result, sizeof(T), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        // hipblasDot accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR((hipblasDotFn)(handle, N, dx, incx, dy, incy, d_hipblas_result));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR((hipblasDotFn)(handle, N, dx, incx, dy, incy, &h_hipblas_result_1));
+
+        CHECK_HIP_ERROR(
+            hipMemcpy(&h_hipblas_result_2, d_hipblas_result, sizeof(T), hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -62,35 +62,35 @@ hipblasStatus_t testing_dot_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(dy.transfer_from(hy));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    // hipblasDot accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR((hipblasDotBatchedFn)(handle,
-                                              N,
-                                              dx.ptr_on_device(),
-                                              incx,
-                                              dy.ptr_on_device(),
-                                              incy,
-                                              batch_count,
-                                              d_hipblas_result));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR((hipblasDotBatchedFn)(handle,
-                                              N,
-                                              dx.ptr_on_device(),
-                                              incx,
-                                              dy.ptr_on_device(),
-                                              incy,
-                                              batch_count,
-                                              h_hipblas_result1));
-
-    CHECK_HIP_ERROR(hipMemcpy(
-        h_hipblas_result2, d_hipblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        // hipblasDot accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR((hipblasDotBatchedFn)(handle,
+                                                  N,
+                                                  dx.ptr_on_device(),
+                                                  incx,
+                                                  dy.ptr_on_device(),
+                                                  incy,
+                                                  batch_count,
+                                                  d_hipblas_result));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR((hipblasDotBatchedFn)(handle,
+                                                  N,
+                                                  dx.ptr_on_device(),
+                                                  incx,
+                                                  dy.ptr_on_device(),
+                                                  incy,
+                                                  batch_count,
+                                                  h_hipblas_result1));
+
+        CHECK_HIP_ERROR(hipMemcpy(
+            h_hipblas_result2, d_hipblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_dot_batched_ex.hpp
+++ b/clients/include/testing_dot_batched_ex.hpp
@@ -65,44 +65,44 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(dy.transfer_from(hy));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasDotBatchedExFn(handle,
-                                              N,
-                                              dx.ptr_on_device(),
-                                              xType,
-                                              incx,
-                                              dy.ptr_on_device(),
-                                              yType,
-                                              incy,
-                                              batch_count,
-                                              h_hipblas_result_host,
-                                              resultType,
-                                              executionType));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasDotBatchedExFn(handle,
-                                              N,
-                                              dx.ptr_on_device(),
-                                              xType,
-                                              incx,
-                                              dy.ptr_on_device(),
-                                              yType,
-                                              incy,
-                                              batch_count,
-                                              d_hipblas_result,
-                                              resultType,
-                                              executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
-                              d_hipblas_result,
-                              sizeof(Tr) * batch_count,
-                              hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasDotBatchedExFn(handle,
+                                                  N,
+                                                  dx.ptr_on_device(),
+                                                  xType,
+                                                  incx,
+                                                  dy.ptr_on_device(),
+                                                  yType,
+                                                  incy,
+                                                  batch_count,
+                                                  h_hipblas_result_host,
+                                                  resultType,
+                                                  executionType));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasDotBatchedExFn(handle,
+                                                  N,
+                                                  dx.ptr_on_device(),
+                                                  xType,
+                                                  incx,
+                                                  dy.ptr_on_device(),
+                                                  yType,
+                                                  incy,
+                                                  batch_count,
+                                                  d_hipblas_result,
+                                                  resultType,
+                                                  executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                                  d_hipblas_result,
+                                  sizeof(Tr) * batch_count,
+                                  hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_dot_ex.hpp
+++ b/clients/include/testing_dot_ex.hpp
@@ -64,31 +64,40 @@ hipblasStatus_t testing_dot_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasDotExFn(handle,
-                                       N,
-                                       dx,
-                                       xType,
-                                       incx,
-                                       dy,
-                                       yType,
-                                       incy,
-                                       &hipblas_result_host,
-                                       resultType,
-                                       executionType));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasDotExFn(
-        handle, N, dx, xType, incx, dy, yType, incy, d_hipblas_result, resultType, executionType));
-
-    CHECK_HIP_ERROR(
-        hipMemcpy(&hipblas_result_device, d_hipblas_result, sizeof(Tr), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasDotExFn(handle,
+                                           N,
+                                           dx,
+                                           xType,
+                                           incx,
+                                           dy,
+                                           yType,
+                                           incy,
+                                           &hipblas_result_host,
+                                           resultType,
+                                           executionType));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasDotExFn(handle,
+                                           N,
+                                           dx,
+                                           xType,
+                                           incx,
+                                           dy,
+                                           yType,
+                                           incy,
+                                           d_hipblas_result,
+                                           resultType,
+                                           executionType));
+
+        CHECK_HIP_ERROR(
+            hipMemcpy(&hipblas_result_device, d_hipblas_result, sizeof(Tr), hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -68,39 +68,39 @@ hipblasStatus_t testing_dot_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    // hipblasDot accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR((hipblasDotStridedBatchedFn)(handle,
-                                                     N,
-                                                     dx,
-                                                     incx,
-                                                     stridex,
-                                                     dy,
-                                                     incy,
-                                                     stridey,
-                                                     batch_count,
-                                                     d_hipblas_result));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR((hipblasDotStridedBatchedFn)(handle,
-                                                     N,
-                                                     dx,
-                                                     incx,
-                                                     stridex,
-                                                     dy,
-                                                     incy,
-                                                     stridey,
-                                                     batch_count,
-                                                     h_hipblas_result1));
-
-    CHECK_HIP_ERROR(hipMemcpy(
-        h_hipblas_result2, d_hipblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        // hipblasDot accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR((hipblasDotStridedBatchedFn)(handle,
+                                                         N,
+                                                         dx,
+                                                         incx,
+                                                         stridex,
+                                                         dy,
+                                                         incy,
+                                                         stridey,
+                                                         batch_count,
+                                                         d_hipblas_result));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR((hipblasDotStridedBatchedFn)(handle,
+                                                         N,
+                                                         dx,
+                                                         incx,
+                                                         stridex,
+                                                         dy,
+                                                         incy,
+                                                         stridey,
+                                                         batch_count,
+                                                         h_hipblas_result1));
+
+        CHECK_HIP_ERROR(hipMemcpy(
+            h_hipblas_result2, d_hipblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_dot_strided_batched_ex.hpp
+++ b/clients/include/testing_dot_strided_batched_ex.hpp
@@ -71,48 +71,48 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy, hy, sizeof(Ty) * sizeY, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedExFn(handle,
-                                                     N,
-                                                     dx,
-                                                     xType,
-                                                     incx,
-                                                     stridex,
-                                                     dy,
-                                                     yType,
-                                                     incy,
-                                                     stridey,
-                                                     batch_count,
-                                                     h_hipblas_result_host,
-                                                     resultType,
-                                                     executionType));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedExFn(handle,
-                                                     N,
-                                                     dx,
-                                                     xType,
-                                                     incx,
-                                                     stridex,
-                                                     dy,
-                                                     yType,
-                                                     incy,
-                                                     stridey,
-                                                     batch_count,
-                                                     d_hipblas_result,
-                                                     resultType,
-                                                     executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
-                              d_hipblas_result,
-                              sizeof(Tr) * batch_count,
-                              hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedExFn(handle,
+                                                         N,
+                                                         dx,
+                                                         xType,
+                                                         incx,
+                                                         stridex,
+                                                         dy,
+                                                         yType,
+                                                         incy,
+                                                         stridey,
+                                                         batch_count,
+                                                         h_hipblas_result_host,
+                                                         resultType,
+                                                         executionType));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedExFn(handle,
+                                                         N,
+                                                         dx,
+                                                         xType,
+                                                         incx,
+                                                         stridex,
+                                                         dy,
+                                                         yType,
+                                                         incy,
+                                                         stridey,
+                                                         batch_count,
+                                                         d_hipblas_result,
+                                                         resultType,
+                                                         executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                                  d_hipblas_result,
+                                  sizeof(Tr) * batch_count,
+                                  hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_gbmv.hpp
+++ b/clients/include/testing_gbmv.hpp
@@ -28,9 +28,9 @@ hipblasStatus_t testing_gbmv(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    int A_size = lda * N;
-    int X_size;
-    int Y_size;
+    size_t A_size = size_t(lda) * N;
+    int    X_size;
+    int    Y_size;
 
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
 
@@ -89,26 +89,26 @@ hipblasStatus_t testing_gbmv(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGbmvFn(
-        handle, transA, M, N, KL, KU, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
-
-    CHECK_HIP_ERROR(
-        hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size * incy, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size * incy, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasGbmvFn(handle, transA, M, N, KL, KU, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
-
-    CHECK_HIP_ERROR(
-        hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size * incy, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGbmvFn(
+            handle, transA, M, N, KL, KU, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
+
+        CHECK_HIP_ERROR(
+            hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size * incy, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGbmvFn(
+            handle, transA, M, N, KL, KU, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
+
+        CHECK_HIP_ERROR(
+            hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size * incy, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_gbmv_batched.hpp
+++ b/clients/include/testing_gbmv_batched.hpp
@@ -29,9 +29,9 @@ hipblasStatus_t testing_gbmv_batched(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    int A_size = lda * N;
-    int X_size;
-    int Y_size;
+    size_t A_size = size_t(lda) * N;
+    int    X_size;
+    int    Y_size;
 
     int batch_count = argus.batch_count;
 
@@ -100,50 +100,50 @@ hipblasStatus_t testing_gbmv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGbmvBatchedFn(handle,
-                                             transA,
-                                             M,
-                                             N,
-                                             KL,
-                                             KU,
-                                             (T*)&h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             (T*)&h_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
-    CHECK_HIP_ERROR(dy.transfer_from(hy));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasGbmvBatchedFn(handle,
-                                             transA,
-                                             M,
-                                             N,
-                                             KL,
-                                             KU,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             d_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGbmvBatchedFn(handle,
+                                                 transA,
+                                                 M,
+                                                 N,
+                                                 KL,
+                                                 KU,
+                                                 (T*)&h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 (T*)&h_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+        CHECK_HIP_ERROR(dy.transfer_from(hy));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGbmvBatchedFn(handle,
+                                                 transA,
+                                                 M,
+                                                 N,
+                                                 KL,
+                                                 KU,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 d_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_gbmv_strided_batched.hpp
+++ b/clients/include/testing_gbmv_strided_batched.hpp
@@ -31,13 +31,13 @@ hipblasStatus_t testing_gbmv_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stride_A = lda * N * stride_scale;
+    hipblasStride stride_A = size_t(lda) * N * stride_scale;
     hipblasStride stride_x;
     hipblasStride stride_y;
 
-    int A_size = stride_A * batch_count;
-    int X_size;
-    int Y_size;
+    size_t A_size = stride_A * batch_count;
+    int    X_size;
+    int    Y_size;
 
     int x_els;
     int y_els;
@@ -107,56 +107,56 @@ hipblasStatus_t testing_gbmv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGbmvStridedBatchedFn(handle,
-                                                    transA,
-                                                    M,
-                                                    N,
-                                                    KL,
-                                                    KU,
-                                                    (T*)&h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    (T*)&h_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasGbmvStridedBatchedFn(handle,
-                                                    transA,
-                                                    M,
-                                                    N,
-                                                    KL,
-                                                    KU,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    d_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGbmvStridedBatchedFn(handle,
+                                                        transA,
+                                                        M,
+                                                        N,
+                                                        KL,
+                                                        KU,
+                                                        (T*)&h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        (T*)&h_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGbmvStridedBatchedFn(handle,
+                                                        transA,
+                                                        M,
+                                                        N,
+                                                        KL,
+                                                        KU,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        d_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_geam.hpp
+++ b/clients/include/testing_geam.hpp
@@ -101,33 +101,33 @@ hipblasStatus_t testing_geam(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    {
-        // &h_alpha and &h_beta are host pointers
-        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        CHECK_HIPBLAS_ERROR(hipblasGeamFn(
-            handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc));
-
-        CHECK_HIP_ERROR(hipMemcpy(hC1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    }
-    {
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC2.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
-
-        // d_alpha and d_beta are device pointers
-        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-        CHECK_HIPBLAS_ERROR(hipblasGeamFn(
-            handle, transA, transB, M, N, d_alpha, dA, lda, d_beta, dB, ldb, dC, ldc));
-
-        CHECK_HIP_ERROR(hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    }
-
-    /* =====================================================================
-            CPU BLAS
-    =================================================================== */
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        {
+            // &h_alpha and &h_beta are host pointers
+            CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+            CHECK_HIPBLAS_ERROR(hipblasGeamFn(
+                handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc));
+
+            CHECK_HIP_ERROR(hipMemcpy(hC1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        }
+        {
+            CHECK_HIP_ERROR(hipMemcpy(dC, hC2.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
+
+            // d_alpha and d_beta are device pointers
+            CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+            CHECK_HIPBLAS_ERROR(hipblasGeamFn(
+                handle, transA, transB, M, N, d_alpha, dA, lda, d_beta, dB, ldb, dC, ldc));
+
+            CHECK_HIP_ERROR(hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        }
+
+        /* =====================================================================
+                CPU BLAS
+        =================================================================== */
         cblas_geam(
             transA, transB, M, N, &h_alpha, (T*)hA, lda, &h_beta, (T*)hB, ldb, (T*)hC_copy, ldc);
 

--- a/clients/include/testing_geam_batched.hpp
+++ b/clients/include/testing_geam_batched.hpp
@@ -108,57 +108,57 @@ hipblasStatus_t testing_geam_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    {
-        // &h_alpha and &h_beta are host pointers
-        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        CHECK_HIPBLAS_ERROR(hipblasGeamBatchedFn(handle,
-                                                 transA,
-                                                 transB,
-                                                 M,
-                                                 N,
-                                                 &h_alpha,
-                                                 dA.ptr_on_device(),
-                                                 lda,
-                                                 &h_beta,
-                                                 dB.ptr_on_device(),
-                                                 ldb,
-                                                 dC.ptr_on_device(),
-                                                 ldc,
-                                                 batch_count));
-
-        CHECK_HIP_ERROR(hC1.transfer_from(dC));
-    }
-    {
-        CHECK_HIP_ERROR(dC.transfer_from(hC2));
-
-        // d_alpha and d_beta are device pointers
-        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-        CHECK_HIPBLAS_ERROR(hipblasGeamBatchedFn(handle,
-                                                 transA,
-                                                 transB,
-                                                 M,
-                                                 N,
-                                                 d_alpha,
-                                                 dA.ptr_on_device(),
-                                                 lda,
-                                                 d_beta,
-                                                 dB.ptr_on_device(),
-                                                 ldb,
-                                                 dC.ptr_on_device(),
-                                                 ldc,
-                                                 batch_count));
-
-        CHECK_HIP_ERROR(hC2.transfer_from(dC));
-    }
-
-    /* =====================================================================
-            CPU BLAS
-    =================================================================== */
     if(argus.norm_check || argus.unit_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        {
+            // &h_alpha and &h_beta are host pointers
+            CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+            CHECK_HIPBLAS_ERROR(hipblasGeamBatchedFn(handle,
+                                                     transA,
+                                                     transB,
+                                                     M,
+                                                     N,
+                                                     &h_alpha,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     &h_beta,
+                                                     dB.ptr_on_device(),
+                                                     ldb,
+                                                     dC.ptr_on_device(),
+                                                     ldc,
+                                                     batch_count));
+
+            CHECK_HIP_ERROR(hC1.transfer_from(dC));
+        }
+        {
+            CHECK_HIP_ERROR(dC.transfer_from(hC2));
+
+            // d_alpha and d_beta are device pointers
+            CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+            CHECK_HIPBLAS_ERROR(hipblasGeamBatchedFn(handle,
+                                                     transA,
+                                                     transB,
+                                                     M,
+                                                     N,
+                                                     d_alpha,
+                                                     dA.ptr_on_device(),
+                                                     lda,
+                                                     d_beta,
+                                                     dB.ptr_on_device(),
+                                                     ldb,
+                                                     dC.ptr_on_device(),
+                                                     ldc,
+                                                     batch_count));
+
+            CHECK_HIP_ERROR(hC2.transfer_from(dC));
+        }
+
+        /* =====================================================================
+                CPU BLAS
+        =================================================================== */
         // reference calculation
         for(int b = 0; b < batch_count; b++)
         {

--- a/clients/include/testing_geam_strided_batched.hpp
+++ b/clients/include/testing_geam_strided_batched.hpp
@@ -114,63 +114,63 @@ hipblasStatus_t testing_geam_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    {
-        // &h_alpha and &h_beta are host pointers
-        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        CHECK_HIPBLAS_ERROR(hipblasGeamStridedBatchedFn(handle,
-                                                        transA,
-                                                        transB,
-                                                        M,
-                                                        N,
-                                                        &h_alpha,
-                                                        dA,
-                                                        lda,
-                                                        stride_A,
-                                                        &h_beta,
-                                                        dB,
-                                                        ldb,
-                                                        stride_B,
-                                                        dC,
-                                                        ldc,
-                                                        stride_C,
-                                                        batch_count));
-
-        CHECK_HIP_ERROR(hipMemcpy(hC1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    }
-    {
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC2.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
-
-        // d_alpha and d_beta are device pointers
-        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-        CHECK_HIPBLAS_ERROR(hipblasGeamStridedBatchedFn(handle,
-                                                        transA,
-                                                        transB,
-                                                        M,
-                                                        N,
-                                                        d_alpha,
-                                                        dA,
-                                                        lda,
-                                                        stride_A,
-                                                        d_beta,
-                                                        dB,
-                                                        ldb,
-                                                        stride_B,
-                                                        dC,
-                                                        ldc,
-                                                        stride_C,
-                                                        batch_count));
-
-        CHECK_HIP_ERROR(hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    }
-
-    /* =====================================================================
-            CPU BLAS
-    =================================================================== */
     if(argus.norm_check || argus.unit_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        {
+            // &h_alpha and &h_beta are host pointers
+            CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+            CHECK_HIPBLAS_ERROR(hipblasGeamStridedBatchedFn(handle,
+                                                            transA,
+                                                            transB,
+                                                            M,
+                                                            N,
+                                                            &h_alpha,
+                                                            dA,
+                                                            lda,
+                                                            stride_A,
+                                                            &h_beta,
+                                                            dB,
+                                                            ldb,
+                                                            stride_B,
+                                                            dC,
+                                                            ldc,
+                                                            stride_C,
+                                                            batch_count));
+
+            CHECK_HIP_ERROR(hipMemcpy(hC1.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        }
+        {
+            CHECK_HIP_ERROR(hipMemcpy(dC, hC2.data(), sizeof(T) * C_size, hipMemcpyHostToDevice));
+
+            // d_alpha and d_beta are device pointers
+            CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+            CHECK_HIPBLAS_ERROR(hipblasGeamStridedBatchedFn(handle,
+                                                            transA,
+                                                            transB,
+                                                            M,
+                                                            N,
+                                                            d_alpha,
+                                                            dA,
+                                                            lda,
+                                                            stride_A,
+                                                            d_beta,
+                                                            dB,
+                                                            ldb,
+                                                            stride_B,
+                                                            dC,
+                                                            ldc,
+                                                            stride_C,
+                                                            batch_count));
+
+            CHECK_HIP_ERROR(hipMemcpy(hC2.data(), dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        }
+
+        /* =====================================================================
+                CPU BLAS
+        =================================================================== */
         // reference calculation
         for(int b = 0; b < batch_count; b++)
         {

--- a/clients/include/testing_gemm.hpp
+++ b/clients/include/testing_gemm.hpp
@@ -102,26 +102,26 @@ hipblasStatus_t testing_gemm(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-
-    // library interface
-    CHECK_HIPBLAS_ERROR(hipblasGemmFn(
-        handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * ldc * N, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * ldc * N, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasGemmFn(handle, transA, transB, M, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * ldc * N, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+
+        // library interface
+        CHECK_HIPBLAS_ERROR(hipblasGemmFn(
+            handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * ldc * N, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * ldc * N, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGemmFn(
+            handle, transA, transB, M, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * ldc * N, hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -132,57 +132,58 @@ hipblasStatus_t testing_gemm_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha_Tc, sizeof(Tex), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta_Tc, sizeof(Tex), hipMemcpyHostToDevice));
 
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGemmBatchedExFn(handle,
-                                               transA,
-                                               transB,
-                                               M,
-                                               N,
-                                               K,
-                                               &h_alpha_Tc,
-                                               (const void**)(Ta**)dA.ptr_on_device(),
-                                               a_type,
-                                               lda,
-                                               (const void**)(Tb**)dB.ptr_on_device(),
-                                               b_type,
-                                               ldb,
-                                               &h_beta_Tc,
-                                               (void**)(Tc**)dC.ptr_on_device(),
-                                               c_type,
-                                               ldc,
-                                               batch_count,
-                                               compute_type,
-                                               algo));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasGemmBatchedExFn(handle,
-                                               transA,
-                                               transB,
-                                               M,
-                                               N,
-                                               K,
-                                               d_alpha,
-                                               (const void**)(Ta**)dA.ptr_on_device(),
-                                               a_type,
-                                               lda,
-                                               (const void**)(Tb**)dB.ptr_on_device(),
-                                               b_type,
-                                               ldb,
-                                               d_beta,
-                                               (void**)(Tc**)dC.ptr_on_device(),
-                                               c_type,
-                                               ldc,
-                                               batch_count,
-                                               compute_type,
-                                               algo));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(unit_check || norm_check)
     {
+        // hipBLAS
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGemmBatchedExFn(handle,
+                                                   transA,
+                                                   transB,
+                                                   M,
+                                                   N,
+                                                   K,
+                                                   &h_alpha_Tc,
+                                                   (const void**)(Ta**)dA.ptr_on_device(),
+                                                   a_type,
+                                                   lda,
+                                                   (const void**)(Tb**)dB.ptr_on_device(),
+                                                   b_type,
+                                                   ldb,
+                                                   &h_beta_Tc,
+                                                   (void**)(Tc**)dC.ptr_on_device(),
+                                                   c_type,
+                                                   ldc,
+                                                   batch_count,
+                                                   compute_type,
+                                                   algo));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGemmBatchedExFn(handle,
+                                                   transA,
+                                                   transB,
+                                                   M,
+                                                   N,
+                                                   K,
+                                                   d_alpha,
+                                                   (const void**)(Ta**)dA.ptr_on_device(),
+                                                   a_type,
+                                                   lda,
+                                                   (const void**)(Tb**)dB.ptr_on_device(),
+                                                   b_type,
+                                                   ldb,
+                                                   d_beta,
+                                                   (void**)(Tc**)dC.ptr_on_device(),
+                                                   c_type,
+                                                   ldc,
+                                                   batch_count,
+                                                   compute_type,
+                                                   algo));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
         // CPU BLAS
         for(int b = 0; b < batch_count; b++)
         {

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -122,55 +122,57 @@ hipblasStatus_t testing_gemm_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha_Tc, sizeof(Tex), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta_Tc, sizeof(Tex), hipMemcpyHostToDevice));
 
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
-                                        transA,
-                                        transB,
-                                        M,
-                                        N,
-                                        K,
-                                        &h_alpha_Tc,
-                                        dA,
-                                        a_type,
-                                        lda,
-                                        dB,
-                                        b_type,
-                                        ldb,
-                                        &h_beta_Tc,
-                                        dC,
-                                        c_type,
-                                        ldc,
-                                        compute_type,
-                                        algo));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
-                                        transA,
-                                        transB,
-                                        M,
-                                        N,
-                                        K,
-                                        d_alpha,
-                                        dA,
-                                        a_type,
-                                        lda,
-                                        dB,
-                                        b_type,
-                                        ldb,
-                                        d_beta,
-                                        dC,
-                                        c_type,
-                                        ldc,
-                                        compute_type,
-                                        algo));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
-
     if(unit_check || norm_check)
     {
+        // hipBLAS
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
+                                            transA,
+                                            transB,
+                                            M,
+                                            N,
+                                            K,
+                                            &h_alpha_Tc,
+                                            dA,
+                                            a_type,
+                                            lda,
+                                            dB,
+                                            b_type,
+                                            ldb,
+                                            &h_beta_Tc,
+                                            dC,
+                                            c_type,
+                                            ldc,
+                                            compute_type,
+                                            algo));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
+                                            transA,
+                                            transB,
+                                            M,
+                                            N,
+                                            K,
+                                            d_alpha,
+                                            dA,
+                                            a_type,
+                                            lda,
+                                            dB,
+                                            b_type,
+                                            ldb,
+                                            d_beta,
+                                            dC,
+                                            c_type,
+                                            ldc,
+                                            compute_type,
+                                            algo));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
+
+        // reference BLAS
         cblas_gemm<Ta, Tc, Tex>(transA,
                                 transB,
                                 M,

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -133,63 +133,64 @@ hipblasStatus_t testing_gemm_strided_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha_Tc, sizeof(Tex), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta_Tc, sizeof(Tex), hipMemcpyHostToDevice));
 
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGemmStridedBatchedExFn(handle,
-                                                      transA,
-                                                      transB,
-                                                      M,
-                                                      N,
-                                                      K,
-                                                      &h_alpha_Tc,
-                                                      dA,
-                                                      a_type,
-                                                      lda,
-                                                      stride_A,
-                                                      dB,
-                                                      b_type,
-                                                      ldb,
-                                                      stride_B,
-                                                      &h_beta_Tc,
-                                                      dC,
-                                                      c_type,
-                                                      ldc,
-                                                      stride_C,
-                                                      batch_count,
-                                                      compute_type,
-                                                      algo));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasGemmStridedBatchedExFn(handle,
-                                                      transA,
-                                                      transB,
-                                                      M,
-                                                      N,
-                                                      K,
-                                                      d_alpha,
-                                                      dA,
-                                                      a_type,
-                                                      lda,
-                                                      stride_A,
-                                                      dB,
-                                                      b_type,
-                                                      ldb,
-                                                      stride_B,
-                                                      d_beta,
-                                                      dC,
-                                                      c_type,
-                                                      ldc,
-                                                      stride_C,
-                                                      batch_count,
-                                                      compute_type,
-                                                      algo));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
-
     if(unit_check || norm_check)
     {
+        // hipBLAS
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGemmStridedBatchedExFn(handle,
+                                                          transA,
+                                                          transB,
+                                                          M,
+                                                          N,
+                                                          K,
+                                                          &h_alpha_Tc,
+                                                          dA,
+                                                          a_type,
+                                                          lda,
+                                                          stride_A,
+                                                          dB,
+                                                          b_type,
+                                                          ldb,
+                                                          stride_B,
+                                                          &h_beta_Tc,
+                                                          dC,
+                                                          c_type,
+                                                          ldc,
+                                                          stride_C,
+                                                          batch_count,
+                                                          compute_type,
+                                                          algo));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGemmStridedBatchedExFn(handle,
+                                                          transA,
+                                                          transB,
+                                                          M,
+                                                          N,
+                                                          K,
+                                                          d_alpha,
+                                                          dA,
+                                                          a_type,
+                                                          lda,
+                                                          stride_A,
+                                                          dB,
+                                                          b_type,
+                                                          ldb,
+                                                          stride_B,
+                                                          d_beta,
+                                                          dC,
+                                                          c_type,
+                                                          ldc,
+                                                          stride_C,
+                                                          batch_count,
+                                                          compute_type,
+                                                          algo));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
+
         // CPU BLAS
         for(int b = 0; b < batch_count; b++)
         {

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -27,7 +27,7 @@ hipblasStatus_t testing_ger(const Arguments& argus)
     int incy = argus.incy;
     int lda  = argus.lda;
 
-    int A_size = lda * N;
+    size_t A_size = size_t(lda) * N;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -70,22 +70,22 @@ hipblasStatus_t testing_ger(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGerFn(handle, M, N, (T*)&h_alpha, dx, incx, dy, incy, dA, lda));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasGerFn(handle, M, N, d_alpha, dx, incx, dy, incy, dA, lda));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGerFn(handle, M, N, (T*)&h_alpha, dx, incx, dy, incy, dA, lda));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGerFn(handle, M, N, d_alpha, dx, incx, dy, incy, dA, lda));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_ger_batched.hpp
+++ b/clients/include/testing_ger_batched.hpp
@@ -29,9 +29,7 @@ hipblasStatus_t testing_ger_batched(const Arguments& argus)
     int lda         = argus.lda;
     int batch_count = argus.batch_count;
 
-    int A_size = lda * N;
-    int x_size = M * incx;
-    int y_size = N * incy;
+    size_t A_size = size_t(lda) * N;
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
@@ -80,42 +78,42 @@ hipblasStatus_t testing_ger_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dy.transfer_from(hy));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGerBatchedFn(handle,
-                                            M,
-                                            N,
-                                            (T*)&h_alpha,
-                                            dx.ptr_on_device(),
-                                            incx,
-                                            dy.ptr_on_device(),
-                                            incy,
-                                            dA.ptr_on_device(),
-                                            lda,
-                                            batch_count));
-
-    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasGerBatchedFn(handle,
-                                            M,
-                                            N,
-                                            d_alpha,
-                                            dx.ptr_on_device(),
-                                            incx,
-                                            dy.ptr_on_device(),
-                                            incy,
-                                            dA.ptr_on_device(),
-                                            lda,
-                                            batch_count));
-
-    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGerBatchedFn(handle,
+                                                M,
+                                                N,
+                                                (T*)&h_alpha,
+                                                dx.ptr_on_device(),
+                                                incx,
+                                                dy.ptr_on_device(),
+                                                incy,
+                                                dA.ptr_on_device(),
+                                                lda,
+                                                batch_count));
+
+        CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGerBatchedFn(handle,
+                                                M,
+                                                N,
+                                                d_alpha,
+                                                dx.ptr_on_device(),
+                                                incx,
+                                                dy.ptr_on_device(),
+                                                incy,
+                                                dA.ptr_on_device(),
+                                                lda,
+                                                batch_count));
+
+        CHECK_HIP_ERROR(hA_device.transfer_from(dA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_ger_strided_batched.hpp
+++ b/clients/include/testing_ger_strided_batched.hpp
@@ -31,12 +31,12 @@ hipblasStatus_t testing_ger_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stride_A = lda * N * stride_scale;
-    hipblasStride stride_x = M * incx * stride_scale;
-    hipblasStride stride_y = N * incy * stride_scale;
-    int           A_size   = stride_A * batch_count;
-    int           x_size   = stride_x * batch_count;
-    int           y_size   = stride_y * batch_count;
+    hipblasStride stride_A = size_t(lda) * N * stride_scale;
+    hipblasStride stride_x = size_t(M) * incx * stride_scale;
+    hipblasStride stride_y = size_t(N) * incy * stride_scale;
+    size_t        A_size   = stride_A * batch_count;
+    size_t        x_size   = stride_x * batch_count;
+    size_t        y_size   = stride_y * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -83,48 +83,48 @@ hipblasStatus_t testing_ger_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasGerStridedBatchedFn(handle,
-                                                   M,
-                                                   N,
-                                                   (T*)&h_alpha,
-                                                   dx,
-                                                   incx,
-                                                   stride_x,
-                                                   dy,
-                                                   incy,
-                                                   stride_y,
-                                                   dA,
-                                                   lda,
-                                                   stride_A,
-                                                   batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasGerStridedBatchedFn(handle,
-                                                   M,
-                                                   N,
-                                                   d_alpha,
-                                                   dx,
-                                                   incx,
-                                                   stride_x,
-                                                   dy,
-                                                   incy,
-                                                   stride_y,
-                                                   dA,
-                                                   lda,
-                                                   stride_A,
-                                                   batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGerStridedBatchedFn(handle,
+                                                       M,
+                                                       N,
+                                                       (T*)&h_alpha,
+                                                       dx,
+                                                       incx,
+                                                       stride_x,
+                                                       dy,
+                                                       incy,
+                                                       stride_y,
+                                                       dA,
+                                                       lda,
+                                                       stride_A,
+                                                       batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGerStridedBatchedFn(handle,
+                                                       M,
+                                                       N,
+                                                       d_alpha,
+                                                       dx,
+                                                       incx,
+                                                       stride_x,
+                                                       dy,
+                                                       incy,
+                                                       stride_y,
+                                                       dA,
+                                                       lda,
+                                                       stride_A,
+                                                       batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -68,22 +68,21 @@ hipblasStatus_t testing_getrf(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemset(dIpiv, 0, Ipiv_size * sizeof(int)));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, sizeof(int)));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasGetrfFn(handle, N, dA, lda, dIpiv, dInfo));
-
-    // Copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hA1, dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hIpiv1, dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hInfo1, dInfo, sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasGetrfFn(handle, N, dA, lda, dIpiv, dInfo));
+
+        // Copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hA1, dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hIpiv1, dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hInfo1, dInfo, sizeof(int), hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU LAPACK
         =================================================================== */
-
         hInfo[0] = cblas_getrf(M, N, hA.data(), lda, hIpiv.data());
 
         hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1);

--- a/clients/include/testing_getrf_batched.hpp
+++ b/clients/include/testing_getrf_batched.hpp
@@ -75,25 +75,24 @@ hipblasStatus_t testing_getrf_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemset(dIpiv, 0, Ipiv_size * sizeof(int)));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(
-        hipblasGetrfBatchedFn(handle, N, dA.ptr_on_device(), lda, dIpiv, dInfo, batch_count));
-
-    // Copy output from device to CPU
-    CHECK_HIP_ERROR(hA1.transfer_from(dA));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(
+            hipblasGetrfBatchedFn(handle, N, dA.ptr_on_device(), lda, dIpiv, dInfo, batch_count));
+
+        // Copy output from device to CPU
+        CHECK_HIP_ERROR(hA1.transfer_from(dA));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU LAPACK
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             hInfo[b] = cblas_getrf(M, N, hA[b], lda, hIpiv.data() + b * strideP);

--- a/clients/include/testing_getrf_npvt.hpp
+++ b/clients/include/testing_getrf_npvt.hpp
@@ -70,10 +70,6 @@ hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), A_size * sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, sizeof(int)));
 
-    // Copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hInfo1.data(), dInfo, sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check)
     {
         /* =====================================================================
@@ -86,6 +82,10 @@ hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
             hipblasDestroy(handle);
             return status;
         }
+
+        // Copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hInfo1.data(), dInfo, sizeof(int), hipMemcpyDeviceToHost));
 
         /* =====================================================================
            CPU LAPACK

--- a/clients/include/testing_getrf_npvt.hpp
+++ b/clients/include/testing_getrf_npvt.hpp
@@ -70,18 +70,6 @@ hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), A_size * sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, sizeof(int)));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-
-    status = hipblasGetrfFn(handle, N, dA, lda, nullptr, dInfo);
-
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
-
     // Copy output from device to CPU
     CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
     CHECK_HIP_ERROR(hipMemcpy(hInfo1.data(), dInfo, sizeof(int), hipMemcpyDeviceToHost));
@@ -89,9 +77,19 @@ hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
     if(argus.unit_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        status = hipblasGetrfFn(handle, N, dA, lda, nullptr, dInfo);
+
+        if(status != HIPBLAS_STATUS_SUCCESS)
+        {
+            hipblasDestroy(handle);
+            return status;
+        }
+
+        /* =====================================================================
            CPU LAPACK
         =================================================================== */
-
         hInfo[0] = cblas_getrf(M, N, hA.data(), lda, hIpiv.data());
 
         if(argus.unit_check)

--- a/clients/include/testing_getrf_npvt_strided_batched.hpp
+++ b/clients/include/testing_getrf_npvt_strided_batched.hpp
@@ -84,30 +84,28 @@ hipblasStatus_t testing_getrf_npvt_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), A_size * sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-
-    status = hipblasGetrfStridedBatchedFn(
-        handle, N, dA, lda, strideA, nullptr, strideP, dInfo, batch_count);
-
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
-
-    // Copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        status = hipblasGetrfStridedBatchedFn(
+            handle, N, dA, lda, strideA, nullptr, strideP, dInfo, batch_count);
+
+        if(status != HIPBLAS_STATUS_SUCCESS)
+        {
+            hipblasDestroy(handle);
+            return status;
+        }
+
+        // Copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU LAPACK
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             hInfo[b] = cblas_getrf(M, N, hA.data() + b * strideA, lda, hIpiv.data() + b * strideP);

--- a/clients/include/testing_getrf_strided_batched.hpp
+++ b/clients/include/testing_getrf_strided_batched.hpp
@@ -82,25 +82,24 @@ hipblasStatus_t testing_getrf_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemset(dIpiv, 0, Ipiv_size * sizeof(int)));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasGetrfStridedBatchedFn(
-        handle, N, dA, lda, strideA, dIpiv, strideP, dInfo, batch_count));
-
-    // Copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasGetrfStridedBatchedFn(
+            handle, N, dA, lda, strideA, dIpiv, strideP, dInfo, batch_count));
+
+        // Copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU LAPACK
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             hInfo[b] = cblas_getrf(M, N, hA.data() + b * strideA, lda, hIpiv.data() + b * strideP);

--- a/clients/include/testing_getri_batched.hpp
+++ b/clients/include/testing_getri_batched.hpp
@@ -83,21 +83,28 @@ hipblasStatus_t testing_getri_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dIpiv, hIpiv, Ipiv_size * sizeof(int), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasGetriBatchedFn(
-        handle, N, dA.ptr_on_device(), lda, dIpiv, dC.ptr_on_device(), lda, dInfo, batch_count));
-
-    // Copy output from device to CPU
-    CHECK_HIP_ERROR(hA1.transfer_from(dC));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasGetriBatchedFn(handle,
+                                                  N,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dIpiv,
+                                                  dC.ptr_on_device(),
+                                                  lda,
+                                                  dInfo,
+                                                  batch_count));
+
+        // Copy output from device to CPU
+        CHECK_HIP_ERROR(hA1.transfer_from(dC));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU LAPACK
         =================================================================== */

--- a/clients/include/testing_getri_npvt_batched.hpp
+++ b/clients/include/testing_getri_npvt_batched.hpp
@@ -96,30 +96,29 @@ hipblasStatus_t testing_getri_npvt_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dC, bC, batch_count * sizeof(T*), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-
-    status = hipblasGetriBatchedFn(handle, N, dA, lda, nullptr, dC, lda, dInfo, batch_count);
-
-    if(status != HIPBLAS_STATUS_SUCCESS)
-    {
-        hipblasDestroy(handle);
-        return status;
-    }
-
-    // Copy output from device to CPU
-    for(int b = 0; b < batch_count; b++)
-        CHECK_HIP_ERROR(hipMemcpy(hA1[b].data(), bC[b], A_size * sizeof(T), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        status = hipblasGetriBatchedFn(handle, N, dA, lda, nullptr, dC, lda, dInfo, batch_count);
+
+        if(status != HIPBLAS_STATUS_SUCCESS)
+        {
+            hipblasDestroy(handle);
+            return status;
+        }
+
+        // Copy output from device to CPU
+        for(int b = 0; b < batch_count; b++)
+            CHECK_HIP_ERROR(
+                hipMemcpy(hA1[b].data(), bC[b], A_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU LAPACK
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             // Workspace query

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -83,21 +83,20 @@ hipblasStatus_t testing_getrs(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dB, hB, B_size * sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dIpiv, hIpiv, Ipiv_size * sizeof(int), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasGetrsFn(handle, op, N, 1, dA, lda, dIpiv, dB, ldb, &info));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hB1, dB, B_size * sizeof(T), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hIpiv1, dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasGetrsFn(handle, op, N, 1, dA, lda, dIpiv, dB, ldb, &info));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hB1, dB, B_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hIpiv1, dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU LAPACK
         =================================================================== */
-
         cblas_getrs('N', N, 1, hA.data(), lda, hIpiv.data(), hB.data(), ldb);
 
         hipblas_error = norm_check_general<T>('F', N, 1, ldb, hB.data(), hB1.data());

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -91,28 +91,28 @@ hipblasStatus_t testing_getrs_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dB.transfer_from(hB));
     CHECK_HIP_ERROR(hipMemcpy(dIpiv, hIpiv.data(), Ipiv_size * sizeof(int), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasGetrsBatchedFn(handle,
-                                              op,
-                                              N,
-                                              1,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dIpiv,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              &info,
-                                              batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hB1.transfer_from(dB));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasGetrsBatchedFn(handle,
+                                                  op,
+                                                  N,
+                                                  1,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dIpiv,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  &info,
+                                                  batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hB1.transfer_from(dB));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU LAPACK
         =================================================================== */

--- a/clients/include/testing_getrs_strided_batched.hpp
+++ b/clients/include/testing_getrs_strided_batched.hpp
@@ -101,23 +101,34 @@ hipblasStatus_t testing_getrs_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dB, hB, B_size * sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dIpiv, hIpiv, Ipiv_size * sizeof(int), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasGetrsStridedBatchedFn(
-        handle, op, N, 1, dA, lda, strideA, dIpiv, strideP, dB, ldb, strideB, &info, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hB1.data(), dB, B_size * sizeof(T), hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(
-        hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasGetrsStridedBatchedFn(handle,
+                                                         op,
+                                                         N,
+                                                         1,
+                                                         dA,
+                                                         lda,
+                                                         strideA,
+                                                         dIpiv,
+                                                         strideP,
+                                                         dB,
+                                                         ldb,
+                                                         strideB,
+                                                         &info,
+                                                         batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hB1.data(), dB, B_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hIpiv1.data(), dIpiv, Ipiv_size * sizeof(int), hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU LAPACK
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_getrs('N',

--- a/clients/include/testing_hbmv_batched.hpp
+++ b/clients/include/testing_hbmv_batched.hpp
@@ -27,15 +27,12 @@ hipblasStatus_t testing_hbmv_batched(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    int A_size = lda * N;
-    int X_size;
-    int Y_size;
+    size_t A_size = size_t(lda) * N;
+    size_t Y_size = size_t(N) * incy;
 
     int batch_count = argus.batch_count;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
-    X_size                 = N * incx;
-    Y_size                 = N * incy;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -86,46 +83,46 @@ hipblasStatus_t testing_hbmv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHbmvBatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             K,
-                                             (T*)&h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             (T*)&h_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
-    CHECK_HIP_ERROR(dy.transfer_from(hy));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHbmvBatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             K,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             d_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHbmvBatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 K,
+                                                 (T*)&h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 (T*)&h_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+        CHECK_HIP_ERROR(dy.transfer_from(hy));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHbmvBatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 K,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 d_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hemm.hpp
+++ b/clients/include/testing_hemm.hpp
@@ -77,25 +77,25 @@ hipblasStatus_t testing_hemm(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHemmFn(handle, side, uplo, M, N, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHemmFn(handle, side, uplo, M, N, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHemmFn(handle, side, uplo, M, N, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHemmFn(handle, side, uplo, M, N, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hemm_batched.hpp
+++ b/clients/include/testing_hemm_batched.hpp
@@ -86,48 +86,48 @@ hipblasStatus_t testing_hemm_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHemmBatchedFn(handle,
-                                             side,
-                                             uplo,
-                                             M,
-                                             N,
-                                             &h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dB.ptr_on_device(),
-                                             ldb,
-                                             &h_beta,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHemmBatchedFn(handle,
-                                             side,
-                                             uplo,
-                                             M,
-                                             N,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dB.ptr_on_device(),
-                                             ldb,
-                                             d_beta,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHemmBatchedFn(handle,
+                                                 side,
+                                                 uplo,
+                                                 M,
+                                                 N,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dB.ptr_on_device(),
+                                                 ldb,
+                                                 &h_beta,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHemmBatchedFn(handle,
+                                                 side,
+                                                 uplo,
+                                                 M,
+                                                 N,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dB.ptr_on_device(),
+                                                 ldb,
+                                                 d_beta,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hemm_strided_batched.hpp
+++ b/clients/include/testing_hemm_strided_batched.hpp
@@ -82,55 +82,55 @@ hipblasStatus_t testing_hemm_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHemmStridedBatchedFn(handle,
-                                                    side,
-                                                    uplo,
-                                                    M,
-                                                    N,
-                                                    &h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dB,
-                                                    ldb,
-                                                    stride_B,
-                                                    &h_beta,
-                                                    dC,
-                                                    ldc,
-                                                    stride_C,
-                                                    batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHemmStridedBatchedFn(handle,
-                                                    side,
-                                                    uplo,
-                                                    M,
-                                                    N,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dB,
-                                                    ldb,
-                                                    stride_B,
-                                                    d_beta,
-                                                    dC,
-                                                    ldc,
-                                                    stride_C,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHemmStridedBatchedFn(handle,
+                                                        side,
+                                                        uplo,
+                                                        M,
+                                                        N,
+                                                        &h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dB,
+                                                        ldb,
+                                                        stride_B,
+                                                        &h_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHemmStridedBatchedFn(handle,
+                                                        side,
+                                                        uplo,
+                                                        M,
+                                                        N,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dB,
+                                                        ldb,
+                                                        stride_B,
+                                                        d_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hemv.hpp
+++ b/clients/include/testing_hemv.hpp
@@ -75,28 +75,27 @@ hipblasStatus_t testing_hemv(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHemvFn(handle, uplo, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHemvFn(handle, uplo, N, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHemvFn(handle, uplo, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHemvFn(handle, uplo, N, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_hemv<T>(
             uplo, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 

--- a/clients/include/testing_hemv_batched.hpp
+++ b/clients/include/testing_hemv_batched.hpp
@@ -83,44 +83,44 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHemvBatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             (T*)&h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             (T*)&h_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
-    CHECK_HIP_ERROR(dy.transfer_from(hy));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHemvBatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             d_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHemvBatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 (T*)&h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 (T*)&h_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+        CHECK_HIP_ERROR(dy.transfer_from(hy));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHemvBatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 d_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hemv_strided_batched.hpp
+++ b/clients/include/testing_hemv_strided_batched.hpp
@@ -82,50 +82,50 @@ hipblasStatus_t testing_hemv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHemvStridedBatchedFn(handle,
-                                                    uplo,
-                                                    N,
-                                                    (T*)&h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    (T*)&h_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHemvStridedBatchedFn(handle,
-                                                    uplo,
-                                                    N,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    d_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHemvStridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        (T*)&h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        (T*)&h_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHemvStridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        d_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_her2.hpp
+++ b/clients/include/testing_her2.hpp
@@ -25,7 +25,7 @@ hipblasStatus_t testing_her2(const Arguments& argus)
     int incy = argus.incy;
     int lda  = argus.lda;
 
-    int               A_size = lda * N;
+    size_t            A_size = size_t(lda) * N;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
@@ -69,22 +69,23 @@ hipblasStatus_t testing_her2(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHer2Fn(handle, uplo, N, (T*)&h_alpha, dx, incx, dy, incy, dA, lda));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHer2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA, lda));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHer2Fn(handle, uplo, N, (T*)&h_alpha, dx, incx, dy, incy, dA, lda));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHer2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA, lda));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_her2_batched.hpp
+++ b/clients/include/testing_her2_batched.hpp
@@ -27,9 +27,7 @@ hipblasStatus_t testing_her2_batched(const Arguments& argus)
     int lda         = argus.lda;
     int batch_count = argus.batch_count;
 
-    int               A_size = lda * N;
-    int               x_size = N * incx;
-    int               y_size = N * incy;
+    size_t            A_size = size_t(lda) * N;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
@@ -77,42 +75,42 @@ hipblasStatus_t testing_her2_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dy.transfer_from(hy));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHer2BatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             (T*)&h_alpha,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHer2BatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             d_alpha,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHer2BatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 (T*)&h_alpha,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHer2BatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 d_alpha,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hA_device.transfer_from(dA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_her2_strided_batched.hpp
+++ b/clients/include/testing_her2_strided_batched.hpp
@@ -28,12 +28,12 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride     stride_A = lda * N * stride_scale;
-    hipblasStride     stride_x = N * incx * stride_scale;
-    hipblasStride     stride_y = N * incy * stride_scale;
-    int               A_size   = stride_A * batch_count;
-    int               x_size   = stride_x * batch_count;
-    int               y_size   = stride_y * batch_count;
+    hipblasStride     stride_A = size_t(lda) * N * stride_scale;
+    hipblasStride     stride_x = size_t(N) * incx * stride_scale;
+    hipblasStride     stride_y = size_t(N) * incy * stride_scale;
+    size_t            A_size   = stride_A * batch_count;
+    size_t            x_size   = stride_x * batch_count;
+    size_t            y_size   = stride_y * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
@@ -81,48 +81,48 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHer2StridedBatchedFn(handle,
-                                                    uplo,
-                                                    N,
-                                                    (T*)&h_alpha,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHer2StridedBatchedFn(handle,
-                                                    uplo,
-                                                    N,
-                                                    d_alpha,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHer2StridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        (T*)&h_alpha,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHer2StridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        d_alpha,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_her2k.hpp
+++ b/clients/include/testing_her2k.hpp
@@ -81,25 +81,25 @@ hipblasStatus_t testing_her2k(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHer2kFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHer2kFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHer2kFn(
+            handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHer2kFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_her2k_batched.hpp
+++ b/clients/include/testing_her2k_batched.hpp
@@ -85,48 +85,48 @@ hipblasStatus_t testing_her2k_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHer2kBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              &h_alpha,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              &h_beta,
-                                              dC.ptr_on_device(),
-                                              ldc,
-                                              batch_count));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHer2kBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              d_alpha,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              d_beta,
-                                              dC.ptr_on_device(),
-                                              ldc,
-                                              batch_count));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHer2kBatchedFn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  N,
+                                                  K,
+                                                  &h_alpha,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  &h_beta,
+                                                  dC.ptr_on_device(),
+                                                  ldc,
+                                                  batch_count));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHer2kBatchedFn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  N,
+                                                  K,
+                                                  d_alpha,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  d_beta,
+                                                  dC.ptr_on_device(),
+                                                  ldc,
+                                                  batch_count));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_her2k_strided_batched.hpp
+++ b/clients/include/testing_her2k_strided_batched.hpp
@@ -86,55 +86,55 @@ hipblasStatus_t testing_her2k_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHer2kStridedBatchedFn(handle,
-                                                     uplo,
-                                                     transA,
-                                                     N,
-                                                     K,
-                                                     &h_alpha,
-                                                     dA,
-                                                     lda,
-                                                     stride_A,
-                                                     dB,
-                                                     ldb,
-                                                     stride_B,
-                                                     &h_beta,
-                                                     dC,
-                                                     ldc,
-                                                     stride_C,
-                                                     batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHer2kStridedBatchedFn(handle,
-                                                     uplo,
-                                                     transA,
-                                                     N,
-                                                     K,
-                                                     d_alpha,
-                                                     dA,
-                                                     lda,
-                                                     stride_A,
-                                                     dB,
-                                                     ldb,
-                                                     stride_B,
-                                                     d_beta,
-                                                     dC,
-                                                     ldc,
-                                                     stride_C,
-                                                     batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHer2kStridedBatchedFn(handle,
+                                                         uplo,
+                                                         transA,
+                                                         N,
+                                                         K,
+                                                         &h_alpha,
+                                                         dA,
+                                                         lda,
+                                                         stride_A,
+                                                         dB,
+                                                         ldb,
+                                                         stride_B,
+                                                         &h_beta,
+                                                         dC,
+                                                         ldc,
+                                                         stride_C,
+                                                         batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHer2kStridedBatchedFn(handle,
+                                                         uplo,
+                                                         transA,
+                                                         N,
+                                                         K,
+                                                         d_alpha,
+                                                         dA,
+                                                         lda,
+                                                         stride_A,
+                                                         dB,
+                                                         ldb,
+                                                         stride_B,
+                                                         d_beta,
+                                                         dC,
+                                                         ldc,
+                                                         stride_C,
+                                                         batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_herk.hpp
+++ b/clients/include/testing_herk.hpp
@@ -72,26 +72,26 @@ hipblasStatus_t testing_herk(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHerkFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, &h_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHerkFn(handle, uplo, transA, N, K, d_alpha, dA, lda, d_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHerkFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, &h_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHerkFn(handle, uplo, transA, N, K, d_alpha, dA, lda, d_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_herk_batched.hpp
+++ b/clients/include/testing_herk_batched.hpp
@@ -78,44 +78,44 @@ hipblasStatus_t testing_herk_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHerkBatchedFn(handle,
-                                             uplo,
-                                             transA,
-                                             N,
-                                             K,
-                                             &h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             &h_beta,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHerkBatchedFn(handle,
-                                             uplo,
-                                             transA,
-                                             N,
-                                             K,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             d_beta,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHerkBatchedFn(handle,
+                                                 uplo,
+                                                 transA,
+                                                 N,
+                                                 K,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 &h_beta,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHerkBatchedFn(handle,
+                                                 uplo,
+                                                 transA,
+                                                 N,
+                                                 K,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 d_beta,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_herk_strided_batched.hpp
+++ b/clients/include/testing_herk_strided_batched.hpp
@@ -79,49 +79,49 @@ hipblasStatus_t testing_herk_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHerkStridedBatchedFn(handle,
-                                                    uplo,
-                                                    transA,
-                                                    N,
-                                                    K,
-                                                    &h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    &h_beta,
-                                                    dC,
-                                                    ldc,
-                                                    stride_C,
-                                                    batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    CHECK_HIPBLAS_ERROR(hipblasHerkStridedBatchedFn(handle,
-                                                    uplo,
-                                                    transA,
-                                                    N,
-                                                    K,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    d_beta,
-                                                    dC,
-                                                    ldc,
-                                                    stride_C,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHerkStridedBatchedFn(handle,
+                                                        uplo,
+                                                        transA,
+                                                        N,
+                                                        K,
+                                                        &h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        &h_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIPBLAS_ERROR(hipblasHerkStridedBatchedFn(handle,
+                                                        uplo,
+                                                        transA,
+                                                        N,
+                                                        K,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        d_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_herkx.hpp
+++ b/clients/include/testing_herkx.hpp
@@ -80,25 +80,25 @@ hipblasStatus_t testing_herkx(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHerkxFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasHerkxFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHerkxFn(
+            handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasHerkxFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_herkx_batched.hpp
+++ b/clients/include/testing_herkx_batched.hpp
@@ -85,48 +85,48 @@ hipblasStatus_t testing_herkx_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHerkxBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              &h_alpha,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              &h_beta,
-                                              dC.ptr_on_device(),
-                                              ldc,
-                                              batch_count));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHerkxBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              d_alpha,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              d_beta,
-                                              dC.ptr_on_device(),
-                                              ldc,
-                                              batch_count));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHerkxBatchedFn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  N,
+                                                  K,
+                                                  &h_alpha,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  &h_beta,
+                                                  dC.ptr_on_device(),
+                                                  ldc,
+                                                  batch_count));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHerkxBatchedFn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  N,
+                                                  K,
+                                                  d_alpha,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  d_beta,
+                                                  dC.ptr_on_device(),
+                                                  ldc,
+                                                  batch_count));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_herkx_strided_batched.hpp
+++ b/clients/include/testing_herkx_strided_batched.hpp
@@ -86,55 +86,55 @@ hipblasStatus_t testing_herkx_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHerkxStridedBatchedFn(handle,
-                                                     uplo,
-                                                     transA,
-                                                     N,
-                                                     K,
-                                                     &h_alpha,
-                                                     dA,
-                                                     lda,
-                                                     stride_A,
-                                                     dB,
-                                                     ldb,
-                                                     stride_B,
-                                                     &h_beta,
-                                                     dC,
-                                                     ldc,
-                                                     stride_C,
-                                                     batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHerkxStridedBatchedFn(handle,
-                                                     uplo,
-                                                     transA,
-                                                     N,
-                                                     K,
-                                                     d_alpha,
-                                                     dA,
-                                                     lda,
-                                                     stride_A,
-                                                     dB,
-                                                     ldb,
-                                                     stride_B,
-                                                     d_beta,
-                                                     dC,
-                                                     ldc,
-                                                     stride_C,
-                                                     batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHerkxStridedBatchedFn(handle,
+                                                         uplo,
+                                                         transA,
+                                                         N,
+                                                         K,
+                                                         &h_alpha,
+                                                         dA,
+                                                         lda,
+                                                         stride_A,
+                                                         dB,
+                                                         ldb,
+                                                         stride_B,
+                                                         &h_beta,
+                                                         dC,
+                                                         ldc,
+                                                         stride_C,
+                                                         batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHerkxStridedBatchedFn(handle,
+                                                         uplo,
+                                                         transA,
+                                                         N,
+                                                         K,
+                                                         d_alpha,
+                                                         dA,
+                                                         lda,
+                                                         stride_A,
+                                                         dB,
+                                                         ldb,
+                                                         stride_B,
+                                                         d_beta,
+                                                         dC,
+                                                         ldc,
+                                                         stride_C,
+                                                         batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hpr.hpp
+++ b/clients/include/testing_hpr.hpp
@@ -24,7 +24,7 @@ hipblasStatus_t testing_hpr(const Arguments& argus)
     int N    = argus.N;
     int incx = argus.incx;
 
-    int               A_size = N * (N + 1) / 2;
+    size_t            A_size = size_t(N) * (N + 1) / 2;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
@@ -64,22 +64,22 @@ hipblasStatus_t testing_hpr(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHprFn(handle, uplo, N, (U*)&h_alpha, dx, incx, dA));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHprFn(handle, uplo, N, d_alpha, dx, incx, dA));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHprFn(handle, uplo, N, (U*)&h_alpha, dx, incx, dA));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHprFn(handle, uplo, N, d_alpha, dx, incx, dA));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hpr2.hpp
+++ b/clients/include/testing_hpr2.hpp
@@ -24,7 +24,7 @@ hipblasStatus_t testing_hpr2(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    int               A_size = N * (N + 1) / 2;
+    size_t            A_size = size_t(N) * (N + 1) / 2;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
@@ -68,22 +68,22 @@ hipblasStatus_t testing_hpr2(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHpr2Fn(handle, uplo, N, (T*)&h_alpha, dx, incx, dy, incy, dA));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHpr2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHpr2Fn(handle, uplo, N, (T*)&h_alpha, dx, incx, dy, incy, dA));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHpr2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hpr2_batched.hpp
+++ b/clients/include/testing_hpr2_batched.hpp
@@ -26,9 +26,7 @@ hipblasStatus_t testing_hpr2_batched(const Arguments& argus)
     int incy        = argus.incy;
     int batch_count = argus.batch_count;
 
-    int               A_size = N * (N + 1) / 2;
-    int               x_size = N * incx;
-    int               y_size = N * incy;
+    size_t            A_size = size_t(N) * (N + 1) / 2;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
@@ -76,40 +74,40 @@ hipblasStatus_t testing_hpr2_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dy.transfer_from(hy));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHpr2BatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             (T*)&h_alpha,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             dA.ptr_on_device(),
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHpr2BatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             d_alpha,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             dA.ptr_on_device(),
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHpr2BatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 (T*)&h_alpha,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 dA.ptr_on_device(),
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHpr2BatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 d_alpha,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 dA.ptr_on_device(),
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hA_device.transfer_from(dA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hpr2_strided_batched.hpp
+++ b/clients/include/testing_hpr2_strided_batched.hpp
@@ -27,13 +27,13 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    int               dim_A    = N * (N + 1) / 2;
+    size_t            dim_A    = size_t(N) * (N + 1) / 2;
     hipblasStride     stride_A = dim_A * stride_scale;
-    hipblasStride     stride_x = N * incx * stride_scale;
-    hipblasStride     stride_y = N * incy * stride_scale;
-    int               A_size   = stride_A * batch_count;
-    int               x_size   = stride_x * batch_count;
-    int               y_size   = stride_y * batch_count;
+    hipblasStride     stride_x = size_t(N) * incx * stride_scale;
+    hipblasStride     stride_y = size_t(N) * incy * stride_scale;
+    size_t            A_size   = stride_A * batch_count;
+    size_t            x_size   = stride_x * batch_count;
+    size_t            y_size   = stride_y * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
@@ -81,46 +81,46 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHpr2StridedBatchedFn(handle,
-                                                    uplo,
-                                                    N,
-                                                    (T*)&h_alpha,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    dA,
-                                                    stride_A,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHpr2StridedBatchedFn(handle,
-                                                    uplo,
-                                                    N,
-                                                    d_alpha,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    dA,
-                                                    stride_A,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHpr2StridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        (T*)&h_alpha,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        dA,
+                                                        stride_A,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHpr2StridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        d_alpha,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        dA,
+                                                        stride_A,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hpr_batched.hpp
+++ b/clients/include/testing_hpr_batched.hpp
@@ -26,8 +26,7 @@ hipblasStatus_t testing_hpr_batched(const Arguments& argus)
     int incx        = argus.incx;
     int batch_count = argus.batch_count;
 
-    int               A_size = N * (N + 1) / 2;
-    int               x_size = N * incx;
+    size_t            A_size = size_t(N) * (N + 1) / 2;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
@@ -70,24 +69,30 @@ hipblasStatus_t testing_hpr_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHprBatchedFn(
-        handle, uplo, N, (U*)&h_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
-
-    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHprBatchedFn(
-        handle, uplo, N, d_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
-
-    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHprBatchedFn(handle,
+                                                uplo,
+                                                N,
+                                                (U*)&h_alpha,
+                                                dx.ptr_on_device(),
+                                                incx,
+                                                dA.ptr_on_device(),
+                                                batch_count));
+
+        CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHprBatchedFn(
+            handle, uplo, N, d_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
+
+        CHECK_HIP_ERROR(hA_device.transfer_from(dA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_hpr_strided_batched.hpp
+++ b/clients/include/testing_hpr_strided_batched.hpp
@@ -27,11 +27,11 @@ hipblasStatus_t testing_hpr_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    int               dim_A    = N * (N + 1) / 2;
+    size_t            dim_A    = size_t(N) * (N + 1) / 2;
     hipblasStride     stride_A = dim_A * stride_scale;
-    hipblasStride     stride_x = N * incx * stride_scale;
-    int               A_size   = stride_A * batch_count;
-    int               x_size   = stride_x * batch_count;
+    hipblasStride     stride_x = size_t(N) * incx * stride_scale;
+    size_t            A_size   = stride_A * batch_count;
+    size_t            x_size   = stride_x * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
@@ -75,24 +75,24 @@ hipblasStatus_t testing_hpr_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasHprStridedBatchedFn(
-        handle, uplo, N, (U*)&h_alpha, dx, incx, stride_x, dA, stride_A, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasHprStridedBatchedFn(
-        handle, uplo, N, d_alpha, dx, incx, stride_x, dA, stride_A, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasHprStridedBatchedFn(
+            handle, uplo, N, (U*)&h_alpha, dx, incx, stride_x, dA, stride_A, batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasHprStridedBatchedFn(
+            handle, uplo, N, d_alpha, dx, incx, stride_x, dA, stride_A, batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -56,22 +56,22 @@ hipblasStatus_t testing_iamax_iamin(const Arguments& argus, hipblas_iamax_iamin_
     double gpu_time_used;
     int    hipblas_error_host, hipblas_error_device;
 
-    /* =====================================================================
-                HIPBLAS
-    =================================================================== */
-    // device_pointer
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, d_hipblas_result));
-
-    CHECK_HIP_ERROR(
-        hipMemcpy(&hipblas_result_device, d_hipblas_result, sizeof(int), hipMemcpyDeviceToHost));
-
-    // host_pointer
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, &hipblas_result_host));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+                    HIPBLAS
+        =================================================================== */
+        // device_pointer
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, d_hipblas_result));
+
+        CHECK_HIP_ERROR(hipMemcpy(
+            &hipblas_result_device, d_hipblas_result, sizeof(int), hipMemcpyDeviceToHost));
+
+        // host_pointer
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, &hipblas_result_host));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_iamax_iamin_batched.hpp
+++ b/clients/include/testing_iamax_iamin_batched.hpp
@@ -69,25 +69,25 @@ hipblasStatus_t testing_iamax_iamin_batched(const Arguments&                 arg
     double gpu_time_used;
     int    hipblas_error_host = 0, hipblas_error_device = 0;
 
-    /* =====================================================================
-                HIPBLAS
-    =================================================================== */
-    // device_pointer
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        func(handle, N, dx.ptr_on_device(), incx, batch_count, d_hipblas_result_device));
-    CHECK_HIP_ERROR(hipMemcpy(hipblas_result_device,
-                              d_hipblas_result_device,
-                              sizeof(int) * batch_count,
-                              hipMemcpyDeviceToHost));
-
-    // host_pointer
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        func(handle, N, dx.ptr_on_device(), incx, batch_count, hipblas_result_host));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+                    HIPBLAS
+        =================================================================== */
+        // device_pointer
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            func(handle, N, dx.ptr_on_device(), incx, batch_count, d_hipblas_result_device));
+        CHECK_HIP_ERROR(hipMemcpy(hipblas_result_device,
+                                  d_hipblas_result_device,
+                                  sizeof(int) * batch_count,
+                                  hipMemcpyDeviceToHost));
+
+        // host_pointer
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            func(handle, N, dx.ptr_on_device(), incx, batch_count, hipblas_result_host));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/testing_iamax_iamin_strided_batched.hpp
@@ -79,22 +79,25 @@ hipblasStatus_t testing_iamax_iamin_strided_batched(const Arguments&            
 
     double gpu_time_used;
     int    hipblas_error_host = 0, hipblas_error_device = 0;
-    /* =====================================================================
-                HIP BLAS
-    =================================================================== */
-    // device_pointer
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, stridex, batch_count, d_hipblas_result));
-
-    CHECK_HIP_ERROR(hipMemcpy(
-        hipblas_result_device, d_hipblas_result, sizeof(int) * batch_count, hipMemcpyDeviceToHost));
-
-    // host_pointer
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, stridex, batch_count, hipblas_result_host));
 
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+                    HIPBLAS
+        =================================================================== */
+        // device_pointer
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, stridex, batch_count, d_hipblas_result));
+
+        CHECK_HIP_ERROR(hipMemcpy(hipblas_result_device,
+                                  d_hipblas_result,
+                                  sizeof(int) * batch_count,
+                                  hipMemcpyDeviceToHost));
+
+        // host_pointer
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, stridex, batch_count, hipblas_result_host));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -49,18 +49,18 @@ hipblasStatus_t testing_nrm2(const Arguments& argus)
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
 
-    // hipblasNrm2 accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2Fn(handle, N, dx, incx, d_hipblas_result));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2Fn(handle, N, dx, incx, &hipblas_result_host));
-
-    CHECK_HIP_ERROR(
-        hipMemcpy(&hipblas_result_device, d_hipblas_result, sizeof(Tr), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        // hipblasNrm2 accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2Fn(handle, N, dx, incx, d_hipblas_result));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2Fn(handle, N, dx, incx, &hipblas_result_host));
+
+        CHECK_HIP_ERROR(
+            hipMemcpy(&hipblas_result_device, d_hipblas_result, sizeof(Tr), hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -56,22 +56,22 @@ hipblasStatus_t testing_nrm2_batched(const Arguments& argus)
     hipblas_init(hx, true);
     CHECK_HIP_ERROR(dx.transfer_from(hx));
 
-    // hipblasNrm2 accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasNrm2BatchedFn(handle, N, dx.ptr_on_device(), incx, batch_count, d_hipblas_result));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedFn(
-        handle, N, dx.ptr_on_device(), incx, batch_count, h_hipblas_result_host));
-
-    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
-                              d_hipblas_result,
-                              sizeof(Tr) * batch_count,
-                              hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        // hipblasNrm2 accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedFn(
+            handle, N, dx.ptr_on_device(), incx, batch_count, d_hipblas_result));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedFn(
+            handle, N, dx.ptr_on_device(), incx, batch_count, h_hipblas_result_host));
+
+        CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                                  d_hipblas_result,
+                                  sizeof(Tr) * batch_count,
+                                  hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -55,36 +55,36 @@ hipblasStatus_t testing_nrm2_batched_ex_template(const Arguments& argus)
     hipblas_init(hx, true);
     CHECK_HIP_ERROR(dx.transfer_from(hx));
 
-    // hipblasNrm2 accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedExFn(handle,
-                                               N,
-                                               dx.ptr_on_device(),
-                                               xType,
-                                               incx,
-                                               batch_count,
-                                               d_hipblas_result,
-                                               resultType,
-                                               executionType));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedExFn(handle,
-                                               N,
-                                               dx.ptr_on_device(),
-                                               xType,
-                                               incx,
-                                               batch_count,
-                                               h_hipblas_result_host,
-                                               resultType,
-                                               executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
-                              d_hipblas_result,
-                              sizeof(Tr) * batch_count,
-                              hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        // hipblasNrm2 accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedExFn(handle,
+                                                   N,
+                                                   dx.ptr_on_device(),
+                                                   xType,
+                                                   incx,
+                                                   batch_count,
+                                                   d_hipblas_result,
+                                                   resultType,
+                                                   executionType));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedExFn(handle,
+                                                   N,
+                                                   dx.ptr_on_device(),
+                                                   xType,
+                                                   incx,
+                                                   batch_count,
+                                                   h_hipblas_result_host,
+                                                   resultType,
+                                                   executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                                  d_hipblas_result,
+                                  sizeof(Tr) * batch_count,
+                                  hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_nrm2_ex.hpp
+++ b/clients/include/testing_nrm2_ex.hpp
@@ -52,20 +52,19 @@ hipblasStatus_t testing_nrm2_ex_template(const Arguments& argus)
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
 
-    // hipblasNrm2 accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasNrm2ExFn(handle, N, dx, xType, incx, d_hipblas_result, resultType, executionType));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2ExFn(
-        handle, N, dx, xType, incx, &hipblas_result_host, resultType, executionType));
-
-    CHECK_HIP_ERROR(
-        hipMemcpy(&hipblas_result_device, d_hipblas_result, sizeof(Tr), hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        // hipblasNrm2 accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2ExFn(
+            handle, N, dx, xType, incx, d_hipblas_result, resultType, executionType));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2ExFn(
+            handle, N, dx, xType, incx, &hipblas_result_host, resultType, executionType));
+
+        CHECK_HIP_ERROR(
+            hipMemcpy(&hipblas_result_device, d_hipblas_result, sizeof(Tr), hipMemcpyDeviceToHost));
 
         /* =====================================================================
                     CPU BLAS

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -60,22 +60,22 @@ hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
 
-    // hipblasNrm2 accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasNrm2StridedBatchedFn(handle, N, dx, incx, stridex, batch_count, d_hipblas_result));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedFn(
-        handle, N, dx, incx, stridex, batch_count, h_hipblas_result_host));
-
-    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
-                              d_hipblas_result,
-                              sizeof(Tr) * batch_count,
-                              hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        // hipblasNrm2 accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedFn(
+            handle, N, dx, incx, stridex, batch_count, d_hipblas_result));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedFn(
+            handle, N, dx, incx, stridex, batch_count, h_hipblas_result_host));
+
+        CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                                  d_hipblas_result,
+                                  sizeof(Tr) * batch_count,
+                                  hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -61,38 +61,38 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
 
-    // hipblasNrm2 accept both dev/host pointer for the scalar
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedExFn(handle,
-                                                      N,
-                                                      dx,
-                                                      xType,
-                                                      incx,
-                                                      stridex,
-                                                      batch_count,
-                                                      d_hipblas_result,
-                                                      resultType,
-                                                      executionType));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedExFn(handle,
-                                                      N,
-                                                      dx,
-                                                      xType,
-                                                      incx,
-                                                      stridex,
-                                                      batch_count,
-                                                      h_hipblas_result_host,
-                                                      resultType,
-                                                      executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
-                              d_hipblas_result,
-                              sizeof(Tr) * batch_count,
-                              hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        // hipblasNrm2 accept both dev/host pointer for the scalar
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedExFn(handle,
+                                                          N,
+                                                          dx,
+                                                          xType,
+                                                          incx,
+                                                          stridex,
+                                                          batch_count,
+                                                          d_hipblas_result,
+                                                          resultType,
+                                                          executionType));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedExFn(handle,
+                                                          N,
+                                                          dx,
+                                                          xType,
+                                                          incx,
+                                                          stridex,
+                                                          batch_count,
+                                                          h_hipblas_result_host,
+                                                          resultType,
+                                                          executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(h_hipblas_result_device,
+                                  d_hipblas_result,
+                                  sizeof(Tr) * batch_count,
+                                  hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_rot_batched_ex.hpp
+++ b/clients/include/testing_rot_batched_ex.hpp
@@ -76,47 +76,48 @@ hipblasStatus_t testing_rot_batched_ex_template(const Arguments& arg)
     CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(Tcs), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(Tcs), hipMemcpyHostToDevice));
 
-    // HIPBLAS
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasRotBatchedExFn(handle,
-                                              N,
-                                              dx.ptr_on_device(),
-                                              xType,
-                                              incx,
-                                              dy.ptr_on_device(),
-                                              yType,
-                                              incy,
-                                              hc,
-                                              hs,
-                                              csType,
-                                              batch_count,
-                                              executionType));
-
-    CHECK_HIP_ERROR(hx_host.transfer_from(dx));
-    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
-    CHECK_HIP_ERROR(dx.transfer_from(hx_device));
-    CHECK_HIP_ERROR(dy.transfer_from(hy_device));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasRotBatchedExFn(handle,
-                                              N,
-                                              dx.ptr_on_device(),
-                                              xType,
-                                              incx,
-                                              dy.ptr_on_device(),
-                                              yType,
-                                              incy,
-                                              dc,
-                                              ds,
-                                              csType,
-                                              batch_count,
-                                              executionType));
-
-    CHECK_HIP_ERROR(hx_device.transfer_from(dx));
-    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
-
     if(arg.unit_check || arg.norm_check)
     {
+        // HIPBLAS
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasRotBatchedExFn(handle,
+                                                  N,
+                                                  dx.ptr_on_device(),
+                                                  xType,
+                                                  incx,
+                                                  dy.ptr_on_device(),
+                                                  yType,
+                                                  incy,
+                                                  hc,
+                                                  hs,
+                                                  csType,
+                                                  batch_count,
+                                                  executionType));
+
+        CHECK_HIP_ERROR(hx_host.transfer_from(dx));
+        CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+        CHECK_HIP_ERROR(dx.transfer_from(hx_device));
+        CHECK_HIP_ERROR(dy.transfer_from(hy_device));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasRotBatchedExFn(handle,
+                                                  N,
+                                                  dx.ptr_on_device(),
+                                                  xType,
+                                                  incx,
+                                                  dy.ptr_on_device(),
+                                                  yType,
+                                                  incy,
+                                                  dc,
+                                                  ds,
+                                                  csType,
+                                                  batch_count,
+                                                  executionType));
+
+        CHECK_HIP_ERROR(hx_device.transfer_from(dx));
+        CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
+        // CBLAS
         for(int b = 0; b < batch_count; b++)
         {
             cblas_rot<Tx, Tcs, Tcs>(N, hx_cpu[b], incx, hy_cpu[b], incy, *hc, *hs);

--- a/clients/include/testing_rot_ex.hpp
+++ b/clients/include/testing_rot_ex.hpp
@@ -79,25 +79,26 @@ hipblasStatus_t testing_rot_ex_template(const Arguments& arg)
     CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(Tcs), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(Tcs), hipMemcpyHostToDevice));
 
-    // HIPBLAS
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasRotExFn(handle, N, dx, xType, incx, dy, yType, incy, hc, hs, csType, executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hy_host, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy_device, sizeof(Ty) * size_y, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasRotExFn(handle, N, dx, xType, incx, dy, yType, incy, dc, ds, csType, executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hy_device, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
-
     if(arg.unit_check || arg.norm_check)
     {
+        // HIPBLAS
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasRotExFn(
+            handle, N, dx, xType, incx, dy, yType, incy, hc, hs, csType, executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_host, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy_device, sizeof(Ty) * size_y, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasRotExFn(
+            handle, N, dx, xType, incx, dy, yType, incy, dc, ds, csType, executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_device, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
+
+        // CBLAS
         cblas_rot<Tx, Tcs, Tcs>(N, hx_cpu.data(), incx, hy_cpu.data(), incy, *hc, *hs);
 
         if(arg.unit_check)

--- a/clients/include/testing_rot_strided_batched_ex.hpp
+++ b/clients/include/testing_rot_strided_batched_ex.hpp
@@ -80,50 +80,50 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(const Arguments& arg)
     CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(Tcs), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(Tcs), hipMemcpyHostToDevice));
 
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasRotStridedBatchedExFn(handle,
-                                                     N,
-                                                     dx,
-                                                     xType,
-                                                     incx,
-                                                     stridex,
-                                                     dy,
-                                                     yType,
-                                                     incy,
-                                                     stridey,
-                                                     hc,
-                                                     hs,
-                                                     csType,
-                                                     batch_count,
-                                                     executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hy_host, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy_device, sizeof(Ty) * size_y, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasRotStridedBatchedExFn(handle,
-                                                     N,
-                                                     dx,
-                                                     xType,
-                                                     incx,
-                                                     stridex,
-                                                     dy,
-                                                     yType,
-                                                     incy,
-                                                     stridey,
-                                                     dc,
-                                                     ds,
-                                                     csType,
-                                                     batch_count,
-                                                     executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hy_device, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
-
     if(arg.unit_check || arg.norm_check)
     {
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasRotStridedBatchedExFn(handle,
+                                                         N,
+                                                         dx,
+                                                         xType,
+                                                         incx,
+                                                         stridex,
+                                                         dy,
+                                                         yType,
+                                                         incy,
+                                                         stridey,
+                                                         hc,
+                                                         hs,
+                                                         csType,
+                                                         batch_count,
+                                                         executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_host, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * size_x, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy_device, sizeof(Ty) * size_y, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasRotStridedBatchedExFn(handle,
+                                                         N,
+                                                         dx,
+                                                         xType,
+                                                         incx,
+                                                         stridex,
+                                                         dy,
+                                                         yType,
+                                                         incy,
+                                                         stridey,
+                                                         dc,
+                                                         ds,
+                                                         csType,
+                                                         batch_count,
+                                                         executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * size_x, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_device, dy, sizeof(Ty) * size_y, hipMemcpyDeviceToHost));
+
         for(int b = 0; b < batch_count; b++)
         {
             cblas_rot<Tx, Tcs, Tcs>(

--- a/clients/include/testing_rotg_batched.hpp
+++ b/clients/include/testing_rotg_batched.hpp
@@ -40,17 +40,29 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
     hipblasLocalHandle handle(arg);
 
     // Initial Data on CPU
+    // host vectors for hipblas host result
     host_batch_vector<T> ha(1, 1, batch_count);
     host_batch_vector<T> hb(1, 1, batch_count);
     host_batch_vector<U> hc(1, 1, batch_count);
     host_batch_vector<T> hs(1, 1, batch_count);
+
+    // host vectors for cblas
     host_batch_vector<T> ca(1, 1, batch_count);
     host_batch_vector<T> cb(1, 1, batch_count);
     host_batch_vector<U> cc(1, 1, batch_count);
     host_batch_vector<T> cs(1, 1, batch_count);
 
+    // host vectors for hipblas device result
+    host_batch_vector<T> ra(1, 1, batch_count);
+    host_batch_vector<T> rb(1, 1, batch_count);
+    host_batch_vector<U> rc(1, 1, batch_count);
+    host_batch_vector<T> rs(1, 1, batch_count);
+
+    // device vectors for hipblas device
     device_batch_vector<T> da(1, 1, batch_count);
     device_batch_vector<T> db(1, 1, batch_count);
+    device_batch_vector<U> dc(1, 1, batch_count);
+    device_batch_vector<T> ds(1, 1, batch_count);
 
     hipblas_init(ha, true);
     hipblas_init(hb, false);
@@ -60,56 +72,24 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
     cb.copy_from(hb);
     cc.copy_from(hc);
     cs.copy_from(hs);
+    ra.copy_from(ha);
+    rb.copy_from(hb);
+    rc.copy_from(hc);
+    rs.copy_from(hs);
 
-    for(int b = 0; b < batch_count; b++)
+    CHECK_HIP_ERROR(da.transfer_from(ha));
+    CHECK_HIP_ERROR(db.transfer_from(hb));
+    CHECK_HIP_ERROR(dc.transfer_from(hc));
+    CHECK_HIP_ERROR(ds.transfer_from(hs));
+
+    if(arg.unit_check || arg.norm_check)
     {
-        cblas_rotg<T, U>(ca[b], cb[b], cc[b], cs[b]);
-    }
-
-    // Test host
-    {
-        host_batch_vector<T> ra(1, 1, batch_count);
-        host_batch_vector<T> rb(1, 1, batch_count);
-        host_batch_vector<U> rc(1, 1, batch_count);
-        host_batch_vector<T> rs(1, 1, batch_count);
-        ra.copy_from(ha);
-        rb.copy_from(hb);
-        rc.copy_from(hc);
-        rs.copy_from(hs);
-
+        // hipBLAS
+        // test host
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        CHECK_HIPBLAS_ERROR(hipblasRotgBatchedFn(handle, ra, rb, rc, rs, batch_count));
+        CHECK_HIPBLAS_ERROR(hipblasRotgBatchedFn(handle, ha, hb, hc, hs, batch_count));
 
-        if(arg.unit_check)
-        {
-            for(int b = 0; b < batch_count; b++)
-            {
-                near_check_general<T>(1, 1, 1, ca[b], ra[b], rel_error);
-                near_check_general<T>(1, 1, 1, cb[b], rb[b], rel_error);
-                near_check_general<U>(1, 1, 1, cc[b], rc[b], rel_error);
-                near_check_general<T>(1, 1, 1, cs[b], rs[b], rel_error);
-            }
-        }
-        if(arg.norm_check)
-        {
-            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, ca, ra, batch_count);
-            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, cb, rb, batch_count);
-            hipblas_error_host += norm_check_general<U>('F', 1, 1, 1, cc, rc, batch_count);
-            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, cs, rs, batch_count);
-        }
-    }
-
-    // Test device
-    {
-        device_batch_vector<T> da(1, 1, batch_count);
-        device_batch_vector<T> db(1, 1, batch_count);
-        device_batch_vector<U> dc(1, 1, batch_count);
-        device_batch_vector<T> ds(1, 1, batch_count);
-        CHECK_HIP_ERROR(da.transfer_from(ha));
-        CHECK_HIP_ERROR(db.transfer_from(hb));
-        CHECK_HIP_ERROR(dc.transfer_from(hc));
-        CHECK_HIP_ERROR(ds.transfer_from(hs));
-
+        // test device
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIPBLAS_ERROR((hipblasRotgBatchedFn(handle,
                                                   da.ptr_on_device(),
@@ -118,27 +98,40 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
                                                   ds.ptr_on_device(),
                                                   batch_count)));
 
-        host_batch_vector<T> ra(1, 1, batch_count);
-        host_batch_vector<T> rb(1, 1, batch_count);
-        host_batch_vector<U> rc(1, 1, batch_count);
-        host_batch_vector<T> rs(1, 1, batch_count);
         CHECK_HIP_ERROR(ra.transfer_from(da));
         CHECK_HIP_ERROR(rb.transfer_from(db));
         CHECK_HIP_ERROR(rc.transfer_from(dc));
         CHECK_HIP_ERROR(rs.transfer_from(ds));
 
+        // CBLAS
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_rotg<T, U>(ca[b], cb[b], cc[b], cs[b]);
+        }
+
         if(arg.unit_check)
         {
             for(int b = 0; b < batch_count; b++)
             {
+                near_check_general<T>(1, 1, 1, ca[b], ha[b], rel_error);
+                near_check_general<T>(1, 1, 1, cb[b], hb[b], rel_error);
+                near_check_general<U>(1, 1, 1, cc[b], hc[b], rel_error);
+                near_check_general<T>(1, 1, 1, cs[b], hs[b], rel_error);
+
                 near_check_general<T>(1, 1, 1, ca[b], ra[b], rel_error);
                 near_check_general<T>(1, 1, 1, cb[b], rb[b], rel_error);
                 near_check_general<U>(1, 1, 1, cc[b], rc[b], rel_error);
                 near_check_general<T>(1, 1, 1, cs[b], rs[b], rel_error);
             }
         }
+
         if(arg.norm_check)
         {
+            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, ca, ha, batch_count);
+            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, cb, hb, batch_count);
+            hipblas_error_host += norm_check_general<U>('F', 1, 1, 1, cc, hc, batch_count);
+            hipblas_error_host += norm_check_general<T>('F', 1, 1, 1, cs, hs, batch_count);
+
             hipblas_error_device = norm_check_general<T>('F', 1, 1, 1, ca, ra, batch_count);
             hipblas_error_device += norm_check_general<T>('F', 1, 1, 1, cb, rb, batch_count);
             hipblas_error_device += norm_check_general<U>('F', 1, 1, 1, cc, rc, batch_count);
@@ -148,14 +141,6 @@ hipblasStatus_t testing_rotg_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        device_batch_vector<T> da(1, 1, batch_count);
-        device_batch_vector<T> db(1, 1, batch_count);
-        device_batch_vector<U> dc(1, 1, batch_count);
-        device_batch_vector<T> ds(1, 1, batch_count);
-        CHECK_HIP_ERROR(da.transfer_from(ha));
-        CHECK_HIP_ERROR(db.transfer_from(hb));
-        CHECK_HIP_ERROR(dc.transfer_from(hc));
-        CHECK_HIP_ERROR(ds.transfer_from(hs));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/testing_rotg_strided_batched.hpp
+++ b/clients/include/testing_rotg_strided_batched.hpp
@@ -67,75 +67,68 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
     host_vector<U> cc = hc;
     host_vector<T> cs = hs;
 
-    for(int b = 0; b < batch_count; b++)
-    {
-        cblas_rotg<T, U>(ca.data() + b * stride_a,
-                         cb.data() + b * stride_b,
-                         cc.data() + b * stride_c,
-                         cs.data() + b * stride_s);
-    }
+    // result vector for hipBLAS device
+    host_vector<T> ra = ha;
+    host_vector<T> rb = hb;
+    host_vector<U> rc = hc;
+    host_vector<T> rs = hs;
 
-    // Test host
+    device_vector<T> da(size_a);
+    device_vector<T> db(size_b);
+    device_vector<U> dc(size_c);
+    device_vector<T> ds(size_s);
+
+    CHECK_HIP_ERROR(hipMemcpy(da, ha, sizeof(T) * size_a, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(db, hb, sizeof(T) * size_b, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U) * size_c, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(T) * size_s, hipMemcpyHostToDevice));
+
+    if(arg.unit_check || arg.norm_check)
     {
-        host_vector<T> ra = ha;
-        host_vector<T> rb = hb;
-        host_vector<U> rc = hc;
-        host_vector<T> rs = hs;
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         CHECK_HIPBLAS_ERROR((hipblasRotgStridedBatchedFn(
-            handle, ra, stride_a, rb, stride_b, rc, stride_c, rs, stride_s, batch_count)));
+            handle, ha, stride_a, hb, stride_b, hc, stride_c, hs, stride_s, batch_count)));
 
-        if(arg.unit_check)
-        {
-            near_check_general<T>(1, 1, batch_count, 1, stride_a, ca, ra, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, stride_b, cb, rb, rel_error);
-            near_check_general<U>(1, 1, batch_count, 1, stride_c, cc, rc, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, stride_s, cs, rs, rel_error);
-        }
-        if(arg.norm_check)
-        {
-            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, stride_a, ca, ra, batch_count);
-            hipblas_error_host
-                += norm_check_general<T>('F', 1, 1, 1, stride_b, cb, rb, batch_count);
-            hipblas_error_host
-                += norm_check_general<U>('F', 1, 1, 1, stride_c, cc, rc, batch_count);
-            hipblas_error_host
-                += norm_check_general<T>('F', 1, 1, 1, stride_s, cs, rs, batch_count);
-        }
-    }
-
-    // Test device
-    {
-        device_vector<T> da(size_a);
-        device_vector<T> db(size_b);
-        device_vector<U> dc(size_c);
-        device_vector<T> ds(size_s);
-        CHECK_HIP_ERROR(hipMemcpy(da, ha, sizeof(T) * size_a, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(db, hb, sizeof(T) * size_b, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U) * size_c, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(T) * size_s, hipMemcpyHostToDevice));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIPBLAS_ERROR((hipblasRotgStridedBatchedFn(
             handle, da, stride_a, db, stride_b, dc, stride_c, ds, stride_s, batch_count)));
 
-        host_vector<T> ra(size_a);
-        host_vector<T> rb(size_b);
-        host_vector<U> rc(size_c);
-        host_vector<T> rs(size_s);
         CHECK_HIP_ERROR(hipMemcpy(ra, da, sizeof(T) * size_a, hipMemcpyDeviceToHost));
         CHECK_HIP_ERROR(hipMemcpy(rb, db, sizeof(T) * size_b, hipMemcpyDeviceToHost));
         CHECK_HIP_ERROR(hipMemcpy(rc, dc, sizeof(U) * size_c, hipMemcpyDeviceToHost));
         CHECK_HIP_ERROR(hipMemcpy(rs, ds, sizeof(T) * size_s, hipMemcpyDeviceToHost));
 
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_rotg<T, U>(ca.data() + b * stride_a,
+                             cb.data() + b * stride_b,
+                             cc.data() + b * stride_c,
+                             cs.data() + b * stride_s);
+        }
+
         if(arg.unit_check)
         {
+            near_check_general<T>(1, 1, batch_count, 1, stride_a, ca, ha, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_b, cb, hb, rel_error);
+            near_check_general<U>(1, 1, batch_count, 1, stride_c, cc, hc, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_s, cs, hs, rel_error);
+
             near_check_general<T>(1, 1, batch_count, 1, stride_a, ca, ra, rel_error);
             near_check_general<T>(1, 1, batch_count, 1, stride_b, cb, rb, rel_error);
             near_check_general<U>(1, 1, batch_count, 1, stride_c, cc, rc, rel_error);
             near_check_general<T>(1, 1, batch_count, 1, stride_s, cs, rs, rel_error);
         }
+
         if(arg.norm_check)
         {
+            hipblas_error_host = norm_check_general<T>('F', 1, 1, 1, stride_a, ca, ha, batch_count);
+            hipblas_error_host
+                += norm_check_general<T>('F', 1, 1, 1, stride_b, cb, hb, batch_count);
+            hipblas_error_host
+                += norm_check_general<U>('F', 1, 1, 1, stride_c, cc, hc, batch_count);
+            hipblas_error_host
+                += norm_check_general<T>('F', 1, 1, 1, stride_s, cs, hs, batch_count);
+
             hipblas_error_device
                 = norm_check_general<T>('F', 1, 1, 1, stride_a, ca, ra, batch_count);
             hipblas_error_device
@@ -149,14 +142,6 @@ hipblasStatus_t testing_rotg_strided_batched(const Arguments& arg)
 
     if(arg.timing)
     {
-        device_vector<T> da(size_a);
-        device_vector<T> db(size_b);
-        device_vector<U> dc(size_c);
-        device_vector<T> ds(size_s);
-        CHECK_HIP_ERROR(hipMemcpy(da, ha, sizeof(T) * size_a, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(db, hb, sizeof(T) * size_b, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dc, hc, sizeof(U) * size_c, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(ds, hs, sizeof(T) * size_s, hipMemcpyHostToDevice));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/testing_rotm.hpp
+++ b/clients/include/testing_rotm.hpp
@@ -58,13 +58,13 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
     const T   FLAGS[FLAG_COUNT] = {-1, 0, 1, -2};
     for(int i = 0; i < FLAG_COUNT; ++i)
     {
-        hparam[0]         = FLAGS[i];
-        host_vector<T> cx = hx;
-        host_vector<T> cy = hy;
-        cblas_rotm<T>(N, cx, incx, cy, incy, hparam);
-
         if(arg.unit_check || arg.norm_check)
         {
+            hparam[0]         = FLAGS[i];
+            host_vector<T> cx = hx;
+            host_vector<T> cy = hy;
+            cblas_rotm<T>(N, cx, incx, cy, incy, hparam);
+
             // Test host
             {
                 CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));

--- a/clients/include/testing_rotmg_strided_batched.hpp
+++ b/clients/include/testing_rotmg_strided_batched.hpp
@@ -51,6 +51,7 @@ hipblasStatus_t testing_rotmg_strided_batched(const Arguments& arg)
     size_t size_param = batch_count * stride_param;
 
     // Initial Data on CPU
+    // host data for hipBLAS host test
     host_vector<T> hd1(size_d1);
     host_vector<T> hd2(size_d2);
     host_vector<T> hx1(size_x1);
@@ -64,80 +65,48 @@ hipblasStatus_t testing_rotmg_strided_batched(const Arguments& arg)
     hipblas_init<T>(hx1, 1, 1, 1, stride_x1, batch_count);
     hipblas_init<T>(hy1, 1, 1, 1, stride_y1, batch_count);
 
+    // host data for CBLAS test
     host_vector<T> cparams = hparams;
     host_vector<T> cd1     = hd1;
     host_vector<T> cd2     = hd2;
     host_vector<T> cx1     = hx1;
     host_vector<T> cy1     = hy1;
 
-    for(int b = 0; b < batch_count; b++)
-    {
-        cblas_rotmg<T>(cd1 + b * stride_d1,
-                       cd2 + b * stride_d2,
-                       cx1 + b * stride_x1,
-                       cy1 + b * stride_y1,
-                       cparams + b * stride_param);
-    }
+    // host data for hipBLAS device test
+    host_vector<T> hd1_d(size_d1);
+    host_vector<T> hd2_d(size_d2);
+    host_vector<T> hx1_d(size_x1);
+    host_vector<T> hy1_d(size_y1);
+    host_vector<T> hparams_d(size_param);
 
-    // Test host
-    {
-        host_vector<T> rd1     = hd1;
-        host_vector<T> rd2     = hd2;
-        host_vector<T> rx1     = hx1;
-        host_vector<T> ry1     = hy1;
-        host_vector<T> rparams = hparams;
+    // device data for hipBLAS device test
+    device_vector<T> dd1(size_d1);
+    device_vector<T> dd2(size_d2);
+    device_vector<T> dx1(size_x1);
+    device_vector<T> dy1(size_y1);
+    device_vector<T> dparams(size_param);
 
+    CHECK_HIP_ERROR(hipMemcpy(dd1, hd1, sizeof(T) * size_d1, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dd2, hd2, sizeof(T) * size_d2, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx1, hx1, sizeof(T) * size_x1, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy1, hy1, sizeof(T) * size_y1, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dparams, hparams, sizeof(T) * size_param, hipMemcpyHostToDevice));
+
+    if(arg.unit_check || arg.norm_check)
+    {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-
         CHECK_HIPBLAS_ERROR(hipblasRotmgStridedBatchedFn(handle,
-                                                         rd1,
+                                                         hd1,
                                                          stride_d1,
-                                                         rd2,
+                                                         hd2,
                                                          stride_d2,
-                                                         rx1,
+                                                         hx1,
                                                          stride_x1,
-                                                         ry1,
+                                                         hy1,
                                                          stride_y1,
-                                                         rparams,
+                                                         hparams,
                                                          stride_param,
                                                          batch_count));
-
-        if(arg.unit_check)
-        {
-            near_check_general<T>(1, 1, batch_count, 1, stride_d1, cd1, rd1, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, stride_d2, cd2, rd2, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, stride_x1, cx1, rx1, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, stride_y1, cy1, ry1, rel_error);
-            near_check_general<T>(1, 5, batch_count, 1, stride_param, cparams, rparams, rel_error);
-        }
-        if(arg.norm_check)
-        {
-            hipblas_error_host
-                = norm_check_general<T>('F', 1, 1, 1, stride_d1, cd1, rd1, batch_count);
-            hipblas_error_host
-                += norm_check_general<T>('F', 1, 1, 1, stride_d2, cd2, rd2, batch_count);
-            hipblas_error_host
-                += norm_check_general<T>('F', 1, 1, 1, stride_x1, cx1, rx1, batch_count);
-            hipblas_error_host
-                += norm_check_general<T>('F', 1, 1, 1, stride_y1, cy1, ry1, batch_count);
-            hipblas_error_host
-                += norm_check_general<T>('F', 1, 5, 1, stride_param, cparams, rparams, batch_count);
-        }
-    }
-
-    // Test device
-    {
-        device_vector<T> dd1(size_d1);
-        device_vector<T> dd2(size_d2);
-        device_vector<T> dx1(size_x1);
-        device_vector<T> dy1(size_y1);
-        device_vector<T> dparams(size_param);
-
-        CHECK_HIP_ERROR(hipMemcpy(dd1, hd1, sizeof(T) * size_d1, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dd2, hd2, sizeof(T) * size_d2, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dx1, hx1, sizeof(T) * size_x1, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dy1, hy1, sizeof(T) * size_y1, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dparams, hparams, sizeof(T) * size_param, hipMemcpyHostToDevice));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIPBLAS_ERROR(hipblasRotmgStridedBatchedFn(handle,
@@ -153,54 +122,66 @@ hipblasStatus_t testing_rotmg_strided_batched(const Arguments& arg)
                                                          stride_param,
                                                          batch_count));
 
-        host_vector<T> rd1(size_d1);
-        host_vector<T> rd2(size_d2);
-        host_vector<T> rx1(size_x1);
-        host_vector<T> ry1(size_y1);
-        host_vector<T> rparams(size_param);
+        CHECK_HIP_ERROR(hipMemcpy(hd1_d, dd1, sizeof(T) * size_d1, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hd2_d, dd2, sizeof(T) * size_d2, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hx1_d, dx1, sizeof(T) * size_x1, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy1_d, dy1, sizeof(T) * size_y1, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(
+            hipMemcpy(hparams_d, dparams, sizeof(T) * size_param, hipMemcpyDeviceToHost));
 
-        CHECK_HIP_ERROR(hipMemcpy(rd1, dd1, sizeof(T) * size_d1, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(rd2, dd2, sizeof(T) * size_d2, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(rx1, dx1, sizeof(T) * size_x1, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(ry1, dy1, sizeof(T) * size_y1, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(rparams, dparams, sizeof(T) * size_param, hipMemcpyDeviceToHost));
+        for(int b = 0; b < batch_count; b++)
+        {
+            cblas_rotmg<T>(cd1 + b * stride_d1,
+                           cd2 + b * stride_d2,
+                           cx1 + b * stride_x1,
+                           cy1 + b * stride_y1,
+                           cparams + b * stride_param);
+        }
 
         if(arg.unit_check)
         {
-            near_check_general<T>(1, 1, batch_count, 1, stride_d1, cd1, rd1, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, stride_d2, cd2, rd2, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, stride_x1, cx1, rx1, rel_error);
-            near_check_general<T>(1, 1, batch_count, 1, stride_y1, cy1, ry1, rel_error);
-            near_check_general<T>(1, 5, batch_count, 1, stride_param, cparams, rparams, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_d1, cd1, hd1, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_d2, cd2, hd2, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_x1, cx1, hx1, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_y1, cy1, hy1, rel_error);
+            near_check_general<T>(1, 5, batch_count, 1, stride_param, cparams, hparams, rel_error);
+
+            near_check_general<T>(1, 1, batch_count, 1, stride_d1, cd1, hd1_d, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_d2, cd2, hd2_d, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_x1, cx1, hx1_d, rel_error);
+            near_check_general<T>(1, 1, batch_count, 1, stride_y1, cy1, hy1_d, rel_error);
+            near_check_general<T>(
+                1, 5, batch_count, 1, stride_param, cparams, hparams_d, rel_error);
         }
+
         if(arg.norm_check)
         {
+            hipblas_error_host
+                = norm_check_general<T>('F', 1, 1, 1, stride_d1, cd1, hd1, batch_count);
+            hipblas_error_host
+                += norm_check_general<T>('F', 1, 1, 1, stride_d2, cd2, hd2, batch_count);
+            hipblas_error_host
+                += norm_check_general<T>('F', 1, 1, 1, stride_x1, cx1, hx1, batch_count);
+            hipblas_error_host
+                += norm_check_general<T>('F', 1, 1, 1, stride_y1, cy1, hy1, batch_count);
+            hipblas_error_host
+                += norm_check_general<T>('F', 1, 5, 1, stride_param, cparams, hparams, batch_count);
+
             hipblas_error_device
-                = norm_check_general<T>('F', 1, 1, 1, stride_d1, cd1, rd1, batch_count);
+                = norm_check_general<T>('F', 1, 1, 1, stride_d1, cd1, hd1_d, batch_count);
             hipblas_error_device
-                += norm_check_general<T>('F', 1, 1, 1, stride_d2, cd2, rd2, batch_count);
+                += norm_check_general<T>('F', 1, 1, 1, stride_d2, cd2, hd2_d, batch_count);
             hipblas_error_device
-                += norm_check_general<T>('F', 1, 1, 1, stride_x1, cx1, rx1, batch_count);
+                += norm_check_general<T>('F', 1, 1, 1, stride_x1, cx1, hx1_d, batch_count);
             hipblas_error_device
-                += norm_check_general<T>('F', 1, 1, 1, stride_y1, cy1, ry1, batch_count);
-            hipblas_error_device
-                += norm_check_general<T>('F', 1, 5, 1, stride_param, cparams, rparams, batch_count);
+                += norm_check_general<T>('F', 1, 1, 1, stride_y1, cy1, hy1_d, batch_count);
+            hipblas_error_device += norm_check_general<T>(
+                'F', 1, 5, 1, stride_param, cparams, hparams_d, batch_count);
         }
     }
 
     if(arg.timing)
     {
-        device_vector<T> dd1(size_d1);
-        device_vector<T> dd2(size_d2);
-        device_vector<T> dx1(size_x1);
-        device_vector<T> dy1(size_y1);
-        device_vector<T> dparams(size_param);
-
-        CHECK_HIP_ERROR(hipMemcpy(dd1, hd1, sizeof(T) * size_d1, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dd2, hd2, sizeof(T) * size_d2, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dx1, hx1, sizeof(T) * size_x1, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dy1, hy1, sizeof(T) * size_y1, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dparams, hparams, sizeof(T) * size_param, hipMemcpyHostToDevice));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/testing_sbmv.hpp
+++ b/clients/include/testing_sbmv.hpp
@@ -74,29 +74,29 @@ hipblasStatus_t testing_sbmv(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSbmvFn(handle, uplo, M, K, &h_alpha, dA, lda, dx, incx, &h_beta, dy, incy));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSbmvFn(handle, uplo, M, K, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSbmvFn(handle, uplo, M, K, &h_alpha, dA, lda, dx, incx, &h_beta, dy, incy));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSbmvFn(handle, uplo, M, K, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
+
+        CHECK_HIP_ERROR(
+            hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_sbmv<T>(
             uplo, M, K, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 

--- a/clients/include/testing_sbmv_batched.hpp
+++ b/clients/include/testing_sbmv_batched.hpp
@@ -83,50 +83,49 @@ hipblasStatus_t testing_sbmv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSbmvBatchedFn(handle,
-                                             uplo,
-                                             M,
-                                             K,
-                                             &h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             &h_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
-    CHECK_HIP_ERROR(dy.transfer_from(hy));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSbmvBatchedFn(handle,
-                                             uplo,
-                                             M,
-                                             K,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             d_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSbmvBatchedFn(handle,
+                                                 uplo,
+                                                 M,
+                                                 K,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 &h_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+        CHECK_HIP_ERROR(dy.transfer_from(hy));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSbmvBatchedFn(handle,
+                                                 uplo,
+                                                 M,
+                                                 K,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 d_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_sbmv<T>(uplo, M, K, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);

--- a/clients/include/testing_sbmv_strided_batched.hpp
+++ b/clients/include/testing_sbmv_strided_batched.hpp
@@ -81,56 +81,55 @@ hipblasStatus_t testing_sbmv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSbmvStridedBatchedFn(handle,
-                                                    uplo,
-                                                    M,
-                                                    K,
-                                                    &h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    &h_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSbmvStridedBatchedFn(handle,
-                                                    uplo,
-                                                    M,
-                                                    K,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    d_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSbmvStridedBatchedFn(handle,
+                                                        uplo,
+                                                        M,
+                                                        K,
+                                                        &h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        &h_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSbmvStridedBatchedFn(handle,
+                                                        uplo,
+                                                        M,
+                                                        K,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        d_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_sbmv<T>(uplo,

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -54,16 +54,16 @@ hipblasStatus_t testing_scal(const Arguments& argus)
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasScalFn(handle, N, &alpha, dx, incx));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasScalFn(handle, N, &alpha, dx, incx));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_scal_batched.hpp
+++ b/clients/include/testing_scal_batched.hpp
@@ -60,17 +60,17 @@ hipblasStatus_t testing_scal_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(dz.transfer_from(hx));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(
-        hipblasScalBatchedFn(handle, N, &alpha, dx.ptr_on_device(), incx, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hx.transfer_from(dx));
-
     if(unit_check || norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(
+            hipblasScalBatchedFn(handle, N, &alpha, dx.ptr_on_device(), incx, batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hx.transfer_from(dx));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_scal_batched_ex.hpp
+++ b/clients/include/testing_scal_batched_ex.hpp
@@ -65,38 +65,38 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx_host));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(Ta), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasScalBatchedExFn(handle,
-                                               N,
-                                               &h_alpha,
-                                               alphaType,
-                                               dx.ptr_on_device(),
-                                               xType,
-                                               incx,
-                                               batch_count,
-                                               executionType));
-
-    CHECK_HIP_ERROR(hx_host.transfer_from(dx));
-    CHECK_HIP_ERROR(dx.transfer_from(hx_device));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasScalBatchedExFn(handle,
-                                               N,
-                                               d_alpha,
-                                               alphaType,
-                                               dx.ptr_on_device(),
-                                               xType,
-                                               incx,
-                                               batch_count,
-                                               executionType));
-
-    CHECK_HIP_ERROR(hx_device.transfer_from(dx));
-
     if(unit_check || norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasScalBatchedExFn(handle,
+                                                   N,
+                                                   &h_alpha,
+                                                   alphaType,
+                                                   dx.ptr_on_device(),
+                                                   xType,
+                                                   incx,
+                                                   batch_count,
+                                                   executionType));
+
+        CHECK_HIP_ERROR(hx_host.transfer_from(dx));
+        CHECK_HIP_ERROR(dx.transfer_from(hx_device));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasScalBatchedExFn(handle,
+                                                   N,
+                                                   d_alpha,
+                                                   alphaType,
+                                                   dx.ptr_on_device(),
+                                                   xType,
+                                                   incx,
+                                                   batch_count,
+                                                   executionType));
+
+        CHECK_HIP_ERROR(hx_device.transfer_from(dx));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_scal_ex.hpp
+++ b/clients/include/testing_scal_ex.hpp
@@ -61,25 +61,25 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx_host, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(Ta), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasScalExFn(handle, N, &h_alpha, alphaType, dx, xType, incx, executionType));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasScalExFn(handle, N, d_alpha, alphaType, dx, xType, incx, executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
-
     if(unit_check || norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasScalExFn(handle, N, &h_alpha, alphaType, dx, xType, incx, executionType));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasScalExFn(handle, N, d_alpha, alphaType, dx, xType, incx, executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -60,17 +60,16 @@ hipblasStatus_t testing_scal_strided_batched(const Arguments& argus)
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(
-        hipblasScalStridedBatchedFn(handle, N, &alpha, dx, incx, stridex, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
-
     if(argus.unit_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(
+            hipblasScalStridedBatchedFn(handle, N, &alpha, dx, incx, stridex, batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
 
         /* =====================================================================
                     CPU BLAS

--- a/clients/include/testing_scal_strided_batched_ex.hpp
+++ b/clients/include/testing_scal_strided_batched_ex.hpp
@@ -70,25 +70,25 @@ hipblasStatus_t testing_scal_strided_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx_host, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(Ta), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasScalStridedBatchedExFn(
-        handle, N, &h_alpha, alphaType, dx, xType, incx, stridex, batch_count, executionType));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasScalStridedBatchedExFn(
-        handle, N, d_alpha, alphaType, dx, xType, incx, stridex, batch_count, executionType));
-
-    CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
-
     if(unit_check || norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasScalStridedBatchedExFn(
+            handle, N, &h_alpha, alphaType, dx, xType, incx, stridex, batch_count, executionType));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx_host, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dx, hx_device, sizeof(Tx) * sizeX, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasScalStridedBatchedExFn(
+            handle, N, d_alpha, alphaType, dx, xType, incx, stridex, batch_count, executionType));
+
+        CHECK_HIP_ERROR(hipMemcpy(hx_device, dx, sizeof(Tx) * sizeX, hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_spmv.hpp
+++ b/clients/include/testing_spmv.hpp
@@ -73,26 +73,28 @@ hipblasStatus_t testing_spmv(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSpmvFn(handle, uplo, M, &h_alpha, dA, dx, incx, &h_beta, dy, incy));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSpmvFn(handle, uplo, M, d_alpha, dA, dx, incx, d_beta, dy, incy));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSpmvFn(handle, uplo, M, &h_alpha, dA, dx, incx, &h_beta, dy, incy));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSpmvFn(handle, uplo, M, d_alpha, dA, dx, incx, d_beta, dy, incy));
+
+        CHECK_HIP_ERROR(
+            hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_spmv<T>(uplo, M, h_alpha, hA.data(), hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_spmv_batched.hpp
+++ b/clients/include/testing_spmv_batched.hpp
@@ -80,46 +80,45 @@ hipblasStatus_t testing_spmv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSpmvBatchedFn(handle,
-                                             uplo,
-                                             M,
-                                             &h_alpha,
-                                             dA.ptr_on_device(),
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             &h_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
-    CHECK_HIP_ERROR(dy.transfer_from(hy));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSpmvBatchedFn(handle,
-                                             uplo,
-                                             M,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             d_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSpmvBatchedFn(handle,
+                                                 uplo,
+                                                 M,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 &h_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+        CHECK_HIP_ERROR(dy.transfer_from(hy));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSpmvBatchedFn(handle,
+                                                 uplo,
+                                                 M,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 d_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_spmv<T>(uplo, M, h_alpha, hA[b], hx[b], incx, h_beta, hy_cpu[b], incy);

--- a/clients/include/testing_spmv_strided_batched.hpp
+++ b/clients/include/testing_spmv_strided_batched.hpp
@@ -79,52 +79,51 @@ hipblasStatus_t testing_spmv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSpmvStridedBatchedFn(handle,
-                                                    uplo,
-                                                    M,
-                                                    &h_alpha,
-                                                    dA,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    &h_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSpmvStridedBatchedFn(handle,
-                                                    uplo,
-                                                    M,
-                                                    d_alpha,
-                                                    dA,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    d_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSpmvStridedBatchedFn(handle,
+                                                        uplo,
+                                                        M,
+                                                        &h_alpha,
+                                                        dA,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        &h_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSpmvStridedBatchedFn(handle,
+                                                        uplo,
+                                                        M,
+                                                        d_alpha,
+                                                        dA,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        d_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_spmv<T>(uplo,

--- a/clients/include/testing_spr.hpp
+++ b/clients/include/testing_spr.hpp
@@ -63,22 +63,22 @@ hipblasStatus_t testing_spr(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSprFn(handle, uplo, N, &h_alpha, dx, incx, dA));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSprFn(handle, uplo, N, d_alpha, dx, incx, dA));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSprFn(handle, uplo, N, &h_alpha, dx, incx, dA));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSprFn(handle, uplo, N, d_alpha, dx, incx, dA));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_spr2.hpp
+++ b/clients/include/testing_spr2.hpp
@@ -72,22 +72,22 @@ hipblasStatus_t testing_spr2(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSpr2Fn(handle, uplo, N, &h_alpha, dx, incx, dy, incy, dA));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSpr2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSpr2Fn(handle, uplo, N, &h_alpha, dx, incx, dy, incy, dA));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSpr2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_spr2_batched.hpp
+++ b/clients/include/testing_spr2_batched.hpp
@@ -72,40 +72,40 @@ hipblasStatus_t testing_spr2_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dy.transfer_from(hy));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSpr2BatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             &h_alpha,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             dA.ptr_on_device(),
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSpr2BatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             d_alpha,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             dA.ptr_on_device(),
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSpr2BatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 &h_alpha,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 dA.ptr_on_device(),
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSpr2BatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 d_alpha,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 dA.ptr_on_device(),
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hA_device.transfer_from(dA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_spr2_strided_batched.hpp
+++ b/clients/include/testing_spr2_strided_batched.hpp
@@ -82,24 +82,46 @@ hipblasStatus_t testing_spr2_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSpr2StridedBatchedFn(
-        handle, uplo, N, &h_alpha, dx, incx, stridex, dy, incy, stridey, dA, strideA, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSpr2StridedBatchedFn(
-        handle, uplo, N, d_alpha, dx, incx, stridex, dy, incy, stridey, dA, strideA, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSpr2StridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        &h_alpha,
+                                                        dx,
+                                                        incx,
+                                                        stridex,
+                                                        dy,
+                                                        incy,
+                                                        stridey,
+                                                        dA,
+                                                        strideA,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSpr2StridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        d_alpha,
+                                                        dx,
+                                                        incx,
+                                                        stridex,
+                                                        dy,
+                                                        incy,
+                                                        stridey,
+                                                        dA,
+                                                        strideA,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_spr_batched.hpp
+++ b/clients/include/testing_spr_batched.hpp
@@ -69,24 +69,24 @@ hipblasStatus_t testing_spr_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSprBatchedFn(
-        handle, uplo, N, &h_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
-
-    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSprBatchedFn(
-        handle, uplo, N, d_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
-
-    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSprBatchedFn(
+            handle, uplo, N, &h_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
+
+        CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSprBatchedFn(
+            handle, uplo, N, d_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), batch_count));
+
+        CHECK_HIP_ERROR(hA_device.transfer_from(dA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_spr_strided_batched.hpp
+++ b/clients/include/testing_spr_strided_batched.hpp
@@ -74,24 +74,24 @@ hipblasStatus_t testing_spr_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSprStridedBatchedFn(
-        handle, uplo, N, &h_alpha, dx, incx, stridex, dA, strideA, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSprStridedBatchedFn(
-        handle, uplo, N, d_alpha, dx, incx, stridex, dA, strideA, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSprStridedBatchedFn(
+            handle, uplo, N, &h_alpha, dx, incx, stridex, dA, strideA, batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSprStridedBatchedFn(
+            handle, uplo, N, d_alpha, dx, incx, stridex, dA, strideA, batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_swap.hpp
+++ b/clients/include/testing_swap.hpp
@@ -33,8 +33,8 @@ hipblasStatus_t testing_swap(const Arguments& argus)
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
-    int sizeX = N * incx;
-    int sizeY = N * incy;
+    size_t sizeX = size_t(N) * incx;
+    size_t sizeY = size_t(N) * incy;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(sizeX);
@@ -63,17 +63,17 @@ hipblasStatus_t testing_swap(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSwapFn(handle, N, dx, incx, dy, incy));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
-
     if(unit_check || norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSwapFn(handle, N, dx, incx, dy, incy));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -39,10 +39,8 @@ hipblasStatus_t testing_swap_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int sizeX = N * incx;
-    int sizeY = N * incy;
-
-    int device_pointer = 1;
+    size_t sizeX = size_t(N) * incx;
+    size_t sizeY = size_t(N) * incy;
 
     double hipblas_error = 0.0;
     double gpu_time_used = 0.0;
@@ -69,17 +67,17 @@ hipblasStatus_t testing_swap_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(dy.transfer_from(hy));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSwapBatchedFn(
-        handle, N, dx.ptr_on_device(), incx, dy.ptr_on_device(), incy, batch_count));
-
-    CHECK_HIP_ERROR(hx.transfer_from(dx));
-    CHECK_HIP_ERROR(hy.transfer_from(dy));
-
     if(unit_check || norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSwapBatchedFn(
+            handle, N, dx.ptr_on_device(), incx, dy.ptr_on_device(), incy, batch_count));
+
+        CHECK_HIP_ERROR(hx.transfer_from(dx));
+        CHECK_HIP_ERROR(hy.transfer_from(dy));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -29,10 +29,10 @@ hipblasStatus_t testing_swap_strided_batched(const Arguments& argus)
     int    norm_check   = argus.norm_check;
     int    timing       = argus.timing;
 
-    hipblasStride stridex = N * incx * stride_scale;
-    hipblasStride stridey = N * incy * stride_scale;
-    int           sizeX   = stridex * batch_count;
-    int           sizeY   = stridey * batch_count;
+    hipblasStride stridex = size_t(N) * incx * stride_scale;
+    hipblasStride stridey = size_t(N) * incy * stride_scale;
+    size_t        sizeX   = stridex * batch_count;
+    size_t        sizeY   = stridey * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
@@ -50,8 +50,6 @@ hipblasStatus_t testing_swap_strided_batched(const Arguments& argus)
     device_vector<T> dx(sizeX);
     device_vector<T> dy(sizeY);
 
-    int device_pointer = 1;
-
     double hipblas_error = 0.0;
     double gpu_time_used = 0.0;
 
@@ -68,18 +66,18 @@ hipblasStatus_t testing_swap_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * sizeY, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-         HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(
-        hipblasSwapStridedBatchedFn(handle, N, dx, incx, stridex, dy, incy, stridey, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
-
     if(unit_check || norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSwapStridedBatchedFn(
+            handle, N, dx, incx, stridex, dy, incy, stridey, batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx.data(), dx, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy.data(), dy, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
+
         /* =====================================================================
                     CPU BLAS
         =================================================================== */

--- a/clients/include/testing_symm.hpp
+++ b/clients/include/testing_symm.hpp
@@ -79,29 +79,28 @@ hipblasStatus_t testing_symm(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSymmFn(handle, side, uplo, M, N, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSymmFn(handle, side, uplo, M, N, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSymmFn(handle, side, uplo, M, N, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSymmFn(handle, side, uplo, M, N, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_symm<T>(side, uplo, M, N, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_symm_batched.hpp
+++ b/clients/include/testing_symm_batched.hpp
@@ -85,51 +85,50 @@ hipblasStatus_t testing_symm_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSymmBatchedFn(handle,
-                                             side,
-                                             uplo,
-                                             M,
-                                             N,
-                                             &h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dB.ptr_on_device(),
-                                             ldb,
-                                             &h_beta,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSymmBatchedFn(handle,
-                                             side,
-                                             uplo,
-                                             M,
-                                             N,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dB.ptr_on_device(),
-                                             ldb,
-                                             d_beta,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSymmBatchedFn(handle,
+                                                 side,
+                                                 uplo,
+                                                 M,
+                                                 N,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dB.ptr_on_device(),
+                                                 ldb,
+                                                 &h_beta,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSymmBatchedFn(handle,
+                                                 side,
+                                                 uplo,
+                                                 M,
+                                                 N,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dB.ptr_on_device(),
+                                                 ldb,
+                                                 d_beta,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_symm<T>(

--- a/clients/include/testing_symm_strided_batched.hpp
+++ b/clients/include/testing_symm_strided_batched.hpp
@@ -84,59 +84,58 @@ hipblasStatus_t testing_symm_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSymmStridedBatchedFn(handle,
-                                                    side,
-                                                    uplo,
-                                                    M,
-                                                    N,
-                                                    &h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dB,
-                                                    ldb,
-                                                    stride_B,
-                                                    &h_beta,
-                                                    dC,
-                                                    ldc,
-                                                    stride_C,
-                                                    batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSymmStridedBatchedFn(handle,
-                                                    side,
-                                                    uplo,
-                                                    M,
-                                                    N,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dB,
-                                                    ldb,
-                                                    stride_B,
-                                                    d_beta,
-                                                    dC,
-                                                    ldc,
-                                                    stride_C,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSymmStridedBatchedFn(handle,
+                                                        side,
+                                                        uplo,
+                                                        M,
+                                                        N,
+                                                        &h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dB,
+                                                        ldb,
+                                                        stride_B,
+                                                        &h_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSymmStridedBatchedFn(handle,
+                                                        side,
+                                                        uplo,
+                                                        M,
+                                                        N,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dB,
+                                                        ldb,
+                                                        stride_B,
+                                                        d_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_symm<T>(side,

--- a/clients/include/testing_symv.hpp
+++ b/clients/include/testing_symv.hpp
@@ -73,29 +73,29 @@ hipblasStatus_t testing_symv(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSymvFn(handle, uplo, M, &h_alpha, dA, lda, dx, incx, &h_beta, dy, incy));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSymvFn(handle, uplo, M, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSymvFn(handle, uplo, M, &h_alpha, dA, lda, dx, incx, &h_beta, dy, incy));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSymvFn(handle, uplo, M, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(
+            hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_symv<T>(
             uplo, M, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 

--- a/clients/include/testing_symv_batched.hpp
+++ b/clients/include/testing_symv_batched.hpp
@@ -82,49 +82,48 @@ hipblasStatus_t testing_symv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSymvBatchedFn(handle,
-                                             uplo,
-                                             M,
-                                             &h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             &h_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hy_host.transfer_from(dy));
-    CHECK_HIP_ERROR(dy.transfer_from(hy));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSymvBatchedFn(handle,
-                                             uplo,
-                                             M,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             d_beta,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hy_device.transfer_from(dy));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSymvBatchedFn(handle,
+                                                 uplo,
+                                                 M,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 &h_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hy_host.transfer_from(dy));
+        CHECK_HIP_ERROR(dy.transfer_from(hy));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSymvBatchedFn(handle,
+                                                 uplo,
+                                                 M,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 d_beta,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hy_device.transfer_from(dy));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_symv<T>(uplo, M, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);

--- a/clients/include/testing_symv_strided_batched.hpp
+++ b/clients/include/testing_symv_strided_batched.hpp
@@ -79,54 +79,53 @@ hipblasStatus_t testing_symv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSymvStridedBatchedFn(handle,
-                                                    uplo,
-                                                    M,
-                                                    &h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    &h_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSymvStridedBatchedFn(handle,
-                                                    uplo,
-                                                    M,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dx,
-                                                    incx,
-                                                    stride_x,
-                                                    d_beta,
-                                                    dy,
-                                                    incy,
-                                                    stride_y,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSymvStridedBatchedFn(handle,
+                                                        uplo,
+                                                        M,
+                                                        &h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        &h_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSymvStridedBatchedFn(handle,
+                                                        uplo,
+                                                        M,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dx,
+                                                        incx,
+                                                        stride_x,
+                                                        d_beta,
+                                                        dy,
+                                                        incy,
+                                                        stride_y,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_symv<T>(uplo,

--- a/clients/include/testing_syr.hpp
+++ b/clients/include/testing_syr.hpp
@@ -64,22 +64,22 @@ hipblasStatus_t testing_syr(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyrFn(handle, uplo, N, &h_alpha, dx, incx, dA, lda));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyrFn(handle, uplo, N, d_alpha, dx, incx, dA, lda));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyrFn(handle, uplo, N, &h_alpha, dx, incx, dA, lda));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyrFn(handle, uplo, N, d_alpha, dx, incx, dA, lda));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syr2.hpp
+++ b/clients/include/testing_syr2.hpp
@@ -73,22 +73,22 @@ hipblasStatus_t testing_syr2(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyr2Fn(handle, uplo, N, &h_alpha, dx, incx, dy, incy, dA, lda));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyr2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA, lda));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2Fn(handle, uplo, N, &h_alpha, dx, incx, dy, incy, dA, lda));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2Fn(handle, uplo, N, d_alpha, dx, incx, dy, incy, dA, lda));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syr2_batched.hpp
+++ b/clients/include/testing_syr2_batched.hpp
@@ -73,42 +73,42 @@ hipblasStatus_t testing_syr2_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dy.transfer_from(hy));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyr2BatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             &h_alpha,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyr2BatchedFn(handle,
-                                             uplo,
-                                             N,
-                                             d_alpha,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             dy.ptr_on_device(),
-                                             incy,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2BatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 &h_alpha,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2BatchedFn(handle,
+                                                 uplo,
+                                                 N,
+                                                 d_alpha,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 dy.ptr_on_device(),
+                                                 incy,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hA_device.transfer_from(dA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syr2_strided_batched.hpp
+++ b/clients/include/testing_syr2_strided_batched.hpp
@@ -82,48 +82,48 @@ hipblasStatus_t testing_syr2_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyr2StridedBatchedFn(handle,
-                                                    uplo,
-                                                    N,
-                                                    &h_alpha,
-                                                    dx,
-                                                    incx,
-                                                    stridex,
-                                                    dy,
-                                                    incy,
-                                                    stridey,
-                                                    dA,
-                                                    lda,
-                                                    strideA,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyr2StridedBatchedFn(handle,
-                                                    uplo,
-                                                    N,
-                                                    d_alpha,
-                                                    dx,
-                                                    incx,
-                                                    stridex,
-                                                    dy,
-                                                    incy,
-                                                    stridey,
-                                                    dA,
-                                                    lda,
-                                                    strideA,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2StridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        &h_alpha,
+                                                        dx,
+                                                        incx,
+                                                        stridex,
+                                                        dy,
+                                                        incy,
+                                                        stridey,
+                                                        dA,
+                                                        lda,
+                                                        strideA,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2StridedBatchedFn(handle,
+                                                        uplo,
+                                                        N,
+                                                        d_alpha,
+                                                        dx,
+                                                        incx,
+                                                        stridex,
+                                                        dy,
+                                                        incy,
+                                                        stridey,
+                                                        dA,
+                                                        lda,
+                                                        strideA,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syr2k.hpp
+++ b/clients/include/testing_syr2k.hpp
@@ -79,25 +79,25 @@ hipblasStatus_t testing_syr2k(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSyr2kFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSyr2kFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2kFn(
+            handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSyr2kFn(handle, uplo, transA, N, K, d_alpha, dA, lda, dB, ldb, d_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syr2k_batched.hpp
+++ b/clients/include/testing_syr2k_batched.hpp
@@ -84,48 +84,48 @@ hipblasStatus_t testing_syr2k_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyr2kBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              &h_alpha,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              &h_beta,
-                                              dC.ptr_on_device(),
-                                              ldc,
-                                              batch_count));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyr2kBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              d_alpha,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              d_beta,
-                                              dC.ptr_on_device(),
-                                              ldc,
-                                              batch_count));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2kBatchedFn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  N,
+                                                  K,
+                                                  &h_alpha,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  &h_beta,
+                                                  dC.ptr_on_device(),
+                                                  ldc,
+                                                  batch_count));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyr2kBatchedFn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  N,
+                                                  K,
+                                                  d_alpha,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  d_beta,
+                                                  dC.ptr_on_device(),
+                                                  ldc,
+                                                  batch_count));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syr2k_strided_batched.hpp
+++ b/clients/include/testing_syr2k_strided_batched.hpp
@@ -86,55 +86,55 @@ hipblasStatus_t testing_syr2k_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyrk2StridedBatchedFn(handle,
-                                                     uplo,
-                                                     transA,
-                                                     N,
-                                                     K,
-                                                     &h_alpha,
-                                                     dA,
-                                                     lda,
-                                                     stride_A,
-                                                     dB,
-                                                     ldb,
-                                                     stride_B,
-                                                     &h_beta,
-                                                     dC,
-                                                     ldc,
-                                                     stride_C,
-                                                     batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyrk2StridedBatchedFn(handle,
-                                                     uplo,
-                                                     transA,
-                                                     N,
-                                                     K,
-                                                     d_alpha,
-                                                     dA,
-                                                     lda,
-                                                     stride_A,
-                                                     dB,
-                                                     ldb,
-                                                     stride_B,
-                                                     d_beta,
-                                                     dC,
-                                                     ldc,
-                                                     stride_C,
-                                                     batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyrk2StridedBatchedFn(handle,
+                                                         uplo,
+                                                         transA,
+                                                         N,
+                                                         K,
+                                                         &h_alpha,
+                                                         dA,
+                                                         lda,
+                                                         stride_A,
+                                                         dB,
+                                                         ldb,
+                                                         stride_B,
+                                                         &h_beta,
+                                                         dC,
+                                                         ldc,
+                                                         stride_C,
+                                                         batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyrk2StridedBatchedFn(handle,
+                                                         uplo,
+                                                         transA,
+                                                         N,
+                                                         K,
+                                                         d_alpha,
+                                                         dA,
+                                                         lda,
+                                                         stride_A,
+                                                         dB,
+                                                         ldb,
+                                                         stride_B,
+                                                         d_beta,
+                                                         dC,
+                                                         ldc,
+                                                         stride_C,
+                                                         batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syr_batched.hpp
+++ b/clients/include/testing_syr_batched.hpp
@@ -70,24 +70,38 @@ hipblasStatus_t testing_syr_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyrBatchedFn(
-        handle, uplo, N, &h_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), lda, batch_count));
-
-    CHECK_HIP_ERROR(hA_host.transfer_from(dA));
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyrBatchedFn(
-        handle, uplo, N, d_alpha, dx.ptr_on_device(), incx, dA.ptr_on_device(), lda, batch_count));
-
-    CHECK_HIP_ERROR(hA_device.transfer_from(dA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyrBatchedFn(handle,
+                                                uplo,
+                                                N,
+                                                &h_alpha,
+                                                dx.ptr_on_device(),
+                                                incx,
+                                                dA.ptr_on_device(),
+                                                lda,
+                                                batch_count));
+
+        CHECK_HIP_ERROR(hA_host.transfer_from(dA));
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyrBatchedFn(handle,
+                                                uplo,
+                                                N,
+                                                d_alpha,
+                                                dx.ptr_on_device(),
+                                                incx,
+                                                dA.ptr_on_device(),
+                                                lda,
+                                                batch_count));
+
+        CHECK_HIP_ERROR(hA_device.transfer_from(dA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syr_strided_batched.hpp
+++ b/clients/include/testing_syr_strided_batched.hpp
@@ -75,24 +75,24 @@ hipblasStatus_t testing_syr_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyrStridedBatchedFn(
-        handle, uplo, N, &h_alpha, dx, incx, stridex, dA, lda, strideA, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyrStridedBatchedFn(
-        handle, uplo, N, d_alpha, dx, incx, stridex, dA, lda, strideA, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyrStridedBatchedFn(
+            handle, uplo, N, &h_alpha, dx, incx, stridex, dA, lda, strideA, batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_host.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyrStridedBatchedFn(
+            handle, uplo, N, d_alpha, dx, incx, stridex, dA, lda, strideA, batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hA_device.data(), dA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syrk.hpp
+++ b/clients/include/testing_syrk.hpp
@@ -73,26 +73,26 @@ hipblasStatus_t testing_syrk(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSyrkFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, &h_beta, dC, ldc));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasSyrkFn(handle, uplo, transA, N, K, d_alpha, dA, lda, d_beta, dC, ldc));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSyrkFn(handle, uplo, transA, N, K, &h_alpha, dA, lda, &h_beta, dC, ldc));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasSyrkFn(handle, uplo, transA, N, K, d_alpha, dA, lda, d_beta, dC, ldc));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syrk_batched.hpp
+++ b/clients/include/testing_syrk_batched.hpp
@@ -76,44 +76,44 @@ hipblasStatus_t testing_syrk_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyrkBatchedFn(handle,
-                                             uplo,
-                                             transA,
-                                             N,
-                                             K,
-                                             &h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             &h_beta,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyrkBatchedFn(handle,
-                                             uplo,
-                                             transA,
-                                             N,
-                                             K,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             d_beta,
-                                             dC.ptr_on_device(),
-                                             ldc,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyrkBatchedFn(handle,
+                                                 uplo,
+                                                 transA,
+                                                 N,
+                                                 K,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 &h_beta,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyrkBatchedFn(handle,
+                                                 uplo,
+                                                 transA,
+                                                 N,
+                                                 K,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 d_beta,
+                                                 dC.ptr_on_device(),
+                                                 ldc,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syrk_strided_batched.hpp
+++ b/clients/include/testing_syrk_strided_batched.hpp
@@ -79,49 +79,49 @@ hipblasStatus_t testing_syrk_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyrkStridedBatchedFn(handle,
-                                                    uplo,
-                                                    transA,
-                                                    N,
-                                                    K,
-                                                    &h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    &h_beta,
-                                                    dC,
-                                                    ldc,
-                                                    stride_C,
-                                                    batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyrkStridedBatchedFn(handle,
-                                                    uplo,
-                                                    transA,
-                                                    N,
-                                                    K,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    d_beta,
-                                                    dC,
-                                                    ldc,
-                                                    stride_C,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyrkStridedBatchedFn(handle,
+                                                        uplo,
+                                                        transA,
+                                                        N,
+                                                        K,
+                                                        &h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        &h_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyrkStridedBatchedFn(handle,
+                                                        uplo,
+                                                        transA,
+                                                        N,
+                                                        K,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        d_beta,
+                                                        dC,
+                                                        ldc,
+                                                        stride_C,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syrkx_batched.hpp
+++ b/clients/include/testing_syrkx_batched.hpp
@@ -46,10 +46,10 @@ hipblasStatus_t testing_syrkx_batched(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int K1     = (transA == HIPBLAS_OP_N ? K : N);
-    int A_size = lda * K1;
-    int B_size = ldb * K1;
-    int C_size = ldc * N;
+    int    K1     = (transA == HIPBLAS_OP_N ? K : N);
+    size_t A_size = size_t(lda) * K1;
+    size_t B_size = size_t(ldb) * K1;
+    size_t C_size = size_t(ldc) * N;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);
@@ -84,48 +84,48 @@ hipblasStatus_t testing_syrkx_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyrkxBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              &h_alpha,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              &h_beta,
-                                              dC.ptr_on_device(),
-                                              ldc,
-                                              batch_count));
-
-    CHECK_HIP_ERROR(hC_host.transfer_from(dC));
-    CHECK_HIP_ERROR(dC.transfer_from(hC_device));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyrkxBatchedFn(handle,
-                                              uplo,
-                                              transA,
-                                              N,
-                                              K,
-                                              d_alpha,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dB.ptr_on_device(),
-                                              ldb,
-                                              d_beta,
-                                              dC.ptr_on_device(),
-                                              ldc,
-                                              batch_count));
-
-    CHECK_HIP_ERROR(hC_device.transfer_from(dC));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyrkxBatchedFn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  N,
+                                                  K,
+                                                  &h_alpha,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  &h_beta,
+                                                  dC.ptr_on_device(),
+                                                  ldc,
+                                                  batch_count));
+
+        CHECK_HIP_ERROR(hC_host.transfer_from(dC));
+        CHECK_HIP_ERROR(dC.transfer_from(hC_device));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyrkxBatchedFn(handle,
+                                                  uplo,
+                                                  transA,
+                                                  N,
+                                                  K,
+                                                  d_alpha,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dB.ptr_on_device(),
+                                                  ldb,
+                                                  d_beta,
+                                                  dC.ptr_on_device(),
+                                                  ldc,
+                                                  batch_count));
+
+        CHECK_HIP_ERROR(hC_device.transfer_from(dC));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_syrkx_strided_batched.hpp
+++ b/clients/include/testing_syrkx_strided_batched.hpp
@@ -50,9 +50,9 @@ hipblasStatus_t testing_syrkx_strided_batched(const Arguments& argus)
     hipblasStride stride_A = size_t(lda) * K1 * stride_scale;
     hipblasStride stride_B = size_t(ldb) * K1 * stride_scale;
     hipblasStride stride_C = size_t(ldc) * N * stride_scale;
-    int           A_size   = stride_A * batch_count;
-    int           B_size   = stride_B * batch_count;
-    int           C_size   = stride_C * batch_count;
+    size_t        A_size   = stride_A * batch_count;
+    size_t        B_size   = stride_B * batch_count;
+    size_t        C_size   = stride_C * batch_count;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
@@ -85,55 +85,55 @@ hipblasStatus_t testing_syrkx_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasSyrkxStridedBatchedFn(handle,
-                                                     uplo,
-                                                     transA,
-                                                     N,
-                                                     K,
-                                                     &h_alpha,
-                                                     dA,
-                                                     lda,
-                                                     stride_A,
-                                                     dB,
-                                                     ldb,
-                                                     stride_B,
-                                                     &h_beta,
-                                                     dC,
-                                                     ldc,
-                                                     stride_C,
-                                                     batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasSyrkxStridedBatchedFn(handle,
-                                                     uplo,
-                                                     transA,
-                                                     N,
-                                                     K,
-                                                     d_alpha,
-                                                     dA,
-                                                     lda,
-                                                     stride_A,
-                                                     dB,
-                                                     ldb,
-                                                     stride_B,
-                                                     d_beta,
-                                                     dC,
-                                                     ldc,
-                                                     stride_C,
-                                                     batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasSyrkxStridedBatchedFn(handle,
+                                                         uplo,
+                                                         transA,
+                                                         N,
+                                                         K,
+                                                         &h_alpha,
+                                                         dA,
+                                                         lda,
+                                                         stride_A,
+                                                         dB,
+                                                         ldb,
+                                                         stride_B,
+                                                         &h_beta,
+                                                         dC,
+                                                         ldc,
+                                                         stride_C,
+                                                         batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasSyrkxStridedBatchedFn(handle,
+                                                         uplo,
+                                                         transA,
+                                                         N,
+                                                         K,
+                                                         d_alpha,
+                                                         dA,
+                                                         lda,
+                                                         stride_A,
+                                                         dB,
+                                                         ldb,
+                                                         stride_B,
+                                                         d_beta,
+                                                         dC,
+                                                         ldc,
+                                                         stride_C,
+                                                         batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(T) * C_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_tbmv.hpp
+++ b/clients/include/testing_tbmv.hpp
@@ -63,20 +63,19 @@ hipblasStatus_t testing_tbmv(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTbmvFn(handle, uplo, transA, diag, M, K, dA, lda, dx, incx));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx_res.data(), dx, sizeof(T) * x_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTbmvFn(handle, uplo, transA, diag, M, K, dA, lda, dx, incx));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx_res.data(), dx, sizeof(T) * x_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_tbmv<T>(uplo, transA, diag, M, K, hA.data(), lda, hx_cpu.data(), incx);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_tbmv_batched.hpp
+++ b/clients/include/testing_tbmv_batched.hpp
@@ -70,29 +70,28 @@ hipblasStatus_t testing_tbmv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(dA.transfer_from(hA));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTbmvBatchedFn(handle,
-                                             uplo,
-                                             transA,
-                                             diag,
-                                             M,
-                                             K,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hx_res.transfer_from(dx));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTbmvBatchedFn(handle,
+                                                 uplo,
+                                                 transA,
+                                                 diag,
+                                                 M,
+                                                 K,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hx_res.transfer_from(dx));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_tbmv<T>(uplo, transA, diag, M, K, hA[b], lda, hx_cpu[b], incx);

--- a/clients/include/testing_tbmv_strided_batched.hpp
+++ b/clients/include/testing_tbmv_strided_batched.hpp
@@ -67,21 +67,20 @@ hipblasStatus_t testing_tbmv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTbmvStridedBatchedFn(
-        handle, uplo, transA, diag, M, K, dA, lda, stride_A, dx, incx, stride_x, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hx_res.data(), dx, sizeof(T) * x_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTbmvStridedBatchedFn(
+            handle, uplo, transA, diag, M, K, dA, lda, stride_A, dx, incx, stride_x, batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hx_res.data(), dx, sizeof(T) * x_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_tbmv<T>(uplo,

--- a/clients/include/testing_tpmv.hpp
+++ b/clients/include/testing_tpmv.hpp
@@ -59,20 +59,19 @@ hipblasStatus_t testing_tpmv(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * M * incx, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTpmvFn(handle, uplo, transA, diag, M, dA, dx, incx));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * M * incx, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTpmvFn(handle, uplo, transA, diag, M, dA, dx, incx));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * M * incx, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_tpmv<T>(uplo, transA, diag, M, hA.data(), hx.data(), incx);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_tpmv_batched.hpp
+++ b/clients/include/testing_tpmv_batched.hpp
@@ -66,21 +66,27 @@ hipblasStatus_t testing_tpmv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dA.transfer_from(hA));
     CHECK_HIP_ERROR(dx.transfer_from(hx));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTpmvBatchedFn(
-        handle, uplo, transA, diag, M, dA.ptr_on_device(), dx.ptr_on_device(), incx, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hx_res.transfer_from(dx));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTpmvBatchedFn(handle,
+                                                 uplo,
+                                                 transA,
+                                                 diag,
+                                                 M,
+                                                 dA.ptr_on_device(),
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hx_res.transfer_from(dx));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_tpmv<T>(uplo, transA, diag, M, hA[b], hx[b], incx);

--- a/clients/include/testing_tpmv_strided_batched.hpp
+++ b/clients/include/testing_tpmv_strided_batched.hpp
@@ -65,21 +65,20 @@ hipblasStatus_t testing_tpmv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTpmvStridedBatchedFn(
-        handle, uplo, transA, diag, M, dA, stride_A, dx, incx, stride_x, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * X_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTpmvStridedBatchedFn(
+            handle, uplo, transA, diag, M, dA, stride_A, dx, incx, stride_x, batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * X_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_tpmv<T>(

--- a/clients/include/testing_trmm.hpp
+++ b/clients/include/testing_trmm.hpp
@@ -71,28 +71,27 @@ hipblasStatus_t testing_trmm(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dB, hB_host, sizeof(T) * B_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(
-        hipblasTrmmFn(handle, side, uplo, transA, diag, M, N, &h_alpha, dA, lda, dB, ldb));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hB_host, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB_device, sizeof(T) * B_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(
-        hipblasTrmmFn(handle, side, uplo, transA, diag, M, N, d_alpha, dA, lda, dB, ldb));
-    CHECK_HIP_ERROR(hipMemcpy(hB_device, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(
+            hipblasTrmmFn(handle, side, uplo, transA, diag, M, N, &h_alpha, dA, lda, dB, ldb));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hB_host, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dB, hB_device, sizeof(T) * B_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasTrmmFn(handle, side, uplo, transA, diag, M, N, d_alpha, dA, lda, dB, ldb));
+        CHECK_HIP_ERROR(hipMemcpy(hB_device, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_trmm<T>(side, uplo, transA, diag, M, N, h_alpha, hA, lda, hB_gold, ldb);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_trmm_batched.hpp
+++ b/clients/include/testing_trmm_batched.hpp
@@ -77,50 +77,49 @@ hipblasStatus_t testing_trmm_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dB.transfer_from(hB_host));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasTrmmBatchedFn(handle,
-                                             side,
-                                             uplo,
-                                             transA,
-                                             diag,
-                                             M,
-                                             N,
-                                             &h_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dB.ptr_on_device(),
-                                             ldb,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hB_host.transfer_from(dB));
-    CHECK_HIP_ERROR(dB.transfer_from(hB_device));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasTrmmBatchedFn(handle,
-                                             side,
-                                             uplo,
-                                             transA,
-                                             diag,
-                                             M,
-                                             N,
-                                             d_alpha,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dB.ptr_on_device(),
-                                             ldb,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hB_device.transfer_from(dB));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasTrmmBatchedFn(handle,
+                                                 side,
+                                                 uplo,
+                                                 transA,
+                                                 diag,
+                                                 M,
+                                                 N,
+                                                 &h_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dB.ptr_on_device(),
+                                                 ldb,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hB_host.transfer_from(dB));
+        CHECK_HIP_ERROR(dB.transfer_from(hB_device));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasTrmmBatchedFn(handle,
+                                                 side,
+                                                 uplo,
+                                                 transA,
+                                                 diag,
+                                                 M,
+                                                 N,
+                                                 d_alpha,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dB.ptr_on_device(),
+                                                 ldb,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hB_device.transfer_from(dB));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_trmm<T>(side, uplo, transA, diag, M, N, h_alpha, hA[b], lda, hB_gold[b], ldb);

--- a/clients/include/testing_trmm_strided_batched.hpp
+++ b/clients/include/testing_trmm_strided_batched.hpp
@@ -76,54 +76,53 @@ hipblasStatus_t testing_trmm_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dB, hB_host, sizeof(T) * B_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasTrmmStridedBatchedFn(handle,
-                                                    side,
-                                                    uplo,
-                                                    transA,
-                                                    diag,
-                                                    M,
-                                                    N,
-                                                    &h_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dB,
-                                                    ldb,
-                                                    stride_B,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hB_host, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB_device, sizeof(T) * B_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasTrmmStridedBatchedFn(handle,
-                                                    side,
-                                                    uplo,
-                                                    transA,
-                                                    diag,
-                                                    M,
-                                                    N,
-                                                    d_alpha,
-                                                    dA,
-                                                    lda,
-                                                    stride_A,
-                                                    dB,
-                                                    ldb,
-                                                    stride_B,
-                                                    batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hB_device, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasTrmmStridedBatchedFn(handle,
+                                                        side,
+                                                        uplo,
+                                                        transA,
+                                                        diag,
+                                                        M,
+                                                        N,
+                                                        &h_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dB,
+                                                        ldb,
+                                                        stride_B,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hB_host, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dB, hB_device, sizeof(T) * B_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasTrmmStridedBatchedFn(handle,
+                                                        side,
+                                                        uplo,
+                                                        transA,
+                                                        diag,
+                                                        M,
+                                                        N,
+                                                        d_alpha,
+                                                        dA,
+                                                        lda,
+                                                        stride_A,
+                                                        dB,
+                                                        ldb,
+                                                        stride_B,
+                                                        batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hB_device, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_trmm<T>(side,

--- a/clients/include/testing_trmv.hpp
+++ b/clients/include/testing_trmv.hpp
@@ -60,20 +60,19 @@ hipblasStatus_t testing_trmv(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * M, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * M * incx, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTrmvFn(handle, uplo, transA, diag, M, dA, lda, dx, incx));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * M * incx, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTrmvFn(handle, uplo, transA, diag, M, dA, lda, dx, incx));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * M * incx, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_trmv<T>(uplo, transA, diag, M, hA.data(), lda, hx.data(), incx);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_trmv_batched.hpp
+++ b/clients/include/testing_trmv_batched.hpp
@@ -66,28 +66,27 @@ hipblasStatus_t testing_trmv_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dA.transfer_from(hA));
     CHECK_HIP_ERROR(dx.transfer_from(hx));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTrmvBatchedFn(handle,
-                                             uplo,
-                                             transA,
-                                             diag,
-                                             M,
-                                             dA.ptr_on_device(),
-                                             lda,
-                                             dx.ptr_on_device(),
-                                             incx,
-                                             batch_count));
-
-    CHECK_HIP_ERROR(hres.transfer_from(dx));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTrmvBatchedFn(handle,
+                                                 uplo,
+                                                 transA,
+                                                 diag,
+                                                 M,
+                                                 dA.ptr_on_device(),
+                                                 lda,
+                                                 dx.ptr_on_device(),
+                                                 incx,
+                                                 batch_count));
+
+        CHECK_HIP_ERROR(hres.transfer_from(dx));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_trmv<T>(uplo, transA, diag, M, hA[b], lda, hx[b], incx);

--- a/clients/include/testing_trmv_strided_batched.hpp
+++ b/clients/include/testing_trmv_strided_batched.hpp
@@ -65,20 +65,19 @@ hipblasStatus_t testing_trmv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTrmvStridedBatchedFn(
-        handle, uplo, transA, diag, M, dA, lda, stride_A, dx, incx, stride_x, batch_count));
-
-    CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * X_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTrmvStridedBatchedFn(
+            handle, uplo, transA, diag, M, dA, lda, stride_A, dx, incx, stride_x, batch_count));
+
+        CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * X_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_trmv<T>(uplo,

--- a/clients/include/testing_trsm_batched.hpp
+++ b/clients/include/testing_trsm_batched.hpp
@@ -132,7 +132,6 @@ hipblasStatus_t testing_trsm_batched(const Arguments& argus)
     /* =====================================================================
            HIPBLAS
     =================================================================== */
-
     if(argus.unit_check || argus.norm_check)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
@@ -173,7 +172,6 @@ hipblasStatus_t testing_trsm_batched(const Arguments& argus)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_trsm<T>(

--- a/clients/include/testing_trsm_ex.hpp
+++ b/clients/include/testing_trsm_ex.hpp
@@ -123,9 +123,6 @@ hipblasStatus_t testing_trsm_ex(const Arguments& argus)
     hipblasStride stride_invA = TRSM_BLOCK * TRSM_BLOCK;
     int           blocks      = K / TRSM_BLOCK;
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
     // Calculate invA
     if(blocks > 0)
     {
@@ -157,52 +154,54 @@ hipblasStatus_t testing_trsm_ex(const Arguments& argus)
                                                           1));
     }
 
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-    CHECK_HIPBLAS_ERROR(hipblasTrsmExFn(handle,
-                                        side,
-                                        uplo,
-                                        transA,
-                                        diag,
-                                        M,
-                                        N,
-                                        &h_alpha,
-                                        dA,
-                                        lda,
-                                        dB,
-                                        ldb,
-                                        dinvA,
-                                        TRSM_BLOCK * K,
-                                        argus.compute_type));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hB_host, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB_device, sizeof(T) * B_size, hipMemcpyHostToDevice));
-
-    CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-    CHECK_HIPBLAS_ERROR(hipblasTrsmExFn(handle,
-                                        side,
-                                        uplo,
-                                        transA,
-                                        diag,
-                                        M,
-                                        N,
-                                        d_alpha,
-                                        dA,
-                                        lda,
-                                        dB,
-                                        ldb,
-                                        dinvA,
-                                        TRSM_BLOCK * K,
-                                        argus.compute_type));
-
-    CHECK_HIP_ERROR(hipMemcpy(hB_device, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasTrsmExFn(handle,
+                                            side,
+                                            uplo,
+                                            transA,
+                                            diag,
+                                            M,
+                                            N,
+                                            &h_alpha,
+                                            dA,
+                                            lda,
+                                            dB,
+                                            ldb,
+                                            dinvA,
+                                            TRSM_BLOCK * K,
+                                            argus.compute_type));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hB_host, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dB, hB_device, sizeof(T) * B_size, hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasTrsmExFn(handle,
+                                            side,
+                                            uplo,
+                                            transA,
+                                            diag,
+                                            M,
+                                            N,
+                                            d_alpha,
+                                            dA,
+                                            lda,
+                                            dB,
+                                            ldb,
+                                            dinvA,
+                                            TRSM_BLOCK * K,
+                                            argus.compute_type));
+
+        CHECK_HIP_ERROR(hipMemcpy(hB_device, dB, sizeof(T) * B_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_trsm<T>(
             side, uplo, transA, diag, M, N, h_alpha, (const T*)hA.data(), lda, hB_cpu.data(), ldb);
 

--- a/clients/include/testing_trsm_strided_batched.hpp
+++ b/clients/include/testing_trsm_strided_batched.hpp
@@ -129,7 +129,6 @@ hipblasStatus_t testing_trsm_strided_batched(const Arguments& argus)
     /* =====================================================================
            HIPBLAS
     =================================================================== */
-
     if(argus.unit_check || argus.norm_check)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
@@ -175,7 +174,6 @@ hipblasStatus_t testing_trsm_strided_batched(const Arguments& argus)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         for(int b = 0; b < batch_count; b++)
         {
             cblas_trsm<T>(side,

--- a/clients/include/testing_trtri.hpp
+++ b/clients/include/testing_trtri.hpp
@@ -82,20 +82,19 @@ hipblasStatus_t testing_trtri(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dinvA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTrtriFn(handle, uplo, diag, N, dA, lda, dinvA, ldinvA));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hA, dinvA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTrtriFn(handle, uplo, diag, N, dA, lda, dinvA, ldinvA));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hA, dinvA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
+        /* =====================================================================
            CPU BLAS
         =================================================================== */
-
         cblas_trtri<T>(char_uplo, char_diag, N, hB, lda);
 
         if(argus.unit_check)

--- a/clients/include/testing_trtri_batched.hpp
+++ b/clients/include/testing_trtri_batched.hpp
@@ -86,24 +86,24 @@ hipblasStatus_t testing_trtri_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dA.transfer_from(hA));
     CHECK_HIP_ERROR(dinvA.transfer_from(hA));
 
-    /* =====================================================================
-           HIPBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTrtriBatchedFn(handle,
-                                              uplo,
-                                              diag,
-                                              N,
-                                              dA.ptr_on_device(),
-                                              lda,
-                                              dinvA.ptr_on_device(),
-                                              ldinvA,
-                                              batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hA.transfer_from(dinvA));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTrtriBatchedFn(handle,
+                                                  uplo,
+                                                  diag,
+                                                  N,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  dinvA.ptr_on_device(),
+                                                  ldinvA,
+                                                  batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hA.transfer_from(dinvA));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */

--- a/clients/include/testing_trtri_strided_batched.hpp
+++ b/clients/include/testing_trtri_strided_batched.hpp
@@ -88,17 +88,17 @@ hipblasStatus_t testing_trtri_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dinvA, hA, sizeof(T) * A_size, hipMemcpyHostToDevice));
 
-    /* =====================================================================
-           ROCBLAS
-    =================================================================== */
-    CHECK_HIPBLAS_ERROR(hipblasTrtriStridedBatchedFn(
-        handle, uplo, diag, N, dA, lda, strideA, dinvA, ldinvA, strideA, batch_count));
-
-    // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hA, dinvA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
-
     if(argus.unit_check || argus.norm_check)
     {
+        /* =====================================================================
+            HIPBLAS
+        =================================================================== */
+        CHECK_HIPBLAS_ERROR(hipblasTrtriStridedBatchedFn(
+            handle, uplo, diag, N, dA, lda, strideA, dinvA, ldinvA, strideA, batch_count));
+
+        // copy output from device to CPU
+        CHECK_HIP_ERROR(hipMemcpy(hA, dinvA, sizeof(T) * A_size, hipMemcpyDeviceToHost));
+
         /* =====================================================================
            CPU BLAS
         =================================================================== */


### PR DESCRIPTION
Moving all the hipBLAS calls into the `if(unit_check || norm_check)` section, will save some time for hipblas-bench calls when the unit_check/norm_check isn't necessary. See https://github.com/ROCmSoftwarePlatform/hipBLAS/pull/373