### PR TITLE
Adding npvt solver tests to hipblas-bench

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -205,8 +205,12 @@
 #include "testing_geqrf_strided_batched.hpp"
 #include "testing_getrf.hpp"
 #include "testing_getrf_batched.hpp"
+#include "testing_getrf_npvt.hpp"
+#include "testing_getrf_npvt_batched.hpp"
+#include "testing_getrf_npvt_strided_batched.hpp"
 #include "testing_getrf_strided_batched.hpp"
 #include "testing_getri_batched.hpp"
+#include "testing_getri_npvt_batched.hpp"
 #include "testing_getrs.hpp"
 #include "testing_getrs_batched.hpp"
 #include "testing_getrs_strided_batched.hpp"
@@ -481,7 +485,11 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same
             {"getrf", testing_getrf<T>},
             {"getrf_batched", testing_getrf_batched<T>},
             {"getrf_strided_batched", testing_getrf_strided_batched<T>},
+            {"getrf_npvt", testing_getrf_npvt<T>},
+            {"getrf_npvt_batched", testing_getrf_npvt_batched<T>},
+            {"getrf_npvt_strided_batched", testing_getrf_npvt_strided_batched<T>},
             {"getri_batched", testing_getri_batched<T>},
+            {"getri_npvt_batched", testing_getri_npvt_batched<T>},
             {"getrs", testing_getrs<T>},
             {"getrs_batched", testing_getrs_batched<T>},
             {"getrs_strided_batched", testing_getrs_strided_batched<T>},
@@ -697,7 +705,11 @@ struct perf_blas<
             {"getrf", testing_getrf<T>},
             {"getrf_batched", testing_getrf_batched<T>},
             {"getrf_strided_batched", testing_getrf_strided_batched<T>},
+            {"getrf_npvt", testing_getrf_npvt<T>},
+            {"getrf_npvt_batched", testing_getrf_npvt_batched<T>},
+            {"getrf_npvt_strided_batched", testing_getrf_npvt_strided_batched<T>},
             {"getri_batched", testing_getri_batched<T>},
+            {"getri_npvt_batched", testing_getri_npvt_batched<T>},
             {"getrs", testing_getrs<T>},
             {"getrs_batched", testing_getrs_batched<T>},
             {"getrs_strided_batched", testing_getrs_strided_batched<T>},

--- a/clients/gtest/getrf_batched_gtest.cpp
+++ b/clients/gtest/getrf_batched_gtest.cpp
@@ -156,7 +156,7 @@ TEST_P(getrf_batched_gtest, getrf_npvt_batched_gtest_float)
 
     Arguments arg = setup_getrf_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt_batched<float, float>(arg);
+    hipblasStatus_t status = testing_getrf_npvt_batched<float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -178,7 +178,7 @@ TEST_P(getrf_batched_gtest, getrf_npvt_batched_gtest_double)
 
     Arguments arg = setup_getrf_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt_batched<double, double>(arg);
+    hipblasStatus_t status = testing_getrf_npvt_batched<double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -200,7 +200,7 @@ TEST_P(getrf_batched_gtest, getrf_npvt_batched_gtest_float_complex)
 
     Arguments arg = setup_getrf_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_getrf_npvt_batched<hipblasComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -222,7 +222,7 @@ TEST_P(getrf_batched_gtest, getrf_npvt_batched_gtest_double_complex)
 
     Arguments arg = setup_getrf_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_getrf_npvt_batched<hipblasDoubleComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrf_gtest.cpp
+++ b/clients/gtest/getrf_gtest.cpp
@@ -158,7 +158,7 @@ TEST_P(getrf_gtest, getrf_npvt_gtest_float)
 
     Arguments arg = setup_getrf_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt<float, float>(arg);
+    hipblasStatus_t status = testing_getrf_npvt<float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -180,7 +180,7 @@ TEST_P(getrf_gtest, getrf_npvt_gtest_double)
 
     Arguments arg = setup_getrf_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt<double, double>(arg);
+    hipblasStatus_t status = testing_getrf_npvt<double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -202,7 +202,7 @@ TEST_P(getrf_gtest, getrf_npvt_gtest_float_complex)
 
     Arguments arg = setup_getrf_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_getrf_npvt<hipblasComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -224,7 +224,7 @@ TEST_P(getrf_gtest, getrf_npvt_gtest_double_complex)
 
     Arguments arg = setup_getrf_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_getrf_npvt<hipblasDoubleComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getrf_strided_batched_gtest.cpp
+++ b/clients/gtest/getrf_strided_batched_gtest.cpp
@@ -158,7 +158,7 @@ TEST_P(getrf_strided_batched_gtest, getrf_npvt_strided_batched_gtest_float)
 
     Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt_strided_batched<float, float>(arg);
+    hipblasStatus_t status = testing_getrf_npvt_strided_batched<float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -180,7 +180,7 @@ TEST_P(getrf_strided_batched_gtest, getrf_npvt_strided_batched_gtest_double)
 
     Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt_strided_batched<double, double>(arg);
+    hipblasStatus_t status = testing_getrf_npvt_strided_batched<double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -202,7 +202,7 @@ TEST_P(getrf_strided_batched_gtest, getrf_npvt_strided_batched_gtest_float_compl
 
     Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt_strided_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_getrf_npvt_strided_batched<hipblasComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -224,7 +224,7 @@ TEST_P(getrf_strided_batched_gtest, getrf_npvt_strided_batched_gtest_double_comp
 
     Arguments arg = setup_getrf_strided_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getrf_npvt_strided_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_getrf_npvt_strided_batched<hipblasDoubleComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/getri_batched_gtest.cpp
+++ b/clients/gtest/getri_batched_gtest.cpp
@@ -151,7 +151,7 @@ TEST_P(getri_batched_gtest, getri_npvt_batched_gtest_float)
 
     Arguments arg = setup_getri_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getri_npvt_batched<float, float>(arg);
+    hipblasStatus_t status = testing_getri_npvt_batched<float>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -173,7 +173,7 @@ TEST_P(getri_batched_gtest, getri_npvt_batched_gtest_double)
 
     Arguments arg = setup_getri_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getri_npvt_batched<double, double>(arg);
+    hipblasStatus_t status = testing_getri_npvt_batched<double>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -195,7 +195,7 @@ TEST_P(getri_batched_gtest, getri_npvt_batched_gtest_float_complex)
 
     Arguments arg = setup_getri_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getri_npvt_batched<hipblasComplex, float>(arg);
+    hipblasStatus_t status = testing_getri_npvt_batched<hipblasComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -217,7 +217,7 @@ TEST_P(getri_batched_gtest, getri_npvt_batched_gtest_double_complex)
 
     Arguments arg = setup_getri_batched_arguments(GetParam());
 
-    hipblasStatus_t status = testing_getri_npvt_batched<hipblasDoubleComplex, double>(arg);
+    hipblasStatus_t status = testing_getri_npvt_batched<hipblasDoubleComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/testing_getrf_npvt.hpp
+++ b/clients/include/testing_getrf_npvt.hpp
@@ -12,9 +12,10 @@
 
 using namespace std;
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
 {
+    using U             = real_t<T>;
     bool FORTRAN        = argus.fortran;
     auto hipblasGetrfFn = FORTRAN ? hipblasGetrf<T, true> : hipblasGetrf<T, false>;
 
@@ -22,10 +23,8 @@ hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
     int N   = argus.N;
     int lda = argus.lda;
 
-    int A_size    = lda * N;
-    int Ipiv_size = min(M, N);
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    size_t A_size    = size_t(lda) * N;
+    size_t Ipiv_size = min(M, N);
 
     // Check to prevent memory allocation error
     if(M < 0 || N < 0 || lda < M)
@@ -43,12 +42,8 @@ hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
     device_vector<T>   dA(A_size);
     device_vector<int> dInfo(1);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial hA on CPU
     srand(1);
@@ -70,18 +65,12 @@ hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), A_size * sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, sizeof(int)));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
             HIPBLAS
         =================================================================== */
-        status = hipblasGetrfFn(handle, N, dA, lda, nullptr, dInfo);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetrfFn(handle, N, dA, lda, nullptr, dInfo));
 
         // Copy output from device to CPU
         CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
@@ -92,16 +81,38 @@ hipblasStatus_t testing_getrf_npvt(const Arguments& argus)
         =================================================================== */
         hInfo[0] = cblas_getrf(M, N, hA.data(), lda, hIpiv.data());
 
+        hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1);
         if(argus.unit_check)
         {
             U      eps       = std::numeric_limits<U>::epsilon();
             double tolerance = eps * 2000;
 
-            double e = norm_check_general<T>('F', M, N, lda, hA.data(), hA1.data());
-            unit_check_error(e, tolerance);
+            unit_check_error(hipblas_error, tolerance);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasGetrfFn(handle, N, dA, lda, nullptr, dInfo));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_lda>{}.log_args<T>(std::cout,
+                                                argus,
+                                                gpu_time_used,
+                                                getrf_gflop_count<T>(N, M),
+                                                ArgumentLogging::NA_value,
+                                                hipblas_error);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_getrf_npvt_batched.hpp
+++ b/clients/include/testing_getrf_npvt_batched.hpp
@@ -12,9 +12,10 @@
 
 using namespace std;
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_getrf_npvt_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasGetrfBatchedFn
         = FORTRAN ? hipblasGetrfBatched<T, true> : hipblasGetrfBatched<T, false>;
@@ -25,10 +26,8 @@ hipblasStatus_t testing_getrf_npvt_batched(const Arguments& argus)
     int batch_count = argus.batch_count;
 
     hipblasStride strideP   = min(M, N);
-    int           A_size    = lda * N;
+    size_t        A_size    = size_t(lda) * N;
     int           Ipiv_size = strideP * batch_count;
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
 
     // Check to prevent memory allocation error
     if(M < 0 || N < 0 || lda < M || batch_count < 0)
@@ -41,33 +40,22 @@ hipblasStatus_t testing_getrf_npvt_batched(const Arguments& argus)
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T>   hA[batch_count];
-    host_vector<T>   hA1[batch_count];
-    host_vector<int> hIpiv(Ipiv_size);
-    host_vector<int> hInfo(batch_count);
-    host_vector<int> hInfo1(batch_count);
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hA1(A_size, 1, batch_count);
+    host_vector<int>     hIpiv(Ipiv_size);
+    host_vector<int>     hInfo(batch_count);
+    host_vector<int>     hInfo1(batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_vector<int>     dInfo(batch_count);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<int>      dInfo(batch_count);
-
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial hA on CPU
-    srand(1);
+    hipblas_init(hA, true);
     for(int b = 0; b < batch_count; b++)
     {
-        hA[b]  = host_vector<T>(A_size);
-        hA1[b] = host_vector<T>(A_size);
-
-        hipblas_init<T>(hA[b], M, N, lda);
-
         // scale A to avoid singularities
         for(int i = 0; i < M; i++)
         {
@@ -79,31 +67,21 @@ hipblasStatus_t testing_getrf_npvt_batched(const Arguments& argus)
                     hA[b][i + j * lda] -= 4;
             }
         }
-
-        // Copy data from CPU to device
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b].data(), A_size * sizeof(T), hipMemcpyHostToDevice));
     }
 
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, batch_count * sizeof(T*), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
             HIPBLAS
         =================================================================== */
-        status = hipblasGetrfBatchedFn(handle, N, dA, lda, nullptr, dInfo, batch_count);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(
+            hipblasGetrfBatchedFn(handle, N, dA.ptr_on_device(), lda, nullptr, dInfo, batch_count));
 
         // Copy output from device to CPU
-        for(int b = 0; b < batch_count; b++)
-            CHECK_HIP_ERROR(
-                hipMemcpy(hA1[b].data(), bA[b], A_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hA1.transfer_from(dA));
         CHECK_HIP_ERROR(
             hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
 
@@ -112,19 +90,42 @@ hipblasStatus_t testing_getrf_npvt_batched(const Arguments& argus)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            hInfo[b] = cblas_getrf(M, N, hA[b].data(), lda, hIpiv.data() + b * strideP);
+            hInfo[b] = cblas_getrf(M, N, hA[b], lda, hIpiv.data() + b * strideP);
+        }
 
-            if(argus.unit_check)
-            {
-                U      eps       = std::numeric_limits<U>::epsilon();
-                double tolerance = eps * 2000;
+        hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1, batch_count);
+        if(argus.unit_check)
+        {
+            U      eps       = std::numeric_limits<U>::epsilon();
+            double tolerance = eps * 2000;
 
-                double e = norm_check_general<T>('F', M, N, lda, hA[b].data(), hA1[b].data());
-                unit_check_error(e, tolerance);
-            }
+            unit_check_error(hipblas_error, tolerance);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasGetrfBatchedFn(
+                handle, N, dA.ptr_on_device(), lda, nullptr, dInfo, batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_lda, e_batch_count>{}.log_args<T>(std::cout,
+                                                               argus,
+                                                               gpu_time_used,
+                                                               getrf_gflop_count<T>(N, M),
+                                                               ArgumentLogging::NA_value,
+                                                               hipblas_error);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_getrf_npvt_batched.hpp
+++ b/clients/include/testing_getrf_npvt_batched.hpp
@@ -27,7 +27,7 @@ hipblasStatus_t testing_getrf_npvt_batched(const Arguments& argus)
 
     hipblasStride strideP   = min(M, N);
     size_t        A_size    = size_t(lda) * N;
-    int           Ipiv_size = strideP * batch_count;
+    size_t        Ipiv_size = strideP * batch_count;
 
     // Check to prevent memory allocation error
     if(M < 0 || N < 0 || lda < M || batch_count < 0)

--- a/clients/include/testing_getrf_npvt_strided_batched.hpp
+++ b/clients/include/testing_getrf_npvt_strided_batched.hpp
@@ -12,9 +12,10 @@
 
 using namespace std;
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_getrf_npvt_strided_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasGetrfStridedBatchedFn
         = FORTRAN ? hipblasGetrfStridedBatched<T, true> : hipblasGetrfStridedBatched<T, false>;
@@ -25,12 +26,10 @@ hipblasStatus_t testing_getrf_npvt_strided_batched(const Arguments& argus)
     int    batch_count  = argus.batch_count;
     double stride_scale = argus.stride_scale;
 
-    hipblasStride strideA   = lda * N * stride_scale;
-    hipblasStride strideP   = min(M, N) * stride_scale;
-    int           A_size    = strideA * batch_count;
-    int           Ipiv_size = strideP * batch_count;
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    hipblasStride strideA   = size_t(lda) * N * stride_scale;
+    hipblasStride strideP   = size_t(min(M, N)) * stride_scale;
+    size_t        A_size    = strideA * batch_count;
+    size_t        Ipiv_size = strideP * batch_count;
 
     // Check to prevent memory allocation error
     if(M < 0 || N < 0 || lda < M || batch_count < 0)
@@ -52,12 +51,8 @@ hipblasStatus_t testing_getrf_npvt_strided_batched(const Arguments& argus)
     device_vector<T>   dA(A_size);
     device_vector<int> dInfo(batch_count);
 
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial hA on CPU
     srand(1);
@@ -84,19 +79,13 @@ hipblasStatus_t testing_getrf_npvt_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), A_size * sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
             HIPBLAS
         =================================================================== */
-        status = hipblasGetrfStridedBatchedFn(
-            handle, N, dA, lda, strideA, nullptr, strideP, dInfo, batch_count);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetrfStridedBatchedFn(
+            handle, N, dA, lda, strideA, nullptr, strideP, dInfo, batch_count));
 
         // Copy output from device to CPU
         CHECK_HIP_ERROR(hipMemcpy(hA1.data(), dA, A_size * sizeof(T), hipMemcpyDeviceToHost));
@@ -109,19 +98,43 @@ hipblasStatus_t testing_getrf_npvt_strided_batched(const Arguments& argus)
         for(int b = 0; b < batch_count; b++)
         {
             hInfo[b] = cblas_getrf(M, N, hA.data() + b * strideA, lda, hIpiv.data() + b * strideP);
+        }
 
-            if(argus.unit_check)
-            {
-                U      eps       = std::numeric_limits<U>::epsilon();
-                double tolerance = eps * 2000;
+        hipblas_error = norm_check_general<T>('F', M, N, lda, strideA, hA, hA1, batch_count);
 
-                double e = norm_check_general<T>(
-                    'F', M, N, lda, hA.data() + b * strideA, hA1.data() + b * strideA);
-                unit_check_error(e, tolerance);
-            }
+        if(argus.unit_check)
+        {
+            U      eps       = std::numeric_limits<U>::epsilon();
+            double tolerance = eps * 2000;
+
+            unit_check_error(hipblas_error, tolerance);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasGetrfStridedBatchedFn(
+                handle, N, dA, lda, strideA, nullptr, strideP, dInfo, batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_lda, e_stride_a, e_batch_count>{}.log_args<T>(
+            std::cout,
+            argus,
+            gpu_time_used,
+            getrf_gflop_count<T>(N, M),
+            ArgumentLogging::NA_value,
+            hipblas_error);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_getrf_strided_batched.hpp
+++ b/clients/include/testing_getrf_strided_batched.hpp
@@ -82,7 +82,7 @@ hipblasStatus_t testing_getrf_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemset(dIpiv, 0, Ipiv_size * sizeof(int)));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
             HIPBLAS

--- a/clients/include/testing_getri_npvt_batched.hpp
+++ b/clients/include/testing_getri_npvt_batched.hpp
@@ -12,9 +12,10 @@
 
 using namespace std;
 
-template <typename T, typename U>
+template <typename T>
 hipblasStatus_t testing_getri_npvt_batched(const Arguments& argus)
 {
+    using U      = real_t<T>;
     bool FORTRAN = argus.fortran;
     auto hipblasGetriBatchedFn
         = FORTRAN ? hipblasGetriBatched<T, true> : hipblasGetriBatched<T, false>;
@@ -25,10 +26,8 @@ hipblasStatus_t testing_getri_npvt_batched(const Arguments& argus)
     int batch_count = argus.batch_count;
 
     hipblasStride strideP   = min(M, N);
-    int           A_size    = lda * N;
-    int           Ipiv_size = strideP * batch_count;
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    size_t        A_size    = size_t(lda) * N;
+    size_t        Ipiv_size = strideP * batch_count;
 
     // Check to prevent memory allocation error
     if(M < 0 || N < 0 || lda < M || batch_count < 0)
@@ -41,38 +40,26 @@ hipblasStatus_t testing_getri_npvt_batched(const Arguments& argus)
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
-    host_vector<T>   hA[batch_count];
-    host_vector<T>   hA1[batch_count];
-    host_vector<T>   hC[batch_count];
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hA1(A_size, 1, batch_count);
+    host_batch_vector<T> hC(A_size, 1, batch_count);
+
     host_vector<int> hIpiv(Ipiv_size);
     host_vector<int> hInfo(batch_count);
     host_vector<int> hInfo1(batch_count);
 
-    device_batch_vector<T> bA(batch_count, A_size);
-    device_batch_vector<T> bC(batch_count, A_size);
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dC(A_size, 1, batch_count);
+    device_vector<int>     dInfo(batch_count);
 
-    device_vector<T*, 0, T> dA(batch_count);
-    device_vector<T*, 0, T> dC(batch_count);
-    device_vector<int>      dInfo(batch_count);
-
-    double gpu_time_used, cpu_time_used;
-    double hipblasGflops, cblas_gflops;
-    double rocblas_error;
-
-    hipblasHandle_t handle;
-    hipblasCreate(&handle);
+    double             gpu_time_used, hipblas_error;
+    hipblasLocalHandle handle(argus);
 
     // Initial hA on CPU
-    srand(1);
+    hipblas_init(hA, true);
+
     for(int b = 0; b < batch_count; b++)
     {
-        hA[b]       = host_vector<T>(A_size);
-        hA1[b]      = host_vector<T>(A_size);
-        hC[b]       = host_vector<T>(A_size);
-        int* hIpivb = hIpiv.data() + b * strideP;
-
-        hipblas_init<T>(hA[b], M, N, lda);
-
         // scale A to avoid singularities
         for(int i = 0; i < M; i++)
         {
@@ -86,33 +73,31 @@ hipblasStatus_t testing_getri_npvt_batched(const Arguments& argus)
         }
 
         // perform LU factorization on A
-        hInfo[b] = cblas_getrf(M, N, hA[b].data(), lda, hIpivb);
-
-        // Copy data from CPU to device
-        CHECK_HIP_ERROR(hipMemcpy(bA[b], hA[b].data(), A_size * sizeof(T), hipMemcpyHostToDevice));
+        int* hIpivb = hIpiv.data() + b * strideP;
+        hInfo[b]    = cblas_getrf(M, N, hA[b], lda, hIpivb);
     }
 
-    CHECK_HIP_ERROR(hipMemcpy(dA, bA, batch_count * sizeof(T*), hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dC, bC, batch_count * sizeof(T*), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dC.transfer_from(hC));
     CHECK_HIP_ERROR(hipMemset(dInfo, 0, batch_count * sizeof(int)));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
             HIPBLAS
         =================================================================== */
-        status = hipblasGetriBatchedFn(handle, N, dA, lda, nullptr, dC, lda, dInfo, batch_count);
-
-        if(status != HIPBLAS_STATUS_SUCCESS)
-        {
-            hipblasDestroy(handle);
-            return status;
-        }
+        CHECK_HIPBLAS_ERROR(hipblasGetriBatchedFn(handle,
+                                                  N,
+                                                  dA.ptr_on_device(),
+                                                  lda,
+                                                  nullptr,
+                                                  dC.ptr_on_device(),
+                                                  lda,
+                                                  dInfo,
+                                                  batch_count));
 
         // Copy output from device to CPU
-        for(int b = 0; b < batch_count; b++)
-            CHECK_HIP_ERROR(
-                hipMemcpy(hA1[b].data(), bC[b], A_size * sizeof(T), hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hA1.transfer_from(dC));
         CHECK_HIP_ERROR(
             hipMemcpy(hInfo1.data(), dInfo, batch_count * sizeof(int), hipMemcpyDeviceToHost));
 
@@ -123,25 +108,54 @@ hipblasStatus_t testing_getri_npvt_batched(const Arguments& argus)
         {
             // Workspace query
             host_vector<T> work(1);
-            cblas_getri(N, hA[b].data(), lda, hIpiv.data() + b * strideP, work.data(), -1);
+            cblas_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), -1);
             int lwork = type2int(work[0]);
 
             // Perform inversion
-            work = host_vector<T>(lwork);
-            hInfo[b]
-                = cblas_getri(N, hA[b].data(), lda, hIpiv.data() + b * strideP, work.data(), lwork);
+            work     = host_vector<T>(lwork);
+            hInfo[b] = cblas_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), lwork);
+        }
 
-            if(argus.unit_check)
-            {
-                U      eps       = std::numeric_limits<U>::epsilon();
-                double tolerance = eps * 2000;
+        hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1, batch_count);
+        if(argus.unit_check)
+        {
+            U      eps       = std::numeric_limits<U>::epsilon();
+            double tolerance = eps * 2000;
 
-                double e = norm_check_general<T>('F', M, N, lda, hA[b].data(), hA1[b].data());
-                unit_check_error(e, tolerance);
-            }
+            unit_check_error(hipblas_error, tolerance);
         }
     }
 
-    hipblasDestroy(handle);
+    if(argus.timing)
+    {
+        hipStream_t stream;
+        CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
+
+        int runs = argus.cold_iters + argus.iters;
+        for(int iter = 0; iter < runs; iter++)
+        {
+            if(iter == argus.cold_iters)
+                gpu_time_used = get_time_us_sync(stream);
+
+            CHECK_HIPBLAS_ERROR(hipblasGetriBatchedFn(handle,
+                                                      N,
+                                                      dA.ptr_on_device(),
+                                                      lda,
+                                                      nullptr,
+                                                      dC.ptr_on_device(),
+                                                      lda,
+                                                      dInfo,
+                                                      batch_count));
+        }
+        gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
+
+        ArgumentModel<e_N, e_lda, e_batch_count>{}.log_args<T>(std::cout,
+                                                               argus,
+                                                               gpu_time_used,
+                                                               getri_gflop_count<T>(N),
+                                                               ArgumentLogging::NA_value,
+                                                               hipblas_error);
+    }
+
     return HIPBLAS_STATUS_SUCCESS;
 }


### PR DESCRIPTION
_Should_ be the final additions to hipblas-bench unless more functions are added.

Remaining work in hipblas tests:
- allow negative incx/incy
- bad enum test ([LWPMLSE-122](https://ontrack-internal.amd.com/browse/LWPMLSE-122))