### PR TITLE
Print version info in hipblas-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log for hipBLAS
 
+## (Unreleased) hipBLAS
+### Fixed
+- Added hipblasVersionMinor define. hipblaseVersionMinor remains defined
+  for backwards compatibility.
+
 ## (Unreleased) hipBLAS 0.49.0
 ### Added
 - Added rocSOLVER functions to hipblas-bench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log for hipBLAS
 
 ## (Unreleased) hipBLAS
+### Added
+- Added library version and device information to hipblas-test output.
+
 ### Fixed
 - Added hipblasVersionMinor define. hipblaseVersionMinor remains defined
   for backwards compatibility.

--- a/clients/gtest/hipblas_gtest_main.cpp
+++ b/clients/gtest/hipblas_gtest_main.cpp
@@ -3,10 +3,29 @@
  *
  * ************************************************************************ */
 
-#ifdef GOOGLE_TEST
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
 #include <gtest/gtest.h>
-#endif
-#include <stdexcept>
+#include <hipblas.h>
+
+#include "utility.h"
+
+#define STRINGIFY(s) STRINGIFY_HELPER(s)
+#define STRINGIFY_HELPER(s) #s
+
+static void print_version_info()
+{
+    // clang-format off
+    std::cout << "hipBLAS version "
+        STRINGIFY(hipblasVersionMajor) "."
+        STRINGIFY(hipblasVersionMinor) "."
+        STRINGIFY(hipblasVersionPatch) "."
+        STRINGIFY(hipblasVersionTweak)
+        << std::endl;
+    // clang-format on
+}
 
 /* =====================================================================
       Main function:
@@ -14,7 +33,20 @@
 
 int main(int argc, char** argv)
 {
+    print_version_info();
+
+    // print device info
+    int device_count = query_device_property();
+    if(device_count <= 0)
+    {
+        std::cerr << "Error: No devices found" << std::endl;
+        return EXIT_FAILURE;
+    }
+    set_device(0); // use first device
+
     ::testing::InitGoogleTest(&argc, argv);
 
-    return RUN_ALL_TESTS();
+    int status = RUN_ALL_TESTS();
+    print_version_info(); // redundant, but convenient when tests fail
+    return status;
 }

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -3,8 +3,6 @@
  * ************************************************************************ */
 
 #pragma once
-#ifndef _TESTING_UTILITY_H_
-#define _TESTING_UTILITY_H_
 
 #include "hipblas.h"
 #include <stdbool.h>
@@ -769,4 +767,3 @@ public:
 #include "hipblas_arguments.hpp"
 
 #endif // __cplusplus
-#endif

--- a/library/include/hipblas-version.h.in
+++ b/library/include/hipblas-version.h.in
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2020 Advanced Micro Devices, Inc.
+ * Copyright 2016-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #ifndef HIPBLAS_VERSION_H_
@@ -9,7 +9,8 @@
  */
 // clang-format off
 #define hipblasVersionMajor @hipblas_VERSION_MAJOR@
-#define hipblaseVersionMinor @hipblas_VERSION_MINOR@
+#define hipblaseVersionMinor @hipblas_VERSION_MINOR@ // typo preserved for compatibility
+#define hipblasVersionMinor @hipblas_VERSION_MINOR@
 #define hipblasVersionPatch @hipblas_VERSION_PATCH@
 #define hipblasVersionTweak @hipblas_VERSION_TWEAK@
 // clang-format on


### PR DESCRIPTION
- Print hipblas version and device info in hipblas-test
- Remove redundant include guard
- Fix typo in hipblasVersionMinor

Related PR: https://github.com/ROCmSoftwarePlatform/hipSOLVER/pull/59