### PR TITLE
Clients CMake cleanup

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -7,10 +7,7 @@ find_package( Threads REQUIRED )
 
 # Linking lapack library requires fortran flags
 enable_language( Fortran )
-find_package( cblas CONFIG REQUIRED )
-if( NOT cblas_FOUND )
-  message( FATAL_ERROR "cblas is a required dependency and is not found;  try adding cblas path to CMAKE_PREFIX_PATH" )
-endif( )
+find_package( cblas REQUIRED CONFIG )
 
 if(LINK_BLIS)
   set( BLIS_CPP ../common/blis_interface.cpp )
@@ -32,11 +29,7 @@ if(LINK_BLIS)
 endif()
 
 if( NOT TARGET hipblas )
-  find_package( hipblas CONFIG PATHS /opt/rocm/hipblas )
-
-  if( NOT hipblas_FOUND )
-    message( FATAL_ERROR "hipBLAS is a required dependency and is not found; try adding hipblas path to CMAKE_PREFIX_PATH")
-  endif( )
+  find_package( hipblas REQUIRED CONFIG PATHS /opt/rocm/hipblas )
 endif( )
 
 find_package( GTest REQUIRED )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -53,6 +53,8 @@ target_compile_features( hipblas-bench PRIVATE cxx_static_assert cxx_nullptr cxx
 
 if(LINK_BLIS)
   target_link_libraries( hipblas-bench PRIVATE ${BLIS_LIBRARY} )
+else()
+  target_link_libraries( hipblas-bench PRIVATE blas )
 endif()
 
 # Internal header includes

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -32,9 +32,6 @@ if( NOT TARGET hipblas )
   find_package( hipblas REQUIRED CONFIG PATHS /opt/rocm/hipblas )
 endif( )
 
-find_package( GTest REQUIRED )
-include_directories(${GTEST_INCLUDE_DIRS})
-
 set( hipblas_benchmark_common
       ../common/utility.cpp
       ../common/cblas_interface.cpp

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -123,8 +123,10 @@ else( )
   target_link_libraries( hipblas-bench PRIVATE ${CUDA_LIBRARIES} Threads::Threads )
 endif( )
 
-set_target_properties( hipblas-bench PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO )
-set_target_properties( hipblas-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
-#add_dependencies( hipblas-bench hipblas-bench-common )
+set_target_properties( hipblas-bench PROPERTIES
+  DEBUG_POSTFIX "-d"
+  CXX_EXTENSIONS OFF
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
+)
 
 target_compile_definitions( hipblas-bench PRIVATE HIPBLAS_BENCH ROCM_USE_FLOAT16 )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -6,17 +6,10 @@
 if(NOT WIN32)
     enable_language( Fortran )
 endif()
-find_package( cblas CONFIG REQUIRED PATHS ${LAPACK_DIR} )
-if( NOT cblas_FOUND )
-  message( FATAL_ERROR "cblas is a required dependency and is not found;  try adding cblas path to CMAKE_PREFIX_PATH" )
-endif( )
+find_package( cblas REQUIRED CONFIG PATHS ${LAPACK_DIR} )
 
 if( NOT TARGET hipblas )
-  find_package( hipblas CONFIG PATHS /opt/rocm/hipblas )
-
-  if( NOT hipblas_FOUND )
-    message( FATAL_ERROR "hipBLAS is a required dependency and is not found; try adding hipblas path to CMAKE_PREFIX_PATH")
-  endif( )
+  find_package( hipblas REQUIRED CONFIG PATHS /opt/rocm/hipblas )
 endif( )
 
 find_package( GTest REQUIRED )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -13,7 +13,6 @@ if( NOT TARGET hipblas )
 endif( )
 
 find_package( GTest REQUIRED )
-include_directories(${GTEST_INCLUDE_DIRS})
 
 set(hipblas_test_source
   hipblas_gtest_main.cpp
@@ -138,7 +137,6 @@ target_compile_definitions( hipblas-test PRIVATE GOOGLE_TEST )
 # External header includes included as SYSTEM files
 target_include_directories( hipblas-test
   SYSTEM PRIVATE
-    $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
     ${ROCM_PATH}/hsa/include
@@ -148,7 +146,7 @@ if (NOT WIN32)
     target_link_libraries( hipblas-test PRIVATE hipblas_fortran_client roc::hipblas cblas lapack)
 endif()
 
-target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack ${GTEST_LIBRARIES} )
+target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack GTest::GTest )
 
 if(LINK_BLIS)
   target_link_libraries( hipblas-test PRIVATE ${BLIS_LIBRARY} )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -150,6 +150,8 @@ target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack GTest::GTe
 
 if(LINK_BLIS)
   target_link_libraries( hipblas-test PRIVATE ${BLIS_LIBRARY} )
+else()
+  target_link_libraries( hipblas-test PRIVATE blas )
 endif()
 
 # need mf16c flag for float->half convertion


### PR DESCRIPTION
When putting together https://github.com/spack/spack/pull/27074, I noticed that hipblas-test can end up missing some blas symbols. I patched it in Spack, but I figured I should probably make the change here, too.

While I was at it, I figured I'd make a couple other changes to clean up the clients build:

- Simplify CMake using REQUIRED
- Cleanup GTest in clients
- Ensure that blas is linked
- Consolidate hipblas-bench target properties
