### PR TITLE
solver function argument checking

### DIFF
--- a/clients/gtest/gels_batched_gtest.cpp
+++ b/clients/gtest/gels_batched_gtest.cpp
@@ -34,6 +34,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, char, int, bool> gels_batched_tuple;
+typedef std::tuple<bool>                         gels_batched_bad_arg_tuple;
 
 // {m, n, nrhs, lda, ldb}
 const vector<vector<int>> matrix_size_range
@@ -71,6 +72,15 @@ Arguments setup_gels_batched_arguments(gels_batched_tuple tup)
     return arg;
 }
 
+class gels_batched_gtest_bad_arg : public ::TestWithParam<gels_batched_bad_arg_tuple>
+{
+protected:
+    gels_batched_gtest_bad_arg() {}
+    virtual ~gels_batched_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class gels_batched_gtest : public ::TestWithParam<gels_batched_tuple>
 {
 protected:
@@ -79,6 +89,16 @@ protected:
     virtual void SetUp() {}
     virtual void TearDown() {}
 };
+
+TEST_P(gels_batched_gtest_bad_arg, gels_batched_gtest_bad_arg_test)
+{
+    Arguments arg;
+
+    EXPECT_EQ(testing_gels_batched_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_batched_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_batched_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_batched_bad_arg<hipblasDoubleComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(gels_batched_gtest, gels_batched_gtest_float)
 {
@@ -183,3 +203,7 @@ INSTANTIATE_TEST_SUITE_P(hipblasGelsBatched,
                                  ValuesIn(trans_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGelsBatchedBadArg,
+                         gels_batched_gtest_bad_arg,
+                         Combine(ValuesIn(is_fortran)));

--- a/clients/gtest/gels_batched_gtest.cpp
+++ b/clients/gtest/gels_batched_gtest.cpp
@@ -90,6 +90,9 @@ protected:
     virtual void TearDown() {}
 };
 
+// Not doing bad_arg testing with cuBLAS backend for now
+// Error codes given by cuBLAS seem inaccurate.
+#ifndef __HIP_PLATFORM_NVCC__
 TEST_P(gels_batched_gtest_bad_arg, gels_batched_gtest_bad_arg_test)
 {
     Arguments arg;
@@ -99,6 +102,7 @@ TEST_P(gels_batched_gtest_bad_arg, gels_batched_gtest_bad_arg_test)
     EXPECT_EQ(testing_gels_batched_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
     EXPECT_EQ(testing_gels_batched_bad_arg<hipblasDoubleComplex>(arg), HIPBLAS_STATUS_SUCCESS);
 }
+#endif
 
 TEST_P(gels_batched_gtest, gels_batched_gtest_float)
 {
@@ -203,7 +207,8 @@ INSTANTIATE_TEST_SUITE_P(hipblasGelsBatched,
                                  ValuesIn(trans_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
-
+#ifndef __HIP_PLATFORM_NVCC__
 INSTANTIATE_TEST_SUITE_P(hipblasGelsBatchedBadArg,
                          gels_batched_gtest_bad_arg,
                          Combine(ValuesIn(is_fortran)));
+#endif

--- a/clients/gtest/gels_gtest.cpp
+++ b/clients/gtest/gels_gtest.cpp
@@ -34,6 +34,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, char, bool> gels_tuple;
+typedef std::tuple<bool>                    gels_bad_arg_tuple;
 
 // {m, n, nrhs, lda, ldb}
 const vector<vector<int>> matrix_size_range
@@ -67,6 +68,15 @@ Arguments setup_gels_arguments(gels_tuple tup)
     return arg;
 }
 
+class gels_gtest_bad_arg : public ::TestWithParam<gels_bad_arg_tuple>
+{
+protected:
+    gels_gtest_bad_arg() {}
+    virtual ~gels_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class gels_gtest : public ::TestWithParam<gels_tuple>
 {
 protected:
@@ -77,6 +87,16 @@ protected:
 };
 
 #ifndef __HIP_PLATFORM_NVCC__
+
+TEST_P(gels_gtest_bad_arg, gels_gtest_bad_arg_test)
+{
+    Arguments arg;
+
+    EXPECT_EQ(testing_gels_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_bad_arg<hipblasDoubleComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(gels_gtest, gels_gtest_float)
 {
@@ -180,5 +200,7 @@ INSTANTIATE_TEST_SUITE_P(hipblasGels,
                          Combine(ValuesIn(matrix_size_range),
                                  ValuesIn(trans_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGelsBadArg, gels_gtest_bad_arg, Combine(ValuesIn(is_fortran)));
 
 #endif

--- a/clients/gtest/gels_strided_batched_gtest.cpp
+++ b/clients/gtest/gels_strided_batched_gtest.cpp
@@ -34,6 +34,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, char, double, int, bool> gels_strided_batched_tuple;
+typedef std::tuple<bool>                                 gels_strided_batched_bad_arg_tuple;
 
 // {m, n, nrhs, lda, ldb}
 const vector<vector<int>> matrix_size_range
@@ -75,6 +76,16 @@ Arguments setup_gels_strided_batched_arguments(gels_strided_batched_tuple tup)
     return arg;
 }
 
+class gels_strided_batched_gtest_bad_arg
+    : public ::TestWithParam<gels_strided_batched_bad_arg_tuple>
+{
+protected:
+    gels_strided_batched_gtest_bad_arg() {}
+    virtual ~gels_strided_batched_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class gels_strided_batched_gtest : public ::TestWithParam<gels_strided_batched_tuple>
 {
 protected:
@@ -85,6 +96,17 @@ protected:
 };
 
 #ifndef __HIP_PLATFORM_NVCC__
+
+TEST_P(gels_strided_batched_gtest_bad_arg, gels_strided_batched_gtest_bad_arg_test)
+{
+    Arguments arg;
+
+    EXPECT_EQ(testing_gels_strided_batched_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_strided_batched_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_strided_batched_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_gels_strided_batched_bad_arg<hipblasDoubleComplex>(arg),
+              HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(gels_strided_batched_gtest, gels_strided_batched_gtest_float)
 {
@@ -190,5 +212,9 @@ INSTANTIATE_TEST_SUITE_P(hipblasGelsStridedBatched,
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGelsStridedBatchedBadArg,
+                         gels_strided_batched_gtest_bad_arg,
+                         Combine(ValuesIn(is_fortran)));
 
 #endif

--- a/clients/gtest/geqrf_batched_gtest.cpp
+++ b/clients/gtest/geqrf_batched_gtest.cpp
@@ -40,7 +40,7 @@ const vector<vector<int>> matrix_size_range = {{10, 10, 10}, {10, 10, 20}, {600,
 
 const vector<double> stride_scale_range = {2.5};
 
-const vector<int> batch_count_range = {-1, 0, 2};
+const vector<int> batch_count_range = {2};
 
 const vector<bool> is_fortran = {false, true};
 

--- a/clients/gtest/geqrf_batched_gtest.cpp
+++ b/clients/gtest/geqrf_batched_gtest.cpp
@@ -34,15 +34,9 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> geqrf_batched_tuple;
+typedef std::tuple<bool>                           geqrf_batched_bad_arg_tuple;
 
-const vector<vector<int>> matrix_size_range = {{-1, 1, 1}, // invalid M
-                                               {1, -1, 1}, // invalid N
-                                               {5, 5, 4}, // invalid lda
-                                               {0, 32, 32}, // M == 0
-                                               {32, 0, 32}, // N == 0
-                                               {10, 10, 10},
-                                               {10, 10, 20},
-                                               {600, 500, 600}};
+const vector<vector<int>> matrix_size_range = {{10, 10, 10}, {10, 10, 20}, {600, 500, 600}};
 
 const vector<double> stride_scale_range = {2.5};
 
@@ -71,6 +65,15 @@ Arguments setup_geqrf_batched_arguments(geqrf_batched_tuple tup)
     return arg;
 }
 
+class geqrf_batched_gtest_bad_arg : public ::TestWithParam<geqrf_batched_bad_arg_tuple>
+{
+protected:
+    geqrf_batched_gtest_bad_arg() {}
+    virtual ~geqrf_batched_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class geqrf_batched_gtest : public ::TestWithParam<geqrf_batched_tuple>
 {
 protected:
@@ -79,6 +82,16 @@ protected:
     virtual void SetUp() {}
     virtual void TearDown() {}
 };
+
+TEST_P(geqrf_batched_gtest_bad_arg, geqrf_batched_gtest_bad_arg_test)
+{
+    Arguments arg;
+
+    EXPECT_EQ(testing_geqrf_batched_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_batched_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_batched_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_batched_bad_arg<hipblasDoubleComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(geqrf_batched_gtest, geqrf_batched_gtest_float)
 {
@@ -179,3 +192,7 @@ INSTANTIATE_TEST_SUITE_P(hipblasGeqrfBatched,
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGeqrfBatchedBadArg,
+                         geqrf_batched_gtest_bad_arg,
+                         Combine(ValuesIn(is_fortran)));

--- a/clients/gtest/geqrf_gtest.cpp
+++ b/clients/gtest/geqrf_gtest.cpp
@@ -34,15 +34,9 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> geqrf_tuple;
+typedef std::tuple<bool>                           geqrf_bad_arg_tuple;
 
-const vector<vector<int>> matrix_size_range = {{-1, 1, 1}, // invalid M
-                                               {1, -1, 1}, // invalid N
-                                               {5, 5, 4}, // invalid lda
-                                               {0, 32, 32}, // M == 0
-                                               {32, 0, 32}, // N == 0
-                                               {10, 10, 10},
-                                               {10, 10, 20},
-                                               {600, 500, 600}};
+const vector<vector<int>> matrix_size_range = {{10, 10, 10}, {10, 10, 20}, {600, 500, 600}};
 
 const vector<double> stride_scale_range = {2.5};
 
@@ -71,6 +65,15 @@ Arguments setup_geqrf_arguments(geqrf_tuple tup)
     return arg;
 }
 
+class geqrf_gtest_bad_arg : public ::TestWithParam<geqrf_bad_arg_tuple>
+{
+protected:
+    geqrf_gtest_bad_arg() {}
+    virtual ~geqrf_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class geqrf_gtest : public ::TestWithParam<geqrf_tuple>
 {
 protected:
@@ -81,6 +84,16 @@ protected:
 };
 
 #ifndef __HIP_PLATFORM_NVCC__
+
+TEST_P(geqrf_gtest_bad_arg, geqrf_gtest_bad_arg_test)
+{
+    Arguments arg;
+
+    EXPECT_EQ(testing_geqrf_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_bad_arg<hipblasDoubleComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(geqrf_gtest, geqrf_gtest_float)
 {
@@ -181,5 +194,7 @@ INSTANTIATE_TEST_SUITE_P(hipblasGeqrf,
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGeqrfBadArg, geqrf_gtest_bad_arg, Combine(ValuesIn(is_fortran)));
 
 #endif

--- a/clients/gtest/geqrf_strided_batched_gtest.cpp
+++ b/clients/gtest/geqrf_strided_batched_gtest.cpp
@@ -34,15 +34,9 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> geqrf_strided_batched_tuple;
+typedef std::tuple<bool>                           geqrf_strided_batched_bad_arg_tuple;
 
-const vector<vector<int>> matrix_size_range = {{-1, 1, 1}, // invalid M
-                                               {1, -1, 1}, // invalid N
-                                               {5, 5, 4}, // invalid lda
-                                               {0, 32, 32}, // M == 0
-                                               {32, 0, 32}, // N == 0
-                                               {10, 10, 10},
-                                               {10, 10, 20},
-                                               {600, 500, 600}};
+const vector<vector<int>> matrix_size_range = {{10, 10, 10}, {10, 10, 20}, {600, 500, 600}};
 
 const vector<double> stride_scale_range = {2.5};
 
@@ -71,6 +65,16 @@ Arguments setup_geqrf_strided_batched_arguments(geqrf_strided_batched_tuple tup)
     return arg;
 }
 
+class geqrf_strided_batched_gtest_bad_arg
+    : public ::TestWithParam<geqrf_strided_batched_bad_arg_tuple>
+{
+protected:
+    geqrf_strided_batched_gtest_bad_arg() {}
+    virtual ~geqrf_strided_batched_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class geqrf_strided_batched_gtest : public ::TestWithParam<geqrf_strided_batched_tuple>
 {
 protected:
@@ -81,6 +85,17 @@ protected:
 };
 
 #ifndef __HIP_PLATFORM_NVCC__
+
+TEST_P(geqrf_strided_batched_gtest_bad_arg, geqrf_strided_batched_gtest_bad_arg_test)
+{
+    Arguments arg;
+
+    EXPECT_EQ(testing_geqrf_strided_batched_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_strided_batched_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_strided_batched_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_geqrf_strided_batched_bad_arg<hipblasDoubleComplex>(arg),
+              HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(geqrf_strided_batched_gtest, geqrf_strided_batched_gtest_float)
 {
@@ -181,5 +196,9 @@ INSTANTIATE_TEST_SUITE_P(hipblasGeqrfStridedBatched,
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGeqrfStridedBatchedBadArg,
+                         geqrf_strided_batched_gtest_bad_arg,
+                         Combine(ValuesIn(is_fortran)));
 
 #endif

--- a/clients/gtest/getrs_batched_gtest.cpp
+++ b/clients/gtest/getrs_batched_gtest.cpp
@@ -193,6 +193,6 @@ INSTANTIATE_TEST_SUITE_P(hipblasGetrsBatched,
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
 
-INSTANTIATE_TEST_SUITE_P(hipblasGetrsBadArg,
+INSTANTIATE_TEST_SUITE_P(hipblasGetrsBatchedBadArg,
                          getrs_batched_gtest_bad_arg,
                          Combine(ValuesIn(is_fortran)));

--- a/clients/gtest/getrs_batched_gtest.cpp
+++ b/clients/gtest/getrs_batched_gtest.cpp
@@ -34,6 +34,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> getrs_batched_tuple;
+typedef std::tuple<bool>                           getrs_batched_bad_arg_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, 1, 1}, {10, 20, 100}, {500, 600, 600}, {1024, 1024, 1024}};
@@ -65,6 +66,15 @@ Arguments setup_getrs_batched_arguments(getrs_batched_tuple tup)
     return arg;
 }
 
+class getrs_batched_gtest_bad_arg : public ::TestWithParam<getrs_batched_bad_arg_tuple>
+{
+protected:
+    getrs_batched_gtest_bad_arg() {}
+    virtual ~getrs_batched_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class getrs_batched_gtest : public ::TestWithParam<getrs_batched_tuple>
 {
 protected:
@@ -73,6 +83,15 @@ protected:
     virtual void SetUp() {}
     virtual void TearDown() {}
 };
+
+TEST_P(getrs_batched_gtest_bad_arg, getrs_batched_gtest_bad_arg_test)
+{
+    Arguments arg;
+    EXPECT_EQ(testing_getrs_batched_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_batched_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_batched_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_batched_bad_arg<hipblasDoubleComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(getrs_batched_gtest, getrs_batched_gtest_float)
 {
@@ -173,3 +192,7 @@ INSTANTIATE_TEST_SUITE_P(hipblasGetrsBatched,
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGetrsBadArg,
+                         getrs_batched_gtest_bad_arg,
+                         Combine(ValuesIn(is_fortran)));

--- a/clients/gtest/getrs_gtest.cpp
+++ b/clients/gtest/getrs_gtest.cpp
@@ -34,6 +34,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> getrs_tuple;
+typedef std::tuple<bool>                           getrs_bad_arg_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, 1, 1}, {10, 20, 100}, {500, 600, 600}, {1024, 1024, 1024}};
@@ -65,6 +66,15 @@ Arguments setup_getrs_arguments(getrs_tuple tup)
     return arg;
 }
 
+class getrs_gtest_bad_arg : public ::TestWithParam<getrs_bad_arg_tuple>
+{
+protected:
+    getrs_gtest_bad_arg() {}
+    virtual ~getrs_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class getrs_gtest : public ::TestWithParam<getrs_tuple>
 {
 protected:
@@ -75,6 +85,16 @@ protected:
 };
 
 #ifndef __HIP_PLATFORM_NVCC__
+
+TEST_P(getrs_gtest_bad_arg, getrs_gtest_bad_arg_test)
+{
+    Arguments arg;
+
+    EXPECT_EQ(testing_getrs_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_bad_arg<hipblasDoubleComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(getrs_gtest, getrs_gtest_float)
 {
@@ -175,5 +195,7 @@ INSTANTIATE_TEST_SUITE_P(hipblasGetrs,
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGetrsBadArg, getrs_gtest_bad_arg, Combine(ValuesIn(is_fortran)));
 
 #endif

--- a/clients/gtest/getrs_strided_batched_gtest.cpp
+++ b/clients/gtest/getrs_strided_batched_gtest.cpp
@@ -34,6 +34,7 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 
 typedef std::tuple<vector<int>, double, int, bool> getrs_strided_batched_tuple;
+typedef std::tuple<bool>                           getrs_strided_batched_bad_arg_tuple;
 
 const vector<vector<int>> matrix_size_range
     = {{-1, 1, 1}, {10, 20, 100}, {500, 600, 600}, {1024, 1024, 1024}};
@@ -65,6 +66,16 @@ Arguments setup_getrs_strided_batched_arguments(getrs_strided_batched_tuple tup)
     return arg;
 }
 
+class getrs_strided_batched_gtest_bad_arg
+    : public ::TestWithParam<getrs_strided_batched_bad_arg_tuple>
+{
+protected:
+    getrs_strided_batched_gtest_bad_arg() {}
+    virtual ~getrs_strided_batched_gtest_bad_arg() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
 class getrs_strided_batched_gtest : public ::TestWithParam<getrs_strided_batched_tuple>
 {
 protected:
@@ -75,6 +86,17 @@ protected:
 };
 
 #ifndef __HIP_PLATFORM_NVCC__
+
+TEST_P(getrs_strided_batched_gtest_bad_arg, getrs_strided_batched_gtest_bad_arg_test)
+{
+    Arguments arg;
+
+    EXPECT_EQ(testing_getrs_strided_batched_bad_arg<float>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_strided_batched_bad_arg<double>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_strided_batched_bad_arg<hipblasComplex>(arg), HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(testing_getrs_strided_batched_bad_arg<hipblasDoubleComplex>(arg),
+              HIPBLAS_STATUS_SUCCESS);
+}
 
 TEST_P(getrs_strided_batched_gtest, getrs_strided_batched_gtest_float)
 {
@@ -175,5 +197,9 @@ INSTANTIATE_TEST_SUITE_P(hipblasGetrsStridedBatched,
                                  ValuesIn(stride_scale_range),
                                  ValuesIn(batch_count_range),
                                  ValuesIn(is_fortran)));
+
+INSTANTIATE_TEST_SUITE_P(hipblasGetrsStridedBatchedBadArg,
+                         getrs_strided_batched_gtest_bad_arg,
+                         Combine(ValuesIn(is_fortran)));
 
 #endif

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -50,8 +50,8 @@ inline hipblasStatus_t testing_gels_bad_arg(const Arguments& arg)
     const hipblasOperation_t opN   = HIPBLAS_OP_N;
     const hipblasOperation_t opBad = is_complex<T> ? HIPBLAS_OP_T : HIPBLAS_OP_C;
 
-    const int A_size = lda * N;
-    const int B_size = ldb * nrhs;
+    const size_t A_size = size_t(lda) * N;
+    const size_t B_size = size_t(ldb) * nrhs;
 
     device_vector<T>   dA(A_size);
     device_vector<T>   dB(B_size);
@@ -152,7 +152,7 @@ inline hipblasStatus_t testing_gels(const Arguments& arg)
     hipblasOperation_t trans = char2hipblas_operation(transc);
 
     size_t A_size = size_t(lda) * N;
-    size_t B_size = ldb * nrhs;
+    size_t B_size = size_t(ldb) * nrhs;
 
     // Check to prevent memory allocation error
     if(M < 0 || N < 0 || nrhs < 0 || lda < M || ldb < M || ldb < N)

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -91,6 +91,7 @@ inline hipblasStatus_t testing_gels_bad_arg(const Arguments& arg)
         HIPBLAS_STATUS_INVALID_VALUE);
     EXPECT_EQ(-7, info);
 
+    // Explicit values to check for ldb < M and ldb < N
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsFn(handle, opN, 100, 200, nrhs, dA, lda, dB, 199, &info, dInfo),
         HIPBLAS_STATUS_INVALID_VALUE);

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -21,6 +21,7 @@
  *
  * ************************************************************************ */
 
+#include "gtest/gtest.h"
 #include <fstream>
 #include <iostream>
 #include <stdlib.h>
@@ -33,6 +34,100 @@ using hipblasGelsModel = ArgumentModel<e_transA, e_M, e_N, e_lda, e_ldb>;
 inline void testname_gels(const Arguments& arg, std::string& name)
 {
     hipblasGelsModel{}.test_name(arg, name);
+}
+
+template <typename T>
+inline hipblasStatus_t testing_gels_bad_arg(const Arguments& arg)
+{
+    auto hipblasGelsFn = arg.fortran ? hipblasGels<T, true> : hipblasGels<T, false>;
+
+    hipblasLocalHandle       handle(arg);
+    const int                M     = 100;
+    const int                N     = 101;
+    const int                nrhs  = 10;
+    const int                lda   = 102;
+    const int                ldb   = 103;
+    const hipblasOperation_t opN   = HIPBLAS_OP_N;
+    const hipblasOperation_t opBad = is_complex<T> ? HIPBLAS_OP_T : HIPBLAS_OP_C;
+
+    const int A_size = lda * N;
+    const int B_size = ldb * nrhs;
+
+    device_vector<T>   dA(A_size);
+    device_vector<T>   dB(B_size);
+    device_vector<int> dInfo(1);
+    int                info = 0;
+
+    EXPECT_HIPBLAS_STATUS(hipblasGelsFn(handle, opN, M, N, nrhs, dA, lda, dB, ldb, nullptr, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGelsFn(handle, opBad, M, N, nrhs, dA, lda, dB, ldb, &info, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-1, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGelsFn(handle, opN, -1, N, nrhs, dA, lda, dB, ldb, &info, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-2, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGelsFn(handle, opN, M, -1, nrhs, dA, lda, dB, ldb, &info, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-3, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGelsFn(handle, opN, M, N, -1, dA, lda, dB, ldb, &info, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-4, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGelsFn(handle, opN, M, N, nrhs, nullptr, lda, dB, ldb, &info, dInfo),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-5, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGelsFn(handle, opN, M, N, nrhs, dA, M - 1, dB, ldb, &info, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-6, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGelsFn(handle, opN, M, N, nrhs, dA, lda, nullptr, ldb, &info, dInfo),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-7, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGelsFn(handle, opN, 100, 200, nrhs, dA, lda, dB, 199, &info, dInfo),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-8, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGelsFn(handle, opN, 200, 100, nrhs, dA, 201, dB, 199, &info, dInfo),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-8, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGelsFn(handle, opN, M, N, nrhs, dA, lda, dB, ldb, &info, nullptr),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-10, info);
+
+    // If M == 0 || N == 0, A can be nullptr
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGelsFn(handle, opN, 0, N, nrhs, nullptr, lda, dB, ldb, &info, dInfo),
+        HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGelsFn(handle, opN, M, 0, nrhs, nullptr, lda, dB, ldb, &info, dInfo),
+        HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    // If nrhs == 0, B can be nullptr
+    EXPECT_HIPBLAS_STATUS(hipblasGelsFn(handle, opN, M, N, 0, dA, lda, nullptr, ldb, &info, dInfo),
+                          HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    // If M == 0 && N == 0, B can be nullptr
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGelsFn(handle, opN, 0, 0, nrhs, nullptr, lda, nullptr, ldb, &info, dInfo),
+        HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    return HIPBLAS_STATUS_SUCCESS;
 }
 
 template <typename T>
@@ -133,8 +228,10 @@ inline hipblasStatus_t testing_gels(const Arguments& arg)
         {
             double eps       = std::numeric_limits<U>::epsilon();
             double tolerance = N * eps * 100;
+            int    zero      = 0;
 
             unit_check_error(hipblas_error, tolerance);
+            unit_check_general(1, 1, 1, &zero, &info_input);
         }
     }
 

--- a/clients/include/testing_gels_batched.hpp
+++ b/clients/include/testing_gels_batched.hpp
@@ -52,8 +52,8 @@ inline hipblasStatus_t testing_gels_batched_bad_arg(const Arguments& arg)
     const hipblasOperation_t opN        = HIPBLAS_OP_N;
     const hipblasOperation_t opBad      = is_complex<T> ? HIPBLAS_OP_T : HIPBLAS_OP_C;
 
-    const int A_size = lda * N;
-    const int B_size = ldb * nrhs;
+    const size_t A_size = size_t(lda) * N;
+    const size_t B_size = size_t(ldb) * nrhs;
 
     device_batch_vector<T> dA(A_size, 1, batchCount);
     device_batch_vector<T> dB(B_size, 1, batchCount);
@@ -192,7 +192,7 @@ inline hipblasStatus_t testing_gels_batched(const Arguments& arg)
     hipblasOperation_t trans = char2hipblas_operation(transc);
 
     size_t A_size = size_t(lda) * N;
-    size_t B_size = ldb * nrhs;
+    size_t B_size = size_t(ldb) * nrhs;
 
     // Check to prevent memory allocation error
     if(M < 0 || N < 0 || nrhs < 0 || lda < M || ldb < M || ldb < N || batchCount < 0)

--- a/clients/include/testing_gels_batched.hpp
+++ b/clients/include/testing_gels_batched.hpp
@@ -109,6 +109,7 @@ inline hipblasStatus_t testing_gels_batched_bad_arg(const Arguments& arg)
         HIPBLAS_STATUS_INVALID_VALUE);
     EXPECT_EQ(-7, info);
 
+    // Explicit values to check for ldb < M and ldb < N
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(
             handle, opN, 100, 200, nrhs, dAp, lda, dBp, 199, &info, dInfo, batchCount),

--- a/clients/include/testing_gels_strided_batched.hpp
+++ b/clients/include/testing_gels_strided_batched.hpp
@@ -165,6 +165,7 @@ inline hipblasStatus_t testing_gels_strided_batched_bad_arg(const Arguments& arg
                           HIPBLAS_STATUS_INVALID_VALUE);
     EXPECT_EQ(-8, info);
 
+    // Explicit values to check for ldb < M and ldb < N
     EXPECT_HIPBLAS_STATUS(hipblasGelsStridedBatchedFn(handle,
                                                       opN,
                                                       100,

--- a/clients/include/testing_gels_strided_batched.hpp
+++ b/clients/include/testing_gels_strided_batched.hpp
@@ -55,8 +55,8 @@ inline hipblasStatus_t testing_gels_strided_batched_bad_arg(const Arguments& arg
 
     const hipblasStride strideA = size_t(lda) * N;
     const hipblasStride strideB = size_t(ldb) * nrhs;
-    const int           A_size  = strideA * batchCount;
-    const int           B_size  = strideB * batchCount;
+    const size_t        A_size  = strideA * batchCount;
+    const size_t        B_size  = strideB * batchCount;
 
     device_vector<T>   dA(A_size);
     device_vector<T>   dB(B_size);

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -75,7 +75,7 @@ inline hipblasStatus_t testing_geqrf_bad_arg(const Arguments& arg)
     const int          M      = 100;
     const int          N      = 101;
     const int          lda    = 102;
-    const int          A_size = N * lda;
+    const size_t       A_size = size_t(N) * lda;
     const int          K      = std::min(M, N);
 
     host_vector<T> hA(A_size);

--- a/clients/include/testing_geqrf_batched.hpp
+++ b/clients/include/testing_geqrf_batched.hpp
@@ -81,7 +81,7 @@ inline hipblasStatus_t testing_geqrf_batched_bad_arg(const Arguments& arg)
     const int          N           = 101;
     const int          lda         = 102;
     const int          batch_count = 2;
-    const int          A_size      = N * lda;
+    const size_t       A_size      = size_t(N) * lda;
     const int          K           = std::min(M, N);
 
     host_batch_vector<T> hA(A_size, 1, batch_count);

--- a/clients/include/testing_geqrf_batched.hpp
+++ b/clients/include/testing_geqrf_batched.hpp
@@ -112,19 +112,9 @@ inline hipblasStatus_t testing_geqrf_batched_bad_arg(const Arguments& arg)
     EXPECT_EQ(-2, info);
 
     EXPECT_HIPBLAS_STATUS(
-        hipblasGeqrfBatchedFn(handle, M, N, nullptr, lda, dIpivp, &info, batch_count),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    EXPECT_EQ(-3, info);
-
-    EXPECT_HIPBLAS_STATUS(
         hipblasGeqrfBatchedFn(handle, M, N, dAp, M - 1, dIpivp, &info, batch_count),
         HIPBLAS_STATUS_INVALID_VALUE);
     EXPECT_EQ(-4, info);
-
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGeqrfBatchedFn(handle, M, N, dAp, lda, nullptr, &info, batch_count),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    EXPECT_EQ(-5, info);
 
     EXPECT_HIPBLAS_STATUS(hipblasGeqrfBatchedFn(handle, M, N, dAp, lda, dIpivp, &info, -1),
                           HIPBLAS_STATUS_INVALID_VALUE);
@@ -142,6 +132,19 @@ inline hipblasStatus_t testing_geqrf_batched_bad_arg(const Arguments& arg)
     EXPECT_EQ(0, info);
 
     // can't make any assumptions about ptrs when batch_count < 0, this is handled by rocSOLVER
+
+    // cuBLAS beckend doesn't check for nullptrs for A and ipiv
+#ifndef __HIP_PLATFORM_NVCC__
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, M, N, nullptr, lda, dIpivp, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-3, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, M, N, dAp, lda, nullptr, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-5, info);
+#endif
 
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_geqrf_batched.hpp
+++ b/clients/include/testing_geqrf_batched.hpp
@@ -21,6 +21,7 @@
  *
  * ************************************************************************ */
 
+#include "gtest/gtest.h"
 #include <fstream>
 #include <iostream>
 #include <stdlib.h>
@@ -33,6 +34,116 @@ using hipblasGeqrfBatchedModel = ArgumentModel<e_M, e_N, e_lda, e_batch_count>;
 inline void testname_geqrf_batched(const Arguments& arg, std::string& name)
 {
     hipblasGeqrfBatchedModel{}.test_name(arg, name);
+}
+
+template <typename T>
+inline hipblasStatus_t setup_geqrf_batched_testing(host_batch_vector<T>&   hA,
+                                                   host_batch_vector<T>&   hIpiv,
+                                                   device_batch_vector<T>& dA,
+                                                   device_batch_vector<T>& dIpiv,
+                                                   int                     M,
+                                                   int                     N,
+                                                   int                     lda,
+                                                   int                     batch_count)
+{
+    // Initial hA on CPU
+    hipblas_init(hA, true);
+    srand(1);
+    for(int b = 0; b < batch_count; b++)
+    {
+        // scale A to avoid singularities
+        for(int i = 0; i < M; i++)
+        {
+            for(int j = 0; j < N; j++)
+            {
+                if(i == j)
+                    hA[b][i + j * lda] += 400;
+                else
+                    hA[b][i + j * lda] -= 4;
+            }
+        }
+    }
+
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dIpiv.transfer_from(hIpiv));
+
+    return HIPBLAS_STATUS_SUCCESS;
+}
+
+template <typename T>
+inline hipblasStatus_t testing_geqrf_batched_bad_arg(const Arguments& arg)
+{
+    auto hipblasGeqrfBatchedFn
+        = arg.fortran ? hipblasGeqrfBatched<T, true> : hipblasGeqrfBatched<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    const int          M           = 100;
+    const int          N           = 101;
+    const int          lda         = 102;
+    const int          batch_count = 2;
+    const int          A_size      = N * lda;
+    const int          K           = std::min(M, N);
+
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hIpiv(K, 1, batch_count);
+
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dIpiv(K, 1, batch_count);
+    int                    info = 0;
+
+    T* const* dAp    = dA.ptr_on_device();
+    T* const* dIpivp = dIpiv.ptr_on_device();
+
+    EXPECT_HIPBLAS_STATUS(setup_geqrf_batched_testing(hA, hIpiv, dA, dIpiv, M, N, lda, batch_count),
+                          HIPBLAS_STATUS_SUCCESS);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, M, N, dAp, lda, dIpivp, nullptr, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, -1, N, dAp, lda, dIpivp, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-1, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, M, -1, dAp, lda, dIpivp, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-2, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, M, N, nullptr, lda, dIpivp, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-3, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, M, N, dAp, M - 1, dIpivp, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-4, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, M, N, dAp, lda, nullptr, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-5, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGeqrfBatchedFn(handle, M, N, dAp, lda, dIpivp, &info, -1),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-7, info);
+
+    // If M == 0 || N == 0, A and ipiv can be nullptr
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, 0, N, nullptr, lda, nullptr, &info, batch_count),
+        HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGeqrfBatchedFn(handle, M, 0, nullptr, lda, nullptr, &info, batch_count),
+        HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    // can't make any assumptions about ptrs when batch_count < 0, this is handled by rocSOLVER
+
+    return HIPBLAS_STATUS_SUCCESS;
 }
 
 template <typename T>
@@ -59,26 +170,7 @@ inline hipblasStatus_t testing_geqrf_batched(const Arguments& arg)
     bool invalid_size = M < 0 || N < 0 || lda < std::max(1, M) || batch_count < 0;
     if(invalid_size || !M || !N || !batch_count)
     {
-        // including pointers so can test other params
-        device_batch_vector<T> dA(1, 1, 1);
-        device_batch_vector<T> dIpiv(1, 1, 1);
-        hipblasStatus_t        status = hipblasGeqrfBatched(
-            handle, M, N, dA.ptr_on_device(), lda, dIpiv.ptr_on_device(), &info, batch_count);
-        EXPECT_HIPBLAS_STATUS(
-            status, (invalid_size ? HIPBLAS_STATUS_INVALID_VALUE : HIPBLAS_STATUS_SUCCESS));
-
-        int expected_info = 0;
-        if(M < 0)
-            expected_info = -1;
-        else if(N < 0)
-            expected_info = -2;
-        else if(lda < std::max(1, M))
-            expected_info = -4;
-        else if(batch_count < 0)
-            expected_info = -7;
-        unit_check_general(1, 1, 1, &expected_info, &info);
-
-        return status;
+        return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     // Naming: dK is in GPU (device) memory. hK is in CPU (host) memory
@@ -92,26 +184,8 @@ inline hipblasStatus_t testing_geqrf_batched(const Arguments& arg)
 
     double gpu_time_used, hipblas_error;
 
-    // Initial hA on CPU
-    hipblas_init(hA, true);
-    srand(1);
-    for(int b = 0; b < batch_count; b++)
-    {
-        // scale A to avoid singularities
-        for(int i = 0; i < M; i++)
-        {
-            for(int j = 0; j < N; j++)
-            {
-                if(i == j)
-                    hA[b][i + j * lda] += 400;
-                else
-                    hA[b][i + j * lda] -= 4;
-            }
-        }
-    }
-
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-    CHECK_HIP_ERROR(dIpiv.transfer_from(hIpiv));
+    EXPECT_HIPBLAS_STATUS(setup_geqrf_batched_testing(hA, hIpiv, dA, dIpiv, M, N, lda, batch_count),
+                          HIPBLAS_STATUS_SUCCESS);
 
     /* =====================================================================
            HIPBLAS

--- a/clients/include/testing_geqrf_strided_batched.hpp
+++ b/clients/include/testing_geqrf_strided_batched.hpp
@@ -91,7 +91,7 @@ inline hipblasStatus_t testing_geqrf_strided_batched_bad_arg(const Arguments& ar
     const int          lda         = 102;
     const int          batch_count = 2;
 
-    hipblasStride strideA   = lda * N;
+    hipblasStride strideA   = size_t(lda) * N;
     hipblasStride strideP   = K;
     size_t        A_size    = strideA * batch_count;
     size_t        Ipiv_size = strideP * batch_count;

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -99,8 +99,8 @@ inline hipblasStatus_t testing_getrs_bad_arg(const Arguments& arg)
     const int          nrhs      = 1;
     const int          lda       = 101;
     const int          ldb       = 102;
-    const int          A_size    = N * lda;
-    const int          B_size    = ldb;
+    const size_t       A_size    = size_t(N) * lda;
+    const size_t       B_size    = ldb;
     const int          Ipiv_size = N;
 
     const hipblasOperation_t op = HIPBLAS_OP_N;

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -158,7 +158,7 @@ inline hipblasStatus_t testing_getrs_bad_arg(const Arguments& arg)
     EXPECT_EQ(0, info);
 
     // if nrhs == 0, B can be nullptr
-    EXPECT_HIPBLAS_STATUS(hipblasGetrsFn(handle, op, 0, nrhs, dA, lda, dIpiv, nullptr, ldb, &info),
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsFn(handle, op, N, 0, dA, lda, dIpiv, nullptr, ldb, &info),
                           HIPBLAS_STATUS_SUCCESS);
     EXPECT_EQ(0, info);
 

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -48,9 +48,9 @@ inline hipblasStatus_t setup_getrs_testing(host_vector<T>&     hA,
                                            int                 lda,
                                            int                 ldb)
 {
-    const int A_size    = N * lda;
-    const int B_size    = ldb;
-    const int Ipiv_size = N;
+    const size_t A_size    = size_t(N) * lda;
+    const size_t B_size    = ldb;
+    const size_t Ipiv_size = N;
 
     // Initial hA, hB, hX on CPU
     srand(1);

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -36,6 +36,165 @@ inline void testname_getrs_batched(const Arguments& arg, std::string& name)
 }
 
 template <typename T>
+inline hipblasStatus_t setup_getrs_batched_testing(host_batch_vector<T>&   hA,
+                                                   host_batch_vector<T>&   hB,
+                                                   host_batch_vector<T>&   hX,
+                                                   host_vector<int>&       hIpiv,
+                                                   device_batch_vector<T>& dA,
+                                                   device_batch_vector<T>& dB,
+                                                   device_vector<int>&     dIpiv,
+                                                   int                     N,
+                                                   int                     lda,
+                                                   int                     ldb,
+                                                   int                     batch_count)
+{
+    hipblasStride strideP   = N;
+    size_t        A_size    = size_t(lda) * N;
+    size_t        B_size    = size_t(ldb) * 1;
+    size_t        Ipiv_size = strideP * batch_count;
+
+    // Initial hA, hB, hX on CPU
+    hipblas_init(hA, true);
+    hipblas_init(hX);
+    srand(1);
+    hipblasOperation_t op = HIPBLAS_OP_N;
+    for(int b = 0; b < batch_count; b++)
+    {
+        // scale A to avoid singularities
+        for(int i = 0; i < N; i++)
+        {
+            for(int j = 0; j < N; j++)
+            {
+                if(i == j)
+                    hA[b][i + j * lda] += 400;
+                else
+                    hA[b][i + j * lda] -= 4;
+            }
+        }
+
+        // Calculate hB = hA*hX;
+        cblas_gemm<T>(op, op, N, 1, N, (T)1, hA[b], lda, hX[b], ldb, (T)0, hB[b], ldb);
+
+        // LU factorize hA on the CPU
+        int info = cblas_getrf<T>(N, N, hA[b], lda, hIpiv.data() + b * strideP);
+        if(info != 0)
+        {
+            std::cerr << "LU decomposition failed" << std::endl;
+            return HIPBLAS_STATUS_INTERNAL_ERROR;
+        }
+    }
+
+    CHECK_HIP_ERROR(dA.transfer_from(hA));
+    CHECK_HIP_ERROR(dB.transfer_from(hB));
+    CHECK_HIP_ERROR(hipMemcpy(dIpiv, hIpiv.data(), Ipiv_size * sizeof(int), hipMemcpyHostToDevice));
+
+    return HIPBLAS_STATUS_SUCCESS;
+}
+
+template <typename T>
+inline hipblasStatus_t testing_getrs_batched_bad_arg(const Arguments& arg)
+{
+    auto hipblasGetrsBatchedFn
+        = arg.fortran ? hipblasGetrsBatched<T, true> : hipblasGetrsBatched<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    const int          N           = 100;
+    const int          nrhs        = 1;
+    const int          lda         = 101;
+    const int          ldb         = 102;
+    const int          batch_count = 2;
+
+    const int A_size    = N * lda;
+    const int B_size    = ldb;
+    const int Ipiv_size = batch_count * N;
+
+    const hipblasOperation_t op = HIPBLAS_OP_N;
+
+    host_batch_vector<T> hA(A_size, 1, batch_count);
+    host_batch_vector<T> hB(B_size, 1, batch_count);
+    host_batch_vector<T> hX(B_size, 1, batch_count);
+    host_vector<int>     hIpiv(Ipiv_size);
+
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dB(B_size, 1, batch_count);
+    device_vector<int>     dIpiv(Ipiv_size);
+    int                    info = 0;
+
+    T* const* dAp = dA.ptr_on_device();
+    T* const* dBp = dB.ptr_on_device();
+
+    // Need initialization code because even with bad params we call roc/cu-solver
+    // so want to give reasonable data
+    EXPECT_HIPBLAS_STATUS(
+        setup_getrs_batched_testing(hA, hB, hX, hIpiv, dA, dB, dIpiv, N, lda, ldb, batch_count),
+        HIPBLAS_STATUS_SUCCESS);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, dIpiv, dBp, ldb, nullptr, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, -1, nrhs, dAp, lda, dIpiv, dBp, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-2, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, N, -1, dAp, lda, dIpiv, dBp, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-3, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(
+            handle, op, N, nrhs, nullptr, lda, dIpiv, dBp, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-4, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, N - 1, dIpiv, dBp, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-5, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, nullptr, dBp, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-6, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(
+            handle, op, N, nrhs, dAp, lda, dIpiv, nullptr, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-7, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, dIpiv, dBp, N - 1, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-8, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, dIpiv, dBp, ldb, &info, -1),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-10, info);
+
+    // If N == 0, A, B, and ipiv can be nullptr
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(
+            handle, op, 0, nrhs, nullptr, lda, nullptr, nullptr, ldb, &info, batch_count),
+        HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    // if nrhs == 0, B can be nullptr
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(
+            handle, op, 0, nrhs, dAp, lda, dIpiv, nullptr, ldb, &info, batch_count),
+        HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    // can't make any assumptions about ptrs when batch_count < 0, this is handled by rocSOLVER
+
+    return HIPBLAS_STATUS_SUCCESS;
+}
+
+template <typename T>
 inline hipblasStatus_t testing_getrs_batched(const Arguments& arg)
 {
     using U      = real_t<T>;
@@ -78,41 +237,11 @@ inline hipblasStatus_t testing_getrs_batched(const Arguments& arg)
 
     double             gpu_time_used, hipblas_error;
     hipblasLocalHandle handle(arg);
-
-    // Initial hA, hB, hX on CPU
-    hipblas_init(hA, true);
-    hipblas_init(hX);
-    srand(1);
     hipblasOperation_t op = HIPBLAS_OP_N;
-    for(int b = 0; b < batch_count; b++)
-    {
-        // scale A to avoid singularities
-        for(int i = 0; i < N; i++)
-        {
-            for(int j = 0; j < N; j++)
-            {
-                if(i == j)
-                    hA[b][i + j * lda] += 400;
-                else
-                    hA[b][i + j * lda] -= 4;
-            }
-        }
 
-        // Calculate hB = hA*hX;
-        cblas_gemm<T>(op, op, N, 1, N, (T)1, hA[b], lda, hX[b], ldb, (T)0, hB[b], ldb);
-
-        // LU factorize hA on the CPU
-        info = cblas_getrf<T>(N, N, hA[b], lda, hIpiv.data() + b * strideP);
-        if(info != 0)
-        {
-            std::cerr << "LU decomposition failed" << std::endl;
-            return HIPBLAS_STATUS_INTERNAL_ERROR;
-        }
-    }
-
-    CHECK_HIP_ERROR(dA.transfer_from(hA));
-    CHECK_HIP_ERROR(dB.transfer_from(hB));
-    CHECK_HIP_ERROR(hipMemcpy(dIpiv, hIpiv.data(), Ipiv_size * sizeof(int), hipMemcpyHostToDevice));
+    EXPECT_HIPBLAS_STATUS(
+        setup_getrs_batched_testing(hA, hB, hX, hIpiv, dA, dB, dIpiv, N, lda, ldb, batch_count),
+        HIPBLAS_STATUS_SUCCESS);
 
     if(arg.unit_check || arg.norm_check)
     {
@@ -150,8 +279,10 @@ inline hipblasStatus_t testing_getrs_batched(const Arguments& arg)
         {
             U      eps       = std::numeric_limits<U>::epsilon();
             double tolerance = N * eps * 100;
+            int    zero      = 0;
 
             unit_check_error(hipblas_error, tolerance);
+            unit_check_general(1, 1, 1, &zero, &info);
         }
     }
 

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -130,10 +130,6 @@ inline hipblasStatus_t testing_getrs_batched_bad_arg(const Arguments& arg)
         HIPBLAS_STATUS_SUCCESS);
 
     EXPECT_HIPBLAS_STATUS(
-        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, dIpiv, dBp, ldb, nullptr, batch_count),
-        HIPBLAS_STATUS_INVALID_VALUE);
-
-    EXPECT_HIPBLAS_STATUS(
         hipblasGetrsBatchedFn(handle, op, -1, nrhs, dAp, lda, dIpiv, dBp, ldb, &info, batch_count),
         HIPBLAS_STATUS_INVALID_VALUE);
     EXPECT_EQ(-2, info);
@@ -144,36 +140,22 @@ inline hipblasStatus_t testing_getrs_batched_bad_arg(const Arguments& arg)
     EXPECT_EQ(-3, info);
 
     EXPECT_HIPBLAS_STATUS(
-        hipblasGetrsBatchedFn(
-            handle, op, N, nrhs, nullptr, lda, dIpiv, dBp, ldb, &info, batch_count),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    EXPECT_EQ(-4, info);
-
-    EXPECT_HIPBLAS_STATUS(
         hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, N - 1, dIpiv, dBp, ldb, &info, batch_count),
         HIPBLAS_STATUS_INVALID_VALUE);
     EXPECT_EQ(-5, info);
-
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, nullptr, dBp, ldb, &info, batch_count),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    EXPECT_EQ(-6, info);
-
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGetrsBatchedFn(
-            handle, op, N, nrhs, dAp, lda, dIpiv, nullptr, ldb, &info, batch_count),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    EXPECT_EQ(-7, info);
 
     EXPECT_HIPBLAS_STATUS(
         hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, dIpiv, dBp, N - 1, &info, batch_count),
         HIPBLAS_STATUS_INVALID_VALUE);
     EXPECT_EQ(-8, info);
 
+    // cuBLAS returns HIPBLAS_STATUS_EXECUTION_FAILED and gives info == 0
+#ifndef __HIP_PLATFORM_NVCC__
     EXPECT_HIPBLAS_STATUS(
         hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, dIpiv, dBp, ldb, &info, -1),
         HIPBLAS_STATUS_INVALID_VALUE);
     EXPECT_EQ(-10, info);
+#endif
 
     // If N == 0, A, B, and ipiv can be nullptr
     EXPECT_HIPBLAS_STATUS(
@@ -190,6 +172,30 @@ inline hipblasStatus_t testing_getrs_batched_bad_arg(const Arguments& arg)
     EXPECT_EQ(0, info);
 
     // can't make any assumptions about ptrs when batch_count < 0, this is handled by rocSOLVER
+
+    // cuBLAS beckend doesn't check for nullptrs, including info, hipBLAS/rocSOLVER does
+#ifndef __HIP_PLATFORM_NVCC__
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, dIpiv, dBp, ldb, nullptr, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(
+            handle, op, N, nrhs, nullptr, lda, dIpiv, dBp, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-4, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(handle, op, N, nrhs, dAp, lda, nullptr, dBp, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-6, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsBatchedFn(
+            handle, op, N, nrhs, dAp, lda, dIpiv, nullptr, ldb, &info, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-7, info);
+#endif
 
     return HIPBLAS_STATUS_SUCCESS;
 }

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -104,9 +104,9 @@ inline hipblasStatus_t testing_getrs_batched_bad_arg(const Arguments& arg)
     const int          ldb         = 102;
     const int          batch_count = 2;
 
-    const int A_size    = N * lda;
-    const int B_size    = ldb;
-    const int Ipiv_size = batch_count * N;
+    const size_t A_size    = size_t(N) * lda;
+    const size_t B_size    = ldb;
+    const size_t Ipiv_size = size_t(N) * batch_count;
 
     const hipblasOperation_t op = HIPBLAS_OP_N;
 

--- a/clients/include/testing_getrs_batched.hpp
+++ b/clients/include/testing_getrs_batched.hpp
@@ -166,8 +166,7 @@ inline hipblasStatus_t testing_getrs_batched_bad_arg(const Arguments& arg)
 
     // if nrhs == 0, B can be nullptr
     EXPECT_HIPBLAS_STATUS(
-        hipblasGetrsBatchedFn(
-            handle, op, 0, nrhs, dAp, lda, dIpiv, nullptr, ldb, &info, batch_count),
+        hipblasGetrsBatchedFn(handle, op, N, 0, dAp, lda, dIpiv, nullptr, ldb, &info, batch_count),
         HIPBLAS_STATUS_SUCCESS);
     EXPECT_EQ(0, info);
 

--- a/clients/include/testing_getrs_strided_batched.hpp
+++ b/clients/include/testing_getrs_strided_batched.hpp
@@ -301,8 +301,8 @@ inline hipblasStatus_t testing_getrs_strided_batched_bad_arg(const Arguments& ar
     // if nrhs == 0, B can be nullptr
     EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
                                                        op,
+                                                       N,
                                                        0,
-                                                       nrhs,
                                                        dA,
                                                        lda,
                                                        strideA,

--- a/clients/include/testing_getrs_strided_batched.hpp
+++ b/clients/include/testing_getrs_strided_batched.hpp
@@ -37,6 +37,291 @@ inline void testname_getrs_strided_batched(const Arguments& arg, std::string& na
 }
 
 template <typename T>
+inline hipblasStatus_t setup_getrs_strided_batched_testing(host_vector<T>&     hA,
+                                                           host_vector<T>&     hB,
+                                                           host_vector<T>&     hX,
+                                                           host_vector<int>&   hIpiv,
+                                                           device_vector<T>&   dA,
+                                                           device_vector<T>&   dB,
+                                                           device_vector<int>& dIpiv,
+                                                           int                 N,
+                                                           int                 lda,
+                                                           int                 ldb,
+                                                           hipblasStride       strideA,
+                                                           hipblasStride       strideB,
+                                                           hipblasStride       strideP,
+                                                           int                 batch_count)
+{
+    size_t A_size    = strideA * batch_count;
+    size_t B_size    = strideB * batch_count;
+    size_t Ipiv_size = strideP * batch_count;
+
+    // Initial hA, hB, hX on CPU
+    srand(1);
+    hipblasOperation_t op = HIPBLAS_OP_N;
+    for(int b = 0; b < batch_count; b++)
+    {
+        T*   hAb    = hA.data() + b * strideA;
+        T*   hXb    = hX.data() + b * strideB;
+        T*   hBb    = hB.data() + b * strideB;
+        int* hIpivb = hIpiv.data() + b * strideP;
+
+        hipblas_init<T>(hAb, N, N, lda);
+        hipblas_init<T>(hXb, N, 1, ldb);
+
+        // scale A to avoid singularities
+        for(int i = 0; i < N; i++)
+        {
+            for(int j = 0; j < N; j++)
+            {
+                if(i == j)
+                    hAb[i + j * lda] += 400;
+                else
+                    hAb[i + j * lda] -= 4;
+            }
+        }
+
+        // Calculate hB = hA*hX;
+        cblas_gemm<T>(op, op, N, 1, N, (T)1, hAb, lda, hXb, ldb, (T)0, hBb, ldb);
+
+        // LU factorize hA on the CPU
+        int info = cblas_getrf<T>(N, N, hAb, lda, hIpivb);
+        if(info != 0)
+        {
+            std::cerr << "LU decomposition failed" << std::endl;
+            return HIPBLAS_STATUS_INTERNAL_ERROR;
+        }
+    }
+
+    // Copy data from CPU to device
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, A_size * sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, B_size * sizeof(T), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dIpiv, hIpiv, Ipiv_size * sizeof(int), hipMemcpyHostToDevice));
+
+    return HIPBLAS_STATUS_SUCCESS;
+}
+
+template <typename T>
+inline hipblasStatus_t testing_getrs_strided_batched_bad_arg(const Arguments& arg)
+{
+    auto hipblasGetrsStridedBatchedFn
+        = arg.fortran ? hipblasGetrsStridedBatched<T, true> : hipblasGetrsStridedBatched<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    const int          N           = 100;
+    const int          nrhs        = 1;
+    const int          lda         = 101;
+    const int          ldb         = 102;
+    const int          batch_count = 2;
+    hipblasStride      strideA     = size_t(lda) * N;
+    hipblasStride      strideB     = size_t(ldb) * 1;
+    hipblasStride      strideP     = size_t(N);
+    size_t             A_size      = strideA * batch_count;
+    size_t             B_size      = strideB * batch_count;
+    size_t             Ipiv_size   = strideP * batch_count;
+
+    const hipblasOperation_t op = HIPBLAS_OP_N;
+
+    host_vector<T>   hA(A_size);
+    host_vector<T>   hB(B_size);
+    host_vector<T>   hX(B_size);
+    host_vector<int> hIpiv(Ipiv_size);
+
+    device_vector<T>   dA(A_size);
+    device_vector<T>   dB(B_size);
+    device_vector<int> dIpiv(Ipiv_size);
+    int                info = 0;
+
+    // Need initialization code because even with bad params we call roc/cu-solver
+    // so want to give reasonable data
+    EXPECT_HIPBLAS_STATUS(
+        setup_getrs_strided_batched_testing(
+            hA, hB, hX, hIpiv, dA, dB, dIpiv, N, lda, ldb, strideA, strideB, strideP, batch_count),
+        HIPBLAS_STATUS_SUCCESS);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       N,
+                                                       nrhs,
+                                                       dA,
+                                                       lda,
+                                                       strideA,
+                                                       dIpiv,
+                                                       strideP,
+                                                       dB,
+                                                       ldb,
+                                                       strideB,
+                                                       nullptr,
+                                                       batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       -1,
+                                                       nrhs,
+                                                       dA,
+                                                       lda,
+                                                       strideA,
+                                                       dIpiv,
+                                                       strideP,
+                                                       dB,
+                                                       ldb,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-2, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       N,
+                                                       -1,
+                                                       dA,
+                                                       lda,
+                                                       strideA,
+                                                       dIpiv,
+                                                       strideP,
+                                                       dB,
+                                                       ldb,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-3, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       N,
+                                                       nrhs,
+                                                       nullptr,
+                                                       lda,
+                                                       strideA,
+                                                       dIpiv,
+                                                       strideP,
+                                                       dB,
+                                                       ldb,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-4, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       N,
+                                                       nrhs,
+                                                       dA,
+                                                       N - 1,
+                                                       strideA,
+                                                       dIpiv,
+                                                       strideP,
+                                                       dB,
+                                                       ldb,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-5, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       N,
+                                                       nrhs,
+                                                       dA,
+                                                       lda,
+                                                       strideA,
+                                                       nullptr,
+                                                       strideP,
+                                                       dB,
+                                                       ldb,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-7, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       N,
+                                                       nrhs,
+                                                       dA,
+                                                       lda,
+                                                       strideA,
+                                                       dIpiv,
+                                                       strideP,
+                                                       nullptr,
+                                                       ldb,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-9, info);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       N,
+                                                       nrhs,
+                                                       dA,
+                                                       lda,
+                                                       strideA,
+                                                       dIpiv,
+                                                       strideP,
+                                                       dB,
+                                                       N - 1,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-10, info);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrsStridedBatchedFn(
+            handle, op, N, nrhs, dA, lda, strideA, dIpiv, strideP, dB, ldb, strideB, &info, -1),
+        HIPBLAS_STATUS_INVALID_VALUE);
+    EXPECT_EQ(-13, info);
+
+    // If N == 0, A, B, and ipiv can be nullptr
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       0,
+                                                       nrhs,
+                                                       nullptr,
+                                                       lda,
+                                                       strideA,
+                                                       nullptr,
+                                                       strideP,
+                                                       nullptr,
+                                                       ldb,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    // if nrhs == 0, B can be nullptr
+    EXPECT_HIPBLAS_STATUS(hipblasGetrsStridedBatchedFn(handle,
+                                                       op,
+                                                       0,
+                                                       nrhs,
+                                                       dA,
+                                                       lda,
+                                                       strideA,
+                                                       dIpiv,
+                                                       strideP,
+                                                       nullptr,
+                                                       ldb,
+                                                       strideB,
+                                                       &info,
+                                                       batch_count),
+                          HIPBLAS_STATUS_SUCCESS);
+    EXPECT_EQ(0, info);
+
+    // can't make any assumptions about ptrs when batch_count < 0, this is handled by rocSOLVER
+
+    return HIPBLAS_STATUS_SUCCESS;
+}
+
+template <typename T>
 inline hipblasStatus_t testing_getrs_strided_batched(const Arguments& arg)
 {
     using U      = real_t<T>;
@@ -82,48 +367,12 @@ inline hipblasStatus_t testing_getrs_strided_batched(const Arguments& arg)
 
     double             gpu_time_used, hipblas_error;
     hipblasLocalHandle handle(arg);
-
-    // Initial hA, hB, hX on CPU
-    srand(1);
     hipblasOperation_t op = HIPBLAS_OP_N;
-    for(int b = 0; b < batch_count; b++)
-    {
-        T*   hAb    = hA.data() + b * strideA;
-        T*   hXb    = hX.data() + b * strideB;
-        T*   hBb    = hB.data() + b * strideB;
-        int* hIpivb = hIpiv.data() + b * strideP;
 
-        hipblas_init<T>(hAb, N, N, lda);
-        hipblas_init<T>(hXb, N, 1, ldb);
-
-        // scale A to avoid singularities
-        for(int i = 0; i < N; i++)
-        {
-            for(int j = 0; j < N; j++)
-            {
-                if(i == j)
-                    hAb[i + j * lda] += 400;
-                else
-                    hAb[i + j * lda] -= 4;
-            }
-        }
-
-        // Calculate hB = hA*hX;
-        cblas_gemm<T>(op, op, N, 1, N, (T)1, hAb, lda, hXb, ldb, (T)0, hBb, ldb);
-
-        // LU factorize hA on the CPU
-        info = cblas_getrf<T>(N, N, hAb, lda, hIpivb);
-        if(info != 0)
-        {
-            std::cerr << "LU decomposition failed" << std::endl;
-            return HIPBLAS_STATUS_INTERNAL_ERROR;
-        }
-    }
-
-    // Copy data from CPU to device
-    CHECK_HIP_ERROR(hipMemcpy(dA, hA, A_size * sizeof(T), hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dB, hB, B_size * sizeof(T), hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dIpiv, hIpiv, Ipiv_size * sizeof(int), hipMemcpyHostToDevice));
+    EXPECT_HIPBLAS_STATUS(
+        setup_getrs_strided_batched_testing(
+            hA, hB, hX, hIpiv, dA, dB, dIpiv, N, lda, ldb, strideA, strideB, strideP, batch_count),
+        HIPBLAS_STATUS_SUCCESS);
 
     if(arg.unit_check || arg.norm_check)
     {
@@ -171,8 +420,10 @@ inline hipblasStatus_t testing_getrs_strided_batched(const Arguments& arg)
         {
             U      eps       = std::numeric_limits<U>::epsilon();
             double tolerance = N * eps * 100;
+            int    zero      = 0;
 
             unit_check_error(hipblas_error, tolerance);
+            unit_check_general(1, 1, 1, &zero, &info);
         }
     }
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -16379,7 +16379,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgetrfStridedBatched(hipblasHandle_t      
     @param[out]
     info      pointer to a int on the host.\n
               If info = 0, successful exit.
-              If info = j < 0, the j-th argument is invalid.
+              If info = j < 0, the argument at position -j is invalid.
    ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSgetrs(hipblasHandle_t          handle,
@@ -16479,7 +16479,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgetrs(hipblasHandle_t          handle,
     @param[out]
     info      pointer to a int on the host.\n
               If info = 0, successful exit.
-              If info = j < 0, the j-th argument is invalid.
+              If info = j < 0, the argument at position -j is invalid.
     @param[in]
     batchCount int. batchCount >= 0.\n
                 Number of instances (systems) in the batch.
@@ -16600,7 +16600,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgetrsBatched(hipblasHandle_t             
     @param[out]
     info      pointer to a int on the host.\n
               If info = 0, successful exit.
-              If info = j < 0, the j-th argument is invalid.
+              If info = j < 0, the argument at position -j is invalid.
     @param[in]
     batchCount int. batchCount >= 0.\n
                 Number of instances (systems) in the batch.
@@ -16818,7 +16818,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgetriBatched(hipblasHandle_t             
     @param[out]
     info        pointer to an int on the host.\n
                 If info = 0, successful exit.
-                If info = j < 0, the j-th argument is invalid.
+                If info = j < 0, the argument at position -j is invalid.
     @param[out]
     deviceInfo  pointer to int on the GPU.\n
                 If info = 0, successful exit.
@@ -16938,7 +16938,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgels(hipblasHandle_t       handle,
     @param[out]
     info        pointer to an int on the host.\n
                 If info = 0, successful exit.
-                If info = j < 0, the j-th argument is invalid.
+                If info = j < 0, the argument at position -j is invalid.
     @param[out]
     deviceInfo  pointer to int. Array of batchCount integers on the GPU.\n
                 If deviceInfo[j] = 0, successful exit for solution of A_j.
@@ -17073,7 +17073,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgelsBatched(hipblasHandle_t             h
     @param[out]
     info        pointer to an int on the host.\n
                 If info = 0, successful exit.
-                If info = j < 0, the j-th argument is invalid.
+                If info = j < 0, the argument at position -j is invalid.
     @param[out]
     deviceInfo  pointer to int. Array of batchCount integers on the GPU.\n
                 If deviceInfo[j] = 0, successful exit for solution of A_j.
@@ -17201,7 +17201,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgelsStridedBatched(hipblasHandle_t       
     @param[out]
     info      pointer to a int on the host.\n
               If info = 0, successful exit.
-              If info = j < 0, the j-th argument is invalid.
+              If info = j < 0, the argument at position -j is invalid.
 
     ********************************************************************/
 
@@ -17296,7 +17296,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgeqrf(hipblasHandle_t       handle,
     @param[out]
     info      pointer to a int on the host.\n
               If info = 0, successful exit.
-              If info = k < 0, the k-th argument is invalid.
+              If info = j < 0, the argument at position -j is invalid.
     @param[in]
     batchCount  int. batchCount >= 0.\n
                  Number of matrices in the batch.
@@ -17405,7 +17405,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgeqrfBatched(hipblasHandle_t             
     @param[out]
     info      pointer to a int on the host.\n
               If info = 0, successful exit.
-              If info = k < 0, the k-th argument is invalid.
+              If info = j < 0, the argument at position -j is invalid.
     @param[in]
     batchCount  int. batchCount >= 0.\n
                  Number of matrices in the batch.

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -15522,17 +15522,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -7;
     else if(ldb < std::max(1, n))
         *info = -8;
@@ -15561,17 +15563,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -7;
     else if(ldb < std::max(1, n))
         *info = -8;
@@ -15600,17 +15604,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -7;
     else if(ldb < std::max(1, n))
         *info = -8;
@@ -15647,17 +15653,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -7;
     else if(ldb < std::max(1, n))
         *info = -8;
@@ -15696,17 +15704,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -7;
     else if(ldb < std::max(1, n))
         *info = -8;
@@ -15748,17 +15758,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -7;
     else if(ldb < std::max(1, n))
         *info = -8;
@@ -15800,17 +15812,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -7;
     else if(ldb < std::max(1, n))
         *info = -8;
@@ -15852,17 +15866,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -7;
     else if(ldb < std::max(1, n))
         *info = -8;
@@ -15908,17 +15924,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -7;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -9;
     else if(ldb < std::max(1, n))
         *info = -10;
@@ -15965,17 +15983,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -7;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -9;
     else if(ldb < std::max(1, n))
         *info = -10;
@@ -16022,17 +16042,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -7;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -9;
     else if(ldb < std::max(1, n))
         *info = -10;
@@ -16079,17 +16101,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(n < 0)
         *info = -2;
     else if(nrhs < 0)
         *info = -3;
-    else if(A == NULL)
+    else if(A == NULL && n)
         *info = -4;
     else if(lda < std::max(1, n))
         *info = -5;
-    else if(ipiv == NULL)
+    else if(ipiv == NULL && n)
         *info = -7;
-    else if(B == NULL)
+    else if(B == NULL && n * nrhs)
         *info = -9;
     else if(ldb < std::max(1, n))
         *info = -10;
@@ -16718,17 +16742,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -7;
     else if(ldb < m || ldb < n)
         *info = -8;
@@ -16769,17 +16795,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -7;
     else if(ldb < m || ldb < n)
         *info = -8;
@@ -16820,17 +16848,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -7;
     else if(ldb < m || ldb < n)
         *info = -8;
@@ -16871,17 +16901,19 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -7;
     else if(ldb < m || ldb < n)
         *info = -8;
@@ -16924,21 +16956,23 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -7;
     else if(ldb < m || ldb < n)
         *info = -8;
-    else if(deviceInfo == NULL)
+    else if(deviceInfo == NULL && batchCount)
         *info = -10;
     else if(batchCount < 0)
         *info = -11;
@@ -16979,21 +17013,23 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -7;
     else if(ldb < m || ldb < n)
         *info = -8;
-    else if(deviceInfo == NULL)
+    else if(deviceInfo == NULL && batchCount)
         *info = -10;
     else if(batchCount < 0)
         *info = -11;
@@ -17034,21 +17070,23 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -7;
     else if(ldb < m || ldb < n)
         *info = -8;
-    else if(deviceInfo == NULL)
+    else if(deviceInfo == NULL && batchCount)
         *info = -10;
     else if(batchCount < 0)
         *info = -11;
@@ -17089,21 +17127,23 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -7;
     else if(ldb < m || ldb < n)
         *info = -8;
-    else if(deviceInfo == NULL)
+    else if(deviceInfo == NULL && batchCount)
         *info = -10;
     else if(batchCount < 0)
         *info = -11;
@@ -17147,21 +17187,23 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -8;
     else if(ldb < m || ldb < n)
         *info = -9;
-    else if(deviceInfo == NULL)
+    else if(deviceInfo == NULL && batchCount)
         *info = -12;
     else if(batchCount < 0)
         *info = -13;
@@ -17206,21 +17248,23 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_T)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -8;
     else if(ldb < m || ldb < n)
         *info = -9;
-    else if(deviceInfo == NULL)
+    else if(deviceInfo == NULL && batchCount)
         *info = -12;
     else if(batchCount < 0)
         *info = -13;
@@ -17265,21 +17309,23 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -8;
     else if(ldb < m || ldb < n)
         *info = -9;
-    else if(deviceInfo == NULL)
+    else if(deviceInfo == NULL && batchCount)
         *info = -12;
     else if(batchCount < 0)
         *info = -13;
@@ -17324,21 +17370,23 @@ try
 {
     if(info == NULL)
         return HIPBLAS_STATUS_INVALID_VALUE;
+    else if(trans != HIPBLAS_OP_N && trans != HIPBLAS_OP_C)
+        *info = -1;
     else if(m < 0)
         *info = -2;
     else if(n < 0)
         *info = -3;
     else if(nrhs < 0)
         *info = -4;
-    else if(A == NULL)
+    else if(A == NULL && m * n)
         *info = -5;
     else if(lda < m)
         *info = -6;
-    else if(B == NULL)
+    else if(B == NULL && (m * nrhs || n * nrhs))
         *info = -8;
     else if(ldb < m || ldb < n)
         *info = -9;
-    else if(deviceInfo == NULL)
+    else if(deviceInfo == NULL && batchCount)
         *info = -12;
     else if(batchCount < 0)
         *info = -13;


### PR DESCRIPTION
Updating info codes in solver-based functions (based off of solver argument checking code). Adding bad_arg tests for solver functions to ensure we're testing the hipBLAS portion of the code.

getrs
-------
- A and ipiv can be nullptr if n == 0
- B can be nullptr if n == 0 || nrhs == 0
- info = -1 if transpose != N || T || C

gels
-----
- A can be nullptr if n == 0 || m == 0
- B can be nullptr if nrhs == 0 || (m == 0 && n == 0)
- info = -1 if transpose != N || T for real cases, or transpsoe != N || C for complex cases
- deviceInfo can be nullptr if batchCount == 0

Aside from deviceInfo in gels, batchCount == 0 doesn't skip any other checks, it looks like this is the case in argument checking in rocSOLVER.