### PR TITLE
Cuda install flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ endif( )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake  ${ROCM_PATH}/lib/cmake/hip /opt/rocm/lib/cmake/hip ${HIP_PATH}/cmake)
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake  ${ROCM_PATH}/lib/cmake/hip /opt/rocm/lib/cmake/hip ${HIP_PATH}/cmake ${CUDA_PATH})
 
 # NOTE:  workaround until hip cmake modules fixes symlink logic in their config files; remove when fixed
 list( APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/llvm /opt/rocm/hip )
@@ -92,7 +92,8 @@ option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 # Find CUDA if the user wants a CUDA version.
 option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
 if (USE_CUDA)
-    find_package( CUDA REQUIRED )
+	set (ENV{CUDA_BIN_PATH} "${CUDA_PATH}" )
+	find_package( CUDA REQUIRED )
 endif()
 
 # Hip headers required of all clients; clients use hip to allocate device memory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ endif( )
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake  ${ROCM_PATH}/lib/cmake/hip /opt/rocm/lib/cmake/hip ${HIP_PATH}/cmake ${CUDA_PATH})
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake  ${ROCM_PATH}/lib/cmake/hip /opt/rocm/lib/cmake/hip ${HIP_PATH}/cmake )
 
 # NOTE:  workaround until hip cmake modules fixes symlink logic in their config files; remove when fixed
 list( APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/llvm /opt/rocm/hip )
@@ -92,7 +92,6 @@ option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 # Find CUDA if the user wants a CUDA version.
 option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
 if (USE_CUDA)
-	set (ENV{CUDA_BIN_PATH} "${CUDA_PATH}" )
 	find_package( CUDA REQUIRED )
 endif()
 

--- a/install.sh
+++ b/install.sh
@@ -455,7 +455,7 @@ declare -a cmake_client_options
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,codecoverage,clients,no-solver,dependencies,debug,hip-clang,no-hip-clang,compiler:,cmake_install,cuda,use-cuda,cudapath:installcuda,installcudaversion:,static,cmakepp,relocatable:,rocm-dev:,rocblas:,rocblas-path:,rocsolver-path:,custom-target:,address-sanitizer,rm-legacy-include-dir,cmake-arg: --options rhicndgp:v:b: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,codecoverage,clients,no-solver,dependencies,debug,hip-clang,no-hip-clang,compiler:,cmake_install,cuda,use-cuda,cudapath:,installcuda,installcudaversion:,static,cmakepp,relocatable:,rocm-dev:,rocblas:,rocblas-path:,rocsolver-path:,custom-target:,address-sanitizer,rm-legacy-include-dir,cmake-arg: --options rhicndgp:v:b: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -513,6 +513,7 @@ while true; do
         shift ;;
     --cudapath)
 	cuda_path=${2}
+	CUDA_BIN_PATH=${cuda_path}
 	shift 2 ;;
     --installcuda)
 	install_cuda=true
@@ -732,7 +733,7 @@ pushd .
     -DROCM_DISABLE_LDCONFIG=ON \
     -DROCM_PATH="${rocm_path}" ../..
   else
-    CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..
+    CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} -DCUDA_PATH=${cuda_path} ../..
   fi
   check_exit_code "$?"
 

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ cat <<EOF
     -d, --dependencies            Build and install external dependencies. Dependecies are to be installed in /usr/local.
                                   This should be done only once (this does not install rocBLAS, rocSolver, or cuda).
 
-    --installcuda                 Install cuda pacakge
+    --installcuda                 Install cuda package.
 
     --installcudaversion <version> Used with --installcuda, optionally specify cuda version to install.
 
@@ -332,40 +332,44 @@ install_cuda_package()
 
   local cuda_dependencies=("cuda")
   case "${ID}" in
-	  ubuntu)
-		  elevate_if_not_root apt update
-		  if [[ "${cuda_version_install}" == "default" ]]; then
-			  install_apt_packages "${cuda_dependencies[@]}"
-	          else
-		 	  install_apt_packages_version "${cuda_dependencies[@]}" "${cuda_version_install}"
-                  fi
-		  ;;
-	  centos|rhel)
-		  if [[ "${cuda_version_install}" == "default" ]]; then
-			  install_yum_packages "${cuda_dependencies[@]}"
-		  else
-		  	  install_yum_packages_version "${cuda_dependencies[@]}" "${cuda_version_install}"
-		  fi
-		  ;;
-	  fedora)
-		  if [[ "${cuda_version_install}" == "default" ]]; then
-			  install_dnf_packages "${cuda_dependencies[@]}"
-		  else
-		  	  install_dnf_packages_version "${cuda_dependencies[@]}" "${cuda_version_install}"
-		  fi
-		  ;;
-	  sles|opensuse-leap)
-		  if [[ "${cuda_version_install}" == "default" ]]; then
-			  install_zypper_packages "${cuda_dependencies[@]}"
-		  else
-		  	install_zypper_packages_version "${cuda_dependencies[@]}" "${cuda_version_install}"
-	          fi
-		  ;;
-	  *)
-		  echo "This script is currently supported on Ubuntu, SLES, CentOS, RHEL and Fedora"
-		  exit 2
-		  ;;
- esac
+    ubuntu)
+      elevate_if_not_root apt update
+      if [[ "${cuda_version_install}" == "default" ]]; then
+        install_apt_packages "${cuda_dependencies[@]}"
+      else
+        install_apt_packages_version "${cuda_dependencies[@]}" "${cuda_version_install}"
+      fi
+      ;;
+
+    centos|rhel)
+      if [[ "${cuda_version_install}" == "default" ]]; then
+        install_yum_packages "${cuda_dependencies[@]}"
+      else
+        install_yum_packages_version "${cuda_dependencies[@]}" "${cuda_version_install}"
+      fi
+      ;;
+
+    fedora)
+      if [[ "${cuda_version_install}" == "default" ]]; then
+        install_dnf_packages "${cuda_dependencies[@]}"
+      else
+        install_dnf_packages_version "${cuda_dependencies[@]}" "${cuda_version_install}"
+      fi
+      ;;
+
+    sles|opensuse-leap)
+      if [[ "${cuda_version_install}" == "default" ]]; then
+        install_zypper_packages "${cuda_dependencies[@]}"
+      else
+        install_zypper_packages_version "${cuda_dependencies[@]}" "${cuda_version_install}"
+      fi
+      ;;
+
+    *)
+      echo "This script is currently supported on Ubuntu, SLES, CentOS, RHEL and Fedora"
+      exit 2
+      ;;
+  esac
 }
 
 # Take an array of packages as input, and install those packages with 'zypper' if they are not already installed
@@ -513,7 +517,7 @@ while true; do
         shift ;;
     --cudapath)
 	cuda_path=${2}
-	CUDA_BIN_PATH=${cuda_path}
+	export CUDA_BIN_PATH=${cuda_path}
 	shift 2 ;;
     --installcuda)
 	install_cuda=true
@@ -733,7 +737,7 @@ pushd .
     -DROCM_DISABLE_LDCONFIG=ON \
     -DROCM_PATH="${rocm_path}" ../..
   else
-    CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} -DCUDA_PATH=${cuda_path} ../..
+    CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..
   fi
   check_exit_code "$?"
 


### PR DESCRIPTION
- removed installation of cuda when passing in `-d` to install script. We aren't installing rocBLAS/rocSOLVER when passing in this flag either. It seems dangerous to do this as it will update cuda, even if it is already installed - users may not want this
- adds `--cudapath` to allow user to specify which cuda build they want to use (default to `/usr/local/cuda`. I've tested with a couple `/usr/local/cuda-VER` and it seems to work as expected)
- adds `--installcuda` to install cuda package via package manager, simply `apt install cuda` or similar
- adds `--installcudaversion` to be used with `--installcuda` to specify which version of cuda to install, for example: `./install.sh --cuda --installcuda --installcudaversion 11.4` will install cuda v11.4 using package manager

Tested flags on centos8 and ubuntu and they seem to work as expected. Working on testing sles now. Adding Cory as a reviewer as him and Torre always catch my cmake/bash errors :)