### PR TITLE
Removing support for packed int8

### DIFF
--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -334,37 +334,6 @@ int getArch()
 int getArchMajor()
 {
     return getArch() / 100;
-}
-
-/*******************************************************************************
- * gemm_ex int8 layout
- ******************************************************************************/
-bool layout_pack_int8(hipblasHandle_t handle)
-{
-    // This function should match the rocBLAS function: rocblas_query_int8_layout_flag
-    //
-    // Default behavior is from when int8 was supported on gfx908 and other architectures
-    // used packed_int8x4. All architectures support int8 since the following two PRs
-    // for ROCm 4.2:
-    // - Tensile PR 680
-    // - rocBLAS-internal PR 1328
-
-    hipblasInt8Datatype_t int8Type;
-    hipblasGetInt8Datatype(handle, &int8Type);
-    if(HIPBLAS_INT8_DATATYPE_DEFAULT == int8Type)
-    {
-        int arch = getArch();
-        return arch != 908;
-    }
-    else if(HIPBLAS_INT8_DATATYPE_INT8 == int8Type)
-    {
-        return false;
-    }
-    else if(HIPBLAS_INT8_DATATYPE_PACK_INT8x4 == int8Type)
-    {
-        return true;
-    }
-    return false;
 }
 
 #ifdef __cplusplus

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,17 +51,6 @@ typedef std::tuple<vector<int>, vector<double>, vector<char>, vector<hipblasData
 // clang-format off
 // vector of vector, each vector is a {M, N, K, lda, ldb, ldc};
 // add/delete as a group
-const vector<vector<int>> int8_matrix_size_range = {
-
-    { 4,  4,  4,  4,  4,  4},
-    { 8,  8,  8,  8,  8,  8},
-    {12, 12, 12, 12, 12, 12},
-    {16, 16, 16, 16, 16, 16},
-    {20, 20, 20, 20, 20, 20},
-    { 8,  4,  4,  8,  8,  8},
-    { 8, 12, 12, 12, 12, 12},
-};
-
 const vector<vector<int>> small_matrix_size_range = {
     { 1,  1,  1,  1,  1,  1},
     { 1,  2,  3,  4,  5,  6},
@@ -488,64 +477,9 @@ TEST_P(gemm_batch_ex_gtest, gemm_strided_batched_ex)
     }
 }
 
-// TODO: Disabling some gemm int8 tests as not supported by rocBLAS for all architectures
-// class parameterized_chunk_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
-// {
-// protected:
-//     parameterized_chunk_gemm_ex() {}
-//     virtual ~parameterized_chunk_gemm_ex() {}
-//     virtual void SetUp() {}
-//     virtual void TearDown() {}
-// };
-
-// TEST_P(parameterized_chunk_gemm_ex, float)
-// {
-//     // GetParam return a tuple. Tee setup routine unpack the tuple
-//     // and initializes arg(Arguments) which will be passed to testing routine
-//     // The Arguments data struture have physical meaning associated.
-//     // while the tuple is non-intuitive.
-
-//     Arguments arg = setup_gemm_ex_arguments(GetParam());
-
-//     hipblasStatus_t status = testing_gemm_ex(arg);
-
-//     // if not success, then the input argument is problematic, so detect the error message
-//     if(status != HIPBLAS_STATUS_SUCCESS)
-//     {
-//         if(arg.M < 0 || arg.N < 0 || arg.K < 0)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else if(arg.transA == 'N' ? arg.lda < arg.M : arg.lda < arg.K)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else if(arg.transB == 'N' ? arg.ldb < arg.K : arg.ldb < arg.N)
-//         {
-//             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
-//         }
-//         else
-//         {
-//             // Only available in cuda cc >= 5.0.
-//             // If we want we can change this to call query_device_property() and
-//             // call this only if cc < 5.0 on a CUDA device, else fail.
-//             EXPECT_EQ(HIPBLAS_STATUS_ARCH_MISMATCH, status);
-//         }
-//     }
-// }
-
-// class parameterized_half_gemm_ex : public ::TestWithParam<gemm_ex_tuple>
-// {
-// protected:
-//     parameterized_half_gemm_ex() {}
-//     virtual ~parameterized_half_gemm_ex() {}
-//     virtual void SetUp() {}
-//     virtual void TearDown() {}
-// };
-
 INSTANTIATE_TEST_SUITE_P(quick_blas_ex_small_int8,
                          gemm_ex_gtest,
-                         Combine(ValuesIn(int8_matrix_size_range),
+                         Combine(ValuesIn(medium_matrix_size_range),
                                  ValuesIn(alpha_beta_range_int8),
                                  ValuesIn(transA_transB_range),
                                  ValuesIn(precision_int8),
@@ -703,7 +637,7 @@ INSTANTIATE_TEST_SUITE_P(quick_blas_batched_ex_small_double_complex,
 
 INSTANTIATE_TEST_SUITE_P(quick_blas_batched_ex_small_int8,
                          gemm_batch_ex_gtest,
-                         Combine(ValuesIn(int8_matrix_size_range),
+                         Combine(ValuesIn(medium_matrix_size_range),
                                  ValuesIn(alpha_beta_range_int8),
                                  ValuesIn(transA_transB_range),
                                  ValuesIn(precision_int8),

--- a/clients/gtest/gemm_ex_gtest.cpp
+++ b/clients/gtest/gemm_ex_gtest.cpp
@@ -364,12 +364,23 @@ TEST_P(gemm_ex_gtest, standard)
         {
             EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
         }
-        else
+        else if(status == HIPBLAS_STATUS_ARCH_MISMATCH)
         {
             // Only available in cuda cc >= 5.0.
             // If we want we can change this to call query_device_property() and
             // call this only if cc < 5.0 on a CUDA device, else fail.
             EXPECT_EQ(HIPBLAS_STATUS_ARCH_MISMATCH, status);
+        }
+        else
+        {
+#ifndef __HIP_PLATFORM_NVCC__
+            // on HIP we should pass all tests
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+#else
+            // cublas/rocblas do not have identical support
+            // (i.e. cublas doesn't support i8/i32 here)
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
+#endif
         }
     }
 }

--- a/clients/include/testing_gemm_batched_ex.hpp
+++ b/clients/include/testing_gemm_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -130,36 +130,8 @@ inline hipblasStatus_t testing_gemm_batched_ex_template(const Arguments& arg)
     srand(1);
     for(int b = 0; b < batch_count; b++)
     {
-#ifdef __HIP_PLATFORM_NVCC__
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         CHECK_HIP_ERROR(dB.transfer_from(hB));
-#else
-        if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N && layout_pack_int8(handle))
-        {
-            host_batch_vector<Ta> hA_packed(size_A, 1, batch_count);
-            hA_packed.copy_from(hA);
-            for(int b = 0; b < batch_count; b++)
-                hipblas_packInt8(hA_packed[b], hA[b], M, K, lda);
-            CHECK_HIP_ERROR(dA.transfer_from(hA_packed));
-        }
-        else
-        {
-            CHECK_HIP_ERROR(dA.transfer_from(hA));
-        }
-
-        if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N && layout_pack_int8(handle))
-        {
-            host_batch_vector<Tb> hB_packed(size_B, 1, batch_count);
-            hB_packed.copy_from(hB);
-            for(int b = 0; b < batch_count; b++)
-                hipblas_packInt8(hB_packed[b], hB[b], N, K, ldb);
-            CHECK_HIP_ERROR(dB.transfer_from(hB_packed));
-        }
-        else
-        {
-            CHECK_HIP_ERROR(dB.transfer_from(hB));
-        }
-#endif
     }
 
     CHECK_HIP_ERROR(dC.transfer_from(hC_host));

--- a/clients/include/testing_gemm_ex.hpp
+++ b/clients/include/testing_gemm_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,150 +105,111 @@ inline hipblasStatus_t testing_gemm_ex_template(const Arguments& arg)
     double             gpu_time_used, hipblas_error_host, hipblas_error_device;
     hipblasLocalHandle handle(arg);
 
-    for(auto int8Type : {HIPBLAS_INT8_DATATYPE_DEFAULT,
-                         HIPBLAS_INT8_DATATYPE_INT8,
-                         HIPBLAS_INT8_DATATYPE_PACK_INT8x4})
+    // Initial Data on CPU
+    hipblas_init_matrix(hA, arg, A_row, A_col, lda, 0, 1, hipblas_client_alpha_sets_nan, true);
+    hipblas_init_matrix(
+        hB, arg, B_row, B_col, ldb, 0, 1, hipblas_client_alpha_sets_nan, false, true);
+    hipblas_init_matrix(hC_host, arg, M, N, ldc, 0, 1, hipblas_client_beta_sets_nan);
+
+    hC_gold = hC_device = hC_host;
+
+    // copy data from CPU to device
+
+    CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
+
+    CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha_Tc, sizeof(Tex), hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta_Tc, sizeof(Tex), hipMemcpyHostToDevice));
+
+    if(unit_check || norm_check)
     {
-        // only need to test multiple int8Type for int8_t, for other datatypes break
-        if(!(std::is_same<Ta, int8_t>{}) && HIPBLAS_INT8_DATATYPE_DEFAULT != int8Type)
-            break;
+        // hipBLAS
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+        CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
+                                            transA,
+                                            transB,
+                                            M,
+                                            N,
+                                            K,
+                                            &h_alpha_Tc,
+                                            dA,
+                                            a_type,
+                                            lda,
+                                            dB,
+                                            b_type,
+                                            ldb,
+                                            &h_beta_Tc,
+                                            dC,
+                                            c_type,
+                                            ldc,
+                                            compute_type,
+                                            algo));
 
-        hipblasSetInt8Datatype(handle, int8Type);
+        CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
+        CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
 
-        // Initial Data on CPU
-        hipblas_init_matrix(hA, arg, A_row, A_col, lda, 0, 1, hipblas_client_alpha_sets_nan, true);
-        hipblas_init_matrix(
-            hB, arg, B_row, B_col, ldb, 0, 1, hipblas_client_alpha_sets_nan, false, true);
-        hipblas_init_matrix(hC_host, arg, M, N, ldc, 0, 1, hipblas_client_beta_sets_nan);
+        CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
+        CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
+                                            transA,
+                                            transB,
+                                            M,
+                                            N,
+                                            K,
+                                            d_alpha,
+                                            dA,
+                                            a_type,
+                                            lda,
+                                            dB,
+                                            b_type,
+                                            ldb,
+                                            d_beta,
+                                            dC,
+                                            c_type,
+                                            ldc,
+                                            compute_type,
+                                            algo));
 
-        hC_gold = hC_device = hC_host;
+        CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
 
-        // copy data from CPU to device
+        // reference BLAS
+        cblas_gemm<Ta, Tc, Tex>(transA,
+                                transB,
+                                M,
+                                N,
+                                K,
+                                h_alpha_Tc,
+                                hA.data(),
+                                lda,
+                                hB.data(),
+                                ldb,
+                                h_beta_Tc,
+                                hC_gold.data(),
+                                ldc);
 
-        // CUDA doesn't do packing
-#ifdef __HIP_PLATFORM_NVCC__
-        if(HIPBLAS_INT8_DATATYPE_DEFAULT != int8Type)
-            break;
-        CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
-#else
-        if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N && layout_pack_int8(handle))
+        if(unit_check)
         {
-            host_vector<Ta> hA_packed(hA);
-            hipblas_packInt8(hA_packed, M, K, lda);
-            CHECK_HIP_ERROR(hipMemcpy(dA, hA_packed, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
-        }
-        else
-        {
-            CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
-        }
-
-        if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N && layout_pack_int8(handle))
-        {
-            host_vector<Tb> hB_packed(hB);
-            hipblas_packInt8(hB_packed, N, K, ldb);
-            CHECK_HIP_ERROR(hipMemcpy(dB, hB_packed, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
-        }
-        else
-        {
-            CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
-        }
-#endif
-
-        CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha_Tc, sizeof(Tex), hipMemcpyHostToDevice));
-        CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta_Tc, sizeof(Tex), hipMemcpyHostToDevice));
-
-        if(unit_check || norm_check)
-        {
-            // hipBLAS
-            CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-            CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
-                                                transA,
-                                                transB,
-                                                M,
-                                                N,
-                                                K,
-                                                &h_alpha_Tc,
-                                                dA,
-                                                a_type,
-                                                lda,
-                                                dB,
-                                                b_type,
-                                                ldb,
-                                                &h_beta_Tc,
-                                                dC,
-                                                c_type,
-                                                ldc,
-                                                compute_type,
-                                                algo));
-
-            CHECK_HIP_ERROR(hipMemcpy(hC_host, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
-            CHECK_HIP_ERROR(hipMemcpy(dC, hC_device, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
-
-            CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
-            CHECK_HIPBLAS_ERROR(hipblasGemmExFn(handle,
-                                                transA,
-                                                transB,
-                                                M,
-                                                N,
-                                                K,
-                                                d_alpha,
-                                                dA,
-                                                a_type,
-                                                lda,
-                                                dB,
-                                                b_type,
-                                                ldb,
-                                                d_beta,
-                                                dC,
-                                                c_type,
-                                                ldc,
-                                                compute_type,
-                                                algo));
-
-            CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(Tc) * size_C, hipMemcpyDeviceToHost));
-
-            // reference BLAS
-            cblas_gemm<Ta, Tc, Tex>(transA,
-                                    transB,
-                                    M,
-                                    N,
-                                    K,
-                                    h_alpha_Tc,
-                                    hA.data(),
-                                    lda,
-                                    hB.data(),
-                                    ldb,
-                                    h_beta_Tc,
-                                    hC_gold.data(),
-                                    ldc);
-
-            if(unit_check)
+            // check for float16/bfloat16 input
+            if((getArchMajor() == 11)
+               && ((std::is_same<Tex, float>{} && std::is_same<Ta, hipblasBfloat16>{})
+                   || (std::is_same<Tex, float>{} && std::is_same<Ta, hipblasHalf>{})
+                   || (std::is_same<Tex, hipblasHalf>{} && std::is_same<Ta, hipblasHalf>{})))
             {
-                // check for float16/bfloat16 input
-                if((getArchMajor() == 11)
-                   && ((std::is_same<Tex, float>{} && std::is_same<Ta, hipblasBfloat16>{})
-                       || (std::is_same<Tex, float>{} && std::is_same<Ta, hipblasHalf>{})
-                       || (std::is_same<Tex, hipblasHalf>{} && std::is_same<Ta, hipblasHalf>{})))
-                {
-                    const double tol = K * sum_error_tolerance_for_gfx11<Tex, Ta, Tc>;
-                    near_check_general<Tc>(M, N, ldc, hC_gold.data(), hC_host.data(), tol);
-                    near_check_general<Tc>(M, N, ldc, hC_gold.data(), hC_device.data(), tol);
-                }
-                else
-                {
-                    unit_check_general<Tc>(M, N, ldc, hC_gold, hC_host);
-                    unit_check_general<Tc>(M, N, ldc, hC_gold, hC_device);
-                }
+                const double tol = K * sum_error_tolerance_for_gfx11<Tex, Ta, Tc>;
+                near_check_general<Tc>(M, N, ldc, hC_gold.data(), hC_host.data(), tol);
+                near_check_general<Tc>(M, N, ldc, hC_gold.data(), hC_device.data(), tol);
             }
-            if(norm_check)
+            else
             {
-                hipblas_error_host
-                    = std::abs(norm_check_general<Tc>('F', M, N, ldc, hC_gold, hC_host));
-                hipblas_error_device
-                    = std::abs(norm_check_general<Tc>('F', M, N, ldc, hC_gold, hC_device));
+                unit_check_general<Tc>(M, N, ldc, hC_gold, hC_host);
+                unit_check_general<Tc>(M, N, ldc, hC_gold, hC_device);
             }
+        }
+        if(norm_check)
+        {
+            hipblas_error_host = std::abs(norm_check_general<Tc>('F', M, N, ldc, hC_gold, hC_host));
+            hipblas_error_device
+                = std::abs(norm_check_general<Tc>('F', M, N, ldc, hC_gold, hC_device));
         }
     }
 

--- a/clients/include/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/testing_gemm_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -137,32 +137,8 @@ inline hipblasStatus_t testing_gemm_strided_batched_ex_template(const Arguments&
     hC_gold = hC_device = hC_host;
 
     // copy data from CPU to device
-#ifdef __HIP_PLATFORM_NVCC__
     CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
-#else
-    if(std::is_same<Ta, int8_t>{} && transA == HIPBLAS_OP_N && layout_pack_int8(handle))
-    {
-        host_vector<Ta> hA_packed(hA);
-        hipblas_packInt8(hA_packed, M, K, lda, batch_count, stride_A);
-        CHECK_HIP_ERROR(hipMemcpy(dA, hA_packed, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
-    }
-    else
-    {
-        CHECK_HIP_ERROR(hipMemcpy(dA, hA, sizeof(Ta) * size_A, hipMemcpyHostToDevice));
-    }
-
-    if(std::is_same<Tb, int8_t>{} && transB != HIPBLAS_OP_N && layout_pack_int8(handle))
-    {
-        host_vector<Tb> hB_packed(hB);
-        hipblas_packInt8(hB_packed, N, K, ldb, batch_count, stride_B);
-        CHECK_HIP_ERROR(hipMemcpy(dB, hB_packed, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
-    }
-    else
-    {
-        CHECK_HIP_ERROR(hipMemcpy(dB, hB, sizeof(Tb) * size_B, hipMemcpyHostToDevice));
-    }
-#endif
 
     CHECK_HIP_ERROR(hipMemcpy(dC, hC_host, sizeof(Tc) * size_C, hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha_Tc, sizeof(Tex), hipMemcpyHostToDevice));

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -921,11 +921,6 @@ void set_device(int device_id);
 int getArch();
 int getArchMajor();
 
-/* query what rocBLAS recommends for int8 layout. We are /always/ passing in the flag which
- * rocBLAS recommends, thus we need to know what layout to format our data in our tests.
- * returns true if should be packed. */
-bool layout_pack_int8(hipblasHandle_t handle);
-
 /* ============================================================================================ */
 /*  timing: HIP only provides very limited timers function clock() and not general;
             hipblas sync CPU and device and use more accurate CPU timer*/
@@ -960,10 +955,10 @@ public:
 
     ~hipblasLocalHandle();
 
-    hipblasLocalHandle(const hipblasLocalHandle&) = delete;
-    hipblasLocalHandle(hipblasLocalHandle&&)      = delete;
+    hipblasLocalHandle(const hipblasLocalHandle&)            = delete;
+    hipblasLocalHandle(hipblasLocalHandle&&)                 = delete;
     hipblasLocalHandle& operator=(const hipblasLocalHandle&) = delete;
-    hipblasLocalHandle& operator=(hipblasLocalHandle&&) = delete;
+    hipblasLocalHandle& operator=(hipblasLocalHandle&&)      = delete;
 
     // Allow hipblasLocalHandle to be used anywhere hipblas_handle is expected
     operator hipblasHandle_t&()

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -923,10 +923,10 @@ public:
 
     ~hipblasLocalHandle();
 
-    hipblasLocalHandle(const hipblasLocalHandle&)            = delete;
-    hipblasLocalHandle(hipblasLocalHandle&&)                 = delete;
+    hipblasLocalHandle(const hipblasLocalHandle&) = delete;
+    hipblasLocalHandle(hipblasLocalHandle&&)      = delete;
     hipblasLocalHandle& operator=(const hipblasLocalHandle&) = delete;
-    hipblasLocalHandle& operator=(hipblasLocalHandle&&)      = delete;
+    hipblasLocalHandle& operator=(hipblasLocalHandle&&) = delete;
 
     // Allow hipblasLocalHandle to be used anywhere hipblas_handle is expected
     operator hipblasHandle_t&()

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -433,38 +433,6 @@ inline hipblasBfloat16 random_hpl_generator()
 /* ============================================================================================ */
 
 /* ============================================================================================ */
-/*! \brief Packs strided_batched matricies into groups of 4 in N */
-template <typename T>
-void hipblas_packInt8(
-    std::vector<T>& A, size_t M, size_t N, size_t lda, size_t batch_count = 1, size_t stride_a = 0)
-{
-    if(N % 4 != 0)
-        std::cerr << "ERROR: dimension must be a multiple of 4 in order to pack" << std::endl;
-
-    std::vector<T> temp(A);
-    for(size_t b = 0; b < batch_count; b++)
-        for(size_t colBase = 0; colBase < N; colBase += 4)
-            for(size_t row = 0; row < lda; row++)
-                for(size_t colOffset = 0; colOffset < 4; colOffset++)
-                    A[(colBase * lda + 4 * row) + colOffset + (stride_a * b)]
-                        = temp[(colBase + colOffset) * lda + row + (stride_a * b)];
-}
-
-template <typename T>
-void hipblas_packInt8(T* A, const T* temp, size_t M, size_t N, size_t lda)
-{
-    if(N % 4 != 0)
-        std::cerr << "ERROR: dimension must be a multiple of 4 in order to pack" << std::endl;
-
-    for(size_t colBase = 0; colBase < N; colBase += 4)
-        for(size_t row = 0; row < lda; row++)
-            for(size_t colOffset = 0; colOffset < 4; colOffset++)
-                A[(colBase * lda + 4 * row) + colOffset] = temp[(colBase + colOffset) * lda + row];
-}
-
-/* ============================================================================================ */
-
-/* ============================================================================================ */
 /*! \brief  matrix/vector initialization: */
 // for vector x (M=1, N=lengthX, lda=incx);
 // for complex number, the real/imag part would be initialized with the same value

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -463,13 +463,6 @@ typedef enum
     HIPBLAS_ATOMICS_ALLOWED = 1 /**< Algorithms will take advantage of atomics where applicable. */
 } hipblasAtomicsMode_t;
 
-typedef enum
-{
-    HIPBLAS_INT8_DATATYPE_DEFAULT     = 0x0,
-    HIPBLAS_INT8_DATATYPE_INT8        = 0x1,
-    HIPBLAS_INT8_DATATYPE_PACK_INT8x4 = 0x2
-} hipblasInt8Datatype_t;
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -492,25 +485,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasSetPointerMode(hipblasHandle_t      handle
 /*! \brief Get hipblas pointer mode */
 HIPBLAS_EXPORT hipblasStatus_t hipblasGetPointerMode(hipblasHandle_t       handle,
                                                      hipblasPointerMode_t* mode);
-// clang-format off
-HIPBLAS_DEPRECATED_MSG("The hipblasSetInt8Datatype function will be removed in a future \
-release and only int8_t datatype will be supported. packed_int8x4 datatype support \
-will be removed.")
-// clang-format on
 
-/*! \brief Set hipblas int8 Datatype */
-HIPBLAS_EXPORT hipblasStatus_t hipblasSetInt8Datatype(hipblasHandle_t       handle,
-                                                      hipblasInt8Datatype_t int8Type);
-
-// clang-format off
-HIPBLAS_DEPRECATED_MSG("The hipblasGetInt8Datatype function will be removed in a future \
-release and only int8_t datatype will be supported. packed_int8x4 datatype support \
-will be removed.")
-// clang-format on
-
-/*! \brief Get hipblas int8 Datatype*/
-HIPBLAS_EXPORT hipblasStatus_t hipblasGetInt8Datatype(hipblasHandle_t        handle,
-                                                      hipblasInt8Datatype_t* int8Type);
 /*! \brief copy vector from host to device
     @param[in]
     n           [int]
@@ -17484,10 +17459,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZgeqrfStridedBatched(hipblasHandle_t      
 
     - Supported types are determined by the backend. See rocBLAS/cuBLAS documentation.
 
-    Note for int8 users - For rocBLAS backend, please read rocblas_gemm_ex documentation on int8
-    data layout requirements. hipBLAS makes the assumption that the data layout is in the preferred
-    format for a given device as documented in rocBLAS.
-
     @param[in]
     handle    [hipblasHandle_t]
               handle to the hipblas library context queue.
@@ -17584,10 +17555,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasGemmEx(hipblasHandle_t    handle,
     The number of pointers to matrices is batchCount.
 
     - Supported types are determined by the backend. See rocBLAS/cuBLAS documentation.
-
-    Note for int8 users - For rocBLAS backend, please read rocblas_gemm_batched_ex documentation on int8
-    data layout requirements. hipBLAS makes the assumption that the data layout is in the preferred
-    format for a given device as documented in rocBLAS.
 
     @param[in]
     handle    [hipblasHandle_t]
@@ -17696,10 +17663,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasGemmBatchedEx(hipblasHandle_t    handle,
     The number of matrices is batchCount.
 
     - Supported types are determined by the backend. See rocBLAS/cuBLAS documentation.
-
-    Note for int8 users - For rocBLAS backend, please read rocblas_gemm_strided_batched_ex documentation on int8
-    data layout requirements. hipBLAS makes the assumption that the data layout is in the preferred
-    format for a given device as documented in rocBLAS.
 
     @param[in]
     handle    [hipblasHandle_t]

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -336,34 +336,6 @@ hipblasAtomicsMode_t RocblasAtomicsModeToHIPAtomicsMode(rocblas_atomics_mode mod
     throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
-rocblas_int8_type_for_hipblas HIPInt8DatatypeToRocblasInt8Datatype(hipblasInt8Datatype_t flags)
-{
-    switch(flags)
-    {
-    case HIPBLAS_INT8_DATATYPE_DEFAULT:
-        return rocblas_int8_type_for_hipblas_default;
-    case HIPBLAS_INT8_DATATYPE_PACK_INT8x4:
-        return rocblas_int8_type_for_hipblas_pack_int8x4;
-    case HIPBLAS_INT8_DATATYPE_INT8:
-        return rocblas_int8_type_for_hipblas_int8;
-    }
-    throw HIPBLAS_STATUS_INVALID_ENUM;
-}
-
-hipblasInt8Datatype_t RocblasInt8DatatypeToHIPInt8Datatype(rocblas_int8_type_for_hipblas flags)
-{
-    switch(flags)
-    {
-    case rocblas_int8_type_for_hipblas_default:
-        return HIPBLAS_INT8_DATATYPE_DEFAULT;
-    case rocblas_int8_type_for_hipblas_pack_int8x4:
-        return HIPBLAS_INT8_DATATYPE_PACK_INT8x4;
-    case rocblas_int8_type_for_hipblas_int8:
-        return HIPBLAS_INT8_DATATYPE_INT8;
-    }
-    throw HIPBLAS_STATUS_INVALID_ENUM;
-}
-
 hipblasStatus_t rocBLASStatusToHIPStatus(rocblas_status_ error)
 {
     switch(error)
@@ -458,31 +430,6 @@ try
     rocblas_pointer_mode rocblas_mode;
     rocblas_status       status = rocblas_get_pointer_mode((rocblas_handle)handle, &rocblas_mode);
     *mode                       = RocblasPointerModeToHIPPointerMode(rocblas_mode);
-    return rocBLASStatusToHIPStatus(status);
-}
-catch(...)
-{
-    return exception_to_hipblas_status();
-}
-
-hipblasStatus_t hipblasSetInt8Datatype(hipblasHandle_t handle, hipblasInt8Datatype_t int8Type)
-try
-{
-    return rocBLASStatusToHIPStatus(rocblas_set_int8_type_for_hipblas(
-        (rocblas_handle)handle, HIPInt8DatatypeToRocblasInt8Datatype(int8Type)));
-}
-catch(...)
-{
-    return exception_to_hipblas_status();
-}
-
-hipblasStatus_t hipblasGetInt8Datatype(hipblasHandle_t handle, hipblasInt8Datatype_t* int8Type)
-try
-{
-    rocblas_int8_type_for_hipblas rocblas_type;
-    rocblas_status                status
-        = rocblas_get_int8_type_for_hipblas((rocblas_handle)handle, &rocblas_type);
-    *int8Type = RocblasInt8DatatypeToHIPInt8Datatype(rocblas_type);
     return rocBLASStatusToHIPStatus(status);
 }
 catch(...)
@@ -18141,10 +18088,6 @@ try
     uint32_t           solution_index = 0;
     rocblas_gemm_flags flags          = rocblas_gemm_flags_none;
 
-    rocblas_status status = rocblas_query_int8_layout_flag((rocblas_handle)handle, &flags);
-    if(status != rocblas_status_success)
-        return rocBLASStatusToHIPStatus(status);
-
     return rocBLASStatusToHIPStatus(rocblas_gemm_ex((rocblas_handle)handle,
                                                     hipOperationToHCCOperation(transa),
                                                     hipOperationToHCCOperation(transb),
@@ -18199,10 +18142,6 @@ try
 {
     uint32_t           solution_index = 0;
     rocblas_gemm_flags flags          = rocblas_gemm_flags_none;
-
-    rocblas_status status = rocblas_query_int8_layout_flag((rocblas_handle)handle, &flags);
-    if(status != rocblas_status_success)
-        return rocBLASStatusToHIPStatus(status);
 
     return rocBLASStatusToHIPStatus(
         rocblas_gemm_batched_ex((rocblas_handle)handle,
@@ -18263,10 +18202,6 @@ try
 {
     uint32_t           solution_index = 0;
     rocblas_gemm_flags flags          = rocblas_gemm_flags_none;
-
-    rocblas_status status = rocblas_query_int8_layout_flag((rocblas_handle)handle, &flags);
-    if(status != rocblas_status_success)
-        return rocBLASStatusToHIPStatus(status);
 
     return rocBLASStatusToHIPStatus(
         rocblas_gemm_strided_batched_ex((rocblas_handle)handle,

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -18061,9 +18061,6 @@ catch(...)
 }
 
 // gemm_ex
-// Note for int8 users - For rocBLAS backend, please read rocblas_gemm_ex documentation on int8
-// data layout requirements. hipBLAS makes the assumption that the data layout is in the preferred
-// format for a given device as documented in rocBLAS.
 hipblasStatus_t hipblasGemmEx(hipblasHandle_t    handle,
                               hipblasOperation_t transa,
                               hipblasOperation_t transb,

--- a/library/src/hipblas_module.f90
+++ b/library/src/hipblas_module.f90
@@ -98,14 +98,6 @@ module hipblas_enums
         enumerator :: HIPBLAS_ATOMICS_ALLOWED = 1
     end enum
 
-    enum, bind(c)
-        enumerator :: HIPBLAS_INT8_DATATYPE_DEFAULT = 0
-        enumerator :: HIPBLAS_INT8_DATATYPE_INT8 = 1
-        enumerator :: HIPBLAS_INT8_DATATYPE_PACK_INT8x4 = 2
-    end enum
-
-
-
 end module hipblas_enums
 
 module hipblas

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -353,26 +353,6 @@ try
     cublasStatus        status = cublasGetPointerMode((cublasHandle_t)handle, &cublasMode);
     *mode                      = CudaPointerModeToHIPPointerMode(cublasMode);
     return hipCUBLASStatusToHIPStatus(status);
-}
-catch(...)
-{
-    return exception_to_hipblas_status();
-}
-
-hipblasStatus_t hipblasSetInt8Datatype(hipblasHandle_t handle, hipblasInt8Datatype_t int8Datatype)
-try
-{
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
-}
-catch(...)
-{
-    return exception_to_hipblas_status();
-}
-
-hipblasStatus_t hipblasGetInt8Datatype(hipblasHandle_t handle, hipblasInt8Datatype_t* int8Datatype)
-try
-{
-    return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 catch(...)
 {


### PR DESCRIPTION
Removes support for:
- `hipblasInt8Datatype_t` enum
- `hipblasSetInt8Datatype`
- `hipblasGetInt8Datatype`
- related internal functions

Removes testing, and removes some documentation. Will add in CHANGELOG at FC unless there's somewhere better to include this (deprecation.rst?)