### PR TITLE
Change dot_ex tests to use near_check for fp16

### DIFF
--- a/clients/common/near.cpp
+++ b/clients/common/near.cpp
@@ -76,7 +76,8 @@
 
 #endif
 
-#define NEAR_ASSERT_HALF(a, b, err) ASSERT_NEAR(float(a), float(b), err)
+#define NEAR_ASSERT_HALF(a, b, err) ASSERT_NEAR(half_to_float(a), half_to_float(b), err)
+#define NEAR_ASSERT_BF16(a, b, err) ASSERT_NEAR(bfloat16_to_float(a), bfloat16_to_float(b), err)
 
 #define NEAR_ASSERT_COMPLEX(a, b, err)          \
     do                                          \
@@ -103,6 +104,13 @@ void near_check_general(
     int M, int N, int lda, hipblasHalf* hCPU, hipblasHalf* hGPU, double abs_error)
 {
     NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_HALF);
+}
+
+template <>
+void near_check_general(
+    int M, int N, int lda, hipblasBfloat16* hCPU, hipblasBfloat16* hGPU, double abs_error)
+{
+    NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_BF16);
 }
 
 template <>
@@ -161,6 +169,19 @@ void near_check_general(int           M,
 }
 
 template <>
+void near_check_general(int              M,
+                        int              N,
+                        int              batch_count,
+                        int              lda,
+                        hipblasStride    strideA,
+                        hipblasBfloat16* hCPU,
+                        hipblasBfloat16* hGPU,
+                        double           abs_error)
+{
+    NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, abs_error, NEAR_ASSERT_BF16);
+}
+
+template <>
 void near_check_general(int             M,
                         int             N,
                         int             batch_count,
@@ -198,6 +219,18 @@ void near_check_general(int                      M,
                         double                   abs_error)
 {
     NEAR_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, abs_error, NEAR_ASSERT_HALF);
+}
+
+template <>
+void near_check_general(int                          M,
+                        int                          N,
+                        int                          batch_count,
+                        int                          lda,
+                        host_vector<hipblasBfloat16> hCPU[],
+                        host_vector<hipblasBfloat16> hGPU[],
+                        double                       abs_error)
+{
+    NEAR_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, abs_error, NEAR_ASSERT_BF16);
 }
 
 template <>
@@ -260,6 +293,18 @@ void near_check_general(int          M,
                         double       abs_error)
 {
     NEAR_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, abs_error, NEAR_ASSERT_HALF);
+}
+
+template <>
+void near_check_general(int              M,
+                        int              N,
+                        int              batch_count,
+                        int              lda,
+                        hipblasBfloat16* hCPU[],
+                        hipblasBfloat16* hGPU[],
+                        double           abs_error)
+{
+    NEAR_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, abs_error, NEAR_ASSERT_BF16);
 }
 
 template <>

--- a/clients/include/near.h
+++ b/clients/include/near.h
@@ -81,10 +81,10 @@ void near_check_general(int            M,
 
 // currently only used for half-precision comparisons int dot_ex tests
 template <class T>
-HIPBLAS_CLANG_STATIC double error_tolerance = 0.0;
+HIPBLAS_CLANG_STATIC constexpr double error_tolerance = 0.0;
 
 // 2 ^ -14, smallest positive normal number for IEEE16
 template <>
-HIPBLAS_CLANG_STATIC double error_tolerance<hipblasHalf> = 0.000061035;
+HIPBLAS_CLANG_STATIC constexpr double error_tolerance<hipblasHalf> = 0.000061035;
 
 #endif

--- a/clients/include/near.h
+++ b/clients/include/near.h
@@ -79,4 +79,12 @@ void near_check_general(int            M,
                         host_vector<T> hGPU[],
                         double         abs_error);
 
+// currently only used for half-precision comparisons int dot_ex tests
+template <class T>
+static double error_tolerance = 0.0;
+
+// 2 ^ -14, smallest positive normal number for IEEE16
+template <>
+static double error_tolerance<hipblasHalf> = 0.000061035;
+
 #endif

--- a/clients/include/near.h
+++ b/clients/include/near.h
@@ -81,10 +81,10 @@ void near_check_general(int            M,
 
 // currently only used for half-precision comparisons int dot_ex tests
 template <class T>
-static double error_tolerance = 0.0;
+HIPBLAS_CLANG_STATIC double error_tolerance = 0.0;
 
 // 2 ^ -14, smallest positive normal number for IEEE16
 template <>
-static double error_tolerance<hipblasHalf> = 0.000061035;
+HIPBLAS_CLANG_STATIC double error_tolerance<hipblasHalf> = 0.000061035;
 
 #endif

--- a/clients/include/testing_dot_batched_ex.hpp
+++ b/clients/include/testing_dot_batched_ex.hpp
@@ -105,7 +105,7 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Initial Data on CPU
-    hipblas_init(hy, true, true);
+    hipblas_init(hy, true, false);
     hipblas_init_alternating_sign(hx);
     CHECK_HIP_ERROR(dx.transfer_from(hx));
     CHECK_HIP_ERROR(dy.transfer_from(hy));
@@ -159,8 +159,19 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_host);
-            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_device);
+            if(std::is_same<Tr, hipblasHalf>{})
+            {
+                double tol = pow(2, -14) * N;
+                near_check_general(
+                    1, 1, batch_count, 1, 1, h_cpu_result, h_hipblas_result_host, tol);
+                near_check_general(
+                    1, 1, batch_count, 1, 1, h_cpu_result, h_hipblas_result_device, tol);
+            }
+            else
+            {
+                unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_host);
+                unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_device);
+            }
         }
         if(argus.norm_check)
         {

--- a/clients/include/testing_dot_batched_ex.hpp
+++ b/clients/include/testing_dot_batched_ex.hpp
@@ -161,7 +161,7 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
         {
             if(std::is_same<Tr, hipblasHalf>{})
             {
-                double tol = pow(2, -14) * N;
+                double tol = error_tolerance<Tr> * N;
                 near_check_general(1,
                                    1,
                                    batch_count,

--- a/clients/include/testing_dot_batched_ex.hpp
+++ b/clients/include/testing_dot_batched_ex.hpp
@@ -162,10 +162,22 @@ hipblasStatus_t testing_dot_batched_ex_template(const Arguments& argus)
             if(std::is_same<Tr, hipblasHalf>{})
             {
                 double tol = pow(2, -14) * N;
-                near_check_general(
-                    1, 1, batch_count, 1, 1, h_cpu_result, h_hipblas_result_host, tol);
-                near_check_general(
-                    1, 1, batch_count, 1, 1, h_cpu_result, h_hipblas_result_device, tol);
+                near_check_general(1,
+                                   1,
+                                   batch_count,
+                                   1,
+                                   1,
+                                   h_cpu_result.data(),
+                                   h_hipblas_result_host.data(),
+                                   tol);
+                near_check_general(1,
+                                   1,
+                                   batch_count,
+                                   1,
+                                   1,
+                                   h_cpu_result.data(),
+                                   h_hipblas_result_device.data(),
+                                   tol);
             }
             else
             {

--- a/clients/include/testing_dot_ex.hpp
+++ b/clients/include/testing_dot_ex.hpp
@@ -147,8 +147,17 @@ hipblasStatus_t testing_dot_ex_template(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            unit_check_general<Tr>(1, 1, 1, &cpu_result, &hipblas_result_host);
-            unit_check_general<Tr>(1, 1, 1, &cpu_result, &hipblas_result_device);
+            if(std::is_same<Tr, hipblasHalf>{})
+            {
+                double tol = pow(2, -14) * N;
+                near_check_general(1, 1, 1, &cpu_result, &hipblas_result_host, tol);
+                near_check_general(1, 1, 1, &cpu_result, &hipblas_result_device);
+            }
+            else
+            {
+                unit_check_general<Tr>(1, 1, 1, &cpu_result, &hipblas_result_host);
+                unit_check_general<Tr>(1, 1, 1, &cpu_result, &hipblas_result_device);
+            }
         }
         if(argus.norm_check)
         {

--- a/clients/include/testing_dot_ex.hpp
+++ b/clients/include/testing_dot_ex.hpp
@@ -151,7 +151,7 @@ hipblasStatus_t testing_dot_ex_template(const Arguments& argus)
             {
                 double tol = pow(2, -14) * N;
                 near_check_general(1, 1, 1, &cpu_result, &hipblas_result_host, tol);
-                near_check_general(1, 1, 1, &cpu_result, &hipblas_result_device);
+                near_check_general(1, 1, 1, &cpu_result, &hipblas_result_device, tol);
             }
             else
             {

--- a/clients/include/testing_dot_ex.hpp
+++ b/clients/include/testing_dot_ex.hpp
@@ -149,7 +149,7 @@ hipblasStatus_t testing_dot_ex_template(const Arguments& argus)
         {
             if(std::is_same<Tr, hipblasHalf>{})
             {
-                double tol = pow(2, -14) * N;
+                double tol = error_tolerance<Tr> * N;
                 near_check_general(1, 1, 1, &cpu_result, &hipblas_result_host, tol);
                 near_check_general(1, 1, 1, &cpu_result, &hipblas_result_device, tol);
             }

--- a/clients/include/testing_dot_strided_batched_ex.hpp
+++ b/clients/include/testing_dot_strided_batched_ex.hpp
@@ -180,8 +180,19 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(const Arguments& argus)
 
         if(argus.unit_check)
         {
-            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_host);
-            unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_device);
+            if(std::is_same<Tr, hipblasHalf>{})
+            {
+                double tol = pow(2, -14) * N;
+                near_check_general(
+                    1, 1, batch_count, 1, 1, h_cpu_result, h_hipblas_result_host, tol);
+                near_check_general(
+                    1, 1, batch_count, 1, 1, h_cpu_result, h_hipblas_result_device, tol);
+            }
+            else
+            {
+                unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_host);
+                unit_check_general<Tr>(1, batch_count, 1, h_cpu_result, h_hipblas_result_device);
+            }
         }
         if(argus.norm_check)
         {

--- a/clients/include/testing_dot_strided_batched_ex.hpp
+++ b/clients/include/testing_dot_strided_batched_ex.hpp
@@ -183,10 +183,22 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(const Arguments& argus)
             if(std::is_same<Tr, hipblasHalf>{})
             {
                 double tol = pow(2, -14) * N;
-                near_check_general(
-                    1, 1, batch_count, 1, 1, h_cpu_result, h_hipblas_result_host, tol);
-                near_check_general(
-                    1, 1, batch_count, 1, 1, h_cpu_result, h_hipblas_result_device, tol);
+                near_check_general(1,
+                                   1,
+                                   batch_count,
+                                   1,
+                                   1,
+                                   h_cpu_result.data(),
+                                   h_hipblas_result_host.data(),
+                                   tol);
+                near_check_general(1,
+                                   1,
+                                   batch_count,
+                                   1,
+                                   1,
+                                   h_cpu_result.data(),
+                                   h_hipblas_result_device.data(),
+                                   tol);
             }
             else
             {

--- a/clients/include/testing_dot_strided_batched_ex.hpp
+++ b/clients/include/testing_dot_strided_batched_ex.hpp
@@ -182,7 +182,7 @@ hipblasStatus_t testing_dot_strided_batched_ex_template(const Arguments& argus)
         {
             if(std::is_same<Tr, hipblasHalf>{})
             {
-                double tol = pow(2, -14) * N;
+                double tol = error_tolerance<Tr> * N;
                 near_check_general(1,
                                    1,
                                    batch_count,


### PR DESCRIPTION
Some dot_ex tests failed while testing out gfx11. It appears that it's just a conversion from fp16->fp32->fp16->fp32 which is causing the issue. Only seen when the result is 0, we get a cpu result of 0 and a gpu result of (very small number). I added some example output at SWDEV-333517.

This change dot_ex tests to use near_check rather than unit_check for half precision. Using a tolerance of epsilon * N.