### PR TITLE
Merge back changelog hotfix for ROCm 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added hipblasVersionMinor define. hipblaseVersionMinor remains defined
   for backwards compatibility.
 
-## (Unreleased) hipBLAS 0.49.0
+## [hipBLAS 0.49.0 for ROCm 5.0.0]
 ### Added
 - Added rocSOLVER functions to hipblas-bench
 - Added option ROCM_MATHLIBS_API_USE_HIP_COMPLEX to opt-in to use hipFloatComplex and hipDoubleComplex


### PR DESCRIPTION
Following the instructions for [changelog updates](https://confluence.amd.com/display/MLSE/Changelogs+and+Release+Notes), I updated the changelog on release branch 5.0. I accidentally committed directly to the release branch rather than my fork and creating a PR. The only change was to CHANGELOG.md so I think it should be fine, but let me know if either of you disagree. This PR is for the merge back into develop.