### PR TITLE
Reducing test time

### DIFF
--- a/clients/gtest/dgmm_gtest.cpp
+++ b/clients/gtest/dgmm_gtest.cpp
@@ -42,7 +42,7 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // vector of vector, each vector is a {M, N, lda, incx, ldc};
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
-    {-1, -1, -1, -1, -1}, {128, 128, 150, -1, 150}, {1000, 1000, 1000, 2, 1000},
+    {-1, -1, -1, -1, -1}, {128, 128, 150, 2, 150}, {1000, 1000, 1000, 2, 1000},
 
     // TODO: rocBLAS dgmm is currently broken when (M != N && incx < 0 && side == L)
     // {128, 130, 150, -1, 150},
@@ -53,8 +53,8 @@ const vector<char> side_range = {
     'R',
 };
 
-const vector<double> stride_scale_range = {1.0, 2.5};
-const vector<int>    batch_count_range  = {-1, 1, 2, 10};
+const vector<double> stride_scale_range = {2.5};
+const vector<int>    batch_count_range  = {-1, 1, 5};
 
 const bool is_fortran[] = {false, true};
 

--- a/clients/gtest/gbmv_batched_gtest.cpp
+++ b/clients/gtest/gbmv_batched_gtest.cpp
@@ -41,28 +41,20 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
     {-1, -1, -1, -1, -1},
-    //        {10, 10, 2},
-    //        {600,500, 500},
     {1000, 1000, 150, 84, 1000},
-    //        {2000, 2000, 2000},
-    //        {4011, 4011, 4011},
-    //        {8000, 8000, 8000},
 };
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {2, 1}, {0, -1}, {-1, -1},
-    //              {10, 100},
+    {2, 1},
+    {-1, -1},
 };
 
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0},
-    {-1.0, -1.0},
     {2.0, 1.0},
-    {0.0, 1.0},
 };
 
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
@@ -72,11 +64,8 @@ const vector<char> transA_range = {
     // 'C',
 };
 
-// number of gemms in batched gemm
-const vector<int> batch_count_range = {
-    -1, 0, 1, 2, 10,
-    //               100,
-};
+// number of gbmv in batched gbmv
+const vector<int> batch_count_range = {-1, 0, 1, 5};
 
 const bool is_fortran[] = {false, true};
 

--- a/clients/gtest/gbmv_strided_batched_gtest.cpp
+++ b/clients/gtest/gbmv_strided_batched_gtest.cpp
@@ -41,36 +41,27 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
     {-1, -1, -1, -1, -1},
-    //        {10, 10, 2},
-    //        {600,500, 500},
     {1000, 1000, 150, 84, 1000},
-    //        {2000, 2000, 2000},
-    //        {4011, 4011, 4011},
-    //        {8000, 8000, 8000},
 };
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {2, 1}, {0, -1}, {-1, -1},
-    //              {10, 100},
+    {2, 1},
+    {-1, -1},
 };
 
 // a vector of single double values. This value will be multiplied by
 // appropriate dimensions to get the stride between vectors and matrices
 const vector<double> stride_scale_range = {
     1,
-    1.5,
     2,
 };
 
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0},
-    {-1.0, -1.0},
     {2.0, 1.0},
-    {0.0, 1.0},
 };
 
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
@@ -81,10 +72,7 @@ const vector<char> transA_range = {
 };
 
 // number of gemms in batched gemm
-const vector<int> batch_count_range = {
-    -1, 0, 1, 2, 10,
-    //               100,
-};
+const vector<int> batch_count_range = {-1, 0, 1, 5};
 
 const bool is_fortran[] = {false, true};
 

--- a/clients/gtest/gemv_batched_gtest.cpp
+++ b/clients/gtest/gemv_batched_gtest.cpp
@@ -68,8 +68,7 @@ const vector<char> transA_range = {
 const vector<int> batch_count_range = {
     -1,
     0,
-    1,
-    5,
+    2,
 };
 
 const bool is_fortran[] = {false, true};

--- a/clients/gtest/gemv_batched_gtest.cpp
+++ b/clients/gtest/gemv_batched_gtest.cpp
@@ -41,28 +41,20 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
     {-1, -1, -1},
-    //        {10, 10, 2},
-    //        {600,500, 500},
     {1000, 1000, 1000},
-    //        {2000, 2000, 2000},
-    //        {4011, 4011, 4011},
-    //        {8000, 8000, 8000},
 };
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {2, 1}, {0, -1}, {-1, -1},
-    //              {10, 100},
+    {2, 1},
+    {-1, -1},
 };
 
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0},
-    {-1.0, -1.0},
     {2.0, 1.0},
-    {0.0, 1.0},
 };
 
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
@@ -74,8 +66,10 @@ const vector<char> transA_range = {
 
 // number of gemms in batched gemm
 const vector<int> batch_count_range = {
-    -1, 0, 1, 2, 10,
-    //               100,
+    -1,
+    0,
+    1,
+    5,
 };
 
 const bool is_fortran[] = {false, true};

--- a/clients/gtest/gemv_strided_batched_gtest.cpp
+++ b/clients/gtest/gemv_strided_batched_gtest.cpp
@@ -41,19 +41,14 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
     {-1, -1, -1},
-    //        {10, 10, 2},
-    //        {600,500, 500},
     {1000, 1000, 1000},
-    //        {2000, 2000, 2000},
-    //        {4011, 4011, 4011},
-    //        {8000, 8000, 8000},
 };
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {2, 1}, {0, -1}, {-1, -1},
-    //              {10, 100},
+    {2, 1},
+    {-1, -1},
 };
 
 // a vector of single double values. This value will be multiplied by
@@ -67,10 +62,7 @@ const vector<double> stride_scale_range = {
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0},
-    {-1.0, -1.0},
     {2.0, 1.0},
-    {0.0, 1.0},
 };
 
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
@@ -82,8 +74,10 @@ const vector<char> transA_range = {
 
 // number of gemms in batched gemm
 const vector<int> batch_count_range = {
-    -1, 0, 1, 2, 10,
-    //               100,
+    -1,
+    0,
+    1,
+    5,
 };
 
 const bool is_fortran[] = {false, true};

--- a/clients/gtest/gemv_strided_batched_gtest.cpp
+++ b/clients/gtest/gemv_strided_batched_gtest.cpp
@@ -76,8 +76,7 @@ const vector<char> transA_range = {
 const vector<int> batch_count_range = {
     -1,
     0,
-    1,
-    5,
+    2,
 };
 
 const bool is_fortran[] = {false, true};

--- a/clients/gtest/hbmv_gtest.cpp
+++ b/clients/gtest/hbmv_gtest.cpp
@@ -76,7 +76,7 @@ const vector<char> transA_range = {
 };
 
 const vector<double> stride_scale_range = {2.0};
-const vector<int>    batch_count_range  = {-1, 0, 1, 5};
+const vector<int>    batch_count_range  = {-1, 0, 2};
 
 const bool is_fortran[] = {false, true};
 

--- a/clients/gtest/hbmv_gtest.cpp
+++ b/clients/gtest/hbmv_gtest.cpp
@@ -43,7 +43,6 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
     {-1, -1, -1},
-    {10, 20, 15},
     //        {10, 10, 2},
     //        {600,500, 500},
     {1000, 1000, 501},
@@ -76,8 +75,8 @@ const vector<char> transA_range = {
     'C',
 };
 
-const vector<double> stride_scale_range = {1.0, 2.5};
-const vector<int>    batch_count_range  = {-1, 0, 1, 2, 10};
+const vector<double> stride_scale_range = {2.0};
+const vector<int>    batch_count_range  = {-1, 0, 1, 5};
 
 const bool is_fortran[] = {false, true};
 

--- a/clients/gtest/hemm_gtest.cpp
+++ b/clients/gtest/hemm_gtest.cpp
@@ -63,7 +63,7 @@ const vector<vector<char>> side_uplo_range = {
 
 const vector<double> stride_scale_range = {2};
 
-const vector<int> batch_count_range = {1, 5};
+const vector<int> batch_count_range = {2};
 
 /* ===============Google Unit Test==================================================== */
 

--- a/clients/gtest/hemm_gtest.cpp
+++ b/clients/gtest/hemm_gtest.cpp
@@ -47,12 +47,7 @@ const vector<vector<int>> matrix_size_range = {
     {600, 500, 600, 600, 700},
 };
 
-const vector<vector<int>> full_matrix_size_range = {
-    {192, 192, 192, 192, 192},
-    {640, 640, 960, 960, 960},
-};
-
-const vector<vector<double>> alpha_beta_range = {{1.0, 1.0, 1.0, 1.0}, {-5.0, 2.0, 3.0, -2.0}};
+const vector<vector<double>> alpha_beta_range = {{-5.0, 2.0, 3.0, -2.0}};
 
 // vector of vector, each pair is a {side, uplo};
 // side has two option "Lefe (L), Right (R)"
@@ -66,17 +61,9 @@ const vector<vector<char>> side_uplo_range = {
     {'R', 'U'},
 };
 
-// has all the 16 options
-const vector<vector<char>> full_side_uplo_range = {
-    {'L', 'L'},
-    {'R', 'L'},
-    {'L', 'U'},
-    {'R', 'U'},
-};
+const vector<double> stride_scale_range = {2};
 
-const vector<double> stride_scale_range = {1, 3};
-
-const vector<int> batch_count_range = {1, 3, 5};
+const vector<int> batch_count_range = {1, 5};
 
 /* ===============Google Unit Test==================================================== */
 
@@ -226,25 +213,10 @@ TEST_P(hemm_gtest, hemm_strided_batched_gtest_double_complex)
 // so each elment in xxx_range is a avector,
 // ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda, ldb}, alpha, {side, diag} }
-
-// THis function mainly test the scope of matrix_size. the scope of side_uplo_range is
-// small
-// Testing order: side_uplo_xx first, alpha_beta_range second, full_matrix_size last
-// i.e fix the matrix size and alpha, test all the side_uplo_xx first.
 INSTANTIATE_TEST_SUITE_P(hipblashemm_matrix_size,
-                         hemm_gtest,
-                         Combine(ValuesIn(full_matrix_size_range),
-                                 ValuesIn(alpha_beta_range),
-                                 ValuesIn(side_uplo_range),
-                                 ValuesIn(stride_scale_range),
-                                 ValuesIn(batch_count_range)));
-
-// THis function mainly test the scope of  full_side_uplo_range,.the scope of
-// matrix_size_range is small
-INSTANTIATE_TEST_SUITE_P(hipblashemm_scalar_transpose,
                          hemm_gtest,
                          Combine(ValuesIn(matrix_size_range),
                                  ValuesIn(alpha_beta_range),
-                                 ValuesIn(full_side_uplo_range),
+                                 ValuesIn(side_uplo_range),
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range)));

--- a/clients/gtest/hemv_batched_gtest.cpp
+++ b/clients/gtest/hemv_batched_gtest.cpp
@@ -68,8 +68,7 @@ const vector<char> transA_range = {
 const vector<int> batch_count_range = {
     -1,
     0,
-    1,
-    5,
+    2,
 };
 
 const bool is_fortran[] = {false, true};

--- a/clients/gtest/hemv_batched_gtest.cpp
+++ b/clients/gtest/hemv_batched_gtest.cpp
@@ -41,28 +41,20 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
     {-1, -1},
-    //        {10, 10, 2},
-    //        {600,500, 500},
     {1000, 1000},
-    //        {2000, 2000, 2000},
-    //        {4011, 4011, 4011},
-    //        {8000, 8000, 8000},
 };
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {2, 1}, {0, -1}, {-1, -1},
-    //              {10, 100},
+    {2, 1},
+    {-1, -1},
 };
 
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0},
-    {-1.0, -1.0},
     {2.0, 1.0},
-    {0.0, 1.0},
 };
 
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
@@ -72,10 +64,12 @@ const vector<char> transA_range = {
     // 'C',
 };
 
-// number of gemms in batched gemm
+// number of hemvs in batched hemv
 const vector<int> batch_count_range = {
-    -1, 0, 1, 2, 10,
-    //               100,
+    -1,
+    0,
+    1,
+    5,
 };
 
 const bool is_fortran[] = {false, true};

--- a/clients/gtest/hemv_strided_batched_gtest.cpp
+++ b/clients/gtest/hemv_strided_batched_gtest.cpp
@@ -74,8 +74,9 @@ const vector<char> transA_range = {
 
 // number of gemms in batched gemm
 const vector<int> batch_count_range = {
-    -1, 0, 1, 5,
-    //               100,
+    -1,
+    0,
+    2,
 };
 
 const bool is_fortran[] = {false, true};

--- a/clients/gtest/hemv_strided_batched_gtest.cpp
+++ b/clients/gtest/hemv_strided_batched_gtest.cpp
@@ -41,19 +41,14 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
     {-1, -1},
-    //        {10, 10, 2},
-    //        {600,500, 500},
     {1000, 1000},
-    //        {2000, 2000, 2000},
-    //        {4011, 4011, 4011},
-    //        {8000, 8000, 8000},
 };
 
 // vector of vector, each pair is a {incx, incy};
 // add/delete this list in pairs, like {1, 1}
 const vector<vector<int>> incx_incy_range = {
-    {2, 1}, {0, -1}, {-1, -1},
-    //              {10, 100},
+    {2, 1},
+    {-1, -1},
 };
 
 // a vector of single double values. This value will be multiplied by
@@ -67,10 +62,7 @@ const vector<double> stride_scale_range = {
 // vector of vector, each pair is a {alpha, beta};
 // add/delete this list in pairs, like {2.0, 4.0}
 const vector<vector<double>> alpha_beta_range = {
-    {1.0, 0.0},
-    {-1.0, -1.0},
     {2.0, 1.0},
-    {0.0, 1.0},
 };
 
 // for single/double precision, 'C'(conjTranspose) will downgraded to 'T' (transpose) internally in
@@ -82,7 +74,7 @@ const vector<char> transA_range = {
 
 // number of gemms in batched gemm
 const vector<int> batch_count_range = {
-    -1, 0, 1, 2, 10,
+    -1, 0, 1, 5,
     //               100,
 };
 

--- a/clients/gtest/hpmv_gtest.cpp
+++ b/clients/gtest/hpmv_gtest.cpp
@@ -71,7 +71,7 @@ const vector<char> transA_range = {
 };
 
 const vector<double> stride_scale_range = {2.5};
-const vector<int>    batch_count_range  = {-1, 0, 1, 5};
+const vector<int>    batch_count_range  = {-1, 0, 2};
 
 const bool is_fortran[] = {false, true};
 

--- a/clients/gtest/hpmv_gtest.cpp
+++ b/clients/gtest/hpmv_gtest.cpp
@@ -43,7 +43,6 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<int> matrix_size_range = {
     -1,
-    128,
     1000,
 };
 
@@ -71,8 +70,8 @@ const vector<char> transA_range = {
     'C',
 };
 
-const vector<double> stride_scale_range = {1.0, 2.5};
-const vector<int>    batch_count_range  = {-1, 0, 1, 2, 10};
+const vector<double> stride_scale_range = {2.5};
+const vector<int>    batch_count_range  = {-1, 0, 1, 5};
 
 const bool is_fortran[] = {false, true};
 

--- a/clients/gtest/symm_gtest.cpp
+++ b/clients/gtest/symm_gtest.cpp
@@ -62,7 +62,7 @@ const vector<vector<char>> side_uplo_range = {
 
 const vector<double> stride_scale_range = {2};
 
-const vector<int> batch_count_range = {1, 5};
+const vector<int> batch_count_range = {2};
 
 const bool is_fortran[] = {false, true};
 

--- a/clients/gtest/symm_gtest.cpp
+++ b/clients/gtest/symm_gtest.cpp
@@ -43,16 +43,10 @@ Representative sampling is sufficient, endless brute-force sampling is not neces
 // add/delete as a group
 const vector<vector<int>> matrix_size_range = {
     {-1, -1, 1, 1, 1},
-    {10, 10, 20, 100, 100},
     {600, 500, 600, 600, 700},
 };
 
-const vector<vector<int>> full_matrix_size_range = {
-    {192, 192, 192, 192, 192},
-    {640, 640, 960, 960, 960},
-};
-
-const vector<vector<double>> alpha_beta_range = {{1.0, 1.0, 1.0, 1.0}, {-5.0, 2.0, 3.0, -2.0}};
+const vector<vector<double>> alpha_beta_range = {{-5.0, 2.0, 3.0, -2.0}};
 
 // vector of vector, each pair is a {side, uplo};
 // side has two option "Lefe (L), Right (R)"
@@ -66,20 +60,11 @@ const vector<vector<char>> side_uplo_range = {
     {'R', 'U'},
 };
 
-// has all the 16 options
-const vector<vector<char>> full_side_uplo_range = {
-    {'L', 'L'},
-    {'R', 'L'},
-    {'L', 'U'},
-    {'R', 'U'},
-};
+const vector<double> stride_scale_range = {2};
 
-const vector<double> stride_scale_range = {1, 3};
+const vector<int> batch_count_range = {1, 5};
 
-const vector<int> batch_count_range = {1, 3, 5};
-
-const bool is_fortran[]       = {false, true};
-const bool is_fortran_false[] = {false};
+const bool is_fortran[] = {false, true};
 
 /* ===============Google Unit Test==================================================== */
 
@@ -313,27 +298,11 @@ TEST_P(symm_gtest, symm_strided_batched_gtest_double_complex)
 // so each elment in xxx_range is a avector,
 // ValuesIn take each element (a vector) and combine them and feed them to test_p
 // The combinations are  { {M, N, lda, ldb}, alpha, {side, diag} }
-
-// THis function mainly test the scope of matrix_size. the scope of side_uplo_range is
-// small
-// Testing order: side_uplo_xx first, alpha_beta_range second, full_matrix_size last
-// i.e fix the matrix size and alpha, test all the side_uplo_xx first.
 INSTANTIATE_TEST_SUITE_P(hipblassymm_matrix_size,
                          symm_gtest,
-                         Combine(ValuesIn(full_matrix_size_range),
+                         Combine(ValuesIn(matrix_size_range),
                                  ValuesIn(alpha_beta_range),
                                  ValuesIn(side_uplo_range),
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
-
-// THis function mainly test the scope of  full_side_uplo_range,.the scope of
-// matrix_size_range is small
-INSTANTIATE_TEST_SUITE_P(hipblassymm_scalar_transpose,
-                         symm_gtest,
-                         Combine(ValuesIn(matrix_size_range),
-                                 ValuesIn(alpha_beta_range),
-                                 ValuesIn(full_side_uplo_range),
-                                 ValuesIn(stride_scale_range),
-                                 ValuesIn(batch_count_range),
-                                 ValuesIn(is_fortran_false)));


### PR DESCRIPTION
Removing some tests from hipBLAS, these changes make it take about half the time on my vega20 compared to previously. Windows tests have been taking a long time, this is some low hanging fruit to try to reduce that.

This is mostly reducing batched tests which took longer than expected. We don't need to do exhaustive testing here because the backends themselves should ensure their own correctness.

See LWPMLSE-232 for more info on test timing.