### PR TITLE
Fix rocm-smi path for ROCm 5.2 and above

### DIFF
--- a/scripts/performance/blas/commandrunner.py
+++ b/scripts/performance/blas/commandrunner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Copyright (C) 2018-2020 Advanced Micro Devices, Inc. All rights reserved.
+"""Copyright (C) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -73,6 +73,7 @@ import string
 import subprocess
 import sys
 import time
+from decimal import Decimal
 
 import getspecs
 
@@ -113,8 +114,13 @@ def import_rocm_smi(install_path):
     global smi_imported
     if not smi_imported:
         smi_imported = True
+        host_rocm_ver = Decimal('.'.join(getspecs.getrocmversion().split('.')[0:2])) # get host's rocm major.minor version
+        rocm_5_2_ver = Decimal('5.2')
         try:
-            sys.path.append(os.path.join(install_path, 'bin'))
+            if rocm_5_2_ver.compare(host_rocm_ver) == 1:
+                sys.path.append(os.path.join(install_path, 'bin')) # For versions below ROCm 5.2
+            else:
+                sys.path.append(os.path.join(install_path, 'libexec/rocm_smi')) # For versions equal or above ROCm 5.2
             import rocm_smi
             smi = rocm_smi
 


### PR DESCRIPTION
resolves # LWPMLSE-317

ROCm 5.2 has adopted new Linux filesystem hierarchy.

rocm_smi.py and rsmiBindings.py files are moved to /opt/rocm/libexec/rocm_smi directory for ROCm 5.2 and above.

Summary of proposed changes:
- Update the rocm-smi path based on ROCm version.

For ROCm version below 5.2 , install_path will be /opt/rocm/bin

For ROCm version 5.2 and above, install_path will be /opt/rocm/libexec/rocm_smi
