### PR TITLE
Fixing geqrf return status for nullptrs, updating tests

### DIFF
--- a/clients/gtest/geqrf_batched_gtest.cpp
+++ b/clients/gtest/geqrf_batched_gtest.cpp
@@ -35,12 +35,18 @@ using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> geqrf_batched_tuple;
 
-const vector<vector<int>> matrix_size_range
-    = {{-1, -1, 1, 1}, {10, 10, 10, 10}, {10, 10, 20, 100}, {600, 500, 600, 600}};
+const vector<vector<int>> matrix_size_range = {{-1, 1, 1}, // invalid M
+                                               {1, -1, 1}, // invalid N
+                                               {5, 5, 4}, // invalid lda
+                                               {0, 32, 32}, // M == 0
+                                               {32, 0, 32}, // N == 0
+                                               {10, 10, 10},
+                                               {10, 10, 20},
+                                               {600, 500, 600}};
 
 const vector<double> stride_scale_range = {2.5};
 
-const vector<int> batch_count_range = {-1, 0, 1, 2};
+const vector<int> batch_count_range = {-1, 0, 2};
 
 const vector<bool> is_fortran = {false, true};
 
@@ -56,7 +62,6 @@ Arguments setup_geqrf_batched_arguments(geqrf_batched_tuple tup)
     arg.M   = matrix_size[0];
     arg.N   = matrix_size[1];
     arg.lda = matrix_size[2];
-    //arg.ldb = matrix_size[3];
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;

--- a/clients/gtest/geqrf_gtest.cpp
+++ b/clients/gtest/geqrf_gtest.cpp
@@ -35,8 +35,14 @@ using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> geqrf_tuple;
 
-const vector<vector<int>> matrix_size_range
-    = {{-1, -1, 1, 1}, {10, 10, 10, 10}, {10, 10, 20, 100}, {600, 500, 600, 600}};
+const vector<vector<int>> matrix_size_range = {{-1, 1, 1}, // invalid M
+                                               {1, -1, 1}, // invalid N
+                                               {5, 5, 4}, // invalid lda
+                                               {0, 32, 32}, // M == 0
+                                               {32, 0, 32}, // N == 0
+                                               {10, 10, 10},
+                                               {10, 10, 20},
+                                               {600, 500, 600}};
 
 const vector<double> stride_scale_range = {2.5};
 
@@ -56,7 +62,6 @@ Arguments setup_geqrf_arguments(geqrf_tuple tup)
     arg.M   = matrix_size[0];
     arg.N   = matrix_size[1];
     arg.lda = matrix_size[2];
-    //arg.ldb = matrix_size[3];
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;

--- a/clients/gtest/geqrf_strided_batched_gtest.cpp
+++ b/clients/gtest/geqrf_strided_batched_gtest.cpp
@@ -35,12 +35,18 @@ using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> geqrf_strided_batched_tuple;
 
-const vector<vector<int>> matrix_size_range
-    = {{-1, -1, 1, 1}, {10, 10, 10, 10}, {10, 10, 20, 100}, {600, 500, 600, 600}};
+const vector<vector<int>> matrix_size_range = {{-1, 1, 1}, // invalid M
+                                               {1, -1, 1}, // invalid N
+                                               {5, 5, 4}, // invalid lda
+                                               {0, 32, 32}, // M == 0
+                                               {32, 0, 32}, // N == 0
+                                               {10, 10, 10},
+                                               {10, 10, 20},
+                                               {600, 500, 600}};
 
 const vector<double> stride_scale_range = {2.5};
 
-const vector<int> batch_count_range = {-1, 0, 1, 2};
+const vector<int> batch_count_range = {-1, 0, 2};
 
 const vector<bool> is_fortran = {false, true};
 
@@ -56,7 +62,6 @@ Arguments setup_geqrf_strided_batched_arguments(geqrf_strided_batched_tuple tup)
     arg.M   = matrix_size[0];
     arg.N   = matrix_size[1];
     arg.lda = matrix_size[2];
-    //arg.ldb = matrix_size[3];
 
     arg.stride_scale = stride_scale;
     arg.batch_count  = batch_count;

--- a/clients/include/testing_geqrf_strided_batched.hpp
+++ b/clients/include/testing_geqrf_strided_batched.hpp
@@ -55,15 +55,34 @@ inline hipblasStatus_t testing_geqrf_strided_batched(const Arguments& arg)
     hipblasStride strideP   = K * stride_scale;
     int           A_size    = strideA * batch_count;
     int           Ipiv_size = strideP * batch_count;
+    int           info;
+
+    hipblasLocalHandle handle(arg);
 
     // Check to prevent memory allocation error
-    if(M < 0 || N < 0 || lda < M || batch_count < 0)
+    bool invalid_size = M < 0 || N < 0 || lda < std::max(1, M) || batch_count < 0;
+    if(invalid_size || !M || !N || !batch_count)
     {
-        return HIPBLAS_STATUS_INVALID_VALUE;
-    }
-    if(batch_count == 0)
-    {
-        return HIPBLAS_STATUS_SUCCESS;
+        // including pointers so can test other params
+        device_vector<T> dA(1);
+        device_vector<T> dIpiv(1);
+        hipblasStatus_t  status = hipblasGeqrfStridedBatchedFn(
+            handle, M, N, dA, lda, strideA, dIpiv, strideP, &info, batch_count);
+        EXPECT_HIPBLAS_STATUS(
+            status, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
+
+        int expected_info = 0;
+        if(M < 0)
+            expected_info = -1;
+        else if(N < 0)
+            expected_info = -2;
+        else if(lda < std::max(1, M))
+            expected_info = -4;
+        else if(batch_count < 0)
+            expected_info = -9;
+        unit_check_general(1, 1, 1, &expected_info, &info);
+
+        return status;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -71,13 +90,11 @@ inline hipblasStatus_t testing_geqrf_strided_batched(const Arguments& arg)
     host_vector<T> hA1(A_size);
     host_vector<T> hIpiv(Ipiv_size);
     host_vector<T> hIpiv1(Ipiv_size);
-    int            info;
 
     device_vector<T> dA(A_size);
     device_vector<T> dIpiv(Ipiv_size);
 
-    double             gpu_time_used, hipblas_error;
-    hipblasLocalHandle handle(arg);
+    double gpu_time_used, hipblas_error;
 
     // Initial hA on CPU
     srand(1);
@@ -144,6 +161,8 @@ inline hipblasStatus_t testing_geqrf_strided_batched(const Arguments& arg)
 
             unit_check_error(e1, tolerance);
             unit_check_error(e2, tolerance);
+            int zero = 0;
+            unit_check_general(1, 1, 1, &zero, &info);
         }
     }
 

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -16261,11 +16261,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -5;
     else
         *info = 0;
@@ -16293,11 +16293,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -5;
     else
         *info = 0;
@@ -16325,11 +16325,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -5;
     else
         *info = 0;
@@ -16362,11 +16362,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -5;
     else
         *info = 0;
@@ -16401,11 +16401,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -5;
     else if(batch_count < 0)
         *info = -7;
@@ -16436,11 +16436,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -5;
     else if(batch_count < 0)
         *info = -7;
@@ -16471,11 +16471,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -5;
     else if(batch_count < 0)
         *info = -7;
@@ -16512,11 +16512,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -5;
     else if(batch_count < 0)
         *info = -7;
@@ -16556,11 +16556,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -6;
     else if(batch_count < 0)
         *info = -9;
@@ -16593,11 +16593,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -6;
     else if(batch_count < 0)
         *info = -9;
@@ -16630,11 +16630,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -6;
     else if(batch_count < 0)
         *info = -9;
@@ -16675,11 +16675,11 @@ try
         *info = -1;
     else if(n < 0)
         *info = -2;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -3;
     else if(lda < std::max(1, m))
         *info = -4;
-    else if(tau == NULL)
+    else if(tau == NULL && m * n)
         *info = -6;
     else if(batch_count < 0)
         *info = -9;


### PR DESCRIPTION
SWDEV-344553

- geqrf (and batched variants) will now return info = 0 when nullptrs are passed in with either n == 0 || m == 0. Note that batch_count == 0 will return bad info if a nullptr is passed in
- added some tests to tests this case and other bad input cases

TODO:
- the test suite is still not thorough, should add bad_args or something similar to rocBLAS as we aren't testing all cases for nullptrs, just added some ad-hoc testing for this fix
- will go through other rocSOLVER functions as this fix is probably needed in other places. Just wanted this to be ready quick/put in separately in case needed for a hotfix