### PR TITLE
Batched gemmEx int8 fix

### DIFF
--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2021 Advanced Micro Devices, Inc.
+ * Copyright 2016-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "testing_gemm_batched_ex.hpp"
@@ -410,9 +410,14 @@ TEST_P(parameterized_gemm_batched_ex, standard_batched)
         }
         else
         {
+#ifndef __HIP_PLATFORM_NVCC__
+            // on HIP we should pass all tests
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+#else
             // cublas/rocblas do not have identical support
             // (i.e. cublas doesn't support i8/i32 here)
             EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
+#endif
         }
     }
 }
@@ -452,9 +457,14 @@ TEST_P(parameterized_gemm_batched_ex, standard_strided_batched)
         }
         else
         {
+#ifndef __HIP_PLATFORM_NVCC__
+            // on HIP we should pass all tests
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+#else
             // cublas/rocblas do not have identical support
             // (i.e. cublas doesn't support i8/i32 here)
             EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
+#endif
         }
     }
 }
@@ -514,14 +524,14 @@ TEST_P(parameterized_gemm_batched_ex, standard_strided_batched)
 //     virtual void TearDown() {}
 // };
 
-// INSTANTIATE_TEST_SUITE_P(quick_blas_ex_small_int8,
-//                          parameterized_gemm_ex,
-//                          Combine(ValuesIn(int8_matrix_size_range),
-//                                  ValuesIn(alpha_beta_range_int8),
-//                                  ValuesIn(transA_transB_range),
-//                                  ValuesIn(precision_int8),
-//                                  ValuesIn(batch_count_range_small),
-//                                  ValuesIn(is_fortran)));
+INSTANTIATE_TEST_SUITE_P(quick_blas_ex_small_int8,
+                         parameterized_gemm_ex,
+                         Combine(ValuesIn(int8_matrix_size_range),
+                                 ValuesIn(alpha_beta_range_int8),
+                                 ValuesIn(transA_transB_range),
+                                 ValuesIn(precision_int8),
+                                 ValuesIn(batch_count_range_small),
+                                 ValuesIn(is_fortran)));
 
 // TEST(pre_checkin_blas_ex_bad_arg, float) { testing_gemm_ex_bad_arg(); }
 
@@ -672,11 +682,11 @@ INSTANTIATE_TEST_SUITE_P(quick_blas_batched_ex_small_double_complex,
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
 
-// INSTANTIATE_TEST_SUITE_P(quick_blas_batched_ex_small_int8,
-//                          parameterized_gemm_batched_ex,
-//                          Combine(ValuesIn(int8_matrix_size_range),
-//                                  ValuesIn(alpha_beta_range_int8),
-//                                  ValuesIn(transA_transB_range),
-//                                  ValuesIn(precision_int8),
-//                                  ValuesIn(batch_count_range),
-//                                  ValuesIn(is_fortran)));
+INSTANTIATE_TEST_SUITE_P(quick_blas_batched_ex_small_int8,
+                         parameterized_gemm_batched_ex,
+                         Combine(ValuesIn(int8_matrix_size_range),
+                                 ValuesIn(alpha_beta_range_int8),
+                                 ValuesIn(transA_transB_range),
+                                 ValuesIn(precision_int8),
+                                 ValuesIn(batch_count_range),
+                                 ValuesIn(is_fortran)));

--- a/library/src/hcc_detail/hipblas.cpp
+++ b/library/src/hcc_detail/hipblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2016-2021 Advanced Micro Devices, Inc.
+ * Copyright 2016-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 #include "hipblas.h"
 #include "exceptions.hpp"
@@ -17392,8 +17392,12 @@ hipblasStatus_t hipblasGemmBatchedEx(hipblasHandle_t    handle,
                                      hipblasGemmAlgo_t  algo)
 try
 {
-    uint32_t solution_index = 0;
-    uint32_t flags          = 0;
+    uint32_t           solution_index = 0;
+    rocblas_gemm_flags flags          = rocblas_gemm_flags_none;
+
+    rocblas_status status = rocblas_query_int8_layout_flag((rocblas_handle)handle, &flags);
+    if(status != rocblas_status_success)
+        return rocBLASStatusToHIPStatus(status);
 
     return rocBLASStatusToHIPStatus(
         rocblas_gemm_batched_ex((rocblas_handle)handle,
@@ -17452,8 +17456,12 @@ hipblasStatus_t hipblasGemmStridedBatchedEx(hipblasHandle_t    handle,
                                             hipblasGemmAlgo_t  algo)
 try
 {
-    uint32_t solution_index = 0;
-    uint32_t flags          = 0;
+    uint32_t           solution_index = 0;
+    rocblas_gemm_flags flags          = rocblas_gemm_flags_none;
+
+    rocblas_status status = rocblas_query_int8_layout_flag((rocblas_handle)handle, &flags);
+    if(status != rocblas_status_success)
+        return rocBLASStatusToHIPStatus(status);
 
     return rocBLASStatusToHIPStatus(
         rocblas_gemm_strided_batched_ex((rocblas_handle)handle,


### PR DESCRIPTION
Potential fix for SWDEV-315039.

It looks like the batched versions of gemm_ex int8 fail on some architectures as they do not query the gemm flag for rocBLAS. This PR hopefully fixes that, and adds back tests for int8. Currently aimed at a master hotfix as I didn't find the problem until after I finished feature complete, unfortunately. Will have to wait for CI to ensure this works on all architectures, including cuBLAS backend.