### PR TITLE
add MSVC deprecation form

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -57,7 +57,11 @@
 #endif
 
 #ifndef HIPBLAS_DEPRECATED_MSG
+#ifndef _MSC_VER
 #define HIPBLAS_DEPRECATED_MSG(MSG) __attribute__((deprecated(#MSG)))
+#else
+#define HIPBLAS_DEPRECATED_MSG(MSG) __declspec(deprecated(#MSG))
+#endif
 #endif
 
 /*


### PR DESCRIPTION
* matches rocBLAS fix for Visual Studio compiler support