### PR TITLE
Allowing negative increments in hipblas tests (L1)

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -664,21 +664,21 @@ void cblas_rot<hipblasComplex>(int             n,
                                hipblasComplex  s)
 {
     float c_real = std::real(c);
-    crot_(&n, x, &incx, y, &incx, &c_real, &s);
+    crot_(&n, x, &incx, y, &incy, &c_real, &s);
 }
 
 template <>
 void cblas_rot<hipblasComplex, float>(
     int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy, float c, hipblasComplex s)
 {
-    crot_(&n, x, &incx, y, &incx, &c, &s);
+    crot_(&n, x, &incx, y, &incy, &c, &s);
 }
 
 template <>
 void cblas_rot<hipblasComplex, float, float>(
     int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy, float c, float s)
 {
-    csrot_(&n, x, &incx, y, &incx, &c, &s);
+    csrot_(&n, x, &incx, y, &incy, &c, &s);
 }
 
 template <>
@@ -691,7 +691,7 @@ void cblas_rot<hipblasDoubleComplex>(int                   n,
                                      hipblasDoubleComplex  s)
 {
     double c_real = std::real(c);
-    zrot_(&n, x, &incx, y, &incx, &c_real, &s);
+    zrot_(&n, x, &incx, y, &incy, &c_real, &s);
 }
 
 template <>
@@ -703,14 +703,14 @@ void cblas_rot<hipblasDoubleComplex, double>(int                   n,
                                              double                c,
                                              hipblasDoubleComplex  s)
 {
-    zrot_(&n, x, &incx, y, &incx, &c, &s);
+    zrot_(&n, x, &incx, y, &incy, &c, &s);
 }
 
 template <>
 void cblas_rot<hipblasDoubleComplex, double, double>(
     int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy, double c, double s)
 {
-    zdrot_(&n, x, &incx, y, &incx, &c, &s);
+    zdrot_(&n, x, &incx, y, &incy, &c, &s);
 }
 
 // rotg

--- a/clients/gtest/axpy_ex_gtest.cpp
+++ b/clients/gtest/axpy_ex_gtest.cpp
@@ -60,8 +60,9 @@ const vector<vector<double>> alpha_range = {{1.0, 2.0}};
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 2}
-// incx , incy must > 0, otherwise there is no real computation taking place,
-// but throw a message, which will still be detected by gtest
+// negative increments use absolute value for comparisons, so
+// some combinations may not work as expected. {-1, -1} as done
+// here is fine
 const vector<vector<int>> incx_incy_range = {
     {1, 1},
     {2, 3},

--- a/clients/gtest/axpy_ex_gtest.cpp
+++ b/clients/gtest/axpy_ex_gtest.cpp
@@ -64,6 +64,7 @@ const vector<vector<double>> alpha_range = {{1.0, 2.0}};
 // but throw a message, which will still be detected by gtest
 const vector<vector<int>> incx_incy_range = {
     {1, 1},
+    {2, 3},
     {-1, -1},
 };
 

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -96,6 +96,7 @@ const vector<vector<double>> alpha_beta_range = {{1.0, 2.0, 0.0, 0.0}, {2.0, -1.
 // but throw a message, which will still be detected by gtest
 const vector<vector<int>> incx_incy_range = {
     {1, 1},
+    {1, 2},
     {-1, -1},
 };
 

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -92,8 +92,9 @@ const vector<vector<double>> alpha_beta_range = {{1.0, 2.0, 0.0, 0.0}, {2.0, -1.
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 2}
-// incx , incy must > 0, otherwise there is no real computation taking place,
-// but throw a message, which will still be detected by gtest
+// negative increments use absolute value for comparisons, so
+// some combinations may not work as expected. {-1, -1} as done
+// here is fine
 const vector<vector<int>> incx_incy_range = {
     {1, 1},
     {1, 2},

--- a/clients/gtest/dot_ex_gtest.cpp
+++ b/clients/gtest/dot_ex_gtest.cpp
@@ -55,8 +55,9 @@ const int N_range[] = {-1, 10, 500, 1000, 7111};
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 2}
-// incx , incy must > 0, otherwise there is no real computation taking place,
-// but throw a message, which will still be detected by gtest
+// negative increments use absolute value for comparisons, so
+// some combinations may not work as expected. {-1, -1} as done
+// here is fine
 const vector<vector<int>> incx_incy_range = {
     {1, 1},
     {-1, -1},

--- a/clients/gtest/rot_ex_gtest.cpp
+++ b/clients/gtest/rot_ex_gtest.cpp
@@ -55,8 +55,9 @@ const int N_range[] = {-1, 10, 500, 1000, 7111, 10000};
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 2}
-// incx , incy must > 0, otherwise there is no real computation taking place,
-// but throw a message, which will still be detected by gtest
+// negative increments use absolute value for comparisons, so
+// some combinations may not work as expected. {-1, -1} as done
+// here is fine
 const vector<vector<int>> incx_incy_range = {
     {1, 1},
     {-1, -1},

--- a/clients/include/device_batch_vector.hpp
+++ b/clients/include/device_batch_vector.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Advanced Micro Devices, Inc.
+// Copyright 2018-2021 Advanced Micro Devices, Inc.
 //
 #pragma once
 
@@ -39,9 +39,9 @@ public:
     //!
     explicit device_batch_vector(int n, int inc, int batch_count)
         : m_n(n)
-        , m_inc(inc)
+        , m_inc(inc ? inc : 1)
         , m_batch_count(batch_count)
-        , d_vector<T, PAD, U>(size_t(n) * std::abs(inc))
+        , d_vector<T, PAD, U>(size_t(n) * std::abs(inc ? inc : 1))
     {
         if(false == this->try_initialize_memory())
         {

--- a/clients/include/host_batch_vector.hpp
+++ b/clients/include/host_batch_vector.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2018-2020 Advanced Micro Devices, Inc.
+// Copyright 2018-2021 Advanced Micro Devices, Inc.
 //
 #pragma once
 
@@ -36,7 +36,7 @@ public:
     //!
     explicit host_batch_vector(int n, int inc, int batch_count)
         : m_n(n)
-        , m_inc(inc)
+        , m_inc(inc ? inc : 1)
         , m_batch_count(batch_count)
     {
         if(false == this->try_initialize_memory())

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -24,9 +24,9 @@ hipblasStatus_t testing_asum(const Arguments& argus)
     int incx = argus.incx;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0)
+    if(N <= 0 || incx <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     size_t sizeX = size_t(N) * incx;

--- a/clients/include/testing_asum.hpp
+++ b/clients/include/testing_asum.hpp
@@ -23,9 +23,25 @@ hipblasStatus_t testing_asum(const Arguments& argus)
     int N    = argus.N;
     int incx = argus.incx;
 
+    hipblasLocalHandle handle(argus);
+
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0)
     {
+        device_vector<Tr> d_hipblas_result_0(1);
+        host_vector<Tr>   h_hipblas_result_0(1);
+        hipblas_init_nan(h_hipblas_result_0.data(), 1);
+        CHECK_HIP_ERROR(
+            hipMemcpy(d_hipblas_result_0, h_hipblas_result_0, sizeof(Tr), hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasAsumFn(handle, N, nullptr, incx, d_hipblas_result_0));
+
+        host_vector<Tr> cpu_0(1);
+        host_vector<Tr> gpu_0(1);
+        CHECK_HIP_ERROR(hipMemcpy(gpu_0, d_hipblas_result_0, sizeof(Tr), hipMemcpyDeviceToHost));
+        unit_check_general<Tr>(1, 1, 1, cpu_0, gpu_0);
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -39,8 +55,6 @@ hipblasStatus_t testing_asum(const Arguments& argus)
     Tr                cpu_result, hipblas_result_host, hipblas_result_device;
 
     double gpu_time_used, hipblas_error_host = 0, hipblas_error_device = 0;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -26,11 +26,7 @@ hipblasStatus_t testing_asum_batched(const Arguments& argus)
     int batch_count = argus.batch_count;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(batch_count == 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -25,15 +25,36 @@ hipblasStatus_t testing_asum_batched(const Arguments& argus)
     int incx        = argus.incx;
     int batch_count = argus.batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
+        device_vector<Tr> d_hipblas_result_0(std::max(1, batch_count));
+        host_vector<Tr>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(Tr) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(
+            hipblasAsumBatchedFn(handle, N, nullptr, incx, batch_count, d_hipblas_result_0));
+
+        if(batch_count > 0)
+        {
+            host_vector<Tr> cpu_0(1);
+            host_vector<Tr> gpu_0(1);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+        }
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hx(N, incx, batch_count);

--- a/clients/include/testing_asum_batched.hpp
+++ b/clients/include/testing_asum_batched.hpp
@@ -44,8 +44,8 @@ hipblasStatus_t testing_asum_batched(const Arguments& argus)
 
         if(batch_count > 0)
         {
-            host_vector<Tr> cpu_0(1);
-            host_vector<Tr> gpu_0(1);
+            host_vector<Tr> cpu_0(batch_count);
+            host_vector<Tr> gpu_0(batch_count);
             CHECK_HIP_ERROR(hipMemcpy(
                 gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
             unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);

--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -32,13 +32,8 @@ hipblasStatus_t testing_asum_strided_batched(const Arguments& argus)
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0 || batch_count < 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(batch_count == 0)
-    {
-        // return early so we don't get invalid_value from hipblas because of bad result pointer
         return HIPBLAS_STATUS_SUCCESS;
     }
 

--- a/clients/include/testing_asum_strided_batched.hpp
+++ b/clients/include/testing_asum_strided_batched.hpp
@@ -29,15 +29,34 @@ hipblasStatus_t testing_asum_strided_batched(const Arguments& argus)
     hipblasStride stridex = size_t(N) * incx * stride_scale;
     size_t        sizeX   = stridex * batch_count;
 
-    double gpu_time_used, hipblas_error_host, hipblas_error_device;
+    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
+    hipblasLocalHandle handle(argus);
 
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
+        device_vector<Tr> d_hipblas_result_0(std::max(1, batch_count));
+        host_vector<Tr>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(Tr) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasAsumStridedBatchedFn(
+            handle, N, nullptr, incx, stridex, batch_count, d_hipblas_result_0));
+
+        if(batch_count > 0)
+        {
+            host_vector<Tr> cpu_0(batch_count);
+            host_vector<Tr> gpu_0(batch_count);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+        }
         return HIPBLAS_STATUS_SUCCESS;
     }
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T>  hx(sizeX);

--- a/clients/include/testing_axpy.hpp
+++ b/clients/include/testing_axpy.hpp
@@ -28,14 +28,19 @@ hipblasStatus_t testing_axpy(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || !incx || !incy)
+    if(N <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     size_t sizeX = size_t(N) * abs_incx;
     size_t sizeY = size_t(N) * abs_incy;
-    T      alpha = argus.get_alpha<T>();
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
+
+    T alpha = argus.get_alpha<T>();
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(sizeX);
@@ -93,7 +98,7 @@ hipblasStatus_t testing_axpy(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, abs_incx, hy_cpu.data(), hy_host.data());
+            unit_check_general<T>(1, N, abs_incy, hy_cpu.data(), hy_host.data());
             unit_check_general<T>(1, N, abs_incy, hy_cpu.data(), hy_device.data());
         }
         if(argus.norm_check)

--- a/clients/include/testing_axpy.hpp
+++ b/clients/include/testing_axpy.hpp
@@ -26,10 +26,13 @@ hipblasStatus_t testing_axpy(const Arguments& argus)
     int abs_incx = incx < 0 ? -incx : incx;
     int abs_incy = incy < 0 ? -incy : incy;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasAxpyFn(handle, N, nullptr, nullptr, incx, nullptr, incy));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -55,8 +58,6 @@ hipblasStatus_t testing_axpy(const Arguments& argus)
     device_vector<T> d_alpha(1);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_axpy_batched.hpp
+++ b/clients/include/testing_axpy_batched.hpp
@@ -40,15 +40,15 @@ hipblasStatus_t testing_axpy_batched(const Arguments& argus)
     hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy_host(N, incy ? incy : 1, batch_count);
-    host_batch_vector<T> hy_device(N, incy ? incy : 1, batch_count);
-    host_batch_vector<T> hx_cpu(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy_cpu(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy_host(N, incy, batch_count);
+    host_batch_vector<T> hy_device(N, incy, batch_count);
+    host_batch_vector<T> hx_cpu(N, incx, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy, batch_count);
 
-    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<T> dy_host(N, incy ? incy : 1, batch_count);
-    device_batch_vector<T> dy_device(N, incy ? incy : 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy_host(N, incy, batch_count);
+    device_batch_vector<T> dy_device(N, incy, batch_count);
     device_vector<T>       d_alpha(1);
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy_host.memcheck());

--- a/clients/include/testing_axpy_batched.hpp
+++ b/clients/include/testing_axpy_batched.hpp
@@ -24,16 +24,11 @@ hipblasStatus_t testing_axpy_batched(const Arguments& argus)
     int incx        = argus.incx;
     int incy        = argus.incy;
     int batch_count = argus.batch_count;
-    int abs_incx    = incx < 0 ? -incx : incx;
     int abs_incy    = incy < 0 ? -incy : incy;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || !incx || !incy || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(!batch_count)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
@@ -45,15 +40,15 @@ hipblasStatus_t testing_axpy_batched(const Arguments& argus)
     hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<T> hx(N, incx, batch_count);
-    host_batch_vector<T> hy_host(N, incy, batch_count);
-    host_batch_vector<T> hy_device(N, incy, batch_count);
-    host_batch_vector<T> hx_cpu(N, incx, batch_count);
-    host_batch_vector<T> hy_cpu(N, incy, batch_count);
+    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
+    host_batch_vector<T> hy_host(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hy_device(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx_cpu(N, incx ? incx : 1, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy ? incy : 1, batch_count);
 
-    device_batch_vector<T> dx(N, incx, batch_count);
-    device_batch_vector<T> dy_host(N, incy, batch_count);
-    device_batch_vector<T> dy_device(N, incy, batch_count);
+    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
+    device_batch_vector<T> dy_host(N, incy ? incy : 1, batch_count);
+    device_batch_vector<T> dy_device(N, incy ? incy : 1, batch_count);
     device_vector<T>       d_alpha(1);
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy_host.memcheck());
@@ -110,7 +105,7 @@ hipblasStatus_t testing_axpy_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, abs_incx, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy_host);
             unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)

--- a/clients/include/testing_axpy_batched.hpp
+++ b/clients/include/testing_axpy_batched.hpp
@@ -26,18 +26,20 @@ hipblasStatus_t testing_axpy_batched(const Arguments& argus)
     int batch_count = argus.batch_count;
     int abs_incy    = incy < 0 ? -incy : incy;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(
+            hipblasAxpyBatchedFn(handle, N, nullptr, nullptr, incx, nullptr, incy, batch_count));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
     T alpha = argus.get_alpha<T>();
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hx(N, incx, batch_count);

--- a/clients/include/testing_axpy_batched_ex.hpp
+++ b/clients/include/testing_axpy_batched_ex.hpp
@@ -41,13 +41,13 @@ hipblasStatus_t testing_axpy_batched_ex_template(const Arguments& argus)
     Ta h_alpha = argus.get_alpha<Ta>();
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<Tx> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<Ty> hy_host(N, incy ? incy : 1, batch_count);
-    host_batch_vector<Ty> hy_device(N, incy ? incy : 1, batch_count);
-    host_batch_vector<Ty> hy_cpu(N, incy ? incy : 1, batch_count);
+    host_batch_vector<Tx> hx(N, incx, batch_count);
+    host_batch_vector<Ty> hy_host(N, incy, batch_count);
+    host_batch_vector<Ty> hy_device(N, incy, batch_count);
+    host_batch_vector<Ty> hy_cpu(N, incy, batch_count);
 
-    device_batch_vector<Tx> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<Ty> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<Tx> dx(N, incx, batch_count);
+    device_batch_vector<Ty> dy(N, incy, batch_count);
     device_vector<Ta>       d_alpha(1);
 
     CHECK_HIP_ERROR(dx.memcheck());

--- a/clients/include/testing_axpy_batched_ex.hpp
+++ b/clients/include/testing_axpy_batched_ex.hpp
@@ -24,17 +24,31 @@ hipblasStatus_t testing_axpy_batched_ex_template(const Arguments& argus)
     int incy        = argus.incy;
     int batch_count = argus.batch_count;
 
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(N <= 0 || batch_count <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
     hipblasDatatype_t alphaType     = argus.a_type;
     hipblasDatatype_t xType         = argus.b_type;
     hipblasDatatype_t yType         = argus.c_type;
     hipblasDatatype_t executionType = argus.compute_type;
+
+    hipblasLocalHandle handle(argus);
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N <= 0 || batch_count <= 0)
+    {
+        CHECK_HIPBLAS_ERROR(hipblasAxpyBatchedExFn(handle,
+                                                   N,
+                                                   nullptr,
+                                                   alphaType,
+                                                   nullptr,
+                                                   xType,
+                                                   incx,
+                                                   nullptr,
+                                                   yType,
+                                                   incy,
+                                                   batch_count,
+                                                   executionType));
+        return HIPBLAS_STATUS_SUCCESS;
+    }
 
     int abs_incy = incy < 0 ? -incy : incy;
 
@@ -53,8 +67,7 @@ hipblasStatus_t testing_axpy_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy.memcheck());
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     hipblas_init(hx, true);

--- a/clients/include/testing_axpy_ex.hpp
+++ b/clients/include/testing_axpy_ex.hpp
@@ -23,17 +23,30 @@ hipblasStatus_t testing_axpy_ex_template(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(N <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
+    hipblasLocalHandle handle(argus);
 
     hipblasDatatype_t alphaType     = argus.a_type;
     hipblasDatatype_t xType         = argus.b_type;
     hipblasDatatype_t yType         = argus.c_type;
     hipblasDatatype_t executionType = argus.compute_type;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N <= 0)
+    {
+        CHECK_HIPBLAS_ERROR(hipblasAxpyExFn(handle,
+                                            N,
+                                            nullptr,
+                                            alphaType,
+                                            nullptr,
+                                            xType,
+                                            incx,
+                                            nullptr,
+                                            yType,
+                                            incy,
+                                            executionType));
+        return HIPBLAS_STATUS_SUCCESS;
+    }
 
     int abs_incx = incx < 0 ? -incx : incx;
     int abs_incy = incy < 0 ? -incy : incy;
@@ -57,8 +70,7 @@ hipblasStatus_t testing_axpy_ex_template(const Arguments& argus)
     device_vector<Ty> dy(sizeY);
     device_vector<Ta> d_alpha(1);
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_axpy_ex.hpp
+++ b/clients/include/testing_axpy_ex.hpp
@@ -25,7 +25,7 @@ hipblasStatus_t testing_axpy_ex_template(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || !incx || !incy)
+    if(N <= 0)
     {
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
@@ -38,9 +38,14 @@ hipblasStatus_t testing_axpy_ex_template(const Arguments& argus)
     int abs_incx = incx < 0 ? -incx : incx;
     int abs_incy = incy < 0 ? -incy : incy;
 
-    size_t sizeX   = size_t(N) * abs_incx;
-    size_t sizeY   = size_t(N) * abs_incy;
-    Ta     h_alpha = argus.get_alpha<Ta>();
+    size_t sizeX = size_t(N) * abs_incx;
+    size_t sizeY = size_t(N) * abs_incy;
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
+
+    Ta h_alpha = argus.get_alpha<Ta>();
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx(sizeX);
@@ -49,7 +54,7 @@ hipblasStatus_t testing_axpy_ex_template(const Arguments& argus)
     host_vector<Ty> hy_cpu(sizeY);
 
     device_vector<Tx> dx(sizeX);
-    device_vector<Ty> dy(sizeX);
+    device_vector<Ty> dy(sizeY);
     device_vector<Ta> d_alpha(1);
 
     double             gpu_time_used, hipblas_error_host, hipblas_error_device;
@@ -94,7 +99,7 @@ hipblasStatus_t testing_axpy_ex_template(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<Ty>(1, N, abs_incx, hy_cpu, hy_host);
+            unit_check_general<Ty>(1, N, abs_incy, hy_cpu, hy_host);
             unit_check_general<Ty>(1, N, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)

--- a/clients/include/testing_axpy_ex.hpp
+++ b/clients/include/testing_axpy_ex.hpp
@@ -27,7 +27,7 @@ hipblasStatus_t testing_axpy_ex_template(const Arguments& argus)
     // memory
     if(N <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     hipblasDatatype_t alphaType     = argus.a_type;

--- a/clients/include/testing_axpy_strided_batched.hpp
+++ b/clients/include/testing_axpy_strided_batched.hpp
@@ -39,10 +39,14 @@ hipblasStatus_t testing_axpy_strided_batched(const Arguments& argus)
     if(!sizeY)
         sizeY = 1;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasAxpyStridedBatchedFn(
+            handle, N, nullptr, nullptr, incx, stridex, nullptr, incy, stridey, batch_count));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -59,8 +63,6 @@ hipblasStatus_t testing_axpy_strided_batched(const Arguments& argus)
     device_vector<T> d_alpha(1);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_axpy_strided_batched.hpp
+++ b/clients/include/testing_axpy_strided_batched.hpp
@@ -34,14 +34,14 @@ hipblasStatus_t testing_axpy_strided_batched(const Arguments& argus)
     hipblasStride stridey = size_t(N) * abs_incy * stride_scale;
     size_t        sizeX   = stridex * batch_count;
     size_t        sizeY   = stridey * batch_count;
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || !incx || !incy || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(!batch_count)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
@@ -93,7 +93,7 @@ hipblasStatus_t testing_axpy_strided_batched(const Arguments& argus)
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(
-            hipMemcpy(hy_host.data(), dy_host, sizeof(T) * sizeX, hipMemcpyDeviceToHost));
+            hipMemcpy(hy_host.data(), dy_host, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
         CHECK_HIP_ERROR(
             hipMemcpy(hy_device.data(), dy_device, sizeof(T) * sizeY, hipMemcpyDeviceToHost));
 
@@ -111,16 +111,16 @@ hipblasStatus_t testing_axpy_strided_batched(const Arguments& argus)
         if(argus.unit_check)
         {
             unit_check_general<T>(
-                1, N, batch_count, abs_incx, stridex, hy_cpu.data(), hy_host.data());
+                1, N, batch_count, abs_incy, stridex, hy_cpu.data(), hy_host.data());
             unit_check_general<T>(
                 1, N, batch_count, abs_incy, stridey, hy_cpu.data(), hy_device.data());
         }
         if(argus.norm_check)
         {
             hipblas_error_host = norm_check_general<T>(
-                'F', 1, N, 1, stridey, hy_cpu.data(), hy_host.data(), batch_count);
+                'F', 1, N, abs_incy, stridey, hy_cpu.data(), hy_host.data(), batch_count);
             hipblas_error_device = norm_check_general<T>(
-                'F', 1, N, 1, stridey, hy_cpu.data(), hy_device.data(), batch_count);
+                'F', 1, N, abs_incy, stridey, hy_cpu.data(), hy_device.data(), batch_count);
         }
     } // end of if unit check
 

--- a/clients/include/testing_axpy_strided_batched_ex.hpp
+++ b/clients/include/testing_axpy_strided_batched_ex.hpp
@@ -31,10 +31,6 @@ hipblasStatus_t testing_axpy_strided_batched_ex_template(const Arguments& argus)
     // memory
     if(N <= 0 || batch_count <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(!batch_count)
-    {
         return HIPBLAS_STATUS_SUCCESS;
     }
 

--- a/clients/include/testing_copy.hpp
+++ b/clients/include/testing_copy.hpp
@@ -23,10 +23,13 @@ hipblasStatus_t testing_copy(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasCopyFn(handle, N, nullptr, incx, nullptr, incy));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -51,8 +54,6 @@ hipblasStatus_t testing_copy(const Arguments& argus)
 
     double hipblas_error = 0.0;
     double gpu_time_used = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_copy.hpp
+++ b/clients/include/testing_copy.hpp
@@ -25,17 +25,19 @@ hipblasStatus_t testing_copy(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0)
+    if(N <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(incx < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
-    size_t sizeX = size_t(N) * incx;
-    size_t sizeY = size_t(N) * incy;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t sizeX    = size_t(N) * abs_incx;
+    size_t sizeY    = size_t(N) * abs_incy;
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(sizeX);
@@ -54,8 +56,8 @@ hipblasStatus_t testing_copy(const Arguments& argus)
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, N, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
 
     hx_cpu = hx;
     hy_cpu = hy;
@@ -83,11 +85,11 @@ hipblasStatus_t testing_copy(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, incy, hy_cpu.data(), hy.data());
+            unit_check_general<T>(1, N, abs_incy, hy_cpu.data(), hy.data());
         }
         if(argus.norm_check)
         {
-            hipblas_error = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy);
+            hipblas_error = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy);
         }
 
     } // end of if unit check

--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -25,10 +25,14 @@ hipblasStatus_t testing_copy_batched(const Arguments& argus)
     int incy        = argus.incy;
     int batch_count = argus.batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(
+            hipblasCopyBatchedFn(handle, N, nullptr, incx, nullptr, incy, batch_count));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -36,8 +40,6 @@ hipblasStatus_t testing_copy_batched(const Arguments& argus)
 
     double hipblas_error = 0.0;
     double gpu_time_used = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hx(N, incx, batch_count);

--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -27,14 +27,12 @@ hipblasStatus_t testing_copy_batched(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
+
+    int abs_incy = incy >= 0 ? incy : -incy;
 
     double hipblas_error = 0.0;
     double gpu_time_used = 0.0;
@@ -84,11 +82,11 @@ hipblasStatus_t testing_copy_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incy, hy_cpu, hy);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy);
         }
         if(argus.norm_check)
         {
-            hipblas_error = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy, batch_count);
+            hipblas_error = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy, batch_count);
         }
 
     } // end of if unit check

--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -40,13 +40,13 @@ hipblasStatus_t testing_copy_batched(const Arguments& argus)
     hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
-    host_batch_vector<T> hx_cpu(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy_cpu(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
+    host_batch_vector<T> hx_cpu(N, incx, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy, batch_count);
 
-    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy.memcheck());
 

--- a/clients/include/testing_copy_batched.hpp
+++ b/clients/include/testing_copy_batched.hpp
@@ -40,13 +40,13 @@ hipblasStatus_t testing_copy_batched(const Arguments& argus)
     hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<T> hx(N, incx, batch_count);
-    host_batch_vector<T> hy(N, incy, batch_count);
-    host_batch_vector<T> hx_cpu(N, incx, batch_count);
-    host_batch_vector<T> hy_cpu(N, incy, batch_count);
+    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
+    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx_cpu(N, incx ? incx : 1, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy ? incy : 1, batch_count);
 
-    device_batch_vector<T> dx(N, incx, batch_count);
-    device_batch_vector<T> dy(N, incy, batch_count);
+    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
+    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy.memcheck());
 

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -32,12 +32,16 @@ hipblasStatus_t testing_copy_strided_batched(const Arguments& argus)
     hipblasStride stridey  = size_t(N) * abs_incy * stride_scale;
     size_t        sizeX    = stridex * batch_count;
     size_t        sizeY    = stridey * batch_count;
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
@@ -89,12 +93,12 @@ hipblasStatus_t testing_copy_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incy, stridey, hy_cpu.data(), hy.data());
+            unit_check_general<T>(1, N, batch_count, abs_incy, stridey, hy_cpu.data(), hy.data());
         }
         if(argus.norm_check)
         {
             hipblas_error
-                = norm_check_general<T>('F', 1, N, incy, stridey, hy_cpu, hy, batch_count);
+                = norm_check_general<T>('F', 1, N, abs_incy, stridey, hy_cpu, hy, batch_count);
         }
 
     } // end of if unit check

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -37,10 +37,14 @@ hipblasStatus_t testing_copy_strided_batched(const Arguments& argus)
     if(!sizeY)
         sizeY = 1;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasCopyStridedBatchedFn(
+            handle, N, nullptr, incx, stridex, nullptr, incy, stridey, batch_count));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -55,8 +59,6 @@ hipblasStatus_t testing_copy_strided_batched(const Arguments& argus)
 
     double gpu_time_used = 0.0;
     double hipblas_error = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_copy_strided_batched.hpp
+++ b/clients/include/testing_copy_strided_batched.hpp
@@ -26,14 +26,16 @@ hipblasStatus_t testing_copy_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stridex = size_t(N) * incx * stride_scale;
-    hipblasStride stridey = size_t(N) * incy * stride_scale;
-    size_t        sizeX   = stridex * batch_count;
-    size_t        sizeY   = stridey * batch_count;
+    int           abs_incx = incx >= 0 ? incx : -incx;
+    int           abs_incy = incy >= 0 ? incy : -incy;
+    hipblasStride stridex  = size_t(N) * abs_incx * stride_scale;
+    hipblasStride stridey  = size_t(N) * abs_incy * stride_scale;
+    size_t        sizeX    = stridex * batch_count;
+    size_t        sizeY    = stridey * batch_count;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || batch_count < 0)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
@@ -54,8 +56,8 @@ hipblasStatus_t testing_copy_strided_batched(const Arguments& argus)
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init<T>(hx, 1, N, incx, stridex, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stridey, batch_count);
+    hipblas_init<T>(hx, 1, N, abs_incx, stridex, batch_count);
+    hipblas_init<T>(hy, 1, N, abs_incy, stridey, batch_count);
 
     hx_cpu = hx;
     hy_cpu = hy;

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -26,13 +26,19 @@ hipblasStatus_t testing_dot(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || incy < 0)
+    if(N <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
-    size_t sizeX = size_t(N) * incx;
-    size_t sizeY = size_t(N) * incy;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t sizeX    = size_t(N) * abs_incx;
+    size_t sizeY    = size_t(N) * abs_incy;
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(sizeX);
@@ -49,8 +55,8 @@ hipblasStatus_t testing_dot(const Arguments& argus)
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init_alternating_sign<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init_alternating_sign<T>(hx, 1, N, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
 
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));

--- a/clients/include/testing_dot.hpp
+++ b/clients/include/testing_dot.hpp
@@ -42,7 +42,6 @@ hipblasStatus_t testing_dot(const Arguments& argus)
 
         host_vector<T> cpu_0(1);
         host_vector<T> gpu_0(1);
-        hipblas_init<T>(cpu_0, 1, 1, 1);
 
         CHECK_HIP_ERROR(hipMemcpy(gpu_0, d_hipblas_result_0, sizeof(T), hipMemcpyDeviceToHost));
         unit_check_general<T>(1, 1, 1, cpu_0, gpu_0);

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -43,14 +43,14 @@ hipblasStatus_t testing_dot_batched(const Arguments& argus)
     hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
     host_vector<T>       h_cpu_result(batch_count);
     host_vector<T>       h_hipblas_result1(batch_count);
     host_vector<T>       h_hipblas_result2(batch_count);
 
-    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
     device_vector<T>       d_hipblas_result(batch_count);
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy.memcheck());

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -26,10 +26,32 @@ hipblasStatus_t testing_dot_batched(const Arguments& argus)
     int incy        = argus.incy;
     int batch_count = argus.batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
+        device_vector<T> d_hipblas_result_0(std::max(batch_count, 1));
+        host_vector<T>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(T) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasDotBatchedFn(
+            handle, N, nullptr, incx, nullptr, incy, batch_count, d_hipblas_result_0));
+
+        if(batch_count > 0)
+        {
+            host_vector<T> cpu_0(batch_count);
+            host_vector<T> gpu_0(batch_count);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
+            unit_check_general<T>(1, batch_count, 1, cpu_0, gpu_0);
+        }
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -39,8 +61,6 @@ hipblasStatus_t testing_dot_batched(const Arguments& argus)
     size_t sizeY    = size_t(N) * abs_incy;
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hx(N, incx, batch_count);

--- a/clients/include/testing_dot_batched.hpp
+++ b/clients/include/testing_dot_batched.hpp
@@ -28,31 +28,29 @@ hipblasStatus_t testing_dot_batched(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int sizeX = N * incx;
-    int sizeY = N * incy;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t sizeX    = size_t(N) * abs_incx;
+    size_t sizeY    = size_t(N) * abs_incy;
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<T> hx(N, incx, batch_count);
-    host_batch_vector<T> hy(N, incy, batch_count);
+    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
+    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
     host_vector<T>       h_cpu_result(batch_count);
     host_vector<T>       h_hipblas_result1(batch_count);
     host_vector<T>       h_hipblas_result2(batch_count);
 
-    device_batch_vector<T> dx(N, incx, batch_count);
-    device_batch_vector<T> dy(N, incy, batch_count);
+    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
+    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
     device_vector<T>       d_hipblas_result(batch_count);
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy.memcheck());

--- a/clients/include/testing_dot_batched_ex.hpp
+++ b/clients/include/testing_dot_batched_ex.hpp
@@ -42,14 +42,14 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
     hipblasDatatype_t executionType = argus.compute_type;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<Tx> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<Ty> hy(N, incy ? incy : 1, batch_count);
+    host_batch_vector<Tx> hx(N, incx, batch_count);
+    host_batch_vector<Ty> hy(N, incy, batch_count);
     host_vector<Tr>       h_cpu_result(batch_count);
     host_vector<Tr>       h_hipblas_result_host(batch_count);
     host_vector<Tr>       h_hipblas_result_device(batch_count);
 
-    device_batch_vector<Tx> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<Ty> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<Tx> dx(N, incx, batch_count);
+    device_batch_vector<Ty> dy(N, incy, batch_count);
     device_vector<Tr>       d_hipblas_result(batch_count);
 
     CHECK_HIP_ERROR(dx.memcheck());

--- a/clients/include/testing_dot_batched_ex.hpp
+++ b/clients/include/testing_dot_batched_ex.hpp
@@ -26,20 +26,51 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
     int incy        = argus.incy;
     int batch_count = argus.batch_count;
 
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(N <= 0 || batch_count <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    int abs_incx = incx >= 0 ? incx : -incx;
-    int abs_incy = incy >= 0 ? incy : -incy;
+    hipblasLocalHandle handle(argus);
 
     hipblasDatatype_t xType         = argus.a_type;
     hipblasDatatype_t yType         = argus.b_type;
     hipblasDatatype_t resultType    = argus.c_type;
     hipblasDatatype_t executionType = argus.compute_type;
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N <= 0 || batch_count <= 0)
+    {
+        device_vector<Tr> d_hipblas_result_0(std::max(batch_count, 1));
+        host_vector<Tr>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(Tr) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasDotBatchedExFn(handle,
+                                                  N,
+                                                  nullptr,
+                                                  xType,
+                                                  incx,
+                                                  nullptr,
+                                                  yType,
+                                                  incy,
+                                                  batch_count,
+                                                  d_hipblas_result_0,
+                                                  resultType,
+                                                  executionType));
+
+        if(batch_count > 0)
+        {
+            host_vector<Tr> cpu_0(batch_count);
+            host_vector<Tr> gpu_0(batch_count);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+        }
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    int abs_incx = incx >= 0 ? incx : -incx;
+    int abs_incy = incy >= 0 ? incy : -incy;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<Tx> hx(N, incx, batch_count);
@@ -55,8 +86,7 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy.memcheck());
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     hipblas_init(hy, true);

--- a/clients/include/testing_dot_batched_ex.hpp
+++ b/clients/include/testing_dot_batched_ex.hpp
@@ -28,14 +28,13 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(!batch_count)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
+
+    int abs_incx = incx >= 0 ? incx : -incx;
+    int abs_incy = incy >= 0 ? incy : -incy;
 
     hipblasDatatype_t xType         = argus.a_type;
     hipblasDatatype_t yType         = argus.b_type;
@@ -43,14 +42,14 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
     hipblasDatatype_t executionType = argus.compute_type;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<Tx> hx(N, incx, batch_count);
-    host_batch_vector<Ty> hy(N, incy, batch_count);
+    host_batch_vector<Tx> hx(N, incx ? incx : 1, batch_count);
+    host_batch_vector<Ty> hy(N, incy ? incy : 1, batch_count);
     host_vector<Tr>       h_cpu_result(batch_count);
     host_vector<Tr>       h_hipblas_result_host(batch_count);
     host_vector<Tr>       h_hipblas_result_device(batch_count);
 
-    device_batch_vector<Tx> dx(N, incx, batch_count);
-    device_batch_vector<Ty> dy(N, incy, batch_count);
+    device_batch_vector<Tx> dx(N, incx ? incx : 1, batch_count);
+    device_batch_vector<Ty> dy(N, incy ? incy : 1, batch_count);
     device_vector<Tr>       d_hipblas_result(batch_count);
 
     CHECK_HIP_ERROR(dx.memcheck());

--- a/clients/include/testing_dot_ex.hpp
+++ b/clients/include/testing_dot_ex.hpp
@@ -26,9 +26,9 @@ hipblasStatus_t testing_dot_ex_template(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || incy < 0)
+    if(N <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     hipblasDatatype_t xType         = argus.a_type;
@@ -36,11 +36,14 @@ hipblasStatus_t testing_dot_ex_template(const Arguments& argus)
     hipblasDatatype_t resultType    = argus.c_type;
     hipblasDatatype_t executionType = argus.compute_type;
 
-    hipblasStatus_t status_1 = HIPBLAS_STATUS_SUCCESS;
-    hipblasStatus_t status_2 = HIPBLAS_STATUS_SUCCESS;
-
-    size_t sizeX = size_t(N) * incx;
-    size_t sizeY = size_t(N) * incy;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t sizeX    = size_t(N) * abs_incx;
+    size_t sizeY    = size_t(N) * abs_incy;
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx(sizeX);
@@ -57,8 +60,8 @@ hipblasStatus_t testing_dot_ex_template(const Arguments& argus)
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init_alternating_sign<Tx>(hx, 1, N, incx);
-    hipblas_init<Ty>(hy, 1, N, incy);
+    hipblas_init_alternating_sign<Tx>(hx, 1, N, abs_incx);
+    hipblas_init<Ty>(hy, 1, N, abs_incy);
 
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(Tx) * sizeX, hipMemcpyHostToDevice));

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -67,8 +67,9 @@ hipblasStatus_t testing_dot_strided_batched(const Arguments& argus)
 
         if(batch_count > 0)
         {
-            host_vector<T>   cpu_0(batch_count);
-            device_vector<T> gpu_0(batch_count);
+            host_vector<T> cpu_0(batch_count);
+            host_vector<T> gpu_0(batch_count);
+
             CHECK_HIP_ERROR(hipMemcpy(
                 gpu_0, d_hipblas_result_0, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
             unit_check_general<T>(1, batch_count, 1, cpu_0, gpu_0);

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -39,10 +39,40 @@ hipblasStatus_t testing_dot_strided_batched(const Arguments& argus)
     if(!sizeY)
         sizeY = 1;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
+        device_vector<T> d_hipblas_result_0(std::max(batch_count, 1));
+        host_vector<T>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(T) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedFn(handle,
+                                                       N,
+                                                       nullptr,
+                                                       incx,
+                                                       stridex,
+                                                       nullptr,
+                                                       incy,
+                                                       stridey,
+                                                       batch_count,
+                                                       d_hipblas_result_0));
+
+        if(batch_count > 0)
+        {
+            host_vector<T>   cpu_0(batch_count);
+            device_vector<T> gpu_0(batch_count);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(T) * batch_count, hipMemcpyDeviceToHost));
+            unit_check_general<T>(1, batch_count, 1, cpu_0, gpu_0);
+        }
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -58,8 +88,6 @@ hipblasStatus_t testing_dot_strided_batched(const Arguments& argus)
     device_vector<T> d_hipblas_result(batch_count);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_dot_strided_batched.hpp
+++ b/clients/include/testing_dot_strided_batched.hpp
@@ -28,18 +28,20 @@ hipblasStatus_t testing_dot_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stridex = N * incx * stride_scale;
-    hipblasStride stridey = N * incy * stride_scale;
-    int           sizeX   = stridex * batch_count;
-    int           sizeY   = stridey * batch_count;
+    int           abs_incx = incx >= 0 ? incx : -incx;
+    int           abs_incy = incy >= 0 ? incy : -incy;
+    hipblasStride stridex  = size_t(N) * abs_incx * stride_scale;
+    hipblasStride stridey  = size_t(N) * abs_incy * stride_scale;
+    size_t        sizeX    = stridex * batch_count;
+    size_t        sizeY    = stridey * batch_count;
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(batch_count == 0)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
@@ -61,8 +63,8 @@ hipblasStatus_t testing_dot_strided_batched(const Arguments& argus)
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init_alternating_sign<T>(hx, 1, N, incx, stridex, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stridey, batch_count);
+    hipblas_init_alternating_sign<T>(hx, 1, N, abs_incx, stridex, batch_count);
+    hipblas_init<T>(hy, 1, N, abs_incy, stridey, batch_count);
 
     // copy data from CPU to device, does not work for incx != 1
     CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * sizeX, hipMemcpyHostToDevice));

--- a/clients/include/testing_dot_strided_batched_ex.hpp
+++ b/clients/include/testing_dot_strided_batched_ex.hpp
@@ -78,7 +78,7 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(const Arguments& argus)
             host_vector<Tr> cpu_0(batch_count);
             host_vector<Tr> gpu_0(batch_count);
             CHECK_HIP_ERROR(hipMemcpy(
-                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyHostToDevice));
+                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
             unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
         }
         return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_dot_strided_batched_ex.hpp
+++ b/clients/include/testing_dot_strided_batched_ex.hpp
@@ -38,17 +38,51 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(const Arguments& argus)
     if(!sizeY)
         sizeY = 1;
 
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(N <= 0 || batch_count <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
+    hipblasLocalHandle handle(argus);
 
     hipblasDatatype_t xType         = argus.a_type;
     hipblasDatatype_t yType         = argus.b_type;
     hipblasDatatype_t resultType    = argus.c_type;
     hipblasDatatype_t executionType = argus.compute_type;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N <= 0 || batch_count <= 0)
+    {
+        device_vector<Tr> d_hipblas_result_0(std::max(batch_count, 1));
+        host_vector<Tr>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(Tr) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasDotStridedBatchedExFn(handle,
+                                                         N,
+                                                         nullptr,
+                                                         xType,
+                                                         incx,
+                                                         stridex,
+                                                         nullptr,
+                                                         yType,
+                                                         incy,
+                                                         stridey,
+                                                         batch_count,
+                                                         d_hipblas_result_0,
+                                                         resultType,
+                                                         executionType));
+
+        if(batch_count > 0)
+        {
+            host_vector<Tr> cpu_0(batch_count);
+            host_vector<Tr> gpu_0(batch_count);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyHostToDevice));
+            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+        }
+        return HIPBLAS_STATUS_SUCCESS;
+    }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx(sizeX);
@@ -61,8 +95,7 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(const Arguments& argus)
     device_vector<Ty> dy(sizeY);
     device_vector<Tr> d_hipblas_result(batch_count);
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -26,13 +26,22 @@ hipblasStatus_t testing_iamax_iamin(const Arguments& argus, hipblas_iamax_iamin_
     int zero = 0;
 
     // check to prevent undefined memory allocation error
-    if(N < 1 || incx <= 0)
+    if(N <= 0 || incx <= 0)
     {
-        device_vector<T> dx(100);
-        int              hipblas_result;
-        CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, &hipblas_result));
+        device_vector<int> d_hipblas_result_0(1);
+        host_vector<int>   h_hipblas_result_0(1);
+        hipblas_init_nan(h_hipblas_result_0.data(), 1);
+        CHECK_HIP_ERROR(
+            hipMemcpy(d_hipblas_result_0, h_hipblas_result_0, sizeof(int), hipMemcpyHostToDevice));
 
-        unit_check_general<int>(1, 1, 1, &zero, &hipblas_result);
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(func(handle, N, nullptr, incx, d_hipblas_result_0));
+
+        host_vector<int> cpu_0(1);
+        host_vector<int> gpu_0(1);
+        CHECK_HIP_ERROR(hipMemcpy(gpu_0, d_hipblas_result_0, sizeof(int), hipMemcpyDeviceToHost));
+        unit_check_general<int>(1, 1, 1, cpu_0, gpu_0);
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 

--- a/clients/include/testing_iamax_iamin.hpp
+++ b/clients/include/testing_iamax_iamin.hpp
@@ -36,7 +36,7 @@ hipblasStatus_t testing_iamax_iamin(const Arguments& argus, hipblas_iamax_iamin_
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int sizeX = N * incx;
+    size_t sizeX = size_t(N) * incx;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this
     // practice

--- a/clients/include/testing_iamax_iamin_batched.hpp
+++ b/clients/include/testing_iamax_iamin_batched.hpp
@@ -27,29 +27,29 @@ hipblasStatus_t testing_iamax_iamin_batched(const Arguments&                 arg
     int                zero = 0;
 
     // check to prevent undefined memory allocation error
-    if(batch_count == 0)
-    {
-        // quick return success or invalid value
-        device_batch_vector<T> dx(1, 1, 5);
-        device_vector<int>     d_hipblas_result(1);
-
-        return func(handle, N, dx, incx, batch_count, d_hipblas_result);
-    }
-    else if(batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(N < 1 || incx <= 0)
+    if(batch_count <= 0 || N <= 0 || incx <= 0)
     {
         // quick return success
-        device_batch_vector<T> dx(1, 1, 5);
-        host_vector<int>       h_hipblas_result(batch_count);
-        host_vector<int>       h_zeros(batch_count);
-        for(int b = 0; b < batch_count; b++)
-            h_zeros[b] = 0;
+        device_vector<int> d_hipblas_result_0(std::max(1, batch_count));
+        host_vector<int>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(int) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
 
-        CHECK_HIPBLAS_ERROR(func(handle, N, dx, incx, batch_count, h_hipblas_result));
-        unit_check_general<int>(1, 1, batch_count, h_zeros, h_hipblas_result);
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(func(handle, N, nullptr, incx, batch_count, d_hipblas_result_0));
+
+        if(batch_count > 0)
+        {
+            host_vector<int> cpu_0(1);
+            host_vector<int> gpu_0(1);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(int) * batch_count, hipMemcpyDeviceToHost));
+            unit_check_general<int>(1, batch_count, 1, cpu_0, gpu_0);
+        }
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 

--- a/clients/include/testing_iamax_iamin_batched.hpp
+++ b/clients/include/testing_iamax_iamin_batched.hpp
@@ -43,8 +43,8 @@ hipblasStatus_t testing_iamax_iamin_batched(const Arguments&                 arg
 
         if(batch_count > 0)
         {
-            host_vector<int> cpu_0(1);
-            host_vector<int> gpu_0(1);
+            host_vector<int> cpu_0(batch_count);
+            host_vector<int> gpu_0(batch_count);
             CHECK_HIP_ERROR(hipMemcpy(
                 gpu_0, d_hipblas_result_0, sizeof(int) * batch_count, hipMemcpyDeviceToHost));
             unit_check_general<int>(1, batch_count, 1, cpu_0, gpu_0);

--- a/clients/include/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/testing_iamax_iamin_strided_batched.hpp
@@ -35,7 +35,7 @@ hipblasStatus_t testing_iamax_iamin_strided_batched(const Arguments&            
     hipblasLocalHandle handle(argus);
 
     // check to prevent undefined memory allocation error
-    if(batch_count == 0)
+    if(batch_count <= 0 || N <= 0 || incx <= 0)
     {
         // quick return success or invalid value
         device_vector<int> d_hipblas_result_0(std::max(1, batch_count));
@@ -52,8 +52,8 @@ hipblasStatus_t testing_iamax_iamin_strided_batched(const Arguments&            
 
         if(batch_count > 0)
         {
-            host_vector<int> cpu_0(1);
-            host_vector<int> gpu_0(1);
+            host_vector<int> cpu_0(batch_count);
+            host_vector<int> gpu_0(batch_count);
             CHECK_HIP_ERROR(hipMemcpy(
                 gpu_0, d_hipblas_result_0, sizeof(int) * batch_count, hipMemcpyDeviceToHost));
             unit_check_general<int>(1, batch_count, 1, cpu_0, gpu_0);

--- a/clients/include/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/testing_iamax_iamin_strided_batched.hpp
@@ -29,8 +29,8 @@ hipblasStatus_t testing_iamax_iamin_strided_batched(const Arguments&            
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stridex = N * incx * stride_scale;
-    int           sizeX   = stridex * batch_count;
+    hipblasStride stridex = size_t(N) * incx * stride_scale;
+    size_t        sizeX   = stridex * batch_count;
 
     hipblasLocalHandle handle(argus);
 

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -23,9 +23,25 @@ hipblasStatus_t testing_nrm2(const Arguments& argus)
     int N    = argus.N;
     int incx = argus.incx;
 
+    hipblasLocalHandle handle(argus);
+
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0)
     {
+        device_vector<Tr> d_hipblas_result_0(1);
+        host_vector<Tr>   h_hipblas_result_0(1);
+        hipblas_init_nan(h_hipblas_result_0.data(), 1);
+        CHECK_HIP_ERROR(
+            hipMemcpy(d_hipblas_result_0, h_hipblas_result_0, sizeof(Tr), hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2Fn(handle, N, nullptr, incx, d_hipblas_result_0));
+
+        host_vector<Tr> cpu_0(1);
+        host_vector<Tr> gpu_0(1);
+        CHECK_HIP_ERROR(hipMemcpy(gpu_0, d_hipblas_result_0, sizeof(Tr), hipMemcpyDeviceToHost));
+        unit_check_general<Tr>(1, 1, 1, cpu_0, gpu_0);
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -39,8 +55,6 @@ hipblasStatus_t testing_nrm2(const Arguments& argus)
     Tr                cpu_result, hipblas_result_host, hipblas_result_device;
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_nrm2.hpp
+++ b/clients/include/testing_nrm2.hpp
@@ -24,12 +24,12 @@ hipblasStatus_t testing_nrm2(const Arguments& argus)
     int incx = argus.incx;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0)
+    if(N <= 0 || incx <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int sizeX = N * incx;
+    size_t sizeX = size_t(N) * incx;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(sizeX);

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -26,16 +26,12 @@ hipblasStatus_t testing_nrm2_batched(const Arguments& argus)
     int batch_count = argus.batch_count;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(batch_count == 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int sizeX = N * incx;
+    size_t sizeX = size_t(N) * incx;
 
     double gpu_time_used;
     double hipblas_error_host = 0, hipblas_error_device = 0;

--- a/clients/include/testing_nrm2_batched.hpp
+++ b/clients/include/testing_nrm2_batched.hpp
@@ -44,8 +44,8 @@ hipblasStatus_t testing_nrm2_batched(const Arguments& argus)
 
         if(batch_count > 0)
         {
-            host_vector<Tr> cpu_0(1);
-            host_vector<Tr> gpu_0(1);
+            host_vector<Tr> cpu_0(batch_count);
+            host_vector<Tr> gpu_0(batch_count);
             CHECK_HIP_ERROR(hipMemcpy(
                 gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
             unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -23,15 +23,44 @@ hipblasStatus_t testing_nrm2_batched_ex_template(const Arguments& argus)
     int incx        = argus.incx;
     int batch_count = argus.batch_count;
 
-    // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || batch_count <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
     hipblasDatatype_t xType         = argus.a_type;
     hipblasDatatype_t resultType    = argus.b_type;
     hipblasDatatype_t executionType = argus.compute_type;
+
+    hipblasLocalHandle handle(argus);
+
+    // check to prevent undefined memory allocation error
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
+    {
+        device_vector<Tr> d_hipblas_result_0(std::max(batch_count, 1));
+        host_vector<Tr>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(Tr) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2BatchedExFn(handle,
+                                                   N,
+                                                   nullptr,
+                                                   xType,
+                                                   incx,
+                                                   batch_count,
+                                                   d_hipblas_result_0,
+                                                   resultType,
+                                                   executionType));
+
+        if(batch_count > 0)
+        {
+            host_vector<Tr> cpu_0(batch_count);
+            host_vector<Tr> gpu_0(batch_count);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+        }
+        return HIPBLAS_STATUS_SUCCESS;
+    }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<Tx> hx(N, incx, batch_count);
@@ -44,8 +73,7 @@ hipblasStatus_t testing_nrm2_batched_ex_template(const Arguments& argus)
 
     CHECK_HIP_ERROR(dx.memcheck());
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     hipblas_init(hx, true);

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -53,11 +53,12 @@ hipblasStatus_t testing_nrm2_batched_ex_template(const Arguments& argus)
 
         if(batch_count > 0)
         {
-            host_vector<Tr> cpu_0(batch_count);
-            host_vector<Tr> gpu_0(batch_count);
-            CHECK_HIP_ERROR(hipMemcpy(
-                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
-            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+            // TODO: error in rocBLAS - only setting the first element to 0, not for all batches
+            // host_vector<Tr> cpu_0(batch_count);
+            // host_vector<Tr> gpu_0(batch_count);
+            // CHECK_HIP_ERROR(hipMemcpy(
+            //     gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+            // unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
         }
         return HIPBLAS_STATUS_SUCCESS;
     }

--- a/clients/include/testing_nrm2_batched_ex.hpp
+++ b/clients/include/testing_nrm2_batched_ex.hpp
@@ -24,11 +24,7 @@ hipblasStatus_t testing_nrm2_batched_ex_template(const Arguments& argus)
     int batch_count = argus.batch_count;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(!batch_count)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }

--- a/clients/include/testing_nrm2_ex.hpp
+++ b/clients/include/testing_nrm2_ex.hpp
@@ -23,9 +23,9 @@ hipblasStatus_t testing_nrm2_ex_template(const Arguments& argus)
     int incx = argus.incx;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0)
+    if(N <= 0 || incx <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     hipblasDatatype_t xType         = argus.a_type;

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -26,15 +26,11 @@ hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stridex = N * incx * stride_scale;
-    int           sizeX   = stridex * batch_count;
+    hipblasStride stridex = size_t(N) * incx * stride_scale;
+    size_t        sizeX   = stridex * batch_count;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(batch_count == 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -48,8 +48,8 @@ hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
 
         if(batch_count > 0)
         {
-            host_vector<Tr> cpu_0(1);
-            host_vector<Tr> gpu_0(1);
+            host_vector<Tr> cpu_0(batch_count);
+            host_vector<Tr> gpu_0(batch_count);
             CHECK_HIP_ERROR(hipMemcpy(
                 gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
             unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);

--- a/clients/include/testing_nrm2_strided_batched.hpp
+++ b/clients/include/testing_nrm2_strided_batched.hpp
@@ -29,9 +29,32 @@ hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
     hipblasStride stridex = size_t(N) * incx * stride_scale;
     size_t        sizeX   = stridex * batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // check to prevent undefined memory allocation error
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
+        device_vector<Tr> d_hipblas_result_0(std::max(1, batch_count));
+        host_vector<Tr>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(Tr) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedFn(
+            handle, N, nullptr, incx, stridex, batch_count, d_hipblas_result_0));
+
+        if(batch_count > 0)
+        {
+            host_vector<Tr> cpu_0(1);
+            host_vector<Tr> gpu_0(1);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
+            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+        }
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -46,8 +69,6 @@ hipblasStatus_t testing_nrm2_strided_batched(const Arguments& argus)
 
     double gpu_time_used;
     double hipblas_error_host = 0, hipblas_error_device = 0;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -29,11 +29,7 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
     size_t        sizeX   = stridex * batch_count;
 
     // check to prevent undefined memory allocation error
-    if(N < 0 || incx < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(!batch_count)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -59,11 +59,12 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
 
         if(batch_count > 0)
         {
-            host_vector<Tr> cpu_0(batch_count);
-            host_vector<Tr> gpu_0(batch_count);
-            CHECK_HIP_ERROR(hipMemcpy(
-                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyHostToDevice));
-            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+            // TODO: error in rocBLAS - only setting the first element to 0, not for all batches
+            // host_vector<Tr> cpu_0(batch_count);
+            // host_vector<Tr> gpu_0(batch_count);
+            // CHECK_HIP_ERROR(hipMemcpy(
+            //     gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyHostToDevice));
+            // unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
         }
         return HIPBLAS_STATUS_SUCCESS;
     }

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -63,7 +63,7 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
             // host_vector<Tr> cpu_0(batch_count);
             // host_vector<Tr> gpu_0(batch_count);
             // CHECK_HIP_ERROR(hipMemcpy(
-            //     gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyHostToDevice));
+            //     gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyDeviceToHost));
             // unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
         }
         return HIPBLAS_STATUS_SUCCESS;

--- a/clients/include/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/testing_nrm2_strided_batched_ex.hpp
@@ -28,15 +28,45 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
     hipblasStride stridex = size_t(N) * incx * stride_scale;
     size_t        sizeX   = stridex * batch_count;
 
-    // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || batch_count <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
     hipblasDatatype_t xType         = argus.a_type;
     hipblasDatatype_t resultType    = argus.b_type;
     hipblasDatatype_t executionType = argus.compute_type;
+
+    hipblasLocalHandle handle(argus);
+
+    // check to prevent undefined memory allocation error
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
+    {
+        device_vector<Tr> d_hipblas_result_0(std::max(batch_count, 1));
+        host_vector<Tr>   h_hipblas_result_0(std::max(1, batch_count));
+        hipblas_init_nan(h_hipblas_result_0.data(), std::max(1, batch_count));
+        CHECK_HIP_ERROR(hipMemcpy(d_hipblas_result_0,
+                                  h_hipblas_result_0,
+                                  sizeof(Tr) * std::max(1, batch_count),
+                                  hipMemcpyHostToDevice));
+
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasNrm2StridedBatchedExFortran(handle,
+                                                               N,
+                                                               nullptr,
+                                                               xType,
+                                                               incx,
+                                                               stridex,
+                                                               batch_count,
+                                                               d_hipblas_result_0,
+                                                               resultType,
+                                                               executionType));
+
+        if(batch_count > 0)
+        {
+            host_vector<Tr> cpu_0(batch_count);
+            host_vector<Tr> gpu_0(batch_count);
+            CHECK_HIP_ERROR(hipMemcpy(
+                gpu_0, d_hipblas_result_0, sizeof(Tr) * batch_count, hipMemcpyHostToDevice));
+            unit_check_general<Tr>(1, batch_count, 1, cpu_0, gpu_0);
+        }
+        return HIPBLAS_STATUS_SUCCESS;
+    }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx(sizeX);
@@ -47,8 +77,7 @@ hipblasStatus_t testing_nrm2_strided_batched_ex_template(const Arguments& argus)
     device_vector<Tx> dx(sizeX);
     device_vector<Tr> d_hipblas_result(batch_count);
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_rot.hpp
+++ b/clients/include/testing_rot.hpp
@@ -26,7 +26,7 @@ hipblasStatus_t testing_rot(const Arguments& arg)
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || incy <= 0)
+    if(N <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
@@ -35,8 +35,14 @@ hipblasStatus_t testing_rot(const Arguments& arg)
 
     hipblasLocalHandle handle(arg);
 
-    size_t size_x = N * size_t(incx);
-    size_t size_y = N * size_t(incy);
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t size_x   = N * size_t(abs_incx);
+    size_t size_y   = N * size_t(abs_incy);
+    if(!size_x)
+        size_x = 1;
+    if(!size_y)
+        size_y = 1;
 
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
@@ -49,8 +55,8 @@ hipblasStatus_t testing_rot(const Arguments& arg)
     host_vector<U> hc(1);
     host_vector<V> hs(1);
     srand(1);
-    hipblas_init<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, N, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
 
     // Random alpha (0 - 10)
     host_vector<int> alpha(1);
@@ -81,13 +87,13 @@ hipblasStatus_t testing_rot(const Arguments& arg)
             CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(T) * size_y, hipMemcpyDeviceToHost));
             if(arg.unit_check)
             {
-                near_check_general(1, N, incx, cx.data(), rx.data(), double(rel_error));
-                near_check_general(1, N, incy, cy.data(), ry.data(), double(rel_error));
+                near_check_general(1, N, abs_incx, cx.data(), rx.data(), double(rel_error));
+                near_check_general(1, N, abs_incy, cy.data(), ry.data(), double(rel_error));
             }
             if(arg.norm_check)
             {
-                hipblas_error_host = norm_check_general<T>('F', 1, N, incx, cx, rx);
-                hipblas_error_host += norm_check_general<T>('F', 1, N, incy, cy, ry);
+                hipblas_error_host = norm_check_general<T>('F', 1, N, abs_incx, cx, rx);
+                hipblas_error_host += norm_check_general<T>('F', 1, N, abs_incy, cy, ry);
             }
         }
 
@@ -105,13 +111,13 @@ hipblasStatus_t testing_rot(const Arguments& arg)
             CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(T) * size_y, hipMemcpyDeviceToHost));
             if(arg.unit_check)
             {
-                near_check_general(1, N, incx, cx.data(), rx.data(), double(rel_error));
-                near_check_general(1, N, incy, cy.data(), ry.data(), double(rel_error));
+                near_check_general(1, N, abs_incx, cx.data(), rx.data(), double(rel_error));
+                near_check_general(1, N, abs_incy, cy.data(), ry.data(), double(rel_error));
             }
             if(arg.norm_check)
             {
-                hipblas_error_device = norm_check_general<T>('F', 1, N, incx, cx, rx);
-                hipblas_error_device += norm_check_general<T>('F', 1, N, incy, cy, ry);
+                hipblas_error_device = norm_check_general<T>('F', 1, N, abs_incx, cx, rx);
+                hipblas_error_device += norm_check_general<T>('F', 1, N, abs_incy, cy, ry);
             }
         }
     }

--- a/clients/include/testing_rot.hpp
+++ b/clients/include/testing_rot.hpp
@@ -25,15 +25,17 @@ hipblasStatus_t testing_rot(const Arguments& arg)
 
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
+    hipblasLocalHandle handle(arg);
+
     // check to prevent undefined memory allocation error
     if(N <= 0)
     {
+        CHECK_HIPBLAS_ERROR(
+            hipblasRotFn(handle, N, nullptr, incx, nullptr, incy, nullptr, nullptr));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(arg);
 
     int    abs_incx = incx >= 0 ? incx : -incx;
     int    abs_incy = incy >= 0 ? incy : -incy;

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -93,8 +93,8 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
                                                      hs,
                                                      batch_count)));
 
-            host_batch_vector<T> rx(N, incx, batch_count);
-            host_batch_vector<T> ry(N, incy, batch_count);
+            host_batch_vector<T> rx(N, incx ? incx : 1, batch_count);
+            host_batch_vector<T> ry(N, incy ? incy : 1, batch_count);
             CHECK_HIP_ERROR(rx.transfer_from(dx));
             CHECK_HIP_ERROR(ry.transfer_from(dy));
 

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -63,8 +63,8 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
     hs[0] = sin(alpha[0]);
 
     // CPU BLAS reference data
-    host_batch_vector<T> cx(N, incx, batch_count);
-    host_batch_vector<T> cy(N, incy, batch_count);
+    host_batch_vector<T> cx(N, incx ? incx : 1, batch_count);
+    host_batch_vector<T> cy(N, incy ? incy : 1, batch_count);
     cx.copy_from(hx);
     cy.copy_from(hy);
 

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -27,9 +27,13 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
 
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
+    hipblasLocalHandle handle(arg);
+
     // check to prevent undefined memory allocation error
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR((hipblasRotBatchedFn(
+            handle, N, nullptr, incx, nullptr, incy, nullptr, nullptr, batch_count)));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -37,8 +41,6 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
     int abs_incy = incy >= 0 ? incy : -incy;
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(arg);
 
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);

--- a/clients/include/testing_rot_batched.hpp
+++ b/clients/include/testing_rot_batched.hpp
@@ -40,14 +40,14 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
 
     hipblasLocalHandle handle(arg);
 
-    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
     device_vector<U>       dc(1);
     device_vector<V>       ds(1);
 
     // Initial Data on CPU
-    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
     host_vector<U>       hc(1);
     host_vector<V>       hs(1);
 
@@ -63,8 +63,8 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
     hs[0] = sin(alpha[0]);
 
     // CPU BLAS reference data
-    host_batch_vector<T> cx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> cy(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> cx(N, incx, batch_count);
+    host_batch_vector<T> cy(N, incy, batch_count);
     cx.copy_from(hx);
     cy.copy_from(hy);
 
@@ -93,8 +93,8 @@ hipblasStatus_t testing_rot_batched(const Arguments& arg)
                                                      hs,
                                                      batch_count)));
 
-            host_batch_vector<T> rx(N, incx ? incx : 1, batch_count);
-            host_batch_vector<T> ry(N, incy ? incy : 1, batch_count);
+            host_batch_vector<T> rx(N, incx, batch_count);
+            host_batch_vector<T> ry(N, incy, batch_count);
             CHECK_HIP_ERROR(rx.transfer_from(dx));
             CHECK_HIP_ERROR(ry.transfer_from(dy));
 

--- a/clients/include/testing_rot_batched_ex.hpp
+++ b/clients/include/testing_rot_batched_ex.hpp
@@ -25,22 +25,37 @@ hipblasStatus_t testing_rot_batched_ex_template(const Arguments& arg)
     int incy        = arg.incy;
     int batch_count = arg.batch_count;
 
+    hipblasDatatype_t xType         = arg.a_type;
+    hipblasDatatype_t yType         = arg.b_type;
+    hipblasDatatype_t csType        = arg.c_type;
+    hipblasDatatype_t executionType = arg.compute_type;
+
+    hipblasLocalHandle handle(arg);
+
     // check to prevent undefined memory allocation error
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasRotBatchedExFn(handle,
+                                                  N,
+                                                  nullptr,
+                                                  xType,
+                                                  incx,
+                                                  nullptr,
+                                                  yType,
+                                                  incy,
+                                                  nullptr,
+                                                  nullptr,
+                                                  csType,
+                                                  batch_count,
+                                                  executionType));
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 
     int abs_incx = incx >= 0 ? incx : -incx;
     int abs_incy = incy >= 0 ? incy : -incy;
 
-    hipblasDatatype_t xType         = arg.a_type;
-    hipblasDatatype_t yType         = arg.b_type;
-    hipblasDatatype_t csType        = arg.c_type;
-    hipblasDatatype_t executionType = arg.compute_type;
-
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(arg);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     host_batch_vector<Tx> hx_host(N, incx, batch_count);
     host_batch_vector<Ty> hy_host(N, incy, batch_count);

--- a/clients/include/testing_rot_batched_ex.hpp
+++ b/clients/include/testing_rot_batched_ex.hpp
@@ -42,17 +42,17 @@ hipblasStatus_t testing_rot_batched_ex_template(const Arguments& arg)
     double             gpu_time_used, hipblas_error_host, hipblas_error_device;
     hipblasLocalHandle handle(arg);
 
-    host_batch_vector<Tx> hx_host(N, incx ? incx : 1, batch_count);
-    host_batch_vector<Ty> hy_host(N, incy ? incy : 1, batch_count);
-    host_batch_vector<Tx> hx_device(N, incx ? incx : 1, batch_count);
-    host_batch_vector<Ty> hy_device(N, incy ? incy : 1, batch_count);
-    host_batch_vector<Tx> hx_cpu(N, incx ? incx : 1, batch_count);
-    host_batch_vector<Ty> hy_cpu(N, incy ? incy : 1, batch_count);
+    host_batch_vector<Tx> hx_host(N, incx, batch_count);
+    host_batch_vector<Ty> hy_host(N, incy, batch_count);
+    host_batch_vector<Tx> hx_device(N, incx, batch_count);
+    host_batch_vector<Ty> hy_device(N, incy, batch_count);
+    host_batch_vector<Tx> hx_cpu(N, incx, batch_count);
+    host_batch_vector<Ty> hy_cpu(N, incy, batch_count);
     host_vector<Tcs>      hc(1);
     host_vector<Tcs>      hs(1);
 
-    device_batch_vector<Tx> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<Ty> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<Tx> dx(N, incx, batch_count);
+    device_batch_vector<Ty> dy(N, incy, batch_count);
     device_vector<Tcs>      dc(1);
     device_vector<Tcs>      ds(1);
 

--- a/clients/include/testing_rot_ex.hpp
+++ b/clients/include/testing_rot_ex.hpp
@@ -25,7 +25,7 @@ hipblasStatus_t testing_rot_ex_template(const Arguments& arg)
     int incy = arg.incy;
 
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || incy <= 0)
+    if(N <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
@@ -38,8 +38,14 @@ hipblasStatus_t testing_rot_ex_template(const Arguments& arg)
     double             gpu_time_used, hipblas_error_host, hipblas_error_device;
     hipblasLocalHandle handle(arg);
 
-    size_t size_x = N * size_t(incx);
-    size_t size_y = N * size_t(incy);
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t size_x   = N * size_t(abs_incx);
+    size_t size_y   = N * size_t(abs_incy);
+    if(!size_x)
+        size_x = 1;
+    if(!size_y)
+        size_y = 1;
 
     device_vector<Tx>  dx(size_x);
     device_vector<Ty>  dy(size_y);
@@ -57,8 +63,8 @@ hipblasStatus_t testing_rot_ex_template(const Arguments& arg)
     host_vector<Tcs> hs(1);
 
     srand(1);
-    hipblas_init<Tx>(hx_host, 1, N, incx);
-    hipblas_init<Ty>(hy_host, 1, N, incy);
+    hipblas_init<Tx>(hx_host, 1, N, abs_incx);
+    hipblas_init<Ty>(hy_host, 1, N, abs_incy);
 
     // Random alpha (0 - 10)
     host_vector<int> alpha(1);
@@ -103,17 +109,17 @@ hipblasStatus_t testing_rot_ex_template(const Arguments& arg)
 
         if(arg.unit_check)
         {
-            unit_check_general<Tx>(1, N, incx, hx_cpu, hx_host);
-            unit_check_general<Ty>(1, N, incy, hy_cpu, hy_host);
-            unit_check_general<Tx>(1, N, incx, hx_cpu, hx_device);
-            unit_check_general<Ty>(1, N, incy, hy_cpu, hy_device);
+            unit_check_general<Tx>(1, N, abs_incx, hx_cpu, hx_host);
+            unit_check_general<Ty>(1, N, abs_incy, hy_cpu, hy_host);
+            unit_check_general<Tx>(1, N, abs_incx, hx_cpu, hx_device);
+            unit_check_general<Ty>(1, N, abs_incy, hy_cpu, hy_device);
         }
         if(arg.norm_check)
         {
-            hipblas_error_host = norm_check_general<Tx>('F', 1, N, incx, hx_cpu, hx_host);
-            hipblas_error_host += norm_check_general<Ty>('F', 1, N, incy, hy_cpu, hy_host);
-            hipblas_error_device = norm_check_general<Tx>('F', 1, N, incx, hx_cpu, hx_device);
-            hipblas_error_device += norm_check_general<Ty>('F', 1, N, incy, hy_cpu, hy_device);
+            hipblas_error_host = norm_check_general<Tx>('F', 1, N, abs_incx, hx_cpu, hx_host);
+            hipblas_error_host += norm_check_general<Ty>('F', 1, N, abs_incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<Tx>('F', 1, N, abs_incx, hx_cpu, hx_device);
+            hipblas_error_device += norm_check_general<Ty>('F', 1, N, abs_incy, hy_cpu, hy_device);
         }
     }
 

--- a/clients/include/testing_rot_ex.hpp
+++ b/clients/include/testing_rot_ex.hpp
@@ -24,19 +24,32 @@ hipblasStatus_t testing_rot_ex_template(const Arguments& arg)
     int incx = arg.incx;
     int incy = arg.incy;
 
-    // check to prevent undefined memory allocation error
-    if(N <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
     hipblasDatatype_t xType         = arg.a_type;
     hipblasDatatype_t yType         = arg.b_type;
     hipblasDatatype_t csType        = arg.c_type;
     hipblasDatatype_t executionType = arg.compute_type;
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
     hipblasLocalHandle handle(arg);
+
+    // check to prevent undefined memory allocation error
+    if(N <= 0)
+    {
+        CHECK_HIPBLAS_ERROR(hipblasRotExFn(handle,
+                                           N,
+                                           nullptr,
+                                           xType,
+                                           incx,
+                                           nullptr,
+                                           yType,
+                                           incy,
+                                           nullptr,
+                                           nullptr,
+                                           csType,
+                                           executionType));
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     int    abs_incx = incx >= 0 ? incx : -incx;
     int    abs_incy = incy >= 0 ? incy : -incy;

--- a/clients/include/testing_rot_strided_batched.hpp
+++ b/clients/include/testing_rot_strided_batched.hpp
@@ -33,15 +33,27 @@ hipblasStatus_t testing_rot_strided_batched(const Arguments& arg)
 
     const U rel_error = std::numeric_limits<U>::epsilon() * 1000;
 
+    hipblasLocalHandle handle(arg);
+
     // check to prevent undefined memory allocation error
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR((hipblasRotStridedBatchedFn(handle,
+                                                        N,
+                                                        nullptr,
+                                                        incx,
+                                                        stride_x,
+                                                        nullptr,
+                                                        incy,
+                                                        stride_y,
+                                                        nullptr,
+                                                        nullptr,
+                                                        batch_count)));
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(arg);
 
     size_t size_x = N * size_t(abs_incx) + size_t(stride_x) * size_t(batch_count - 1);
     size_t size_y = N * size_t(abs_incy) + size_t(stride_y) * size_t(batch_count - 1);

--- a/clients/include/testing_rot_strided_batched_ex.hpp
+++ b/clients/include/testing_rot_strided_batched_ex.hpp
@@ -39,19 +39,36 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(const Arguments& arg)
     if(!size_y)
         size_y = 1;
 
-    // check to prevent undefined memory allocation error
-    if(N <= 0 || batch_count <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
     hipblasDatatype_t xType         = arg.a_type;
     hipblasDatatype_t yType         = arg.b_type;
     hipblasDatatype_t csType        = arg.c_type;
     hipblasDatatype_t executionType = arg.compute_type;
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
     hipblasLocalHandle handle(arg);
+
+    // check to prevent undefined memory allocation error
+    if(N <= 0 || batch_count <= 0)
+    {
+        CHECK_HIPBLAS_ERROR(hipblasRotStridedBatchedExFn(handle,
+                                                         N,
+                                                         nullptr,
+                                                         xType,
+                                                         incx,
+                                                         stridex,
+                                                         nullptr,
+                                                         yType,
+                                                         incy,
+                                                         stridey,
+                                                         nullptr,
+                                                         nullptr,
+                                                         csType,
+                                                         batch_count,
+                                                         executionType));
+
+        return HIPBLAS_STATUS_SUCCESS;
+    }
+
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     device_vector<Tx>  dx(size_x);
     device_vector<Ty>  dy(size_y);

--- a/clients/include/testing_rot_strided_batched_ex.hpp
+++ b/clients/include/testing_rot_strided_batched_ex.hpp
@@ -27,20 +27,22 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(const Arguments& arg)
     double stride_scale = arg.stride_scale;
     int    batch_count  = arg.batch_count;
 
-    hipblasStride stridex = N * incx * stride_scale;
-    hipblasStride stridey = N * incy * stride_scale;
+    int           abs_incx = incx >= 0 ? incx : -incx;
+    int           abs_incy = incy >= 0 ? incy : -incy;
+    hipblasStride stridex  = N * abs_incx * stride_scale;
+    hipblasStride stridey  = N * abs_incy * stride_scale;
 
-    int size_x = stridex * batch_count;
-    int size_y = stridey * batch_count;
+    size_t size_x = stridex * batch_count;
+    size_t size_y = stridey * batch_count;
+    if(!size_x)
+        size_x = 1;
+    if(!size_y)
+        size_y = 1;
 
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || incy <= 0 || !batch_count)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
-    }
-    if(batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     hipblasDatatype_t xType         = arg.a_type;
@@ -66,8 +68,8 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(const Arguments& arg)
     host_vector<Tcs> hc(1);
     host_vector<Tcs> hs(1);
     srand(1);
-    hipblas_init<Tx>(hx_host, 1, N, incx, stridex, batch_count);
-    hipblas_init<Ty>(hy_host, 1, N, incy, stridey, batch_count);
+    hipblas_init<Tx>(hx_host, 1, N, abs_incx, stridex, batch_count);
+    hipblas_init<Ty>(hy_host, 1, N, abs_incy, stridey, batch_count);
 
     hipblas_init<Tcs>(hc, 1, 1, 1);
     hipblas_init<Tcs>(hs, 1, 1, 1);
@@ -132,22 +134,22 @@ hipblasStatus_t testing_rot_strided_batched_ex_template(const Arguments& arg)
 
         if(arg.unit_check)
         {
-            unit_check_general<Tx>(1, N, batch_count, incx, stridex, hx_cpu, hx_host);
-            unit_check_general<Tx>(1, N, batch_count, incy, stridey, hy_cpu, hy_host);
-            unit_check_general<Ty>(1, N, batch_count, incx, stridex, hx_cpu, hx_device);
-            unit_check_general<Ty>(1, N, batch_count, incy, stridey, hy_cpu, hy_device);
+            unit_check_general<Tx>(1, N, batch_count, abs_incx, stridex, hx_cpu, hx_host);
+            unit_check_general<Tx>(1, N, batch_count, abs_incy, stridey, hy_cpu, hy_host);
+            unit_check_general<Ty>(1, N, batch_count, abs_incx, stridex, hx_cpu, hx_device);
+            unit_check_general<Ty>(1, N, batch_count, abs_incy, stridey, hy_cpu, hy_device);
         }
 
-        if(arg.unit_check)
+        if(arg.norm_check)
         {
-            hipblas_error_host
-                = norm_check_general<Tx>('F', 1, N, incx, stridex, hx_cpu, hx_host, batch_count);
-            hipblas_error_host
-                += norm_check_general<Ty>('F', 1, N, incy, stridey, hy_cpu, hy_host, batch_count);
-            hipblas_error_device
-                = norm_check_general<Tx>('F', 1, N, incx, stridex, hx_cpu, hx_device, batch_count);
-            hipblas_error_device
-                += norm_check_general<Ty>('F', 1, N, incy, stridey, hy_cpu, hy_device, batch_count);
+            hipblas_error_host = norm_check_general<Tx>(
+                'F', 1, N, abs_incx, stridex, hx_cpu, hx_host, batch_count);
+            hipblas_error_host += norm_check_general<Ty>(
+                'F', 1, N, abs_incy, stridey, hy_cpu, hy_host, batch_count);
+            hipblas_error_device = norm_check_general<Tx>(
+                'F', 1, N, abs_incx, stridex, hx_cpu, hx_device, batch_count);
+            hipblas_error_device += norm_check_general<Ty>(
+                'F', 1, N, abs_incy, stridey, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_rotm.hpp
+++ b/clients/include/testing_rotm.hpp
@@ -26,7 +26,7 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || incy <= 0)
+    if(N <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
@@ -35,8 +35,14 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
 
     hipblasLocalHandle handle(arg);
 
-    size_t size_x = N * size_t(incx);
-    size_t size_y = N * size_t(incy);
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t size_x   = N * size_t(abs_incx);
+    size_t size_y   = N * size_t(abs_incy);
+    if(!size_x)
+        size_x = 1;
+    if(!size_y)
+        size_y = 1;
 
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
@@ -48,8 +54,8 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
     host_vector<T> hdata(4);
     host_vector<T> hparam(5);
     srand(1);
-    hipblas_init<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, N, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
     hipblas_init<T>(hdata, 1, 4, 1);
 
     // CPU BLAS reference data
@@ -77,13 +83,13 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
                 CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(T) * size_y, hipMemcpyDeviceToHost));
                 if(arg.unit_check)
                 {
-                    near_check_general(1, N, incx, cx.data(), rx.data(), rel_error);
-                    near_check_general(1, N, incy, cy.data(), ry.data(), rel_error);
+                    near_check_general(1, N, abs_incx, cx.data(), rx.data(), rel_error);
+                    near_check_general(1, N, abs_incy, cy.data(), ry.data(), rel_error);
                 }
                 if(arg.norm_check)
                 {
-                    hipblas_error_host = norm_check_general<T>('F', 1, N, incx, cx, rx);
-                    hipblas_error_host += norm_check_general<T>('F', 1, N, incy, cy, ry);
+                    hipblas_error_host = norm_check_general<T>('F', 1, N, abs_incx, cx, rx);
+                    hipblas_error_host += norm_check_general<T>('F', 1, N, abs_incy, cy, ry);
                 }
             }
 
@@ -100,13 +106,13 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
                 CHECK_HIP_ERROR(hipMemcpy(ry, dy, sizeof(T) * size_y, hipMemcpyDeviceToHost));
                 if(arg.unit_check)
                 {
-                    near_check_general(1, N, incx, cx.data(), rx.data(), rel_error);
-                    near_check_general(1, N, incy, cy.data(), ry.data(), rel_error);
+                    near_check_general(1, N, abs_incx, cx.data(), rx.data(), rel_error);
+                    near_check_general(1, N, abs_incy, cy.data(), ry.data(), rel_error);
                 }
                 if(arg.norm_check)
                 {
-                    hipblas_error_device = norm_check_general<T>('F', 1, N, incx, cx, rx);
-                    hipblas_error_device += norm_check_general<T>('F', 1, N, incy, cy, ry);
+                    hipblas_error_device = norm_check_general<T>('F', 1, N, abs_incx, cx, rx);
+                    hipblas_error_device += norm_check_general<T>('F', 1, N, abs_incy, cy, ry);
                 }
             }
         }

--- a/clients/include/testing_rotm.hpp
+++ b/clients/include/testing_rotm.hpp
@@ -25,15 +25,16 @@ hipblasStatus_t testing_rotm(const Arguments& arg)
 
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
+    hipblasLocalHandle handle(arg);
+
     // check to prevent undefined memory allocation error
     if(N <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasRotmFn(handle, N, nullptr, incx, nullptr, incy, nullptr));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(arg);
 
     int    abs_incx = incx >= 0 ? incx : -incx;
     int    abs_incy = incy >= 0 ? incy : -incy;

--- a/clients/include/testing_rotm_batched.hpp
+++ b/clients/include/testing_rotm_batched.hpp
@@ -40,12 +40,12 @@ hipblasStatus_t testing_rotm_batched(const Arguments& arg)
 
     hipblasLocalHandle handle(arg);
 
-    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
     device_batch_vector<T> dparam(5, 1, batch_count);
 
-    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
     host_batch_vector<T> hdata(4, 1, batch_count);
     host_batch_vector<T> hparam(5, 1, batch_count);
 
@@ -82,13 +82,13 @@ hipblasStatus_t testing_rotm_batched(const Arguments& arg)
                                                      dparam.ptr_on_device(),
                                                      batch_count));
 
-            host_batch_vector<T> rx(N, incx ? incx : 1, batch_count);
-            host_batch_vector<T> ry(N, incy ? incy : 1, batch_count);
+            host_batch_vector<T> rx(N, incx, batch_count);
+            host_batch_vector<T> ry(N, incy, batch_count);
             CHECK_HIP_ERROR(rx.transfer_from(dx));
             CHECK_HIP_ERROR(ry.transfer_from(dy));
 
-            host_batch_vector<T> cx(N, incx ? incx : 1, batch_count);
-            host_batch_vector<T> cy(N, incy ? incy : 1, batch_count);
+            host_batch_vector<T> cx(N, incx, batch_count);
+            host_batch_vector<T> cy(N, incy, batch_count);
             cx.copy_from(hx);
             cy.copy_from(hy);
 

--- a/clients/include/testing_rotm_batched.hpp
+++ b/clients/include/testing_rotm_batched.hpp
@@ -27,9 +27,14 @@ hipblasStatus_t testing_rotm_batched(const Arguments& arg)
 
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
+    hipblasLocalHandle handle(arg);
+
     // check to prevent undefined memory allocation error
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(
+            hipblasRotmBatchedFn(handle, N, nullptr, incx, nullptr, incy, nullptr, batch_count));
+
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -37,8 +42,6 @@ hipblasStatus_t testing_rotm_batched(const Arguments& arg)
     int abs_incy = incy >= 0 ? incy : -incy;
 
     double gpu_time_used, hipblas_error_device;
-
-    hipblasLocalHandle handle(arg);
 
     device_batch_vector<T> dx(N, incx, batch_count);
     device_batch_vector<T> dy(N, incy, batch_count);

--- a/clients/include/testing_rotm_strided_batched.hpp
+++ b/clients/include/testing_rotm_strided_batched.hpp
@@ -33,18 +33,24 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
     const T rel_error = std::numeric_limits<T>::epsilon() * 1000;
 
     // check to prevent undefined memory allocation error
-    if(N <= 0 || incx <= 0 || incy <= 0 || batch_count <= 0)
+    if(N <= 0 || batch_count <= 0)
     {
-        return (batch_count < 0) ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     double gpu_time_used, hipblas_error_device;
 
     hipblasLocalHandle handle(arg);
 
-    size_t size_x     = N * size_t(incx) + size_t(stride_x) * size_t(batch_count - 1);
-    size_t size_y     = N * size_t(incy) + size_t(stride_y) * size_t(batch_count - 1);
+    int    abs_incx   = incx >= 0 ? incx : -incx;
+    int    abs_incy   = incy >= 0 ? incy : -incy;
+    size_t size_x     = N * size_t(abs_incx) + size_t(stride_x) * size_t(batch_count - 1);
+    size_t size_y     = N * size_t(abs_incy) + size_t(stride_y) * size_t(batch_count - 1);
     size_t size_param = 5 + size_t(stride_param) * size_t(batch_count - 1);
+    if(!size_x)
+        size_x = 1;
+    if(!size_y)
+        size_y = 1;
 
     device_vector<T> dx(size_x);
     device_vector<T> dy(size_y);
@@ -56,8 +62,8 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
     host_vector<T> hdata(4 * batch_count);
     host_vector<T> hparam(size_param);
     srand(1);
-    hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, N, abs_incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, N, abs_incy, stride_y, batch_count);
     hipblas_init<T>(hdata, 1, 4, 1, 4, batch_count);
 
     for(int b = 0; b < batch_count; b++)
@@ -112,15 +118,15 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
 
             if(arg.unit_check)
             {
-                near_check_general<T>(1, N, batch_count, incx, stride_x, cx, rx, rel_error);
-                near_check_general<T>(1, N, batch_count, incy, stride_y, cy, ry, rel_error);
+                near_check_general<T>(1, N, batch_count, abs_incx, stride_x, cx, rx, rel_error);
+                near_check_general<T>(1, N, batch_count, abs_incy, stride_y, cy, ry, rel_error);
             }
             if(arg.norm_check)
             {
                 hipblas_error_device
-                    = norm_check_general<T>('F', 1, N, incx, stride_x, cx, rx, batch_count);
+                    = norm_check_general<T>('F', 1, N, abs_incx, stride_x, cx, rx, batch_count);
                 hipblas_error_device
-                    += norm_check_general<T>('F', 1, N, incy, stride_y, cy, ry, batch_count);
+                    += norm_check_general<T>('F', 1, N, abs_incy, stride_y, cy, ry, batch_count);
             }
         }
     }

--- a/clients/include/testing_rotm_strided_batched.hpp
+++ b/clients/include/testing_rotm_strided_batched.hpp
@@ -25,8 +25,6 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
     int           N            = arg.N;
     int           incx         = arg.incx;
     int           incy         = arg.incy;
-    hipblasStride stride_x     = N * incx * stride_scale;
-    hipblasStride stride_y     = N * incy * stride_scale;
     hipblasStride stride_param = 5 * stride_scale;
     int           batch_count  = arg.batch_count;
 
@@ -42,11 +40,13 @@ hipblasStatus_t testing_rotm_strided_batched(const Arguments& arg)
 
     hipblasLocalHandle handle(arg);
 
-    int    abs_incx   = incx >= 0 ? incx : -incx;
-    int    abs_incy   = incy >= 0 ? incy : -incy;
-    size_t size_x     = N * size_t(abs_incx) + size_t(stride_x) * size_t(batch_count - 1);
-    size_t size_y     = N * size_t(abs_incy) + size_t(stride_y) * size_t(batch_count - 1);
-    size_t size_param = 5 + size_t(stride_param) * size_t(batch_count - 1);
+    int           abs_incx   = incx >= 0 ? incx : -incx;
+    int           abs_incy   = incy >= 0 ? incy : -incy;
+    hipblasStride stride_x   = N * abs_incx * stride_scale;
+    hipblasStride stride_y   = N * abs_incy * stride_scale;
+    size_t        size_x     = N * size_t(abs_incx) + size_t(stride_x) * size_t(batch_count - 1);
+    size_t        size_y     = N * size_t(abs_incy) + size_t(stride_y) * size_t(batch_count - 1);
+    size_t        size_param = 5 + size_t(stride_param) * size_t(batch_count - 1);
     if(!size_x)
         size_x = 1;
     if(!size_y)

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -26,9 +26,9 @@ hipblasStatus_t testing_scal(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0)
+    if(N <= 0 || incx <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     int sizeX = N * incx;

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -31,8 +31,8 @@ hipblasStatus_t testing_scal(const Arguments& argus)
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int sizeX = N * incx;
-    U   alpha = argus.get_alpha<U>();
+    size_t sizeX = size_t(N) * incx;
+    U      alpha = argus.get_alpha<U>();
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T>   hx(sizeX);

--- a/clients/include/testing_scal.hpp
+++ b/clients/include/testing_scal.hpp
@@ -24,10 +24,13 @@ hipblasStatus_t testing_scal(const Arguments& argus)
     int unit_check = argus.unit_check;
     int timing     = argus.timing;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || incx <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasScalFn(handle, N, nullptr, nullptr, incx));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -41,8 +44,6 @@ hipblasStatus_t testing_scal(const Arguments& argus)
 
     double gpu_time_used, cpu_time_used;
     double hipblas_error = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_scal_batched.hpp
+++ b/clients/include/testing_scal_batched.hpp
@@ -29,16 +29,12 @@ hipblasStatus_t testing_scal_batched(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    int    sizeX         = N * incx;
+    size_t sizeX         = size_t(N) * incx;
     U      alpha         = argus.get_alpha<U>();
     double gpu_time_used = 0.0, cpu_time_used = 0.0;
     double hipblas_error = 0.0;

--- a/clients/include/testing_scal_batched.hpp
+++ b/clients/include/testing_scal_batched.hpp
@@ -27,10 +27,13 @@ hipblasStatus_t testing_scal_batched(const Arguments& argus)
     int norm_check  = argus.norm_check;
     int timing      = argus.timing;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasScalBatchedFn(handle, N, nullptr, nullptr, incx, batch_count));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -38,8 +41,6 @@ hipblasStatus_t testing_scal_batched(const Arguments& argus)
     U      alpha         = argus.get_alpha<U>();
     double gpu_time_used = 0.0, cpu_time_used = 0.0;
     double hipblas_error = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hx(N, incx, batch_count);

--- a/clients/include/testing_scal_batched_ex.hpp
+++ b/clients/include/testing_scal_batched_ex.hpp
@@ -28,16 +28,20 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
 
     Ta h_alpha = argus.get_alpha<Ta>();
 
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(N <= 0 || incx <= 0 || batch_count <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
+    hipblasLocalHandle handle(argus);
 
     hipblasDatatype_t alphaType     = argus.a_type;
     hipblasDatatype_t xType         = argus.b_type;
     hipblasDatatype_t executionType = argus.compute_type;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
+    {
+        CHECK_HIPBLAS_ERROR(hipblasScalBatchedExFn(
+            handle, N, nullptr, alphaType, nullptr, xType, incx, batch_count, executionType));
+        return HIPBLAS_STATUS_SUCCESS;
+    }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<Tx> hx_host(N, incx, batch_count);
@@ -49,8 +53,7 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
 
     CHECK_HIP_ERROR(dx.memcheck());
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     hipblas_init(hx_host, true);

--- a/clients/include/testing_scal_batched_ex.hpp
+++ b/clients/include/testing_scal_batched_ex.hpp
@@ -30,11 +30,7 @@ hipblasStatus_t testing_scal_batched_ex_template(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(!batch_count)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }

--- a/clients/include/testing_scal_ex.hpp
+++ b/clients/include/testing_scal_ex.hpp
@@ -28,16 +28,20 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
     size_t sizeX   = size_t(N) * incx;
     Ta     h_alpha = argus.get_alpha<Ta>();
 
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(N <= 0 || incx <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
+    hipblasLocalHandle handle(argus);
 
     hipblasDatatype_t alphaType     = argus.a_type;
     hipblasDatatype_t xType         = argus.b_type;
     hipblasDatatype_t executionType = argus.compute_type;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N <= 0 || incx <= 0)
+    {
+        CHECK_HIPBLAS_ERROR(
+            hipblasScalExFn(handle, N, nullptr, alphaType, nullptr, xType, incx, executionType));
+        return HIPBLAS_STATUS_SUCCESS;
+    }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx_host(sizeX);
@@ -47,8 +51,7 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
     device_vector<Tx> dx(sizeX);
     device_vector<Ta> d_alpha(1);
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_scal_ex.hpp
+++ b/clients/include/testing_scal_ex.hpp
@@ -30,9 +30,9 @@ hipblasStatus_t testing_scal_ex_template(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0)
+    if(N <= 0 || incx <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     hipblasDatatype_t alphaType     = argus.a_type;

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -27,8 +27,8 @@ hipblasStatus_t testing_scal_strided_batched(const Arguments& argus)
     int    unit_check   = argus.unit_check;
     int    timing       = argus.timing;
 
-    hipblasStride stridex = N * incx * stride_scale;
-    int           sizeX   = stridex * batch_count;
+    hipblasStride stridex = size_t(N) * incx * stride_scale;
+    size_t        sizeX   = stridex * batch_count;
 
     U alpha = argus.get_alpha<U>();
 

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -34,9 +34,9 @@ hipblasStatus_t testing_scal_strided_batched(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || batch_count < 0)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice

--- a/clients/include/testing_scal_strided_batched.hpp
+++ b/clients/include/testing_scal_strided_batched.hpp
@@ -32,10 +32,14 @@ hipblasStatus_t testing_scal_strided_batched(const Arguments& argus)
 
     U alpha = argus.get_alpha<U>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(
+            hipblasScalStridedBatchedFn(handle, N, nullptr, nullptr, incx, stridex, batch_count));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -47,8 +51,6 @@ hipblasStatus_t testing_scal_strided_batched(const Arguments& argus)
 
     double gpu_time_used = 0.0, cpu_time_used = 0.0;
     double hipblas_error = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_scal_strided_batched_ex.hpp
+++ b/clients/include/testing_scal_strided_batched_ex.hpp
@@ -35,11 +35,7 @@ hipblasStatus_t testing_scal_strided_batched_ex_template(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(!batch_count)
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }

--- a/clients/include/testing_scal_strided_batched_ex.hpp
+++ b/clients/include/testing_scal_strided_batched_ex.hpp
@@ -33,16 +33,28 @@ hipblasStatus_t testing_scal_strided_batched_ex_template(const Arguments& argus)
 
     Ta h_alpha = argus.get_alpha<Ta>();
 
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(N <= 0 || incx <= 0 || batch_count <= 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
+    hipblasLocalHandle handle(argus);
 
     hipblasDatatype_t alphaType     = argus.a_type;
     hipblasDatatype_t xType         = argus.b_type;
     hipblasDatatype_t executionType = argus.compute_type;
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    if(N <= 0 || incx <= 0 || batch_count <= 0)
+    {
+        CHECK_HIPBLAS_ERROR(hipblasScalStridedBatchedExFn(handle,
+                                                          N,
+                                                          nullptr,
+                                                          alphaType,
+                                                          nullptr,
+                                                          xType,
+                                                          incx,
+                                                          stride_scale,
+                                                          batch_count,
+                                                          executionType));
+        return HIPBLAS_STATUS_SUCCESS;
+    }
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<Tx> hx_host(sizeX);
@@ -52,8 +64,7 @@ hipblasStatus_t testing_scal_strided_batched_ex_template(const Arguments& argus)
     device_vector<Tx> dx(sizeX);
     device_vector<Ta> d_alpha(1);
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_swap.hpp
+++ b/clients/include/testing_swap.hpp
@@ -26,10 +26,13 @@ hipblasStatus_t testing_swap(const Arguments& argus)
     int norm_check = argus.norm_check;
     int timing     = argus.timing;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasSwapFn(handle, N, nullptr, incx, nullptr, incy));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -55,8 +58,6 @@ hipblasStatus_t testing_swap(const Arguments& argus)
 
     double gpu_time_used = 0.0, cpu_time_used = 0.0;
     double hipblas_error = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_swap.hpp
+++ b/clients/include/testing_swap.hpp
@@ -28,13 +28,19 @@ hipblasStatus_t testing_swap(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || incy < 0)
+    if(N <= 0)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        return HIPBLAS_STATUS_SUCCESS;
     }
 
-    size_t sizeX = size_t(N) * incx;
-    size_t sizeY = size_t(N) * incy;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t sizeX    = size_t(N) * abs_incx;
+    size_t sizeY    = size_t(N) * abs_incy;
+    if(!sizeX)
+        sizeX = 1;
+    if(!sizeY)
+        sizeY = 1;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_vector<T> hx(sizeX);
@@ -54,8 +60,8 @@ hipblasStatus_t testing_swap(const Arguments& argus)
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, N, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
     hx_cpu = hx;
     hy_cpu = hy;
 
@@ -81,14 +87,14 @@ hipblasStatus_t testing_swap(const Arguments& argus)
 
         if(unit_check)
         {
-            unit_check_general<T>(1, N, incx, hx_cpu.data(), hx.data());
-            unit_check_general<T>(1, N, incy, hy_cpu.data(), hy.data());
+            unit_check_general<T>(1, N, abs_incx, hx_cpu.data(), hx.data());
+            unit_check_general<T>(1, N, abs_incy, hy_cpu.data(), hy.data());
         }
         if(norm_check)
         {
             hipblas_error
-                = std::max(norm_check_general<T>('F', 1, N, incx, hx_cpu.data(), hx.data()),
-                           norm_check_general<T>('F', 1, N, incy, hy_cpu.data(), hy.data()));
+                = std::max(norm_check_general<T>('F', 1, N, abs_incx, hx_cpu.data(), hx.data()),
+                           norm_check_general<T>('F', 1, N, abs_incy, hy_cpu.data(), hy.data()));
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -28,10 +28,14 @@ hipblasStatus_t testing_swap_batched(const Arguments& argus)
     int norm_check  = argus.norm_check;
     int timing      = argus.timing;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(
+            hipblasSwapBatchedFn(handle, N, nullptr, incx, nullptr, incy, batch_count));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -40,8 +44,6 @@ hipblasStatus_t testing_swap_batched(const Arguments& argus)
 
     double hipblas_error = 0.0;
     double gpu_time_used = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     host_batch_vector<T> hx(N, incx, batch_count);

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -44,13 +44,13 @@ hipblasStatus_t testing_swap_batched(const Arguments& argus)
     hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
-    host_batch_vector<T> hx_cpu(N, incx ? incx : 1, batch_count);
-    host_batch_vector<T> hy_cpu(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
+    host_batch_vector<T> hx_cpu(N, incx, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy, batch_count);
 
-    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
-    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
 
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy.memcheck());

--- a/clients/include/testing_swap_batched.hpp
+++ b/clients/include/testing_swap_batched.hpp
@@ -30,17 +30,13 @@ hipblasStatus_t testing_swap_batched(const Arguments& argus)
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx < 0 || incy < 0 || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
+    if(N <= 0 || batch_count <= 0)
     {
         return HIPBLAS_STATUS_SUCCESS;
     }
 
-    size_t sizeX = size_t(N) * incx;
-    size_t sizeY = size_t(N) * incy;
+    int abs_incx = incx >= 0 ? incx : -incx;
+    int abs_incy = incy >= 0 ? incy : -incy;
 
     double hipblas_error = 0.0;
     double gpu_time_used = 0.0;
@@ -48,13 +44,13 @@ hipblasStatus_t testing_swap_batched(const Arguments& argus)
     hipblasLocalHandle handle(argus);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
-    host_batch_vector<T> hx(N, incx, batch_count);
-    host_batch_vector<T> hy(N, incy, batch_count);
-    host_batch_vector<T> hx_cpu(N, incx, batch_count);
-    host_batch_vector<T> hy_cpu(N, incy, batch_count);
+    host_batch_vector<T> hx(N, incx ? incx : 1, batch_count);
+    host_batch_vector<T> hy(N, incy ? incy : 1, batch_count);
+    host_batch_vector<T> hx_cpu(N, incx ? incx : 1, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy ? incy : 1, batch_count);
 
-    device_batch_vector<T> dx(N, incx, batch_count);
-    device_batch_vector<T> dy(N, incy, batch_count);
+    device_batch_vector<T> dx(N, incx ? incx : 1, batch_count);
+    device_batch_vector<T> dy(N, incy ? incy : 1, batch_count);
 
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dy.memcheck());
@@ -88,14 +84,14 @@ hipblasStatus_t testing_swap_batched(const Arguments& argus)
 
         if(unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incy, hy_cpu, hy);
-            unit_check_general<T>(1, N, batch_count, incx, hx_cpu, hx);
+            unit_check_general<T>(1, N, batch_count, abs_incx, hx_cpu, hx);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy);
         }
         if(norm_check)
         {
             hipblas_error
-                = std::max(norm_check_general<T>('F', 1, N, incx, hx_cpu, hx, batch_count),
-                           norm_check_general<T>('F', 1, N, incy, hy_cpu, hy, batch_count));
+                = std::max(norm_check_general<T>('F', 1, N, abs_incx, hx_cpu, hx, batch_count),
+                           norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy, batch_count));
         }
 
     } // end of if unit/norm check

--- a/clients/include/testing_swap_strided_batched.hpp
+++ b/clients/include/testing_swap_strided_batched.hpp
@@ -40,10 +40,14 @@ hipblasStatus_t testing_swap_strided_batched(const Arguments& argus)
     if(!sizeY)
         sizeY = 1;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
     if(N <= 0 || batch_count <= 0)
     {
+        CHECK_HIPBLAS_ERROR(hipblasSwapStridedBatchedFn(
+            handle, N, nullptr, incx, stridex, nullptr, incy, stridey, batch_count));
         return HIPBLAS_STATUS_SUCCESS;
     }
 
@@ -58,8 +62,6 @@ hipblasStatus_t testing_swap_strided_batched(const Arguments& argus)
 
     double hipblas_error = 0.0;
     double gpu_time_used = 0.0;
-
-    hipblasLocalHandle handle(argus);
 
     // Initial Data on CPU
     srand(1);


### PR DESCRIPTION
Allowing negative incx/incy inputs for testing (L1s for now). Also allows incx = 0 and incy = 0, although this typically gives incorrect results.

In rocBLAS we typically test that we still return success even if we're passing in nullptrs, I don't think that's in hipBLAS' scope to test that so I've opted not to add that for now.

- Asum - negative incx/incy not supported in rocBLAS, so not allowing testing here.
- Axpy - allowing negative incx/incy
- Copy - allowing negative incx/incy
- Dot - allowing negative incx/incy
- max/min - negative incx/incy not supported in rocBLAS, so not allowing testing here
- Nrm2 - negative incx/incy not supported in rocBLAS, so not allowing testing here
- Rot - allowing negative incx/incy
- Rotm - allowing negative incx/incy
- Scal - negative incx/incy not supported in rocBLAS, so not allowing testing here
- Swap - allowing negative incx/incy
