### PR TITLE
Allowing negative increments in hipblas tests (L2-2)

### DIFF
--- a/clients/gtest/dgmm_gtest.cpp
+++ b/clients/gtest/dgmm_gtest.cpp
@@ -42,9 +42,10 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // vector of vector, each vector is a {M, N, lda, incx, ldc};
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
-    {-1, -1, -1, -1, -1},
-    {128, 130, 150, 1, 150},
-    {1000, 1000, 1000, 2, 1000},
+    {-1, -1, -1, -1, -1}, {128, 128, 150, -1, 150}, {1000, 1000, 1000, 2, 1000},
+
+    // TODO: rocBLAS dgmm is currently broken when (M != N && incx < 0 && side == L)
+    // {128, 130, 150, -1, 150},
 };
 
 const vector<char> side_range = {

--- a/clients/gtest/ger_gtest.cpp
+++ b/clients/gtest/ger_gtest.cpp
@@ -54,7 +54,7 @@ const vector<vector<int>> matrix_size_range = {
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, -1}, {2, 1}
+    {-1, -1}, {0, -1}, {2, 1}
     //     {10, 100}
 };
 

--- a/clients/gtest/sbmv_gtest.cpp
+++ b/clients/gtest/sbmv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<vector<int>> matrix_size_range = {
 
 // vector of vector, each element is an {incx, incy}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, 0}, {2, 2}
+    {-1, -1}, {0, 0}, {1, 2}
     //     {10, 100}
 };
 

--- a/clients/gtest/spmv_gtest.cpp
+++ b/clients/gtest/spmv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<int> matrix_size_range = {
 
 // vector of vector, each element is an {incx, incy}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, 0}, {2, 2}
+    {-1, -1}, {0, 0}, {1, 2}
     //     {10, 100}
 };
 

--- a/clients/gtest/spr2_gtest.cpp
+++ b/clients/gtest/spr2_gtest.cpp
@@ -45,7 +45,7 @@ const vector<int> matrix_size_range = {-1, 11, 16, 32, 65};
 
 // vector of vector, each element is an {incx, incy}
 const vector<vector<int>> incx_incy_range = {
-    {-2, -2}, {1, 1}, {0, 0}, {2, 2}
+    {-1, -1}, {0, 0}, {1, 2}
     //     {10, 100}
 };
 

--- a/clients/gtest/symv_gtest.cpp
+++ b/clients/gtest/symv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<vector<int>> matrix_size_range = {
 
 // vector of vector, each element is an {incx, incy}
 const vector<vector<int>> incx_incy_range = {
-    {1, 1}, {0, 0}, {2, 2}
+    {-1, -1}, {0, 0}, {1, 2}
     //     {10, 100}
 };
 

--- a/clients/gtest/syr2_gtest.cpp
+++ b/clients/gtest/syr2_gtest.cpp
@@ -45,7 +45,7 @@ const vector<vector<int>> matrix_size_range = {{-1, -1}, {11, 11}, {16, 16}, {32
 
 // vector of vector, each element is an {incx, incy}
 const vector<vector<int>> incx_incy_range = {
-    {-2, -2}, {1, 1}, {0, 0}, {2, 2}
+    {-1, -1}, {0, 0}, {1, 2}
     //     {10, 100}
 };
 

--- a/clients/gtest/tbsv_gtest.cpp
+++ b/clients/gtest/tbsv_gtest.cpp
@@ -53,7 +53,7 @@ const vector<vector<int>> matrix_size_range = {
 
 // vector of vector, each element is an {incx}
 const vector<vector<int>> incx_incy_range = {
-    {1}, {0}, {2}
+    {-1}, {0}, {2}
     //     {10, 100}
 };
 

--- a/clients/include/testing_dgmm_batched.hpp
+++ b/clients/include/testing_dgmm_batched.hpp
@@ -34,11 +34,18 @@ hipblasStatus_t testing_dgmm_batched(const Arguments& argus)
     size_t C_size = size_t(ldc) * N;
     int    k      = (side == HIPBLAS_SIDE_RIGHT ? N : M);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || lda < M || ldc < M || batch_count < 0)
+    bool invalid_size = M < 0 || N < 0 || ldc < M || lda < M || batch_count < 0;
+    if(invalid_size || !N || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasDgmmBatchedFn(
+            handle, side, M, N, nullptr, lda, nullptr, incx, nullptr, ldc, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -58,8 +65,7 @@ hipblasStatus_t testing_dgmm_batched(const Arguments& argus)
     CHECK_HIP_ERROR(dx.memcheck());
     CHECK_HIP_ERROR(dC.memcheck());
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error;
 
     // Initial Data on CPU
     hipblas_init(hA, true);
@@ -98,6 +104,7 @@ hipblasStatus_t testing_dgmm_batched(const Arguments& argus)
         =================================================================== */
 
         // reference calculation
+        ptrdiff_t shift_x = incx < 0 ? -ptrdiff_t(incx) * (N - 1) : 0;
         for(int b = 0; b < batch_count; b++)
         {
             for(size_t i1 = 0; i1 < M; i1++)
@@ -107,12 +114,12 @@ hipblasStatus_t testing_dgmm_batched(const Arguments& argus)
                     if(HIPBLAS_SIDE_RIGHT == side)
                     {
                         hC_gold[b][i1 + i2 * ldc]
-                            = hA_copy[b][i1 + i2 * lda] * hx_copy[b][i2 * incx];
+                            = hA_copy[b][i1 + i2 * lda] * hx_copy[b][shift_x + i2 * incx];
                     }
                     else
                     {
                         hC_gold[b][i1 + i2 * ldc]
-                            = hA_copy[b][i1 + i2 * lda] * hx_copy[b][i1 * incx];
+                            = hA_copy[b][i1 + i2 * lda] * hx_copy[b][shift_x + i1 * incx];
                     }
                 }
             }

--- a/clients/include/testing_dgmm_strided_batched.hpp
+++ b/clients/include/testing_dgmm_strided_batched.hpp
@@ -32,8 +32,9 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    k            = (side == HIPBLAS_SIDE_RIGHT ? N : M);
 
+    int           abs_incx = incx >= 0 ? incx : -incx;
     hipblasStride stride_A = size_t(lda) * N * stride_scale;
-    hipblasStride stride_x = size_t(incx) * k * stride_scale;
+    hipblasStride stride_x = size_t(abs_incx) * k * stride_scale;
     hipblasStride stride_C = size_t(ldc) * N * stride_scale;
     if(!stride_x)
         stride_x = 1;
@@ -42,11 +43,30 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
     size_t C_size = size_t(stride_C) * batch_count;
     size_t X_size = size_t(stride_x) * batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || lda < M || ldc < M || batch_count < 0)
+    bool invalid_size = M < 0 || N < 0 || ldc < M || lda < M || batch_count < 0;
+    if(invalid_size || !N || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasDgmmStridedBatchedFn(handle,
+                                                             side,
+                                                             M,
+                                                             N,
+                                                             nullptr,
+                                                             lda,
+                                                             stride_A,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             nullptr,
+                                                             ldc,
+                                                             stride_C,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -62,13 +82,12 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
     device_vector<T> dx(X_size);
     device_vector<T> dC(C_size);
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error;
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, k, incx, stride_x, batch_count);
+    hipblas_init<T>(hx, 1, k, abs_incx, stride_x, batch_count);
     hipblas_init<T>(hC, M, N, ldc, stride_C, batch_count);
     hA_copy = hA;
     hx_copy = hx;
@@ -108,6 +127,7 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
         =================================================================== */
 
         // reference calculation
+        ptrdiff_t shift_x = incx < 0 ? -ptrdiff_t(incx) * (N - 1) : 0;
         for(int b = 0; b < batch_count; b++)
         {
             auto hC_goldb = hC_gold + b * stride_C;
@@ -119,11 +139,13 @@ hipblasStatus_t testing_dgmm_strided_batched(const Arguments& argus)
                 {
                     if(HIPBLAS_SIDE_RIGHT == side)
                     {
-                        hC_goldb[i1 + i2 * ldc] = hA_copyb[i1 + i2 * lda] * hx_copyb[i2 * incx];
+                        hC_goldb[i1 + i2 * ldc]
+                            = hA_copyb[i1 + i2 * lda] * hx_copyb[shift_x + i2 * incx];
                     }
                     else
                     {
-                        hC_goldb[i1 + i2 * ldc] = hA_copyb[i1 + i2 * lda] * hx_copyb[i1 * incx];
+                        hC_goldb[i1 + i2 * ldc]
+                            = hA_copyb[i1 + i2 * lda] * hx_copyb[shift_x + i1 * incx];
                     }
                 }
             }

--- a/clients/include/testing_ger.hpp
+++ b/clients/include/testing_ger.hpp
@@ -27,13 +27,24 @@ hipblasStatus_t testing_ger(const Arguments& argus)
     int incy = argus.incy;
     int lda  = argus.lda;
 
-    size_t A_size = size_t(lda) * N;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t x_size   = size_t(M) * abs_incx;
+    size_t y_size   = size_t(M) * abs_incy;
+    size_t A_size   = size_t(lda) * N;
+
+    hipblasLocalHandle handle(argus);
 
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || lda < 0 || incx <= 0 || incy <= 0)
+    bool invalid_size = M < 0 || N < 0 || !incx || !incy || lda < M || lda < 1;
+    if(invalid_size || !M || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual
+            = hipblasGerFn(handle, M, N, nullptr, nullptr, incx, nullptr, incy, nullptr, lda);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -41,33 +52,31 @@ hipblasStatus_t testing_ger(const Arguments& argus)
     host_vector<T> hA_host(A_size);
     host_vector<T> hA_device(A_size);
     host_vector<T> hA_cpu(A_size);
-    host_vector<T> hx(M * incx);
-    host_vector<T> hy(N * incy);
+    host_vector<T> hx(x_size);
+    host_vector<T> hy(y_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(M * incx);
-    device_vector<T> dy(N * incy);
+    device_vector<T> dx(x_size);
+    device_vector<T> dy(y_size);
     device_vector<T> d_alpha(1);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     T h_alpha = argus.get_alpha<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda);
-    hipblas_init<T>(hx, 1, M, incx);
-    hipblas_init<T>(hy, 1, N, incy);
+    hipblas_init<T>(hx, 1, M, abs_incx);
+    hipblas_init<T>(hy, 1, N, abs_incy);
 
     // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
     hA_cpu = hA;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * M * incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * N * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
 
     if(argus.unit_check || argus.norm_check)
@@ -109,7 +118,7 @@ hipblasStatus_t testing_ger(const Arguments& argus)
 
     if(argus.timing)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * N, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/testing_ger_strided_batched.hpp
+++ b/clients/include/testing_ger_strided_batched.hpp
@@ -31,22 +31,39 @@ hipblasStatus_t testing_ger_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
+    int           abs_incx = incx >= 0 ? incx : -incx;
+    int           abs_incy = incy >= 0 ? incy : -incy;
     hipblasStride stride_A = size_t(lda) * N * stride_scale;
-    hipblasStride stride_x = size_t(M) * incx * stride_scale;
-    hipblasStride stride_y = size_t(N) * incy * stride_scale;
+    hipblasStride stride_x = size_t(M) * abs_incx * stride_scale;
+    hipblasStride stride_y = size_t(N) * abs_incy * stride_scale;
     size_t        A_size   = stride_A * batch_count;
     size_t        x_size   = stride_x * batch_count;
     size_t        y_size   = stride_y * batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || N < 0 || lda < 0 || incx <= 0 || incy <= 0 || batch_count < 0)
+    bool invalid_size = M < 0 || N < 0 || !incx || !incy || lda < M || lda < 1 || batch_count < 0;
+    if(invalid_size || !M || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasGerStridedBatchedFn(handle,
+                                                            M,
+                                                            N,
+                                                            nullptr,
+                                                            nullptr,
+                                                            incx,
+                                                            stride_x,
+                                                            nullptr,
+                                                            incy,
+                                                            stride_y,
+                                                            nullptr,
+                                                            lda,
+                                                            stride_A,
+                                                            batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -66,13 +83,11 @@ hipblasStatus_t testing_ger_strided_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, N, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, M, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, N, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, M, abs_incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, N, abs_incy, stride_y, batch_count);
 
     // copy matrix is easy in STL; hB = hA: save a copy in hB which will be output of CPU BLAS
     hA_cpu = hA;

--- a/clients/include/testing_sbmv.hpp
+++ b/clients/include/testing_sbmv.hpp
@@ -26,15 +26,26 @@ hipblasStatus_t testing_sbmv(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(lda) * M;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t x_size   = size_t(M) * abs_incx;
+    size_t y_size   = size_t(M) * abs_incy;
+    size_t A_size   = size_t(lda) * M;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || K < 0 || lda < K + 1 || incx == 0 || incy == 0)
+    bool invalid_size = M < 0 || K < 0 || lda < K + 1 || lda < 1 || !incx || !incy;
+    if(invalid_size || !M)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasSbmvFn(
+            handle, uplo, M, K, nullptr, nullptr, lda, nullptr, incx, nullptr, nullptr, incy);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     T h_alpha = argus.get_alpha<T>();
@@ -42,35 +53,33 @@ hipblasStatus_t testing_sbmv(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hx(M * incx);
-    host_vector<T> hy(M * incy);
-    host_vector<T> hy_cpu(M * incy);
-    host_vector<T> hy_host(M * incy);
-    host_vector<T> hy_device(M * incy);
+    host_vector<T> hx(x_size);
+    host_vector<T> hy(y_size);
+    host_vector<T> hy_cpu(y_size);
+    host_vector<T> hy_host(y_size);
+    host_vector<T> hy_device(y_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(M * incx);
-    device_vector<T> dy(M * incy);
+    device_vector<T> dx(x_size);
+    device_vector<T> dy(y_size);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, M, lda);
-    hipblas_init<T>(hx, 1, M, incx);
-    hipblas_init<T>(hy, 1, M, incy);
+    hipblas_init<T>(hx, 1, M, abs_incx);
+    hipblas_init<T>(hy, 1, M, abs_incy);
 
     // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
     hy_cpu = hy;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * M, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * M * incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
@@ -84,15 +93,14 @@ hipblasStatus_t testing_sbmv(const Arguments& argus)
             hipblasSbmvFn(handle, uplo, M, K, &h_alpha, dA, lda, dx, incx, &h_beta, dy, incy));
 
         // copy output from device to CPU
-        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIPBLAS_ERROR(
             hipblasSbmvFn(handle, uplo, M, K, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
 
-        CHECK_HIP_ERROR(
-            hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * y_size, hipMemcpyDeviceToHost));
 
         /* =====================================================================
            CPU BLAS
@@ -104,19 +112,19 @@ hipblasStatus_t testing_sbmv(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, M, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, M, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, M, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
-            hipblas_error_host   = norm_check_general<T>('F', 1, M, incy, hy_cpu, hy_host);
-            hipblas_error_device = norm_check_general<T>('F', 1, M, incy, hy_cpu, hy_device);
+            hipblas_error_host   = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu, hy_device);
         }
     }
 
     if(argus.timing)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/testing_sbmv_batched.hpp
+++ b/clients/include/testing_sbmv_batched.hpp
@@ -27,26 +27,40 @@ hipblasStatus_t testing_sbmv_batched(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(lda) * M;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t A_size   = size_t(lda) * M;
 
     int batch_count = argus.batch_count;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || K < 0 || lda < K + 1 || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size
+        = M < 0 || K < 0 || lda < K + 1 || lda < 1 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasSbmvBatchedFn(handle,
+                                                      uplo,
+                                                      M,
+                                                      K,
+                                                      nullptr,
+                                                      nullptr,
+                                                      lda,
+                                                      nullptr,
+                                                      incx,
+                                                      nullptr,
+                                                      nullptr,
+                                                      incy,
+                                                      batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
@@ -135,16 +149,16 @@ hipblasStatus_t testing_sbmv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, batch_count, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, M, batch_count, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, M, batch_count, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, M, batch_count, abs_incy, hy_cpu, hy_device);
         }
 
         if(argus.norm_check)
         {
             hipblas_error_host
-                = norm_check_general<T>('F', 1, M, incy, hy_cpu, hy_host, batch_count);
+                = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu, hy_host, batch_count);
             hipblas_error_device
-                = norm_check_general<T>('F', 1, M, incy, hy_cpu, hy_device, batch_count);
+                = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_spmv.hpp
+++ b/clients/include/testing_spmv.hpp
@@ -24,16 +24,27 @@ hipblasStatus_t testing_spmv(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(M) * (M + 1) / 2;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t x_size   = size_t(M) * abs_incx;
+    size_t y_size   = size_t(M) * abs_incy;
+    size_t A_size   = size_t(M) * (M + 1) / 2;
 
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
     hipblasStatus_t   status = HIPBLAS_STATUS_SUCCESS;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || incx == 0 || incy == 0)
+    bool invalid_size = M < 0 || !incx || !incy;
+    if(invalid_size || !M)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasSpmvFn(
+            handle, uplo, M, nullptr, nullptr, nullptr, incx, nullptr, nullptr, incy);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     T h_alpha = argus.get_alpha<T>();
@@ -41,35 +52,33 @@ hipblasStatus_t testing_spmv(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hx(M * incx);
-    host_vector<T> hy(M * incy);
-    host_vector<T> hy_cpu(M * incy);
-    host_vector<T> hy_host(M * incy);
-    host_vector<T> hy_device(M * incy);
+    host_vector<T> hx(x_size);
+    host_vector<T> hy(y_size);
+    host_vector<T> hy_cpu(y_size);
+    host_vector<T> hy_host(y_size);
+    host_vector<T> hy_device(y_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(M * incx);
-    device_vector<T> dy(M * incy);
+    device_vector<T> dx(x_size);
+    device_vector<T> dy(y_size);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
-    hipblasLocalHandle handle(argus);
-
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, A_size, 1);
-    hipblas_init<T>(hx, 1, M, incx);
-    hipblas_init<T>(hy, 1, M, incy);
+    hipblas_init<T>(hx, 1, M, abs_incx);
+    hipblas_init<T>(hy, 1, M, abs_incy);
 
     // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
     hy_cpu = hy;
 
     // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * M * incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
@@ -82,15 +91,14 @@ hipblasStatus_t testing_spmv(const Arguments& argus)
         CHECK_HIPBLAS_ERROR(
             hipblasSpmvFn(handle, uplo, M, &h_alpha, dA, dx, incx, &h_beta, dy, incy));
 
-        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIPBLAS_ERROR(
             hipblasSpmvFn(handle, uplo, M, d_alpha, dA, dx, incx, d_beta, dy, incy));
 
-        CHECK_HIP_ERROR(
-            hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * y_size, hipMemcpyDeviceToHost));
 
         /* =====================================================================
            CPU BLAS
@@ -101,19 +109,19 @@ hipblasStatus_t testing_spmv(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, M, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, M, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, M, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
-            hipblas_error_host   = norm_check_general<T>('F', 1, M, incy, hy_cpu, hy_host);
-            hipblas_error_device = norm_check_general<T>('F', 1, M, incy, hy_cpu, hy_device);
+            hipblas_error_host   = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu, hy_host);
+            hipblas_error_device = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu, hy_device);
         }
     }
 
     if(argus.timing)
     {
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
         hipStream_t stream;
         CHECK_HIPBLAS_ERROR(hipblasGetStream(handle, &stream));
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/testing_spmv_batched.hpp
+++ b/clients/include/testing_spmv_batched.hpp
@@ -25,26 +25,28 @@ hipblasStatus_t testing_spmv_batched(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(M) * (M + 1) / 2;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t A_size   = size_t(M) * (M + 1) / 2;
 
     int batch_count = argus.batch_count;
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = M < 0 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasSpmvBatchedFn(
+            handle, uplo, M, nullptr, nullptr, nullptr, incx, nullptr, nullptr, incy, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
-
-    hipblasLocalHandle handle(argus);
 
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
@@ -128,15 +130,15 @@ hipblasStatus_t testing_spmv_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, batch_count, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, M, batch_count, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, M, batch_count, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, M, batch_count, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host
-                = norm_check_general<T>('F', 1, M, incy, hy_cpu, hy_host, batch_count);
+                = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu, hy_host, batch_count);
             hipblas_error_device
-                = norm_check_general<T>('F', 1, M, incy, hy_cpu, hy_device, batch_count);
+                = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_spr.hpp
+++ b/clients/include/testing_spr.hpp
@@ -29,11 +29,17 @@ hipblasStatus_t testing_spr(const Arguments& argus)
     size_t A_size   = size_t(N) * (N + 1) / 2;
     size_t x_size   = abs_incx * size_t(N);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0)
+    bool invalid_size = N < 0 || !incx;
+    if(invalid_size || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasSprFn(handle, uplo, N, nullptr, nullptr, incx, nullptr);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -49,8 +55,7 @@ hipblasStatus_t testing_spr(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_spr2.hpp
+++ b/clients/include/testing_spr2.hpp
@@ -32,14 +32,19 @@ hipblasStatus_t testing_spr2(const Arguments& argus)
     size_t x_size   = abs_incx * size_t(N);
     size_t y_size   = abs_incy * size_t(N);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0 || incy == 0)
+    bool invalid_size = N < 0 || !incx || !incy;
+    if(invalid_size || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual
+            = hipblasSpr2Fn(handle, uplo, N, nullptr, nullptr, incx, nullptr, incy, nullptr);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    if(incx < 0 || incy < 0)
-        return HIPBLAS_STATUS_SUCCESS;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
@@ -56,8 +61,7 @@ hipblasStatus_t testing_spr2(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_spr2_batched.hpp
+++ b/clients/include/testing_spr2_batched.hpp
@@ -34,15 +34,21 @@ hipblasStatus_t testing_spr2_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0 || incy == 0 || batch_count < 0)
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    else if(batch_count == 0)
-        return HIPBLAS_STATUS_SUCCESS;
+    bool invalid_size = N < 0 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
+    {
+        hipblasStatus_t actual = hipblasSpr2BatchedFn(
+            handle, uplo, N, nullptr, nullptr, incx, nullptr, incy, nullptr, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
+    }
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_spr2_strided_batched.hpp
+++ b/clients/include/testing_spr2_strided_batched.hpp
@@ -40,15 +40,29 @@ hipblasStatus_t testing_spr2_strided_batched(const Arguments& argus)
     size_t        x_size  = stridex * batch_count;
     size_t        y_size  = stridey * batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasSpr2StridedBatchedFn(handle,
+                                                             uplo,
+                                                             N,
+                                                             nullptr,
+                                                             nullptr,
+                                                             incx,
+                                                             stridex,
+                                                             nullptr,
+                                                             incy,
+                                                             stridey,
+                                                             nullptr,
+                                                             strideA,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -66,9 +80,7 @@ hipblasStatus_t testing_spr2_strided_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
-
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, 1, A_dim, 1, strideA, batch_count);

--- a/clients/include/testing_spr_batched.hpp
+++ b/clients/include/testing_spr_batched.hpp
@@ -31,20 +31,21 @@ hipblasStatus_t testing_spr_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    // TODO: not ACTUALLY incx < 0 returns invalid as a workaround for cuda tests right now
-    if(N < 0 || incx == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual
+            = hipblasSprBatchedFn(handle, uplo, N, nullptr, nullptr, incx, nullptr, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_symv.hpp
+++ b/clients/include/testing_symv.hpp
@@ -25,16 +25,27 @@ hipblasStatus_t testing_symv(const Arguments& argus)
     int incx = argus.incx;
     int incy = argus.incy;
 
-    size_t A_size = size_t(lda) * M;
+    int    abs_incx = incx >= 0 ? incx : -incx;
+    int    abs_incy = incy >= 0 ? incy : -incy;
+    size_t x_size   = size_t(M) * abs_incx;
+    size_t y_size   = size_t(M) * abs_incy;
+    size_t A_size   = size_t(lda) * M;
 
     hipblasFillMode_t uplo   = char2hipblas_fill(argus.uplo_option);
     hipblasStatus_t   status = HIPBLAS_STATUS_SUCCESS;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || lda < M || incx == 0 || incy == 0)
+    bool invalid_size = M < 0 || lda < M || lda < 1 || !incx || !incy;
+    if(invalid_size || !M)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasSymvFn(
+            handle, uplo, M, nullptr, nullptr, lda, nullptr, incx, nullptr, nullptr, incy);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     T h_alpha = argus.get_alpha<T>();
@@ -42,34 +53,33 @@ hipblasStatus_t testing_symv(const Arguments& argus)
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
-    host_vector<T> hx(M * incx);
-    host_vector<T> hy(M * incy);
-    host_vector<T> hy_cpu(M * incy);
-    host_vector<T> hy_host(M * incy);
-    host_vector<T> hy_device(M * incy);
+    host_vector<T> hx(x_size);
+    host_vector<T> hy(y_size);
+    host_vector<T> hy_cpu(y_size);
+    host_vector<T> hy_host(y_size);
+    host_vector<T> hy_device(y_size);
 
     device_vector<T> dA(A_size);
-    device_vector<T> dx(M * incx);
-    device_vector<T> dy(M * incy);
+    device_vector<T> dx(x_size);
+    device_vector<T> dy(y_size);
     device_vector<T> d_alpha(1);
     device_vector<T> d_beta(1);
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, M, lda);
-    hipblas_init<T>(hx, 1, M, incx);
-    hipblas_init<T>(hy, 1, M, incy);
+    hipblas_init<T>(hx, 1, M, abs_incx);
+    hipblas_init<T>(hy, 1, M, abs_incy);
 
     // copy vector is easy in STL; hz = hy: save a copy in hz which will be output of CPU BLAS
     hy_cpu = hy;
 
     // copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * lda * M, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * M * incx, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA.data(), sizeof(T) * A_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dx, hx.data(), sizeof(T) * x_size, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
@@ -82,16 +92,15 @@ hipblasStatus_t testing_symv(const Arguments& argus)
         CHECK_HIPBLAS_ERROR(
             hipblasSymvFn(handle, uplo, M, &h_alpha, dA, lda, dx, incx, &h_beta, dy, incy));
 
-        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
-        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * M * incy, hipMemcpyHostToDevice));
+        CHECK_HIP_ERROR(hipMemcpy(hy_host.data(), dy, sizeof(T) * y_size, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dy, hy.data(), sizeof(T) * y_size, hipMemcpyHostToDevice));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         CHECK_HIPBLAS_ERROR(
             hipblasSymvFn(handle, uplo, M, d_alpha, dA, lda, dx, incx, d_beta, dy, incy));
 
         // copy output from device to CPU
-        CHECK_HIP_ERROR(
-            hipMemcpy(hy_device.data(), dy, sizeof(T) * M * incy, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(hy_device.data(), dy, sizeof(T) * y_size, hipMemcpyDeviceToHost));
 
         /* =====================================================================
            CPU BLAS
@@ -103,15 +112,15 @@ hipblasStatus_t testing_symv(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, incy, hy_cpu, hy_host);
-            unit_check_general<T>(1, M, incy, hy_cpu, hy_device);
+            unit_check_general<T>(1, M, abs_incy, hy_cpu, hy_host);
+            unit_check_general<T>(1, M, abs_incy, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
             hipblas_error_host
-                = norm_check_general<T>('F', 1, M, incy, hy_cpu.data(), hy_host.data());
+                = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu.data(), hy_host.data());
             hipblas_error_device
-                = norm_check_general<T>('F', 1, M, incy, hy_cpu.data(), hy_device.data());
+                = norm_check_general<T>('F', 1, M, abs_incy, hy_cpu.data(), hy_device.data());
         }
     }
 

--- a/clients/include/testing_symv_strided_batched.hpp
+++ b/clients/include/testing_symv_strided_batched.hpp
@@ -28,9 +28,11 @@ hipblasStatus_t testing_symv_strided_batched(const Arguments& argus)
     double stride_scale = argus.stride_scale;
     int    batch_count  = argus.batch_count;
 
-    hipblasStride stride_A = lda * M * stride_scale;
-    hipblasStride stride_x = M * incx * stride_scale;
-    hipblasStride stride_y = M * incy * stride_scale;
+    int           abs_incx = incx >= 0 ? incx : -incx;
+    int           abs_incy = incy >= 0 ? incy : -incy;
+    hipblasStride stride_A = size_t(lda) * M * stride_scale;
+    hipblasStride stride_x = size_t(M) * abs_incx * stride_scale;
+    hipblasStride stride_y = size_t(M) * abs_incy * stride_scale;
 
     size_t A_size = stride_A * batch_count;
     size_t X_size = stride_x * batch_count;
@@ -38,11 +40,31 @@ hipblasStatus_t testing_symv_strided_batched(const Arguments& argus)
 
     hipblasFillMode_t uplo = char2hipblas_fill(argus.uplo_option);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(M < 0 || lda < M || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = M < 0 || lda < M || lda < 1 || !incx || !incy || batch_count < 0;
+    if(invalid_size || !M || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual = hipblasSymvStridedBatchedFn(handle,
+                                                             uplo,
+                                                             M,
+                                                             nullptr,
+                                                             nullptr,
+                                                             lda,
+                                                             stride_A,
+                                                             nullptr,
+                                                             incx,
+                                                             stride_x,
+                                                             nullptr,
+                                                             nullptr,
+                                                             incy,
+                                                             stride_y,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -62,14 +84,13 @@ hipblasStatus_t testing_symv_strided_batched(const Arguments& argus)
     T h_alpha = argus.get_alpha<T>();
     T h_beta  = argus.get_beta<T>();
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);
     hipblas_init<T>(hA, M, M, lda, stride_A, batch_count);
-    hipblas_init<T>(hx, 1, M, incx, stride_x, batch_count);
-    hipblas_init<T>(hy, 1, M, incy, stride_y, batch_count);
+    hipblas_init<T>(hx, 1, M, abs_incx, stride_x, batch_count);
+    hipblas_init<T>(hy, 1, M, abs_incy, stride_y, batch_count);
     hy_cpu = hy;
 
     // copy data from CPU to device
@@ -144,15 +165,15 @@ hipblasStatus_t testing_symv_strided_batched(const Arguments& argus)
         // unit check and norm check can not be interchanged their order
         if(argus.unit_check)
         {
-            unit_check_general<T>(1, M, batch_count, incy, stride_y, hy_cpu, hy_host);
-            unit_check_general<T>(1, M, batch_count, incy, stride_y, hy_cpu, hy_device);
+            unit_check_general<T>(1, M, batch_count, abs_incy, stride_y, hy_cpu, hy_host);
+            unit_check_general<T>(1, M, batch_count, abs_incy, stride_y, hy_cpu, hy_device);
         }
         if(argus.norm_check)
         {
-            hipblas_error_host
-                = norm_check_general<T>('F', 1, M, incy, stride_y, hy_cpu, hy_host, batch_count);
-            hipblas_error_device
-                = norm_check_general<T>('F', 1, M, incy, stride_y, hy_cpu, hy_device, batch_count);
+            hipblas_error_host = norm_check_general<T>(
+                'F', 1, M, abs_incy, stride_y, hy_cpu, hy_host, batch_count);
+            hipblas_error_device = norm_check_general<T>(
+                'F', 1, M, abs_incy, stride_y, hy_cpu, hy_device, batch_count);
         }
     }
 

--- a/clients/include/testing_syr2.hpp
+++ b/clients/include/testing_syr2.hpp
@@ -33,14 +33,19 @@ hipblasStatus_t testing_syr2(const Arguments& argus)
     size_t x_size   = abs_incx * size_t(N);
     size_t y_size   = abs_incy * size_t(N);
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < 1 || lda < N || incx == 0 || incy == 0)
+    bool invalid_size = N < 0 || !incx || !incy || lda < N || lda < 1;
+    if(invalid_size || !N)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
+        hipblasStatus_t actual
+            = hipblasSyr2Fn(handle, uplo, N, nullptr, nullptr, incx, nullptr, incy, nullptr, lda);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
-    if(incx < 0 || incy < 0)
-        return HIPBLAS_STATUS_SUCCESS;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_vector<T> hA(A_size);
@@ -57,8 +62,7 @@ hipblasStatus_t testing_syr2(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_syr2_batched.hpp
+++ b/clients/include/testing_syr2_batched.hpp
@@ -35,15 +35,21 @@ hipblasStatus_t testing_syr2_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < 1 || lda < N || incx == 0 || incy == 0 || batch_count < 0)
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    else if(batch_count == 0)
-        return HIPBLAS_STATUS_SUCCESS;
+    bool invalid_size = N < 0 || !incx || !incy || lda < N || lda < 1 || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
+    {
+        hipblasStatus_t actual = hipblasSyr2BatchedFn(
+            handle, uplo, N, nullptr, nullptr, incx, nullptr, incy, nullptr, lda, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
+    }
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_syr2_strided_batched.hpp
+++ b/clients/include/testing_syr2_strided_batched.hpp
@@ -40,15 +40,30 @@ hipblasStatus_t testing_syr2_strided_batched(const Arguments& argus)
     size_t        x_size  = stridex * batch_count;
     size_t        y_size  = stridey * batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    if(N < 0 || lda < 1 || lda < N || incx == 0 || incy == 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || !incy || lda < N || lda < 1 || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasSyr2StridedBatchedFn(handle,
+                                                             uplo,
+                                                             N,
+                                                             nullptr,
+                                                             nullptr,
+                                                             incx,
+                                                             stridex,
+                                                             nullptr,
+                                                             incy,
+                                                             stridey,
+                                                             nullptr,
+                                                             lda,
+                                                             strideA,
+                                                             batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -66,8 +81,7 @@ hipblasStatus_t testing_syr2_strided_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);

--- a/clients/include/testing_syr_batched.hpp
+++ b/clients/include/testing_syr_batched.hpp
@@ -32,20 +32,21 @@ hipblasStatus_t testing_syr_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    // TODO: not ACTUALLY incx < 0 returns invalid as a workaround for cuda tests right now
-    if(N < 0 || lda < N || incx <= 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || lda < N || lda < 1 || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasSyrBatchedFn(
+            handle, uplo, N, nullptr, nullptr, incx, nullptr, lda, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_syr_strided_batched.hpp
+++ b/clients/include/testing_syr_strided_batched.hpp
@@ -31,21 +31,23 @@ hipblasStatus_t testing_syr_strided_batched(const Arguments& argus)
 
     int abs_incx = incx < 0 ? -incx : incx;
 
-    hipblasStride strideA = lda * N * stride_scale;
-    hipblasStride stridex = abs_incx * N * stride_scale;
+    hipblasStride strideA = size_t(lda) * N * stride_scale;
+    hipblasStride stridex = size_t(abs_incx) * N * stride_scale;
     size_t        A_size  = strideA * batch_count;
     size_t        x_size  = stridex * batch_count;
 
+    hipblasLocalHandle handle(argus);
+
     // argument sanity check, quick return if input parameters are invalid before allocating invalid
     // memory
-    // TODO: not ACTUALLY incx < 0 returns invalid as a workaround for cuda tests right now
-    if(N < 0 || lda < N || incx <= 0 || batch_count < 0)
+    bool invalid_size = N < 0 || !incx || lda < N || lda < 1 || batch_count < 0;
+    if(invalid_size || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    else if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        hipblasStatus_t actual = hipblasSyrStridedBatchedFn(
+            handle, uplo, N, nullptr, nullptr, incx, stridex, nullptr, lda, strideA, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            actual, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+        return actual;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -61,8 +63,7 @@ hipblasStatus_t testing_syr_strided_batched(const Arguments& argus)
 
     T h_alpha = argus.get_alpha<T>();
 
-    double             gpu_time_used, hipblas_error_host, hipblas_error_device;
-    hipblasLocalHandle handle(argus);
+    double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
     srand(1);


### PR DESCRIPTION
Same as #381 for the following:
- tbsv
- trsv
- tpsv
- symv
- spmv
- sbmv
- ger
- spr
- spr2
- syr
- syr2
- dgmm

Should be it for these changes.