### PR TITLE
Minor tweak to include guards for consistency

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (C) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/library/include/hipblas-version.h.in
+++ b/library/include/hipblas-version.h.in
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,8 +21,8 @@
  *
  * ************************************************************************ */
 
-#ifndef HIPBLAS_VERSION_H_
-#define HIPBLAS_VERSION_H_
+#ifndef HIPBLAS_VERSION_H
+#define HIPBLAS_VERSION_H
 
 /* the configured version and settings
  */
@@ -34,4 +34,4 @@
 #define hipblasVersionTweak @hipblas_VERSION_TWEAK@
 // clang-format on
 
-#endif
+#endif /* HIPBLAS_VERSION_H */


### PR DESCRIPTION
There's nothing wrong with the include guards in hipBLAS, but the version guard does use a slightly different pattern than the other headers. I figured it might be nice to make it consistent.