### PR TITLE
Modify hipBLAS level2 BLAS GFLOPs

### DIFF
--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -325,14 +325,14 @@ constexpr double hemv_gflop_count(int n)
 template <typename T>
 constexpr double her_gflop_count(int n)
 {
-    return (4.0 * n * n + 6.0 * n) / 1e9;
+    return (4.0 * n * n) / 1e9;
 }
 
 /* \brief floating point counts of HER2 */
 template <typename T>
 constexpr double her2_gflop_count(int n)
 {
-    return (8.0 * n * n + 20.0 * n) / 1e9;
+    return (8.0 * (n + 1) * n) / 1e9;
 }
 
 /* \brief floating point counts of HPMV */
@@ -498,35 +498,22 @@ constexpr double spr2_gflop_count(int n)
 }
 
 /* \brief floating point counts of GER */
-template <typename T, bool CONJ>
+template <typename T>
 constexpr double ger_gflop_count(int m, int n)
 {
-    return (2.0 * m * n) / 1e9;
+    return (6.0 * (double(m) * n + std::min(m, n)) + 2.0 * m * n) / 1e9;
 }
 
 template <>
-constexpr double ger_gflop_count<hipblasComplex, false>(int m, int n)
+constexpr double ger_gflop_count<float>(int m, int n)
 {
-    return 4.0 * ger_gflop_count<float, false>(m, n);
+    return ((2.0 * m * n) + std::min(m, n)) / 1e9;
 }
 
 template <>
-constexpr double ger_gflop_count<hipblasComplex, true>(int m, int n)
+constexpr double ger_gflop_count<double>(int m, int n)
 {
-
-    return 4.0 * ger_gflop_count<float, false>(m, n) + n / 1e9; // +n for conjugate
-}
-
-template <>
-constexpr double ger_gflop_count<hipblasDoubleComplex, false>(int m, int n)
-{
-    return ger_gflop_count<hipblasComplex, false>(m, n);
-}
-
-template <>
-constexpr double ger_gflop_count<hipblasDoubleComplex, true>(int m, int n)
-{
-    return ger_gflop_count<hipblasComplex, true>(m, n);
+    return ger_gflop_count<float>(m, n);
 }
 
 /* \brief floating point counts of SYR */

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -401,21 +401,21 @@ template <typename T>
 constexpr double tbmv_gflop_count(int m, int k)
 {
     int k1 = k < m ? k : m;
-    return ((2.0 * m * k1 - k1 * (k1 + 1)) + m) / 1e9;
+    return ((2.0 * m * k1 - double(k1) * (k1 + 1)) + m) / 1e9;
 }
 
 template <>
 constexpr double tbmv_gflop_count<hipblasComplex>(int m, int k)
 {
     int k1 = k < m ? k : m;
-    return (4.0 * (2 * m * k1 - k1 * (k1 + 1)) + 4 * m) / 1e9;
+    return (4.0 * (2.0 * m * k1 - double(k1) * (k1 + 1)) + 4.0 * m) / 1e9;
 }
 
 template <>
 constexpr double tbmv_gflop_count<hipblasDoubleComplex>(int m, int k)
 {
     int k1 = k < m ? k : m;
-    return (4.0 * (2.0 * m * k1 - k1 * (k1 + 1)) + 4 * m) / 1e9;
+    return (4.0 * (2.0 * m * k1 - double(k1) * (k1 + 1)) + 4.0 * m) / 1e9;
 }
 
 /* \brief floating point counts of TPSV */

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -210,38 +210,38 @@ constexpr double swap_gflop_count(int n)
 template <typename T>
 constexpr double tpmv_gflop_count(int m)
 {
-    return (m * m) / 1e9;
+    return (double(m) * m) / 1e9;
 }
 
 template <>
 constexpr double tpmv_gflop_count<hipblasComplex>(int m)
 {
-    return (2.0 * m * (2.0 * m + 1.0)) / 1e9;
+    return (4.0 * m * m) / 1e9;
 }
 
 template <>
 constexpr double tpmv_gflop_count<hipblasDoubleComplex>(int m)
 {
-    return (2.0 * m * (2.0 * m + 1.0)) / 1e9;
+    return tpmv_gflop_count<hipblasComplex>(m);
 }
 
 /* \brief floating point counts of trmv */
 template <typename T>
 constexpr double trmv_gflop_count(int m)
 {
-    return (m * m) / 1e9;
+    return (double(m) * m) / 1e9;
 }
 
 template <>
 constexpr double trmv_gflop_count<hipblasComplex>(int m)
 {
-    return (2.0 * m * (2.0 * m + 1.0)) / 1e9;
+    return (4.0 * m * m) / 1e9;
 }
 
 template <>
 constexpr double trmv_gflop_count<hipblasDoubleComplex>(int m)
 {
-    return (2.0 * m * (2.0 * m + 1.0)) / 1e9;
+    return trmv_gflop_count<hipblasComplex>(m);
 }
 
 /* \brief floating point counts of GBMV */
@@ -346,14 +346,14 @@ constexpr double hpmv_gflop_count(int n)
 template <typename T>
 constexpr double hpr_gflop_count(int n)
 {
-    return (4.0 * n * n + 6.0 * n) / 1e9;
+    return (4.0 * n * n) / 1e9;
 }
 
 /* \brief floating point counts of HPR2 */
 template <typename T>
 constexpr double hpr2_gflop_count(int n)
 {
-    return (8.0 * n * n + 20.0 * n) / 1e9;
+    return (8.0 * (n + 1) * n) / 1e9;
 }
 
 /* \brief floating point counts or TBSV */
@@ -379,9 +379,21 @@ constexpr double tbsv_gflop_count<hipblasDoubleComplex>(int n, int k)
 
 /* \brief floating point counts of TRSV */
 template <typename T>
-constexpr double trsv_gflop_count(int m)
+constexpr double trsv_gflop_count(int n)
 {
-    return (m * m) / 1e9;
+    return (double(n) * n) / 1e9;
+}
+
+template <>
+constexpr double trsv_gflop_count<hipblasComplex>(int n)
+{
+    return (4.0 * n * n) / 1e9;
+}
+
+template <>
+constexpr double trsv_gflop_count<hipblasDoubleComplex>(int n)
+{
+    return trsv_gflop_count<hipblasComplex>(n);
 }
 
 /* \brief floating point counts of TBMV */
@@ -389,28 +401,28 @@ template <typename T>
 constexpr double tbmv_gflop_count(int m, int k)
 {
     int k1 = k < m ? k : m;
-    return ((2 * m * k1 - k1 * (k1 + 1)) + m) / 1e9;
+    return ((2.0 * m * k1 - k1 * (k1 + 1)) + m) / 1e9;
 }
 
 template <>
 constexpr double tbmv_gflop_count<hipblasComplex>(int m, int k)
 {
     int k1 = k < m ? k : m;
-    return (4 * (2 * m * k1 - k1 * (k1 + 1)) + 4 * m) / 1e9;
+    return (4.0 * (2 * m * k1 - k1 * (k1 + 1)) + 4 * m) / 1e9;
 }
 
 template <>
 constexpr double tbmv_gflop_count<hipblasDoubleComplex>(int m, int k)
 {
     int k1 = k < m ? k : m;
-    return (4 * (2 * m * k1 - k1 * (k1 + 1)) + 4 * m) / 1e9;
+    return (4.0 * (2.0 * m * k1 - k1 * (k1 + 1)) + 4 * m) / 1e9;
 }
 
 /* \brief floating point counts of TPSV */
 template <typename T>
 constexpr double tpsv_gflop_count(int n)
 {
-    return (n * n) / 1e9;
+    return (double(n) * n) / 1e9;
 }
 
 template <>
@@ -422,7 +434,7 @@ constexpr double tpsv_gflop_count<hipblasComplex>(int n)
 template <>
 constexpr double tpsv_gflop_count<hipblasDoubleComplex>(int n)
 {
-    return (4.0 * n * n) / 1e9;
+    return tpsv_gflop_count<hipblasComplex>(n);
 }
 
 /* \brief floating point counts of SY(HE)MV */
@@ -521,7 +533,7 @@ constexpr double ger_gflop_count<hipblasDoubleComplex, true>(int m, int n)
 template <typename T>
 constexpr double syr_gflop_count(int n)
 {
-    return (n * (n + 1.0) + n) / 1e9;
+    return (n * (double(n) + 1.0) + n) / 1e9;
 }
 
 template <>
@@ -546,13 +558,13 @@ constexpr double syr2_gflop_count(int n)
 template <>
 constexpr double syr2_gflop_count<hipblasComplex>(int n)
 {
-    return (8 * (n + 1.0) * n + 12.0 * n) / 1e9;
+    return (8.0 * (n + 1.0) * n + 12.0 * n) / 1e9;
 }
 
 template <>
 constexpr double syr2_gflop_count<hipblasDoubleComplex>(int n)
 {
-    return (8 * (n + 1.0) * n + 12.0 * n) / 1e9;
+    return (8.0 * (n + 1.0) * n + 12.0 * n) / 1e9;
 }
 
 /*
@@ -698,7 +710,7 @@ constexpr double herkx_gflop_count<hipblasDoubleComplex>(int n, int k)
 template <typename T>
 constexpr double symm_gflop_count(int m, int n, int k)
 {
-    return ((2 * k - 1.0) * m * n + 2.0 * m * n) / 1e9;
+    return ((2.0 * k - 1.0) * m * n + 2.0 * m * n) / 1e9;
 }
 
 template <>
@@ -825,90 +837,6 @@ template <>
 constexpr double trtri_gflop_count<hipblasDoubleComplex>(int n)
 {
     return (8.0 * n * n * n) / 3e9;
-}
-
-/*
- * ===========================================================================
- *    Solver
- * ===========================================================================
- */
-
-/* \brief floating point counts of GEQRF */
-template <typename T>
-constexpr double geqrf_gflop_count(int n, int m)
-{
-    // Calculation is for m == n, using max of m, n for now
-    int k = std::max(m, n);
-    return ((4.0 / 3.0) * k * k * k);
-}
-
-template <>
-constexpr double geqrf_gflop_count<hipblasComplex>(int n, int m)
-{
-    return 4.0 * geqrf_gflop_count<float>(n, m);
-}
-
-template <>
-constexpr double geqrf_gflop_count<hipblasDoubleComplex>(int n, int m)
-{
-    return 4.0 * geqrf_gflop_count<float>(n, m);
-}
-
-/* \brief floating point counts of GETRF */
-template <typename T>
-constexpr double getrf_gflop_count(int n, int m)
-{
-    return (m * n * n) / 1e9;
-}
-
-template <>
-constexpr double getrf_gflop_count<hipblasComplex>(int n, int m)
-{
-    return 4.0 * getrf_gflop_count<float>(n, m);
-}
-
-template <>
-constexpr double getrf_gflop_count<hipblasDoubleComplex>(int n, int m)
-{
-    return 4.0 * getrf_gflop_count<float>(n, m);
-}
-
-/* \brief floating point counts of GETRI */
-template <typename T>
-constexpr double getri_gflop_count(int n)
-{
-    return ((4.0 / 3.0) * n * n * n) / 1e9;
-}
-
-template <>
-constexpr double getri_gflop_count<hipblasComplex>(int n)
-{
-    return 4.0 * getri_gflop_count<float>(n);
-}
-
-template <>
-constexpr double getri_gflop_count<hipblasDoubleComplex>(int n)
-{
-    return 4.0 * getri_gflop_count<float>(n);
-}
-
-/* \brief floating point counts of GETRS */
-template <typename T>
-constexpr double getrs_gflop_count(int n, int nrhs)
-{
-    return (2.0 * n * n * nrhs) / 1e9;
-}
-
-template <>
-constexpr double getrs_gflop_count<hipblasComplex>(int n, int nrhs)
-{
-    return 4.0 * getrs_gflop_count<float>(n, nrhs);
-}
-
-template <>
-constexpr double getrs_gflop_count<hipblasDoubleComplex>(int n, int nrhs)
-{
-    return 4.0 * getrs_gflop_count<float>(n, nrhs);
 }
 
 #endif /* _HIPBLAS_FLOPS_H_ */

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -839,4 +839,88 @@ constexpr double trtri_gflop_count<hipblasDoubleComplex>(int n)
     return (8.0 * n * n * n) / 3e9;
 }
 
+/*
+ * ===========================================================================
+ *    Solver
+ * ===========================================================================
+ */
+
+/* \brief floating point counts of GEQRF */
+template <typename T>
+constexpr double geqrf_gflop_count(int n, int m)
+{
+    // Calculation is for m == n, using max of m, n for now
+    int k = std::max(m, n);
+    return ((4.0 / 3.0) * k * k * k);
+}
+
+template <>
+constexpr double geqrf_gflop_count<hipblasComplex>(int n, int m)
+{
+    return 4.0 * geqrf_gflop_count<float>(n, m);
+}
+
+template <>
+constexpr double geqrf_gflop_count<hipblasDoubleComplex>(int n, int m)
+{
+    return 4.0 * geqrf_gflop_count<float>(n, m);
+}
+
+/* \brief floating point counts of GETRF */
+template <typename T>
+constexpr double getrf_gflop_count(int n, int m)
+{
+    return (m * n * n) / 1e9;
+}
+
+template <>
+constexpr double getrf_gflop_count<hipblasComplex>(int n, int m)
+{
+    return 4.0 * getrf_gflop_count<float>(n, m);
+}
+
+template <>
+constexpr double getrf_gflop_count<hipblasDoubleComplex>(int n, int m)
+{
+    return 4.0 * getrf_gflop_count<float>(n, m);
+}
+
+/* \brief floating point counts of GETRI */
+template <typename T>
+constexpr double getri_gflop_count(int n)
+{
+    return ((4.0 / 3.0) * n * n * n) / 1e9;
+}
+
+template <>
+constexpr double getri_gflop_count<hipblasComplex>(int n)
+{
+    return 4.0 * getri_gflop_count<float>(n);
+}
+
+template <>
+constexpr double getri_gflop_count<hipblasDoubleComplex>(int n)
+{
+    return 4.0 * getri_gflop_count<float>(n);
+}
+
+/* \brief floating point counts of GETRS */
+template <typename T>
+constexpr double getrs_gflop_count(int n, int nrhs)
+{
+    return (2.0 * n * n * nrhs) / 1e9;
+}
+
+template <>
+constexpr double getrs_gflop_count<hipblasComplex>(int n, int nrhs)
+{
+    return 4.0 * getrs_gflop_count<float>(n, nrhs);
+}
+
+template <>
+constexpr double getrs_gflop_count<hipblasDoubleComplex>(int n, int nrhs)
+{
+    return 4.0 * getrs_gflop_count<float>(n, nrhs);
+}
+
 #endif /* _HIPBLAS_FLOPS_H_ */

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -128,7 +128,7 @@ hipblasStatus_t testing_ger(const Arguments& argus)
             std::cout,
             argus,
             gpu_time_used,
-            ger_gflop_count<T, CONJ>(M, N),
+            ger_gflop_count<T>(M, N),
             ger_gbyte_count<T>(M, N),
             hipblas_error_host,
             hipblas_error_device);

--- a/clients/include/testing_ger_batched.hpp
+++ b/clients/include/testing_ger_batched.hpp
@@ -169,7 +169,7 @@ hipblasStatus_t testing_ger_batched(const Arguments& argus)
             std::cout,
             argus,
             gpu_time_used,
-            ger_gflop_count<T, CONJ>(M, N),
+            ger_gflop_count<T>(M, N),
             ger_gbyte_count<T>(M, N),
             hipblas_error_host,
             hipblas_error_device);

--- a/clients/include/testing_ger_strided_batched.hpp
+++ b/clients/include/testing_ger_strided_batched.hpp
@@ -201,7 +201,7 @@ hipblasStatus_t testing_ger_strided_batched(const Arguments& argus)
             .log_args<T>(std::cout,
                          argus,
                          gpu_time_used,
-                         ger_gflop_count<T, CONJ>(M, N),
+                         ger_gflop_count<T>(M, N),
                          ger_gbyte_count<T>(M, N),
                          hipblas_error_host,
                          hipblas_error_device);


### PR DESCRIPTION
This PR modifies the GFLOPs calculation of hipBLAS level 2 functions to be identical to level 2 rocBLAS functions.


