### PR TITLE
change rocsolver to >= 3.15.0

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -67,8 +67,8 @@ endif( )
 
 # Package specific CPACK vars
 if( NOT USE_CUDA )
-    set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocblas (>= 2.42.0), rocsolver (>= 3.16.0)" )
-    set( CPACK_RPM_PACKAGE_REQUIRES "rocblas >= 2.42.0, rocsolver >= 3.16.0" )
+    set( CPACK_DEBIAN_PACKAGE_DEPENDS "rocblas (>= 2.42.0), rocsolver (>= 3.15.0)" )
+    set( CPACK_RPM_PACKAGE_REQUIRES "rocblas >= 2.42.0, rocsolver >= 3.15.0" )
 endif( )
 
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )


### PR DESCRIPTION
- the Jira ticket SWDEV-304322 has hipBLAS failing with 

2021-09-23T02:10:02.005772274Z  hipblas depends on rocsolver (>= 3.16.0); however:
2021-09-23T02:10:02.005774594Z   Version of rocsolver on system is 3.15.0.50000-crdnnh.8749.

- the rocSOLVER master branch version number is 3.15.0, you can see this here: https://github.com/ROCmSoftwarePlatform/rocSOLVER/blob/master/CMakeLists.txt#L61 
- this PR changes the required rocSOLVER version to >= 3.15.0 to match the rocSOLVER master branch version
