### PR TITLE
addd cblas include directory to hipblas-bench include directory

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -75,6 +75,7 @@ target_include_directories( hipblas-bench
 target_include_directories( hipblas-bench
   SYSTEM PRIVATE
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
 )
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -147,6 +147,7 @@ target_include_directories( hipblas-test
   SYSTEM PRIVATE
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
     ${ROCM_PATH}/hsa/include
 )


### PR DESCRIPTION
resolves SWDEV-311824

- This removes an error where the compile for cblas_interface.cpp cannot locate the file cblas.h
- It adds CBLAS_INCLUDE_DIRS to the hipblas_bench target include directories