### PR TITLE
Allowing negative increments in hipblas tests (L2-1) 

### DIFF
--- a/clients/gtest/gbmv_batched_gtest.cpp
+++ b/clients/gtest/gbmv_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gbmv_batched_gtest.cpp
+++ b/clients/gtest/gbmv_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gbmv_gtest.cpp
+++ b/clients/gtest/gbmv_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gbmv_gtest.cpp
+++ b/clients/gtest/gbmv_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gbmv_strided_batched_gtest.cpp
+++ b/clients/gtest/gbmv_strided_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gbmv_strided_batched_gtest.cpp
+++ b/clients/gtest/gbmv_strided_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gemv_batched_gtest.cpp
+++ b/clients/gtest/gemv_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gemv_batched_gtest.cpp
+++ b/clients/gtest/gemv_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gemv_gtest.cpp
+++ b/clients/gtest/gemv_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gemv_strided_batched_gtest.cpp
+++ b/clients/gtest/gemv_strided_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/gemv_strided_batched_gtest.cpp
+++ b/clients/gtest/gemv_strided_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hbmv_gtest.cpp
+++ b/clients/gtest/hbmv_gtest.cpp
@@ -55,7 +55,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hbmv_gtest.cpp
+++ b/clients/gtest/hbmv_gtest.cpp
@@ -55,7 +55,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hemv_batched_gtest.cpp
+++ b/clients/gtest/hemv_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hemv_batched_gtest.cpp
+++ b/clients/gtest/hemv_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hemv_gtest.cpp
+++ b/clients/gtest/hemv_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hemv_gtest.cpp
+++ b/clients/gtest/hemv_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hemv_strided_batched_gtest.cpp
+++ b/clients/gtest/hemv_strided_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hemv_strided_batched_gtest.cpp
+++ b/clients/gtest/hemv_strided_batched_gtest.cpp
@@ -52,7 +52,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/her2_gtest.cpp
+++ b/clients/gtest/her2_gtest.cpp
@@ -45,7 +45,7 @@ const vector<vector<int>> matrix_size_range = {{-1, -1}, {11, 11}, {16, 16}, {32
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
-const vector<vector<int>> incx_incy_range = {{1, 1}, {0, 0}, {2, 2}};
+const vector<vector<int>> incx_incy_range = {{1, 1}, {0, 0}, {-2, -1}};
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}

--- a/clients/gtest/her2_gtest.cpp
+++ b/clients/gtest/her2_gtest.cpp
@@ -45,7 +45,7 @@ const vector<vector<int>> matrix_size_range = {{-1, -1}, {11, 11}, {16, 16}, {32
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
-const vector<vector<int>> incx_incy_range = {{1, 1}, {0, 0}, {-2, -1}};
+const vector<vector<int>> incx_incy_range = {{2, 1}, {0, 0}, {-1, -1}};
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}

--- a/clients/gtest/her_gtest.cpp
+++ b/clients/gtest/her_gtest.cpp
@@ -45,7 +45,7 @@ const vector<vector<int>> matrix_size_range = {{-1, -1}, {11, 11}, {16, 16}, {32
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
-const vector<vector<int>> incx_incy_range = {{1}, {0}, {2}};
+const vector<vector<int>> incx_incy_range = {{1}, {0}, {-2}};
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}

--- a/clients/gtest/her_gtest.cpp
+++ b/clients/gtest/her_gtest.cpp
@@ -45,7 +45,7 @@ const vector<vector<int>> matrix_size_range = {{-1, -1}, {11, 11}, {16, 16}, {32
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
-const vector<vector<int>> incx_incy_range = {{1}, {0}, {-2}};
+const vector<vector<int>> incx_incy_range = {{-1}, {0}, {2}};
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}

--- a/clients/gtest/hpmv_gtest.cpp
+++ b/clients/gtest/hpmv_gtest.cpp
@@ -50,7 +50,7 @@ const vector<int> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1},
+    {1, 1}, {0, -1}, {-2, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hpmv_gtest.cpp
+++ b/clients/gtest/hpmv_gtest.cpp
@@ -50,7 +50,7 @@ const vector<int> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {-2, -1},
+    {2, 1}, {0, -1}, {-1, -1},
     //              {10, 100},
 };
 

--- a/clients/gtest/hpr2_gtest.cpp
+++ b/clients/gtest/hpr2_gtest.cpp
@@ -45,7 +45,7 @@ const vector<int> matrix_size_range = {-1, 11, 16, 32, 65};
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
-const vector<vector<int>> incx_incy_range = {{1, 1}, {0, 0}, {-2, -1}};
+const vector<vector<int>> incx_incy_range = {{2, 1}, {0, 0}, {-1, -1}};
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}

--- a/clients/gtest/hpr2_gtest.cpp
+++ b/clients/gtest/hpr2_gtest.cpp
@@ -45,7 +45,7 @@ const vector<int> matrix_size_range = {-1, 11, 16, 32, 65};
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
-const vector<vector<int>> incx_incy_range = {{1, 1}, {0, 0}, {2, 2}};
+const vector<vector<int>> incx_incy_range = {{1, 1}, {0, 0}, {-2, -1}};
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}

--- a/clients/gtest/hpr_gtest.cpp
+++ b/clients/gtest/hpr_gtest.cpp
@@ -45,7 +45,7 @@ const vector<int> matrix_size_range = {-1, 11, 16, 32, 65};
 
 // vector of vector, each pair is a {incx};
 // add/delete this list in pairs, like {1}
-const vector<int> incx_incy_range = {1, 0, -2};
+const vector<int> incx_incy_range = {-1, 0, 2};
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}

--- a/clients/gtest/hpr_gtest.cpp
+++ b/clients/gtest/hpr_gtest.cpp
@@ -45,7 +45,7 @@ const vector<int> matrix_size_range = {-1, 11, 16, 32, 65};
 
 // vector of vector, each pair is a {incx};
 // add/delete this list in pairs, like {1}
-const vector<int> incx_incy_range = {1, 0, 2};
+const vector<int> incx_incy_range = {1, 0, -2};
 
 // vector, each entry is  {alpha};
 // add/delete single values, like {2.0}

--- a/clients/gtest/tbmv_gtest.cpp
+++ b/clients/gtest/tbmv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<vector<int>> matrix_size_range = {
 
 // vector of vector, each element is an {incx}
 const vector<vector<int>> incx_incy_range = {
-    {1}, {0}, {2}
+    {1}, {0}, {-2}
     //     {10, 100}
 };
 

--- a/clients/gtest/tbmv_gtest.cpp
+++ b/clients/gtest/tbmv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<vector<int>> matrix_size_range = {
 
 // vector of vector, each element is an {incx}
 const vector<vector<int>> incx_incy_range = {
-    {1}, {0}, {-2}
+    {-1}, {0}, {2}
     //     {10, 100}
 };
 

--- a/clients/gtest/tpmv_gtest.cpp
+++ b/clients/gtest/tpmv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<int> matrix_size_range = {
 
 // vector of vector, each element is an {incx}
 const vector<vector<int>> incx_incy_range = {
-    {1}, {0}, {-2}
+    {-1}, {0}, {2}
     //     {10, 100}
 };
 

--- a/clients/gtest/tpmv_gtest.cpp
+++ b/clients/gtest/tpmv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<int> matrix_size_range = {
 
 // vector of vector, each element is an {incx}
 const vector<vector<int>> incx_incy_range = {
-    {1}, {0}, {2}
+    {1}, {0}, {-2}
     //     {10, 100}
 };
 

--- a/clients/gtest/trmv_gtest.cpp
+++ b/clients/gtest/trmv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<vector<int>> matrix_size_range = {
 
 // vector of vector, each element is an {incx}
 const vector<vector<int>> incx_incy_range = {
-    {1}, {0}, {2}
+    {1}, {0}, {-2}
     //     {10, 100}
 };
 

--- a/clients/gtest/trmv_gtest.cpp
+++ b/clients/gtest/trmv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<vector<int>> matrix_size_range = {
 
 // vector of vector, each element is an {incx}
 const vector<vector<int>> incx_incy_range = {
-    {1}, {0}, {-2}
+    {-1}, {0}, {2}
     //     {10, 100}
 };
 

--- a/clients/include/testing_gbmv.hpp
+++ b/clients/include/testing_gbmv.hpp
@@ -29,40 +29,65 @@ hipblasStatus_t testing_gbmv(const Arguments& argus)
     int incy = argus.incy;
 
     size_t A_size = size_t(lda) * N;
-    int    X_size;
-    int    Y_size;
+    int    dim_x;
+    int    dim_y;
 
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
 
     if(transA == HIPBLAS_OP_N)
     {
-        X_size = N;
-        Y_size = M;
+        dim_x = N;
+        dim_y = M;
     }
     else
     {
-        X_size = M;
-        Y_size = N;
+        dim_x = M;
+        dim_y = N;
     }
+
+    hipblasLocalHandle handle(argus);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || KL < 0 || KU < 0 || lda < KL + KU + 1 || incx == 0 || incy == 0)
+    bool invalid_size = M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || KL < 0 || KU < 0;
+    if(invalid_size || !M || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasGbmvFn(handle,
+                                               transA,
+                                               M,
+                                               N,
+                                               KL,
+                                               KU,
+                                               nullptr,
+                                               nullptr,
+                                               lda,
+                                               nullptr,
+                                               incx,
+                                               nullptr,
+                                               nullptr,
+                                               incy);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
+
+    int abs_incx = incx >= 0 ? incx : -incx;
+    int abs_incy = incy >= 0 ? incy : -incy;
+
+    size_t X_size = size_t(dim_x) * abs_incx;
+    size_t Y_size = size_t(dim_y) * abs_incy;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hx(X_size * incx);
-    host_vector<T> hy(Y_size * incy);
-    host_vector<T> hy_host(Y_size * incy);
-    host_vector<T> hy_device(Y_size * incy);
-    host_vector<T> hy_cpu(Y_size * incy);
+    host_vector<T> hx(X_size);
+    host_vector<T> hy(Y_size);
+    host_vector<T> hy_host(Y_size);
+    host_vector<T> hy_device(Y_size);
+    host_vector<T> hy_cpu(Y_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(X_size * incx);
-    device_vector<T> dy(Y_size * incy);
+    device_vector<T> dx(X_size);
+    device_vector<T> dy(Y_size);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
 
@@ -71,21 +96,19 @@ hipblasStatus_t testing_gbmv(const Arguments& argus)
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda);
-    hipblas_init<T>(hx, 1, X_size, incx);
-    hipblas_init<T>(hy, 1, Y_size, incy);
+    hipblas_init<T>(hx, 1, dim_x, abs_incx);
+    hipblas_init<T>(hy, 1, dim_y, abs_incy);
 
     // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
     hy_cpu = hy;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size * incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * X_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
@@ -98,16 +121,14 @@ hipblasStatus_t testing_gbmv(const Arguments& argus)
         CHECK_HIPBLAS_ERROR(hipblasGbmvFn(
             handle, transA, M, N, KL, KU, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
 
-        CHECK_HIP_ERROR(
-            hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size * incy, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIPBLAS_ERROR(hipblasGbmvFn(
             handle, transA, M, N, KL, KU, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
 
-        CHECK_HIP_ERROR(
-            hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * Y_size, hipMemcpyDeviceToHost));
 
         /* =====================================================================
            CPU BLAS
@@ -131,21 +152,21 @@ hipblasStatus_t testing_gbmv(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, Y_size, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, Y_size, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, dim_y, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, dim_y, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host
-                = norm_check_general<T>('F', 1, Y_size, incy, hy_cpu.data(), hy_host.data());
+                = norm_check_general<T>('F', 1, dim_y, abs_incy, hy_cpu.data(), hy_host.data());
             hipblas_error_device
-                = norm_check_general<T>('F', 1, Y_size, incy, hy_cpu.data(), hy_device.data());
+                = norm_check_general<T>('F', 1, dim_y, abs_incy, hy_cpu.data(), hy_device.data());
         }
     }
 
     if(argus.timing)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * Y_size, hipMemcpyHostToDevice));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/testing_gbmv_batched.hpp
+++ b/clients/include/testing_gbmv_batched.hpp
@@ -30,8 +30,8 @@ hipblasStatus_t testing_gbmv_batched(const Arguments& argus)
     int incy = argus.incy;
 
     size_t A_size = size_t(lda) * N;
-    int    X_size;
-    int    Y_size;
+    int    dim_x;
+    int    dim_y;
 
     int batch_count = argus.batch_count;
 
@@ -39,30 +39,45 @@ hipblasStatus_t testing_gbmv_batched(const Arguments& argus)
 
     if(transA == HIPBLAS_OP_N)
     {
-        X_size = N;
-        Y_size = M;
+        dim_x = N;
+        dim_y = M;
     }
     else
     {
-        X_size = M;
-        Y_size = N;
-    }
-
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
-
-    // argument sanity check, quick return if input parameters are invalid before allocating invalid
-    // memory
-    if(M < 0 || N < 0 || KL < 0 || KU < 0 || lda < KL + KU + 1 || incx == 0 || incy == 0
-       || batch_count < 0)
-    {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        dim_x = M;
+        dim_y = N;
     }
 
     hipblasLocalHandle handle(argus);
+
+    // argument sanity check, quick return if input parameters are invalid before allocating invalid
+    // memory
+    bool invalid_size = M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || batch_count < 0
+                        || KL < 0 || KU < 0;
+    if(invalid_size || !M || !N || !batch_count)
+    {
+        hipblasStatus_t actual = hipblasGbmvBatchedFn(handle,
+                                                      transA,
+                                                      M,
+                                                      N,
+                                                      KL,
+                                                      KU,
+                                                      nullptr,
+                                                      nullptr,
+                                                      lda,
+                                                      nullptr,
+                                                      incx,
+                                                      nullptr,
+                                                      nullptr,
+                                                      incy,
+                                                      batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
+    }
+
+    int abs_incx = incx >= 0 ? incx : -incx;
+    int abs_incy = incy >= 0 ? incy : -incy;
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
@@ -71,16 +86,16 @@ hipblasStatus_t testing_gbmv_batched(const Arguments& argus)
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);
-    host_batch_vector<T> hx(X_size, incx, batch_count);
-    host_batch_vector<T> hy(Y_size, incy, batch_count);
-    host_batch_vector<T> hy_host(Y_size, incy, batch_count);
-    host_batch_vector<T> hy_device(Y_size, incy, batch_count);
-    host_batch_vector<T> hy_cpu(Y_size, incy, batch_count);
+    host_batch_vector<T> hx(dim_x, incx, batch_count);
+    host_batch_vector<T> hy(dim_y, incy, batch_count);
+    host_batch_vector<T> hy_host(dim_y, incy, batch_count);
+    host_batch_vector<T> hy_device(dim_y, incy, batch_count);
+    host_batch_vector<T> hy_cpu(dim_y, incy, batch_count);
 
     // arrays of pointers-to-device on host
     device_batch_vector<T> dA(A_size, 1, batch_count);
-    device_batch_vector<T> dx(X_size, incx, batch_count);
-    device_batch_vector<T> dy(Y_size, incy, batch_count);
+    device_batch_vector<T> dx(dim_x, incx, batch_count);
+    device_batch_vector<T> dy(dim_y, incy, batch_count);
     device_vector<T>       d_alpha(1);
     device_vector<T>       d_beta(1);
 
@@ -158,15 +173,15 @@ hipblasStatus_t testing_gbmv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, dim_y, batch_count, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, dim_y, batch_count, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host
-                = norm_check_general<T>('F', 1, Y_size, incy, hy_cpu, hy_host, batch_count);
+                = norm_check_general<T>('F', 1, dim_y, abs_incy, hy_cpu, hy_host, batch_count);
             hipblas_error_device
-                = norm_check_general<T>('F', 1, Y_size, incy, hy_cpu, hy_device, batch_count);
+                = norm_check_general<T>('F', 1, dim_y, abs_incy, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_gbmv_strided_batched.hpp
+++ b/clients/include/testing_gbmv_strided_batched.hpp
@@ -36,38 +36,59 @@ hipblasStatus_t testing_gbmv_strided_batched(const Arguments& argus)
     hipblasStride stride_y;
 
     size_t A_size = stride_A * batch_count;
-    int    X_size;
-    int    Y_size;
-
-    int x_els;
-    int y_els;
+    int    dim_x;
+    int    dim_y;
 
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
 
     if(transA == HIPBLAS_OP_N)
     {
-        x_els = N;
-        y_els = M;
+        dim_x = N;
+        dim_y = M;
     }
     else
     {
-        x_els = M;
-        y_els = N;
+        dim_x = M;
+        dim_y = N;
     }
 
-    stride_x = x_els * incx * stride_scale;
-    stride_y = y_els * incy * stride_scale;
-    X_size   = stride_x * batch_count;
-    Y_size   = stride_y * batch_count;
+    int abs_incx = incx >= 0 ? incx : -incx;
+    int abs_incy = incy >= 0 ? incy : -incy;
 
-    hipblasStatus_t status = HIPBLAS_STATUS_SUCCESS;
+    stride_x      = size_t(dim_x) * abs_incx * stride_scale;
+    stride_y      = size_t(dim_y) * abs_incy * stride_scale;
+    size_t X_size = stride_x * batch_count;
+    size_t Y_size = stride_y * batch_count;
+
+    hipblasLocalHandle handle(argus);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || KL < 0 || KU < 0 || lda < KL + KU + 1 || incx == 0 || incy == 0
-       || batch_count < 0)
+    bool invalid_size = M < 0 || N < 0 || lda < KL + KU + 1 || !incx || !incy || KL < 0 || KU < 0
+                        || batch_count < 0;
+    if(invalid_size || !M || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasGbmvStridedBatchedFn(handle,
+                                                             transA,
+                                                             M,
+                                                             N,
+                                                             KL,
+                                                             KU,
+                                                             nullptr,
+                                                             nullptr,
+                                                             lda,
+                                                             stride_A,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             nullptr,
+                                                             nullptr,
+                                                             incy,
+                                                             stride_y,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -89,13 +110,11 @@ hipblasStatus_t testing_gbmv_strided_batched(const Arguments& argus)
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, x_els, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, y_els, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, dim_x, abs_incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, dim_y, abs_incy, stride_y, batch_count);
 
     // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
     hy_cpu = hy;
@@ -107,7 +126,7 @@ hipblasStatus_t testing_gbmv_strided_batched(const Arguments& argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
-    if(argus.unit_check)
+    if(argus.unit_check || argus.norm_check)
     {
         /* =====================================================================
             HIPBLAS
@@ -182,15 +201,15 @@ hipblasStatus_t testing_gbmv_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, y_els, batch_count, incy, stride_y, hy_cpu, hy_host);
-            unit_check_general<T>(1, y_els, batch_count, incy, stride_y, hy_cpu, hy_device);
+            unit_check_general<T>(1, dim_y, batch_count, abs_incy, stride_y, hy_cpu, hy_host);
+            unit_check_general<T>(1, dim_y, batch_count, abs_incy, stride_y, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host = norm_check_general<T>(
-                'F', 1, y_els, incy, stride_y, hy_cpu, hy_host, batch_count);
+                'F', 1, dim_y, abs_incy, stride_y, hy_cpu, hy_host, batch_count);
             hipblas_error_device = norm_check_general<T>(
-                'F', 1, y_els, incy, stride_y, hy_cpu, hy_device, batch_count);
+                'F', 1, dim_y, abs_incy, stride_y, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -50,7 +50,7 @@ hipblasStatus_t testing_gemv(const Arguments& argus)
     bool invalid_size = M < 0 || N < 0 || lda < M || lda < 1 || !incx || !incy;
     if(invalid_size || !M || !N)
     {
-        // cuBLAS doesn't seem to work with nullptrs in some cases here
+        // Only rocBLAS conforms to expected behaviour so commenting out
         /*
         hipblasStatus_t actual = hipblasGemvFn(
             handle, transA, M, N, nullptr, nullptr, lda, nullptr, incx, nullptr, nullptr, incy);

--- a/clients/include/testing_gemv.hpp
+++ b/clients/include/testing_gemv.hpp
@@ -50,11 +50,15 @@ hipblasStatus_t testing_gemv(const Arguments& argus)
     bool invalid_size = M < 0 || N < 0 || lda < M || lda < 1 || !incx || !incy;
     if(invalid_size || !M || !N)
     {
+        // cuBLAS doesn't seem to work with nullptrs in some cases here
+        /*
         hipblasStatus_t actual = hipblasGemvFn(
             handle, transA, M, N, nullptr, nullptr, lda, nullptr, incx, nullptr, nullptr, incy);
         EXPECT_HIPBLAS_STATUS(
             actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
         return actual;
+	*/
+        return invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS;
     }
 
     int abs_incx = incx >= 0 ? incx : -incx;

--- a/clients/include/testing_hbmv_batched.hpp
+++ b/clients/include/testing_hbmv_batched.hpp
@@ -27,25 +27,37 @@ hipblasStatus_t testing_hbmv_batched(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(lda) * N;
-    size_t Y_size = size_t(N) * incy;
+    size_t A_size   = size_t(lda) * N;
+    int    abs_incy = incy >= 0 ? incy : -incy;
 
     int batch_count = argus.batch_count;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || K < 0 || lda < K + 1 || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || K < 0 || lda <= K || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHbmvBatchedFn(handle,
+                                                      uplo,
+                                                      N,
+                                                      K,
+                                                      nullptr,
+                                                      nullptr,
+                                                      lda,
+                                                      nullptr,
+                                                      incx,
+                                                      nullptr,
+                                                      nullptr,
+                                                      incy,
+                                                      batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    hipblasLocalHandle handle(argus);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
@@ -136,15 +148,15 @@ hipblasStatus_t testing_hbmv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host
-                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host, batch_count);
+                = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_host, batch_count);
             hipblas_error_device
-                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device, batch_count);
+                = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_hemv.hpp
+++ b/clients/include/testing_hemv.hpp
@@ -25,17 +25,26 @@ hipblasStatus_t testing_hemv(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(lda) * N;
-    size_t X_size = size_t(incx) * N;
-    size_t Y_size = size_t(incy) * N;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t A_size   = size_t(lda) * N;
+    size_t X_size   = size_t(abs_incx) * N;
+    size_t Y_size   = size_t(abs_incy) * N;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < N || incx == 0 || incy == 0)
+    bool invalid_size = N < 0 || lda < N || lda < 1 || !incx || !incy;
+    if(invalid_size || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHemvFn(
+            handle, uplo, N, nullptr, nullptr, lda, nullptr, incx, nullptr, nullptr, incy);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -57,13 +66,11 @@ hipblasStatus_t testing_hemv(const Arguments& argus)
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, N, lda);
-    hipblas_init<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, N, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
 
     // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
     hy_cpu = hy;
@@ -103,13 +110,13 @@ hipblasStatus_t testing_hemv(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, N, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, N, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
-            hipblas_error_host   = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host);
-            hipblas_error_device = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device);
+            hipblas_error_host   = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_device);
         }
     }
 

--- a/clients/include/testing_hemv_batched.hpp
+++ b/clients/include/testing_hemv_batched.hpp
@@ -26,26 +26,37 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
+    int abs_incy = incy >= 0 ? incy : -incy;
+
     size_t A_size = size_t(lda) * N;
-    size_t X_size = size_t(incx) * N;
-    size_t Y_size = size_t(incy) * N;
 
     int batch_count = argus.batch_count;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < N || incx <= 0 || incy <= 0 || batch_count < 0)
+    bool invalid_size = N < 0 || lda < N || lda < 1 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHemvBatchedFn(handle,
+                                                      uplo,
+                                                      N,
+                                                      nullptr,
+                                                      nullptr,
+                                                      lda,
+                                                      nullptr,
+                                                      incx,
+                                                      nullptr,
+                                                      nullptr,
+                                                      incy,
+                                                      batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    hipblasLocalHandle handle(argus);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
@@ -54,16 +65,16 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);
-    host_batch_vector<T> hx(X_size, 1, batch_count);
-    host_batch_vector<T> hy(Y_size, 1, batch_count);
-    host_batch_vector<T> hy_host(Y_size, 1, batch_count);
-    host_batch_vector<T> hy_device(Y_size, 1, batch_count);
-    host_batch_vector<T> hy_cpu(Y_size, 1, batch_count);
+    host_batch_vector<T> hx(N, incx, batch_count);
+    host_batch_vector<T> hy(N, incy, batch_count);
+    host_batch_vector<T> hy_host(N, incy, batch_count);
+    host_batch_vector<T> hy_device(N, incy, batch_count);
+    host_batch_vector<T> hy_cpu(N, incy, batch_count);
 
     // device arrays
     device_batch_vector<T> dA(A_size, 1, batch_count);
-    device_batch_vector<T> dx(X_size, 1, batch_count);
-    device_batch_vector<T> dy(Y_size, 1, batch_count);
+    device_batch_vector<T> dx(N, incx, batch_count);
+    device_batch_vector<T> dy(N, incy, batch_count);
     device_vector<T>       d_alpha(1);
     device_vector<T>       d_beta(1);
 
@@ -134,15 +145,15 @@ hipblasStatus_t testing_hemv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, N, batch_count, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host
-                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host, batch_count);
+                = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_host, batch_count);
             hipblas_error_device
-                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device, batch_count);
+                = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_hemv_strided_batched.hpp
+++ b/clients/include/testing_hemv_strided_batched.hpp
@@ -28,9 +28,12 @@ hipblasStatus_t testing_hemv_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stride_A = lda * N * stride_scale;
-    hipblasStride stride_x = N * incx * stride_scale;
-    hipblasStride stride_y = N * incy * stride_scale;
+    int abs_incx = incx >= 0 ? incx : -incx;
+    int abs_incy = incy >= 0 ? incy : -incy;
+
+    hipblasStride stride_A = size_t(lda) * N * stride_scale;
+    hipblasStride stride_x = size_t(N) * abs_incx * stride_scale;
+    hipblasStride stride_y = size_t(N) * abs_incy * stride_scale;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
@@ -38,11 +41,31 @@ hipblasStatus_t testing_hemv_strided_batched(const Arguments& argus)
     size_t X_size = stride_x * batch_count;
     size_t Y_size = stride_y * batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < N || incx <= 0 || incy <= 0 || batch_count < 0)
+    bool invalid_size = N < 0 || lda < N || lda < 1 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHemvStridedBatchedFn(handle,
+                                                             uplo,
+                                                             N,
+                                                             nullptr,
+                                                             nullptr,
+                                                             lda,
+                                                             stride_A,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             nullptr,
+                                                             nullptr,
+                                                             incy,
+                                                             stride_y,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -64,13 +87,11 @@ hipblasStatus_t testing_hemv_strided_batched(const Arguments& argus)
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, N, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, N, abs_incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, N, abs_incy, stride_y, batch_count);
 
     // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
     hy_cpu = hy;
@@ -148,15 +169,15 @@ hipblasStatus_t testing_hemv_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incy, stride_y, hy_cpu, hy_host);
-            unit_check_general<T>(1, N, batch_count, incy, stride_y, hy_cpu, hy_device);
+            unit_check_general<T>(1, N, batch_count, abs_incy, stride_y, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, abs_incy, stride_y, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
-            hipblas_error_host
-                = norm_check_general<T>('F', 1, N, incy, stride_y, hy_cpu, hy_host, batch_count);
-            hipblas_error_device
-                = norm_check_general<T>('F', 1, N, incy, stride_y, hy_cpu, hy_device, batch_count);
+            hipblas_error_host = norm_check_general<T>(
+                'F', 1, N, abs_incy, stride_y, hy_cpu, hy_host, batch_count);
+            hipblas_error_device = norm_check_general<T>(
+                'F', 1, N, abs_incy, stride_y, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_her.hpp
+++ b/clients/include/testing_her.hpp
@@ -25,14 +25,23 @@ hipblasStatus_t testing_her(const Arguments& argus)
     int incx = argus.incx;
     int lda  = argus.lda;
 
-    size_t            A_size = size_t(lda) * N;
-    hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
+    int               abs_incx = incx >= 0 ? incx : -incx;
+    size_t            A_size   = size_t(lda) * N;
+    size_t            x_size   = size_t(N) * abs_incx;
+    hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
+
+    hipblasLocalHandle handle(argus);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < N || incx == 0)
+    bool invalid_size = N < 0 || lda < N || lda < 1 || !incx;
+    if(invalid_size || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual
+            = hipblasHerFn(handle, uplo, N, nullptr, nullptr, incx, nullptr, lda);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -40,29 +49,27 @@ hipblasStatus_t testing_her(const Arguments& argus)
     host_vector<T> hA_cpu(A_size);
     host_vector<T> hA_host(A_size);
     host_vector<T> hA_device(A_size);
-    host_vector<T> hx(N * incx);
+    host_vector<T> hx(x_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(N * incx);
+    device_vector<T> dx(x_size);
     device_vector<U> d_alpha(1);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     U h_alpha = argus.get_alpha<U>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, N, lda);
-    hipblas_init<T>(hx, 1, N, incx);
+    hipblas_init<T>(hx, 1, N, abs_incx);
 
     // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
     hA_cpu = hA;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(U), hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)

--- a/clients/include/testing_her2_batched.hpp
+++ b/clients/include/testing_her2_batched.hpp
@@ -34,18 +34,19 @@ hipblasStatus_t testing_her2_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < N || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || !incy || lda < N || lda < 1 || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHer2BatchedFn(
+            handle, uplo, N, nullptr, nullptr, incx, nullptr, incy, nullptr, lda, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_her2_strided_batched.hpp
+++ b/clients/include/testing_her2_strided_batched.hpp
@@ -28,23 +28,41 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
+    int abs_incx = incx >= 0 ? incx : -incx;
+    int abs_incy = incy >= 0 ? incy : -incy;
+
     hipblasStride     stride_A = size_t(lda) * N * stride_scale;
-    hipblasStride     stride_x = size_t(N) * incx * stride_scale;
-    hipblasStride     stride_y = size_t(N) * incy * stride_scale;
+    hipblasStride     stride_x = size_t(N) * abs_incx * stride_scale;
+    hipblasStride     stride_y = size_t(N) * abs_incy * stride_scale;
     size_t            A_size   = stride_A * batch_count;
     size_t            x_size   = stride_x * batch_count;
     size_t            y_size   = stride_y * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < N || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || !incy || lda < N || lda < 1 || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasHer2StridedBatchedFn(handle,
+                                                             uplo,
+                                                             N,
+                                                             nullptr,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             nullptr,
+                                                             incy,
+                                                             stride_y,
+                                                             nullptr,
+                                                             lda,
+                                                             stride_A,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -64,13 +82,11 @@ hipblasStatus_t testing_her2_strided_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, N, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, N, abs_incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, N, abs_incy, stride_y, batch_count);
 
     // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
     hA_cpu = hA;

--- a/clients/include/testing_her_batched.hpp
+++ b/clients/include/testing_her_batched.hpp
@@ -34,18 +34,19 @@ hipblasStatus_t testing_her_batched(const Arguments& argus)
 
     U h_alpha = argus.get_alpha<U>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < N || incx == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || lda < N || lda < 1 || !incx || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHerBatchedFn(
+            handle, uplo, N, nullptr, nullptr, incx, nullptr, lda, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_her_strided_batched.hpp
+++ b/clients/include/testing_her_strided_batched.hpp
@@ -28,21 +28,26 @@ hipblasStatus_t testing_her_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
+    int abs_incx = incx >= 0 ? incx : -incx;
+
     hipblasStride     stride_A = size_t(lda) * N * stride_scale;
-    hipblasStride     stride_x = size_t(N) * incx * stride_scale;
+    hipblasStride     stride_x = size_t(N) * abs_incx * stride_scale;
     size_t            A_size   = stride_A * batch_count;
     size_t            x_size   = stride_x * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < N || incx == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || lda < N || lda < 1 || !incx || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasHerStridedBatchedFn(
+            handle, uplo, N, nullptr, nullptr, incx, stride_x, nullptr, lda, stride_A, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -60,12 +65,10 @@ hipblasStatus_t testing_her_strided_batched(const Arguments& argus)
 
     U h_alpha = argus.get_alpha<U>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, N, N, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
+    hipblas_init<T>(hx, 1, N, abs_incx, stride_x, batch_count);
 
     // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
     hA_cpu = hA;

--- a/clients/include/testing_hpmv.hpp
+++ b/clients/include/testing_hpmv.hpp
@@ -24,28 +24,39 @@ hipblasStatus_t testing_hpmv(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(N) * (N + 1) / 2;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t A_size   = size_t(N) * (N + 1) / 2;
+    size_t x_size   = size_t(N) * abs_incx;
+    size_t y_size   = size_t(N) * abs_incy;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0 || incy == 0)
+    bool invalid_size = N < 0 || !incx || !incy;
+    if(invalid_size || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHpmvFn(
+            handle, uplo, N, nullptr, nullptr, nullptr, incx, nullptr, nullptr, incy);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hx(N * incx);
-    host_vector<T> hy(N * incy);
-    host_vector<T> hy_cpu(N * incy);
-    host_vector<T> hy_host(N * incy);
-    host_vector<T> hy_device(N * incy);
+    host_vector<T> hx(x_size);
+    host_vector<T> hy(y_size);
+    host_vector<T> hy_cpu(y_size);
+    host_vector<T> hy_host(y_size);
+    host_vector<T> hy_device(y_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(N * incx);
-    device_vector<T> dy(N * incy);
+    device_vector<T> dx(x_size);
+    device_vector<T> dy(y_size);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
 
@@ -54,21 +65,19 @@ hipblasStatus_t testing_hpmv(const Arguments& argus)
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, A_size, 1);
-    hipblas_init<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, N, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
 
     // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
     hy_cpu = hy;
 
     // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
@@ -81,15 +90,14 @@ hipblasStatus_t testing_hpmv(const Arguments& argus)
         CHECK_HIPBLAS_ERROR(
             hipblasHpmvFn(handle, uplo, N, (T*)&h_alpha, dA, dx, incx, (T*)&h_beta, dy, incy));
 
-        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIPBLAS_ERROR(
             hipblasHpmvFn(handle, uplo, N, d_alpha, dA, dx, incx, d_beta, dy, incy));
 
-        CHECK_HIP_ERROR(
-            hipMemcpy(hy_device.data(), dy, sizeof(T) * N * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * y_size, hipMemcpyDeviceToHost));
 
         /* =====================================================================
            CPU BLAS
@@ -101,19 +109,19 @@ hipblasStatus_t testing_hpmv(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, N, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, N, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
-            hipblas_error_host   = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host);
-            hipblas_error_device = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device);
+            hipblas_error_host   = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_device);
         }
     }
 
     if(argus.timing)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/testing_hpmv_batched.hpp
+++ b/clients/include/testing_hpmv_batched.hpp
@@ -25,25 +25,26 @@ hipblasStatus_t testing_hpmv_batched(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(N) * (N + 1) / 2;
-    size_t Y_size = size_t(N) * incy;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t A_size   = size_t(N) * (N + 1) / 2;
 
     int batch_count = argus.batch_count;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx <= 0 || incy <= 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHpmvBatchedFn(
+            handle, uplo, N, nullptr, nullptr, nullptr, incx, nullptr, nullptr, incy, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    hipblasLocalHandle handle(argus);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
@@ -130,15 +131,15 @@ hipblasStatus_t testing_hpmv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, Y_size, batch_count, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host
-                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_host, batch_count);
+                = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_host, batch_count);
             hipblas_error_device
-                = norm_check_general<T>('F', 1, N, incy, hy_cpu, hy_device, batch_count);
+                = norm_check_general<T>('F', 1, N, abs_incy, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_hpmv_strided_batched.hpp
+++ b/clients/include/testing_hpmv_strided_batched.hpp
@@ -27,21 +27,42 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    int           dim_A    = N * (N + 1) / 2;
+    int           abs_incx = incx >= 0 ? incx : -incx;
+    int           abs_incy = incy >= 0 ? incy : -incy;
+    size_t        dim_A    = size_t(N) * (N + 1) / 2;
     hipblasStride stride_A = dim_A * stride_scale;
-    hipblasStride stride_x = size_t(N) * incx * stride_scale;
-    hipblasStride stride_y = size_t(N) * incy * stride_scale;
+    hipblasStride stride_x = size_t(N) * abs_incx * stride_scale;
+    hipblasStride stride_y = size_t(N) * abs_incy * stride_scale;
 
     size_t            A_size = stride_A * batch_count;
     size_t            X_size = stride_x * batch_count;
     size_t            Y_size = stride_y * batch_count;
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx <= 0 || incy <= 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHpmvStridedBatchedFn(handle,
+                                                             uplo,
+                                                             N,
+                                                             nullptr,
+                                                             nullptr,
+                                                             stride_A,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             nullptr,
+                                                             nullptr,
+                                                             incy,
+                                                             stride_y,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -63,13 +84,11 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, dim_A, 1, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, N, abs_incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, N, abs_incy, stride_y, batch_count);
 
     // copy vector is easy in STL; hy_cpu = hy: save a copy in hy_cpu which will be output of CPU BLAS
     hy_cpu = hy;
@@ -144,15 +163,15 @@ hipblasStatus_t testing_hpmv_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, N, batch_count, incy, stride_y, hy_cpu, hy_host);
-            unit_check_general<T>(1, N, batch_count, incy, stride_y, hy_cpu, hy_device);
+            unit_check_general<T>(1, N, batch_count, abs_incy, stride_y, hy_cpu, hy_host);
+            unit_check_general<T>(1, N, batch_count, abs_incy, stride_y, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
-            hipblas_error_host
-                = norm_check_general<T>('F', 1, N, incy, stride_y, hy_cpu, hy_host, batch_count);
-            hipblas_error_device
-                = norm_check_general<T>('F', 1, N, incy, stride_y, hy_cpu, hy_device, batch_count);
+            hipblas_error_host = norm_check_general<T>(
+                'F', 1, N, abs_incy, stride_y, hy_cpu, hy_host, batch_count);
+            hipblas_error_device = norm_check_general<T>(
+                'F', 1, N, abs_incy, stride_y, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_hpr.hpp
+++ b/clients/include/testing_hpr.hpp
@@ -60,7 +60,7 @@ hipblasStatus_t testing_hpr(const Arguments& argus)
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, A_size, 1);
-    hipblas_init<T>(hx, 1, N, incx);
+    hipblas_init<T>(hx, 1, N, abs_incx);
 
     // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
     hA_cpu = hA;

--- a/clients/include/testing_hpr2.hpp
+++ b/clients/include/testing_hpr2.hpp
@@ -24,14 +24,25 @@ hipblasStatus_t testing_hpr2(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t            A_size = size_t(N) * (N + 1) / 2;
-    hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
+    int               abs_incx = incx >= 0 ? incx : -incx;
+    int               abs_incy = incy >= 0 ? incy : -incy;
+    size_t            x_size   = size_t(N) * abs_incx;
+    size_t            y_size   = size_t(N) * abs_incy;
+    size_t            A_size   = size_t(N) * (N + 1) / 2;
+    hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
+
+    hipblasLocalHandle handle(argus);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0 || incy == 0)
+    bool invalid_size = N < 0 || !incx || !incy;
+    if(invalid_size || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual
+            = hipblasHpr2Fn(handle, uplo, N, nullptr, nullptr, incx, nullptr, incy, nullptr);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -39,33 +50,31 @@ hipblasStatus_t testing_hpr2(const Arguments& argus)
     host_vector<T> hA_cpu(A_size);
     host_vector<T> hA_host(A_size);
     host_vector<T> hA_device(A_size);
-    host_vector<T> hx(N * incx);
-    host_vector<T> hy(N * incy);
+    host_vector<T> hx(x_size);
+    host_vector<T> hy(y_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(N * incx);
-    device_vector<T> dy(N * incy);
+    device_vector<T> dx(x_size);
+    device_vector<T> dy(y_size);
     device_vector<T> d_alpha(1);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     T h_alpha = argus.get_alpha<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, A_size, 1);
-    hipblas_init<T>(hx, 1, N, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, N, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
 
     // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
     hA_cpu = hA;
 
     // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * N * incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)

--- a/clients/include/testing_hpr2_batched.hpp
+++ b/clients/include/testing_hpr2_batched.hpp
@@ -33,18 +33,19 @@ hipblasStatus_t testing_hpr2_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasHpr2BatchedFn(
+            handle, uplo, N, nullptr, nullptr, incx, nullptr, incy, nullptr, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_hpr2_strided_batched.hpp
+++ b/clients/include/testing_hpr2_strided_batched.hpp
@@ -27,24 +27,40 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
+    int               abs_incx = incx >= 0 ? incx : -incx;
+    int               abs_incy = incy >= 0 ? incy : -incy;
     size_t            dim_A    = size_t(N) * (N + 1) / 2;
     hipblasStride     stride_A = dim_A * stride_scale;
-    hipblasStride     stride_x = size_t(N) * incx * stride_scale;
-    hipblasStride     stride_y = size_t(N) * incy * stride_scale;
+    hipblasStride     stride_x = size_t(N) * abs_incx * stride_scale;
+    hipblasStride     stride_y = size_t(N) * abs_incy * stride_scale;
     size_t            A_size   = stride_A * batch_count;
     size_t            x_size   = stride_x * batch_count;
     size_t            y_size   = stride_y * batch_count;
     hipblasFillMode_t uplo     = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasHpr2StridedBatchedFn(handle,
+                                                             uplo,
+                                                             N,
+                                                             nullptr,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             nullptr,
+                                                             incy,
+                                                             stride_y,
+                                                             nullptr,
+                                                             stride_A,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -64,13 +80,11 @@ hipblasStatus_t testing_hpr2_strided_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, dim_A, 1, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, N, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, N, abs_incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, N, abs_incy, stride_y, batch_count);
 
     // copy matrix is easy in STL; hA_cpu = hA: save a copy in hA_cpu which will be output of CPU BLAS
     hA_cpu = hA;

--- a/clients/include/testing_hpr_batched.hpp
+++ b/clients/include/testing_hpr_batched.hpp
@@ -33,18 +33,19 @@ hipblasStatus_t testing_hpr_batched(const Arguments& argus)
 
     U h_alpha = argus.get_alpha<U>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual
+            = hipblasHprBatchedFn(handle, uplo, N, nullptr, nullptr, incx, nullptr, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
-    }
-
-    hipblasLocalHandle handle(argus);
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_tbmv.hpp
+++ b/clients/include/testing_tbmv.hpp
@@ -60,7 +60,7 @@ hipblasStatus_t testing_tbmv(const Arguments& argus)
 
     // Initial Data on CPU
     srand(1);
-    hipblas_init<T>(hA, M, M, lda);
+    hipblas_init<T>(hA, 1, A_size, 1);
     hipblas_init<T>(hx, 1, M, abs_incx);
 
     // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
@@ -89,7 +89,7 @@ hipblasStatus_t testing_tbmv(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, incx, hx_cpu, hx_res);
+            unit_check_general<T>(1, M, abs_incx, hx_cpu, hx_res);
         }
         if(argus.norm_check)
         {

--- a/clients/include/testing_tbmv.hpp
+++ b/clients/include/testing_tbmv.hpp
@@ -25,18 +25,26 @@ hipblasStatus_t testing_tbmv(const Arguments& argus)
     int lda  = argus.lda;
     int incx = argus.incx;
 
-    size_t A_size = size_t(lda) * M;
-    size_t x_size = size_t(M) * incx;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    size_t A_size   = size_t(lda) * M;
+    size_t x_size   = size_t(M) * abs_incx;
 
     hipblasFillMode_t  uplo   = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasDiagType_t  diag   = char2hipblas_diagonal(argus.diag_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || K < 0 || lda < M || incx == 0)
+    bool invalid_size = M < 0 || K < 0 || lda < K + 1 || !incx;
+    if(invalid_size || !M)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual
+            = hipblasTbmvFn(handle, uplo, transA, diag, M, K, nullptr, lda, nullptr, incx);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -48,13 +56,12 @@ hipblasStatus_t testing_tbmv(const Arguments& argus)
     device_vector<T> dA(A_size);
     device_vector<T> dx(x_size);
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error;
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, M, lda);
-    hipblas_init<T>(hx, 1, M, incx);
+    hipblas_init<T>(hx, 1, M, abs_incx);
 
     // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
     hx_cpu = hx;
@@ -86,7 +93,8 @@ hipblasStatus_t testing_tbmv(const Arguments& argus)
         }
         if(argus.norm_check)
         {
-            hipblas_error = norm_check_general<T>('F', 1, M, incx, hx_cpu.data(), hx_res.data());
+            hipblas_error
+                = norm_check_general<T>('F', 1, M, abs_incx, hx_cpu.data(), hx_res.data());
         }
     }
 

--- a/clients/include/testing_tbmv_batched.hpp
+++ b/clients/include/testing_tbmv_batched.hpp
@@ -26,28 +26,30 @@ hipblasStatus_t testing_tbmv_batched(const Arguments& argus)
     int lda  = argus.lda;
     int incx = argus.incx;
 
-    size_t A_size = size_t(lda) * M;
-
-    int batch_count = argus.batch_count;
+    int    abs_incx    = incx >= 0 ? incx : -incx;
+    size_t A_size      = size_t(lda) * M;
+    int    batch_count = argus.batch_count;
 
     hipblasFillMode_t  uplo   = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasDiagType_t  diag   = char2hipblas_diagonal(argus.diag_option);
     hipblasStatus_t    status = HIPBLAS_STATUS_SUCCESS;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || K < 0 || lda < M || incx == 0 || batch_count < 0)
+    bool invalid_size = M < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasTbmvBatchedFn(
+            handle, uplo, transA, diag, M, K, nullptr, lda, nullptr, incx, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error;
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);
@@ -101,11 +103,11 @@ hipblasStatus_t testing_tbmv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, batch_count, incx, hx_cpu, hx_res);
+            unit_check_general<T>(1, M, batch_count, abs_incx, hx_cpu, hx_res);
         }
         if(argus.norm_check)
         {
-            hipblas_error = norm_check_general<T>('F', 1, M, incx, hx_cpu, hx_res, batch_count);
+            hipblas_error = norm_check_general<T>('F', 1, M, abs_incx, hx_cpu, hx_res, batch_count);
         }
     }
 

--- a/clients/include/testing_tbmv_strided_batched.hpp
+++ b/clients/include/testing_tbmv_strided_batched.hpp
@@ -28,8 +28,9 @@ hipblasStatus_t testing_tbmv_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stride_A = lda * M * stride_scale;
-    hipblasStride stride_x = M * incx * stride_scale;
+    int           abs_incx = incx >= 0 ? incx : -incx;
+    hipblasStride stride_A = size_t(lda) * M * stride_scale;
+    hipblasStride stride_x = size_t(M) * abs_incx * stride_scale;
 
     size_t A_size = stride_A * batch_count;
     size_t x_size = stride_x * batch_count;
@@ -38,11 +39,29 @@ hipblasStatus_t testing_tbmv_strided_batched(const Arguments& argus)
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasDiagType_t  diag   = char2hipblas_diagonal(argus.diag_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || K < 0 || lda < M || incx == 0 || batch_count < 0)
+    bool invalid_size = M < 0 || K < 0 || lda < K + 1 || !incx || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasTbmvStridedBatchedFn(handle,
+                                                             uplo,
+                                                             transA,
+                                                             diag,
+                                                             M,
+                                                             K,
+                                                             nullptr,
+                                                             lda,
+                                                             stride_A,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -54,13 +73,12 @@ hipblasStatus_t testing_tbmv_strided_batched(const Arguments& argus)
     device_vector<T> dA(A_size);
     device_vector<T> dx(x_size);
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error;
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, M, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, M, incx, stride_x, batch_count);
+    hipblas_init<T>(hx, 1, M, abs_incx, stride_x, batch_count);
     hx_cpu = hx;
 
     // copy data from CPU to device
@@ -98,12 +116,12 @@ hipblasStatus_t testing_tbmv_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, batch_count, incx, stride_x, hx_cpu, hx_res);
+            unit_check_general<T>(1, M, batch_count, abs_incx, stride_x, hx_cpu, hx_res);
         }
         if(argus.norm_check)
         {
             hipblas_error = norm_check_general<T>(
-                'F', 1, M, incx, stride_x, hx_cpu.data(), hx_res.data(), batch_count);
+                'F', 1, M, abs_incx, stride_x, hx_cpu.data(), hx_res.data(), batch_count);
         }
     }
 

--- a/clients/include/testing_tpmv_strided_batched.hpp
+++ b/clients/include/testing_tpmv_strided_batched.hpp
@@ -65,7 +65,7 @@ hipblasStatus_t testing_tpmv_strided_batched(const Arguments& argus)
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, dim_A, 1, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, M, incx, stride_x, batch_count);
+    hipblas_init<T>(hx, 1, M, abs_incx, stride_x, batch_count);
     hres = hx;
 
     // copy data from CPU to device

--- a/clients/include/testing_trmv.hpp
+++ b/clients/include/testing_trmv.hpp
@@ -24,41 +24,49 @@ hipblasStatus_t testing_trmv(const Arguments& argus)
     int lda  = argus.lda;
     int incx = argus.incx;
 
-    size_t A_size = size_t(lda) * M;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    size_t x_size   = size_t(M) * abs_incx;
+    size_t A_size   = size_t(lda) * M;
 
     hipblasFillMode_t  uplo   = char2hipblas_fill(argus.uplo_option);
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasDiagType_t  diag   = char2hipblas_diagonal(argus.diag_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || lda < M || incx == 0)
+    bool invalid_size = M < 0 || lda < M || lda < 1 || !incx;
+    if(invalid_size || !M)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual
+            = hipblasTrmvFn(handle, uplo, transA, diag, M, nullptr, lda, nullptr, incx);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hx(M * incx);
-    host_vector<T> hres(M * incx);
+    host_vector<T> hx(x_size);
+    host_vector<T> hres(x_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(M * incx);
+    device_vector<T> dx(x_size);
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error;
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, M, lda);
-    hipblas_init<T>(hx, 1, M, incx);
+    hipblas_init<T>(hx, 1, M, abs_incx);
 
     // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
     hres = hx;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * M, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * M * incx, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)
     {
@@ -68,7 +76,7 @@ hipblasStatus_t testing_trmv(const Arguments& argus)
         CHECK_HIPBLAS_ERROR(hipblasTrmvFn(handle, uplo, transA, diag, M, dA, lda, dx, incx));
 
         // copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * M * incx, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hres.data(), dx, sizeof(T) * x_size, hipMemcpyDeviceToHost));
 
         /* =====================================================================
            CPU BLAS
@@ -79,11 +87,11 @@ hipblasStatus_t testing_trmv(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, incx, hx, hres);
+            unit_check_general<T>(1, M, abs_incx, hx, hres);
         }
         if(argus.norm_check)
         {
-            hipblas_error = norm_check_general<T>('F', 1, M, incx, hx.data(), hres.data());
+            hipblas_error = norm_check_general<T>('F', 1, M, abs_incx, hx.data(), hres.data());
         }
     }
 

--- a/clients/include/testing_trmv_batched.hpp
+++ b/clients/include/testing_trmv_batched.hpp
@@ -25,8 +25,8 @@ hipblasStatus_t testing_trmv_batched(const Arguments& argus)
     int lda  = argus.lda;
     int incx = argus.incx;
 
-    size_t A_size = size_t(lda) * M;
-    size_t X_size = size_t(M) * incx;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    size_t A_size   = size_t(lda) * M;
 
     int batch_count = argus.batch_count;
 
@@ -34,19 +34,21 @@ hipblasStatus_t testing_trmv_batched(const Arguments& argus)
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasDiagType_t  diag   = char2hipblas_diagonal(argus.diag_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || lda < M || incx == 0 || batch_count < 0)
+    bool invalid_size = M < 0 || lda < M || lda < 1 || !incx || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasTrmvBatchedFn(
+            handle, uplo, transA, diag, M, nullptr, lda, nullptr, incx, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error;
 
     // arrays of pointers-to-host on host
     host_batch_vector<T> hA(A_size, 1, batch_count);
@@ -96,11 +98,11 @@ hipblasStatus_t testing_trmv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, batch_count, incx, hx, hres);
+            unit_check_general<T>(1, M, batch_count, abs_incx, hx, hres);
         }
         if(argus.norm_check)
         {
-            hipblas_error = norm_check_general<T>('F', 1, M, incx, hx, hres, batch_count);
+            hipblas_error = norm_check_general<T>('F', 1, M, abs_incx, hx, hres, batch_count);
         }
     }
 

--- a/clients/include/testing_trmv_strided_batched.hpp
+++ b/clients/include/testing_trmv_strided_batched.hpp
@@ -27,8 +27,9 @@ hipblasStatus_t testing_trmv_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stride_A = lda * M * stride_scale;
-    hipblasStride stride_x = M * incx * stride_scale;
+    int           abs_incx = incx >= 0 ? incx : -incx;
+    hipblasStride stride_A = size_t(lda) * M * stride_scale;
+    hipblasStride stride_x = size_t(M) * abs_incx * stride_scale;
 
     size_t A_size = stride_A * batch_count;
     size_t X_size = stride_x * batch_count;
@@ -37,11 +38,28 @@ hipblasStatus_t testing_trmv_strided_batched(const Arguments& argus)
     hipblasOperation_t transA = char2hipblas_operation(argus.transA_option);
     hipblasDiagType_t  diag   = char2hipblas_diagonal(argus.diag_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || lda < M || incx == 0 || batch_count < 0)
+    bool invalid_size = M < 0 || lda < M || lda < 1 || !incx || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasTrmvStridedBatchedFn(handle,
+                                                             uplo,
+                                                             transA,
+                                                             diag,
+                                                             M,
+                                                             nullptr,
+                                                             lda,
+                                                             stride_A,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -52,13 +70,12 @@ hipblasStatus_t testing_trmv_strided_batched(const Arguments& argus)
     device_vector<T> dA(A_size);
     device_vector<T> dx(X_size);
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error;
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, M, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, M, incx, stride_x, batch_count);
+    hipblas_init<T>(hx, 1, M, abs_incx, stride_x, batch_count);
     hres = hx;
 
     // copy data from CPU to device
@@ -94,11 +111,12 @@ hipblasStatus_t testing_trmv_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, batch_count, incx, stride_x, hx, hres);
+            unit_check_general<T>(1, M, batch_count, abs_incx, stride_x, hx, hres);
         }
         if(argus.norm_check)
         {
-            hipblas_error = norm_check_general<T>('F', 1, M, incx, stride_x, hx, hres, batch_count);
+            hipblas_error
+                = norm_check_general<T>('F', 1, M, abs_incx, stride_x, hx, hres, batch_count);
         }
     }
 


### PR DESCRIPTION
Allowing negative incx/incy and adding tests for bad inputs. Doing half of the L2s here, will do another PR for the rest.

@TorreZuk After thinking some more about [your comment](https://github.com/ROCmSoftwarePlatform/hipBLAS/pull/376#discussion_r708450335), I think I agree, we should be using the gtest macros. I've done that for these changes, let me know what you think.

I've made these changes here for: gbmv, gemv, hbmv, hemv, her, her2, hpmv, hpr, hpr2, trmv, tpmv, and tbmv.