### PR TITLE
Add const qualifier to hipBLAS functions

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -3338,27 +3338,37 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswap(hipblasHandle_t       handle,
 
     ********************************************************************/
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasSswapBatched(
-    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount);
-
-HIPBLAS_EXPORT hipblasStatus_t hipblasDswapBatched(
-    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount);
-
-HIPBLAS_EXPORT hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
+HIPBLAS_EXPORT hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle,
                                                    int             n,
-                                                   hipblasComplex* x[],
+                                                   float* const    x[],
                                                    int             incx,
-                                                   hipblasComplex* y[],
+                                                   float* const    y[],
                                                    int             incy,
                                                    int             batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasZswapBatched(hipblasHandle_t       handle,
+HIPBLAS_EXPORT hipblasStatus_t hipblasDswapBatched(hipblasHandle_t handle,
+                                                   int             n,
+                                                   double* const   x[],
+                                                   int             incx,
+                                                   double* const   y[],
+                                                   int             incy,
+                                                   int             batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCswapBatched(hipblasHandle_t       handle,
                                                    int                   n,
-                                                   hipblasDoubleComplex* x[],
+                                                   hipblasComplex* const x[],
                                                    int                   incx,
-                                                   hipblasDoubleComplex* y[],
+                                                   hipblasComplex* const y[],
                                                    int                   incy,
                                                    int                   batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZswapBatched(hipblasHandle_t             handle,
+                                                   int                         n,
+                                                   hipblasDoubleComplex* const x[],
+                                                   int                         incx,
+                                                   hipblasDoubleComplex* const y[],
+                                                   int                         incy,
+                                                   int                         batchCount);
 //! @}
 
 /*! @{
@@ -6705,7 +6715,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasSsbmvBatched(hipblasHandle_t    handle,
                                                    const float* const x[],
                                                    int                incx,
                                                    const float*       beta,
-                                                   float*             y[],
+                                                   float* const       y[],
                                                    int                incy,
                                                    int                batchCount);
 
@@ -6719,7 +6729,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDsbmvBatched(hipblasHandle_t     handle,
                                                    const double* const x[],
                                                    int                 incx,
                                                    const double*       beta,
-                                                   double*             y[],
+                                                   double* const       y[],
                                                    int                 incy,
                                                    int                 batchCount);
 //! @}
@@ -6956,7 +6966,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasSspmvBatched(hipblasHandle_t    handle,
                                                    const float* const x[],
                                                    int                incx,
                                                    const float*       beta,
-                                                   float*             y[],
+                                                   float* const       y[],
                                                    int                incy,
                                                    int                batchCount);
 
@@ -6968,7 +6978,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDspmvBatched(hipblasHandle_t     handle,
                                                    const double* const x[],
                                                    int                 incx,
                                                    const double*       beta,
-                                                   double*             y[],
+                                                   double* const       y[],
                                                    int                 incy,
                                                    int                 batchCount);
 //! @}
@@ -7830,7 +7840,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasSsymvBatched(hipblasHandle_t    handle,
                                                    const float* const x[],
                                                    int                incx,
                                                    const float*       beta,
-                                                   float*             y[],
+                                                   float* const       y[],
                                                    int                incy,
                                                    int                batchCount);
 
@@ -7843,7 +7853,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDsymvBatched(hipblasHandle_t     handle,
                                                    const double* const x[],
                                                    int                 incx,
                                                    const double*       beta,
-                                                   double*             y[],
+                                                   double* const       y[],
                                                    int                 incy,
                                                    int                 batchCount);
 
@@ -7856,7 +7866,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCsymvBatched(hipblasHandle_t             h
                                                    const hipblasComplex* const x[],
                                                    int                         incx,
                                                    const hipblasComplex*       beta,
-                                                   hipblasComplex*             y[],
+                                                   hipblasComplex* const       y[],
                                                    int                         incy,
                                                    int                         batchCount);
 
@@ -7869,7 +7879,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZsymvBatched(hipblasHandle_t              
                                                    const hipblasDoubleComplex* const x[],
                                                    int                               incx,
                                                    const hipblasDoubleComplex*       beta,
-                                                   hipblasDoubleComplex*             y[],
+                                                   hipblasDoubleComplex* const       y[],
                                                    int                               incy,
                                                    int                               batchCount);
 //! @}
@@ -15150,7 +15160,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,
                                             int                m,
                                             int                n,
                                             const float*       alpha,
-                                            float*             AP,
+                                            const float*       AP,
                                             int                lda,
                                             float*             BP,
                                             int                ldb);
@@ -15163,7 +15173,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDtrsm(hipblasHandle_t    handle,
                                             int                m,
                                             int                n,
                                             const double*      alpha,
-                                            double*            AP,
+                                            const double*      AP,
                                             int                lda,
                                             double*            BP,
                                             int                ldb);
@@ -15176,7 +15186,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCtrsm(hipblasHandle_t       handle,
                                             int                   m,
                                             int                   n,
                                             const hipblasComplex* alpha,
-                                            hipblasComplex*       AP,
+                                            const hipblasComplex* AP,
                                             int                   lda,
                                             hipblasComplex*       BP,
                                             int                   ldb);
@@ -15189,7 +15199,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZtrsm(hipblasHandle_t             handle,
                                             int                         m,
                                             int                         n,
                                             const hipblasDoubleComplex* alpha,
-                                            hipblasDoubleComplex*       AP,
+                                            const hipblasDoubleComplex* AP,
                                             int                         lda,
                                             hipblasDoubleComplex*       BP,
                                             int                         ldb);
@@ -15281,53 +15291,53 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasStrsmBatched(hipblasHandle_t    handle,
                                                    int                m,
                                                    int                n,
                                                    const float*       alpha,
-                                                   float* const       AP[],
+                                                   const float* const AP[],
                                                    int                lda,
                                                    float*             BP[],
                                                    int                ldb,
                                                    int                batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasDtrsmBatched(hipblasHandle_t    handle,
-                                                   hipblasSideMode_t  side,
-                                                   hipblasFillMode_t  uplo,
-                                                   hipblasOperation_t transA,
-                                                   hipblasDiagType_t  diag,
-                                                   int                m,
-                                                   int                n,
-                                                   const double*      alpha,
-                                                   double* const      AP[],
-                                                   int                lda,
-                                                   double*            BP[],
-                                                   int                ldb,
-                                                   int                batchCount);
+HIPBLAS_EXPORT hipblasStatus_t hipblasDtrsmBatched(hipblasHandle_t     handle,
+                                                   hipblasSideMode_t   side,
+                                                   hipblasFillMode_t   uplo,
+                                                   hipblasOperation_t  transA,
+                                                   hipblasDiagType_t   diag,
+                                                   int                 m,
+                                                   int                 n,
+                                                   const double*       alpha,
+                                                   const double* const AP[],
+                                                   int                 lda,
+                                                   double*             BP[],
+                                                   int                 ldb,
+                                                   int                 batchCount);
 
-HIPBLAS_EXPORT hipblasStatus_t hipblasCtrsmBatched(hipblasHandle_t       handle,
-                                                   hipblasSideMode_t     side,
-                                                   hipblasFillMode_t     uplo,
-                                                   hipblasOperation_t    transA,
-                                                   hipblasDiagType_t     diag,
-                                                   int                   m,
-                                                   int                   n,
-                                                   const hipblasComplex* alpha,
-                                                   hipblasComplex* const AP[],
-                                                   int                   lda,
-                                                   hipblasComplex*       BP[],
-                                                   int                   ldb,
-                                                   int                   batchCount);
-
-HIPBLAS_EXPORT hipblasStatus_t hipblasZtrsmBatched(hipblasHandle_t             handle,
+HIPBLAS_EXPORT hipblasStatus_t hipblasCtrsmBatched(hipblasHandle_t             handle,
                                                    hipblasSideMode_t           side,
                                                    hipblasFillMode_t           uplo,
                                                    hipblasOperation_t          transA,
                                                    hipblasDiagType_t           diag,
                                                    int                         m,
                                                    int                         n,
-                                                   const hipblasDoubleComplex* alpha,
-                                                   hipblasDoubleComplex* const AP[],
+                                                   const hipblasComplex*       alpha,
+                                                   const hipblasComplex* const AP[],
                                                    int                         lda,
-                                                   hipblasDoubleComplex*       BP[],
+                                                   hipblasComplex*             BP[],
                                                    int                         ldb,
                                                    int                         batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZtrsmBatched(hipblasHandle_t                   handle,
+                                                   hipblasSideMode_t                 side,
+                                                   hipblasFillMode_t                 uplo,
+                                                   hipblasOperation_t                transA,
+                                                   hipblasDiagType_t                 diag,
+                                                   int                               m,
+                                                   int                               n,
+                                                   const hipblasDoubleComplex*       alpha,
+                                                   const hipblasDoubleComplex* const AP[],
+                                                   int                               lda,
+                                                   hipblasDoubleComplex*             BP[],
+                                                   int                               ldb,
+                                                   int                               batchCount);
 //! @}
 
 /*! @{
@@ -15423,7 +15433,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasStrsmStridedBatched(hipblasHandle_t    han
                                                           int                m,
                                                           int                n,
                                                           const float*       alpha,
-                                                          float*             AP,
+                                                          const float*       AP,
                                                           int                lda,
                                                           hipblasStride      strideA,
                                                           float*             BP,
@@ -15439,7 +15449,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDtrsmStridedBatched(hipblasHandle_t    han
                                                           int                m,
                                                           int                n,
                                                           const double*      alpha,
-                                                          double*            AP,
+                                                          const double*      AP,
                                                           int                lda,
                                                           hipblasStride      strideA,
                                                           double*            BP,
@@ -15455,7 +15465,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCtrsmStridedBatched(hipblasHandle_t       
                                                           int                   m,
                                                           int                   n,
                                                           const hipblasComplex* alpha,
-                                                          hipblasComplex*       AP,
+                                                          const hipblasComplex* AP,
                                                           int                   lda,
                                                           hipblasStride         strideA,
                                                           hipblasComplex*       BP,
@@ -15471,7 +15481,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZtrsmStridedBatched(hipblasHandle_t       
                                                           int                         m,
                                                           int                         n,
                                                           const hipblasDoubleComplex* alpha,
-                                                          hipblasDoubleComplex*       AP,
+                                                          const hipblasDoubleComplex* AP,
                                                           int                         lda,
                                                           hipblasStride               strideA,
                                                           hipblasDoubleComplex*       BP,

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -15293,7 +15293,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasStrsmBatched(hipblasHandle_t    handle,
                                                    const float*       alpha,
                                                    const float* const AP[],
                                                    int                lda,
-                                                   float*             BP[],
+                                                   float* const       BP[],
                                                    int                ldb,
                                                    int                batchCount);
 
@@ -15307,7 +15307,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDtrsmBatched(hipblasHandle_t     handle,
                                                    const double*       alpha,
                                                    const double* const AP[],
                                                    int                 lda,
-                                                   double*             BP[],
+                                                   double* const       BP[],
                                                    int                 ldb,
                                                    int                 batchCount);
 
@@ -15321,7 +15321,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasCtrsmBatched(hipblasHandle_t             h
                                                    const hipblasComplex*       alpha,
                                                    const hipblasComplex* const AP[],
                                                    int                         lda,
-                                                   hipblasComplex*             BP[],
+                                                   hipblasComplex* const       BP[],
                                                    int                         ldb,
                                                    int                         batchCount);
 
@@ -15335,7 +15335,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZtrsmBatched(hipblasHandle_t              
                                                    const hipblasDoubleComplex*       alpha,
                                                    const hipblasDoubleComplex* const AP[],
                                                    int                               lda,
-                                                   hipblasDoubleComplex*             BP[],
+                                                   hipblasDoubleComplex* const       BP[],
                                                    int                               ldb,
                                                    int                               batchCount);
 //! @}

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -3667,8 +3667,13 @@ catch(...)
 }
 
 // swap_batched
-hipblasStatus_t hipblasSswapBatched(
-    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount)
+hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle,
+                                    int             n,
+                                    float* const    x[],
+                                    int             incx,
+                                    float* const    y[],
+                                    int             incy,
+                                    int             batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(
@@ -3679,8 +3684,13 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasDswapBatched(
-    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount)
+hipblasStatus_t hipblasDswapBatched(hipblasHandle_t handle,
+                                    int             n,
+                                    double* const   x[],
+                                    int             incx,
+                                    double* const   y[],
+                                    int             incy,
+                                    int             batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(
@@ -3691,13 +3701,13 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
-                                    int             n,
-                                    hipblasComplex* x[],
-                                    int             incx,
-                                    hipblasComplex* y[],
-                                    int             incy,
-                                    int             batchCount)
+hipblasStatus_t hipblasCswapBatched(hipblasHandle_t       handle,
+                                    int                   n,
+                                    hipblasComplex* const x[],
+                                    int                   incx,
+                                    hipblasComplex* const y[],
+                                    int                   incy,
+                                    int                   batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_cswap_batched((rocblas_handle)handle,
@@ -3713,13 +3723,13 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasZswapBatched(hipblasHandle_t       handle,
-                                    int                   n,
-                                    hipblasDoubleComplex* x[],
-                                    int                   incx,
-                                    hipblasDoubleComplex* y[],
-                                    int                   incy,
-                                    int                   batchCount)
+hipblasStatus_t hipblasZswapBatched(hipblasHandle_t             handle,
+                                    int                         n,
+                                    hipblasDoubleComplex* const x[],
+                                    int                         incx,
+                                    hipblasDoubleComplex* const y[],
+                                    int                         incy,
+                                    int                         batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zswap_batched((rocblas_handle)handle,
@@ -6610,7 +6620,7 @@ hipblasStatus_t hipblasSsbmvBatched(hipblasHandle_t    handle,
                                     const float* const x[],
                                     int                incx,
                                     const float*       beta,
-                                    float*             y[],
+                                    float* const       y[],
                                     int                incy,
                                     int                batchCount)
 try
@@ -6644,7 +6654,7 @@ hipblasStatus_t hipblasDsbmvBatched(hipblasHandle_t     handle,
                                     const double* const x[],
                                     int                 incx,
                                     const double*       beta,
-                                    double*             y[],
+                                    double* const       y[],
                                     int                 incy,
                                     int                 batchCount)
 try
@@ -6799,7 +6809,7 @@ hipblasStatus_t hipblasSspmvBatched(hipblasHandle_t    handle,
                                     const float* const x[],
                                     int                incx,
                                     const float*       beta,
-                                    float*             y[],
+                                    float* const       y[],
                                     int                incy,
                                     int                batchCount)
 try
@@ -6829,7 +6839,7 @@ hipblasStatus_t hipblasDspmvBatched(hipblasHandle_t     handle,
                                     const double* const x[],
                                     int                 incx,
                                     const double*       beta,
-                                    double*             y[],
+                                    double* const       y[],
                                     int                 incy,
                                     int                 batchCount)
 try
@@ -7463,7 +7473,7 @@ hipblasStatus_t hipblasSsymvBatched(hipblasHandle_t    handle,
                                     const float* const x[],
                                     int                incx,
                                     const float*       beta,
-                                    float*             y[],
+                                    float* const       y[],
                                     int                incy,
                                     int                batchCount)
 try
@@ -7495,7 +7505,7 @@ hipblasStatus_t hipblasDsymvBatched(hipblasHandle_t     handle,
                                     const double* const x[],
                                     int                 incx,
                                     const double*       beta,
-                                    double*             y[],
+                                    double* const       y[],
                                     int                 incy,
                                     int                 batchCount)
 try
@@ -7527,7 +7537,7 @@ hipblasStatus_t hipblasCsymvBatched(hipblasHandle_t             handle,
                                     const hipblasComplex* const x[],
                                     int                         incx,
                                     const hipblasComplex*       beta,
-                                    hipblasComplex*             y[],
+                                    hipblasComplex* const       y[],
                                     int                         incy,
                                     int                         batchCount)
 try
@@ -7559,7 +7569,7 @@ hipblasStatus_t hipblasZsymvBatched(hipblasHandle_t                   handle,
                                     const hipblasDoubleComplex* const x[],
                                     int                               incx,
                                     const hipblasDoubleComplex*       beta,
-                                    hipblasDoubleComplex*             y[],
+                                    hipblasDoubleComplex* const       y[],
                                     int                               incy,
                                     int                               batchCount)
 try
@@ -14044,7 +14054,7 @@ hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,
                              int                m,
                              int                n,
                              const float*       alpha,
-                             float*             A,
+                             const float*       A,
                              int                lda,
                              float*             B,
                              int                ldb)
@@ -14077,7 +14087,7 @@ hipblasStatus_t hipblasDtrsm(hipblasHandle_t    handle,
                              int                m,
                              int                n,
                              const double*      alpha,
-                             double*            A,
+                             const double*      A,
                              int                lda,
                              double*            B,
                              int                ldb)
@@ -14110,7 +14120,7 @@ hipblasStatus_t hipblasCtrsm(hipblasHandle_t       handle,
                              int                   m,
                              int                   n,
                              const hipblasComplex* alpha,
-                             hipblasComplex*       A,
+                             const hipblasComplex* A,
                              int                   lda,
                              hipblasComplex*       B,
                              int                   ldb)
@@ -14143,7 +14153,7 @@ hipblasStatus_t hipblasZtrsm(hipblasHandle_t             handle,
                              int                         m,
                              int                         n,
                              const hipblasDoubleComplex* alpha,
-                             hipblasDoubleComplex*       A,
+                             const hipblasDoubleComplex* A,
                              int                         lda,
                              hipblasDoubleComplex*       B,
                              int                         ldb)
@@ -14177,7 +14187,7 @@ hipblasStatus_t hipblasStrsmBatched(hipblasHandle_t    handle,
                                     int                m,
                                     int                n,
                                     const float*       alpha,
-                                    float* const       A[],
+                                    const float* const A[],
                                     int                lda,
                                     float*             B[],
                                     int                ldb,
@@ -14204,19 +14214,19 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasDtrsmBatched(hipblasHandle_t    handle,
-                                    hipblasSideMode_t  side,
-                                    hipblasFillMode_t  uplo,
-                                    hipblasOperation_t transA,
-                                    hipblasDiagType_t  diag,
-                                    int                m,
-                                    int                n,
-                                    const double*      alpha,
-                                    double* const      A[],
-                                    int                lda,
-                                    double*            B[],
-                                    int                ldb,
-                                    int                batch_count)
+hipblasStatus_t hipblasDtrsmBatched(hipblasHandle_t     handle,
+                                    hipblasSideMode_t   side,
+                                    hipblasFillMode_t   uplo,
+                                    hipblasOperation_t  transA,
+                                    hipblasDiagType_t   diag,
+                                    int                 m,
+                                    int                 n,
+                                    const double*       alpha,
+                                    const double* const A[],
+                                    int                 lda,
+                                    double*             B[],
+                                    int                 ldb,
+                                    int                 batch_count)
 try
 {
     return HIPBLAS_DEMAND_ALLOC(
@@ -14239,19 +14249,19 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasCtrsmBatched(hipblasHandle_t       handle,
-                                    hipblasSideMode_t     side,
-                                    hipblasFillMode_t     uplo,
-                                    hipblasOperation_t    transA,
-                                    hipblasDiagType_t     diag,
-                                    int                   m,
-                                    int                   n,
-                                    const hipblasComplex* alpha,
-                                    hipblasComplex* const A[],
-                                    int                   lda,
-                                    hipblasComplex*       B[],
-                                    int                   ldb,
-                                    int                   batch_count)
+hipblasStatus_t hipblasCtrsmBatched(hipblasHandle_t             handle,
+                                    hipblasSideMode_t           side,
+                                    hipblasFillMode_t           uplo,
+                                    hipblasOperation_t          transA,
+                                    hipblasDiagType_t           diag,
+                                    int                         m,
+                                    int                         n,
+                                    const hipblasComplex*       alpha,
+                                    const hipblasComplex* const A[],
+                                    int                         lda,
+                                    hipblasComplex*             B[],
+                                    int                         ldb,
+                                    int                         batch_count)
 try
 {
     return HIPBLAS_DEMAND_ALLOC(
@@ -14274,19 +14284,19 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasZtrsmBatched(hipblasHandle_t             handle,
-                                    hipblasSideMode_t           side,
-                                    hipblasFillMode_t           uplo,
-                                    hipblasOperation_t          transA,
-                                    hipblasDiagType_t           diag,
-                                    int                         m,
-                                    int                         n,
-                                    const hipblasDoubleComplex* alpha,
-                                    hipblasDoubleComplex* const A[],
-                                    int                         lda,
-                                    hipblasDoubleComplex*       B[],
-                                    int                         ldb,
-                                    int                         batch_count)
+hipblasStatus_t hipblasZtrsmBatched(hipblasHandle_t                   handle,
+                                    hipblasSideMode_t                 side,
+                                    hipblasFillMode_t                 uplo,
+                                    hipblasOperation_t                transA,
+                                    hipblasDiagType_t                 diag,
+                                    int                               m,
+                                    int                               n,
+                                    const hipblasDoubleComplex*       alpha,
+                                    const hipblasDoubleComplex* const A[],
+                                    int                               lda,
+                                    hipblasDoubleComplex*             B[],
+                                    int                               ldb,
+                                    int                               batch_count)
 try
 {
     return HIPBLAS_DEMAND_ALLOC(
@@ -14318,7 +14328,7 @@ hipblasStatus_t hipblasStrsmStridedBatched(hipblasHandle_t    handle,
                                            int                m,
                                            int                n,
                                            const float*       alpha,
-                                           float*             A,
+                                           const float*       A,
                                            int                lda,
                                            hipblasStride      strideA,
                                            float*             B,
@@ -14357,7 +14367,7 @@ hipblasStatus_t hipblasDtrsmStridedBatched(hipblasHandle_t    handle,
                                            int                m,
                                            int                n,
                                            const double*      alpha,
-                                           double*            A,
+                                           const double*      A,
                                            int                lda,
                                            hipblasStride      strideA,
                                            double*            B,
@@ -14396,7 +14406,7 @@ hipblasStatus_t hipblasCtrsmStridedBatched(hipblasHandle_t       handle,
                                            int                   m,
                                            int                   n,
                                            const hipblasComplex* alpha,
-                                           hipblasComplex*       A,
+                                           const hipblasComplex* A,
                                            int                   lda,
                                            hipblasStride         strideA,
                                            hipblasComplex*       B,
@@ -14435,7 +14445,7 @@ hipblasStatus_t hipblasZtrsmStridedBatched(hipblasHandle_t             handle,
                                            int                         m,
                                            int                         n,
                                            const hipblasDoubleComplex* alpha,
-                                           hipblasDoubleComplex*       A,
+                                           const hipblasDoubleComplex* A,
                                            int                         lda,
                                            hipblasStride               strideA,
                                            hipblasDoubleComplex*       B,

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -14189,7 +14189,7 @@ hipblasStatus_t hipblasStrsmBatched(hipblasHandle_t    handle,
                                     const float*       alpha,
                                     const float* const A[],
                                     int                lda,
-                                    float*             B[],
+                                    float* const       B[],
                                     int                ldb,
                                     int                batch_count)
 try
@@ -14224,7 +14224,7 @@ hipblasStatus_t hipblasDtrsmBatched(hipblasHandle_t     handle,
                                     const double*       alpha,
                                     const double* const A[],
                                     int                 lda,
-                                    double*             B[],
+                                    double* const       B[],
                                     int                 ldb,
                                     int                 batch_count)
 try
@@ -14259,7 +14259,7 @@ hipblasStatus_t hipblasCtrsmBatched(hipblasHandle_t             handle,
                                     const hipblasComplex*       alpha,
                                     const hipblasComplex* const A[],
                                     int                         lda,
-                                    hipblasComplex*             B[],
+                                    hipblasComplex* const       B[],
                                     int                         ldb,
                                     int                         batch_count)
 try
@@ -14294,7 +14294,7 @@ hipblasStatus_t hipblasZtrsmBatched(hipblasHandle_t                   handle,
                                     const hipblasDoubleComplex*       alpha,
                                     const hipblasDoubleComplex* const A[],
                                     int                               lda,
-                                    hipblasDoubleComplex*             B[],
+                                    hipblasDoubleComplex* const       B[],
                                     int                               ldb,
                                     int                               batch_count)
 try

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -2576,36 +2576,46 @@ catch(...)
 }
 
 // swap_batched
-hipblasStatus_t hipblasSswapBatched(
-    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batchCount)
-{
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
-}
-
-hipblasStatus_t hipblasDswapBatched(
-    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batchCount)
-{
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
-}
-
-hipblasStatus_t hipblasCswapBatched(hipblasHandle_t handle,
+hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle,
                                     int             n,
-                                    hipblasComplex* x[],
+                                    float* const    x[],
                                     int             incx,
-                                    hipblasComplex* y[],
+                                    float* const    y[],
                                     int             incy,
                                     int             batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasZswapBatched(hipblasHandle_t       handle,
+hipblasStatus_t hipblasDswapBatched(hipblasHandle_t handle,
+                                    int             n,
+                                    double* const   x[],
+                                    int             incx,
+                                    double* const   y[],
+                                    int             incy,
+                                    int             batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCswapBatched(hipblasHandle_t       handle,
                                     int                   n,
-                                    hipblasDoubleComplex* x[],
+                                    hipblasComplex* const x[],
                                     int                   incx,
-                                    hipblasDoubleComplex* y[],
+                                    hipblasComplex* const y[],
                                     int                   incy,
                                     int                   batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZswapBatched(hipblasHandle_t             handle,
+                                    int                         n,
+                                    hipblasDoubleComplex* const x[],
+                                    int                         incx,
+                                    hipblasDoubleComplex* const y[],
+                                    int                         incy,
+                                    int                         batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -4601,7 +4611,7 @@ hipblasStatus_t hipblasSsbmvBatched(hipblasHandle_t    handle,
                                     const float* const x[],
                                     int                incx,
                                     const float*       beta,
-                                    float*             y[],
+                                    float* const       y[],
                                     int                incy,
                                     int                batchCount)
 {
@@ -4618,7 +4628,7 @@ hipblasStatus_t hipblasDsbmvBatched(hipblasHandle_t     handle,
                                     const double* const x[],
                                     int                 incx,
                                     const double*       beta,
-                                    double*             y[],
+                                    double* const       y[],
                                     int                 incy,
                                     int                 batchCount)
 {
@@ -4716,7 +4726,7 @@ hipblasStatus_t hipblasSspmvBatched(hipblasHandle_t    handle,
                                     const float* const x[],
                                     int                incx,
                                     const float*       beta,
-                                    float*             y[],
+                                    float* const       y[],
                                     int                incy,
                                     int                batchCount)
 {
@@ -4731,7 +4741,7 @@ hipblasStatus_t hipblasDspmvBatched(hipblasHandle_t     handle,
                                     const double* const x[],
                                     int                 incx,
                                     const double*       beta,
-                                    double*             y[],
+                                    double* const       y[],
                                     int                 incy,
                                     int                 batchCount)
 {
@@ -5154,7 +5164,7 @@ hipblasStatus_t hipblasSsymvBatched(hipblasHandle_t    handle,
                                     const float* const x[],
                                     int                incx,
                                     const float*       beta,
-                                    float*             y[],
+                                    float* const       y[],
                                     int                incy,
                                     int                batchCount)
 {
@@ -5170,7 +5180,7 @@ hipblasStatus_t hipblasDsymvBatched(hipblasHandle_t     handle,
                                     const double* const x[],
                                     int                 incx,
                                     const double*       beta,
-                                    double*             y[],
+                                    double* const       y[],
                                     int                 incy,
                                     int                 batchCount)
 {
@@ -5186,7 +5196,7 @@ hipblasStatus_t hipblasCsymvBatched(hipblasHandle_t             handle,
                                     const hipblasComplex* const x[],
                                     int                         incx,
                                     const hipblasComplex*       beta,
-                                    hipblasComplex*             y[],
+                                    hipblasComplex* const       y[],
                                     int                         incy,
                                     int                         batchCount)
 {
@@ -5202,7 +5212,7 @@ hipblasStatus_t hipblasZsymvBatched(hipblasHandle_t                   handle,
                                     const hipblasDoubleComplex* const x[],
                                     int                               incx,
                                     const hipblasDoubleComplex*       beta,
-                                    hipblasDoubleComplex*             y[],
+                                    hipblasDoubleComplex* const       y[],
                                     int                               incy,
                                     int                               batchCount)
 {
@@ -9392,7 +9402,7 @@ hipblasStatus_t hipblasStrsm(hipblasHandle_t    handle,
                              int                m,
                              int                n,
                              const float*       alpha,
-                             float*             A,
+                             const float*       A,
                              int                lda,
                              float*             B,
                              int                ldb)
@@ -9424,7 +9434,7 @@ hipblasStatus_t hipblasDtrsm(hipblasHandle_t    handle,
                              int                m,
                              int                n,
                              const double*      alpha,
-                             double*            A,
+                             const double*      A,
                              int                lda,
                              double*            B,
                              int                ldb)
@@ -9456,7 +9466,7 @@ hipblasStatus_t hipblasCtrsm(hipblasHandle_t       handle,
                              int                   m,
                              int                   n,
                              const hipblasComplex* alpha,
-                             hipblasComplex*       A,
+                             const hipblasComplex* A,
                              int                   lda,
                              hipblasComplex*       B,
                              int                   ldb)
@@ -9488,7 +9498,7 @@ hipblasStatus_t hipblasZtrsm(hipblasHandle_t             handle,
                              int                         m,
                              int                         n,
                              const hipblasDoubleComplex* alpha,
-                             hipblasDoubleComplex*       A,
+                             const hipblasDoubleComplex* A,
                              int                         lda,
                              hipblasDoubleComplex*       B,
                              int                         ldb)
@@ -9521,9 +9531,9 @@ hipblasStatus_t hipblasStrsmBatched(hipblasHandle_t    handle,
                                     int                m,
                                     int                n,
                                     const float*       alpha,
-                                    float* const       A[],
+                                    const float* const A[],
                                     int                lda,
-                                    float*             B[],
+                                    float* const       B[],
                                     int                ldb,
                                     int                batch_count)
 try
@@ -9547,19 +9557,19 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasDtrsmBatched(hipblasHandle_t    handle,
-                                    hipblasSideMode_t  side,
-                                    hipblasFillMode_t  uplo,
-                                    hipblasOperation_t transA,
-                                    hipblasDiagType_t  diag,
-                                    int                m,
-                                    int                n,
-                                    const double*      alpha,
-                                    double* const      A[],
-                                    int                lda,
-                                    double*            B[],
-                                    int                ldb,
-                                    int                batch_count)
+hipblasStatus_t hipblasDtrsmBatched(hipblasHandle_t     handle,
+                                    hipblasSideMode_t   side,
+                                    hipblasFillMode_t   uplo,
+                                    hipblasOperation_t  transA,
+                                    hipblasDiagType_t   diag,
+                                    int                 m,
+                                    int                 n,
+                                    const double*       alpha,
+                                    const double* const A[],
+                                    int                 lda,
+                                    double* const       B[],
+                                    int                 ldb,
+                                    int                 batch_count)
 try
 {
     return hipCUBLASStatusToHIPStatus(cublasDtrsmBatched((cublasHandle_t)handle,
@@ -9581,19 +9591,19 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasCtrsmBatched(hipblasHandle_t       handle,
-                                    hipblasSideMode_t     side,
-                                    hipblasFillMode_t     uplo,
-                                    hipblasOperation_t    transA,
-                                    hipblasDiagType_t     diag,
-                                    int                   m,
-                                    int                   n,
-                                    const hipblasComplex* alpha,
-                                    hipblasComplex* const A[],
-                                    int                   lda,
-                                    hipblasComplex*       B[],
-                                    int                   ldb,
-                                    int                   batch_count)
+hipblasStatus_t hipblasCtrsmBatched(hipblasHandle_t             handle,
+                                    hipblasSideMode_t           side,
+                                    hipblasFillMode_t           uplo,
+                                    hipblasOperation_t          transA,
+                                    hipblasDiagType_t           diag,
+                                    int                         m,
+                                    int                         n,
+                                    const hipblasComplex*       alpha,
+                                    const hipblasComplex* const A[],
+                                    int                         lda,
+                                    hipblasComplex* const       B[],
+                                    int                         ldb,
+                                    int                         batch_count)
 try
 {
     return hipCUBLASStatusToHIPStatus(cublasCtrsmBatched((cublasHandle_t)handle,
@@ -9615,19 +9625,19 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
-hipblasStatus_t hipblasZtrsmBatched(hipblasHandle_t             handle,
-                                    hipblasSideMode_t           side,
-                                    hipblasFillMode_t           uplo,
-                                    hipblasOperation_t          transA,
-                                    hipblasDiagType_t           diag,
-                                    int                         m,
-                                    int                         n,
-                                    const hipblasDoubleComplex* alpha,
-                                    hipblasDoubleComplex* const A[],
-                                    int                         lda,
-                                    hipblasDoubleComplex*       B[],
-                                    int                         ldb,
-                                    int                         batch_count)
+hipblasStatus_t hipblasZtrsmBatched(hipblasHandle_t                   handle,
+                                    hipblasSideMode_t                 side,
+                                    hipblasFillMode_t                 uplo,
+                                    hipblasOperation_t                transA,
+                                    hipblasDiagType_t                 diag,
+                                    int                               m,
+                                    int                               n,
+                                    const hipblasDoubleComplex*       alpha,
+                                    const hipblasDoubleComplex* const A[],
+                                    int                               lda,
+                                    hipblasDoubleComplex* const       B[],
+                                    int                               ldb,
+                                    int                               batch_count)
 try
 {
     return hipCUBLASStatusToHIPStatus(cublasZtrsmBatched((cublasHandle_t)handle,
@@ -9658,7 +9668,7 @@ hipblasStatus_t hipblasStrsmStridedBatched(hipblasHandle_t    handle,
                                            int                m,
                                            int                n,
                                            const float*       alpha,
-                                           float*             A,
+                                           const float*       A,
                                            int                lda,
                                            hipblasStride      strideA,
                                            float*             B,
@@ -9677,7 +9687,7 @@ hipblasStatus_t hipblasDtrsmStridedBatched(hipblasHandle_t    handle,
                                            int                m,
                                            int                n,
                                            const double*      alpha,
-                                           double*            A,
+                                           const double*      A,
                                            int                lda,
                                            hipblasStride      strideA,
                                            double*            B,
@@ -9696,7 +9706,7 @@ hipblasStatus_t hipblasCtrsmStridedBatched(hipblasHandle_t       handle,
                                            int                   m,
                                            int                   n,
                                            const hipblasComplex* alpha,
-                                           hipblasComplex*       A,
+                                           const hipblasComplex* A,
                                            int                   lda,
                                            hipblasStride         strideA,
                                            hipblasComplex*       B,
@@ -9715,7 +9725,7 @@ hipblasStatus_t hipblasZtrsmStridedBatched(hipblasHandle_t             handle,
                                            int                         m,
                                            int                         n,
                                            const hipblasDoubleComplex* alpha,
-                                           hipblasDoubleComplex*       A,
+                                           const hipblasDoubleComplex* A,
                                            int                         lda,
                                            hipblasStride               strideA,
                                            hipblasDoubleComplex*       B,


### PR DESCRIPTION
resolves #[LWPMLSE-343](https://ontrack-internal.amd.com/browse/LWPMLSE-343) and issue [#543](https://github.com/ROCmSoftwarePlatform/hipBLAS/issues/543)

Summary of proposed changes:
- Add const qualifier to hipBLAS functions swap, sbmv, spmv, symv, trsm.
