### PR TITLE
correct CHECK_HIPBLAS_ERROR macro to print hipBLAS in place of rocBLAS

### DIFF
--- a/clients/samples/example_hgemm.cpp
+++ b/clients/samples/example_hgemm.cpp
@@ -46,7 +46,7 @@
 #define CHECK_HIPBLAS_ERROR(error)                              \
     if(error != HIPBLAS_STATUS_SUCCESS)                         \
     {                                                           \
-        fprintf(stderr, "rocBLAS error: ");                     \
+        fprintf(stderr, "hipBLAS error: ");                     \
         if(error == HIPBLAS_STATUS_NOT_INITIALIZED)             \
             fprintf(stderr, "HIPBLAS_STATUS_NOT_INITIALIZED");  \
         if(error == HIPBLAS_STATUS_ALLOC_FAILED)                \

--- a/clients/samples/example_hgemm_hip_half.cpp
+++ b/clients/samples/example_hgemm_hip_half.cpp
@@ -46,7 +46,7 @@
 #define CHECK_HIPBLAS_ERROR(error)                              \
     if(error != HIPBLAS_STATUS_SUCCESS)                         \
     {                                                           \
-        fprintf(stderr, "rocBLAS error: ");                     \
+        fprintf(stderr, "hipBLAS error: ");                     \
         if(error == HIPBLAS_STATUS_NOT_INITIALIZED)             \
             fprintf(stderr, "HIPBLAS_STATUS_NOT_INITIALIZED");  \
         if(error == HIPBLAS_STATUS_ALLOC_FAILED)                \

--- a/clients/samples/example_sgemm.cpp
+++ b/clients/samples/example_sgemm.cpp
@@ -46,7 +46,7 @@
 #define CHECK_HIPBLAS_ERROR(error)                              \
     if(error != HIPBLAS_STATUS_SUCCESS)                         \
     {                                                           \
-        fprintf(stderr, "rocBLAS error: ");                     \
+        fprintf(stderr, "hipBLAS error: ");                     \
         if(error == HIPBLAS_STATUS_NOT_INITIALIZED)             \
             fprintf(stderr, "HIPBLAS_STATUS_NOT_INITIALIZED");  \
         if(error == HIPBLAS_STATUS_ALLOC_FAILED)                \

--- a/clients/samples/example_sgemm_strided_batched.cpp
+++ b/clients/samples/example_sgemm_strided_batched.cpp
@@ -46,7 +46,7 @@
 #define CHECK_HIPBLAS_ERROR(error)                              \
     if(error != HIPBLAS_STATUS_SUCCESS)                         \
     {                                                           \
-        fprintf(stderr, "rocBLAS error: ");                     \
+        fprintf(stderr, "hipBLAS error: ");                     \
         if(error == HIPBLAS_STATUS_NOT_INITIALIZED)             \
             fprintf(stderr, "HIPBLAS_STATUS_NOT_INITIALIZED");  \
         if(error == HIPBLAS_STATUS_ALLOC_FAILED)                \

--- a/clients/samples/example_strmm.cpp
+++ b/clients/samples/example_strmm.cpp
@@ -47,7 +47,7 @@
 #define CHECK_HIPBLAS_ERROR(error)                              \
     if(error != HIPBLAS_STATUS_SUCCESS)                         \
     {                                                           \
-        fprintf(stderr, "rocBLAS error: ");                     \
+        fprintf(stderr, "hipBLAS error: ");                     \
         if(error == HIPBLAS_STATUS_NOT_INITIALIZED)             \
             fprintf(stderr, "HIPBLAS_STATUS_NOT_INITIALIZED");  \
         if(error == HIPBLAS_STATUS_ALLOC_FAILED)                \


### PR DESCRIPTION
- small correction in samples code to change CHECK_HIPBLAS_ERROR macro from printing rocBLAS to print hipBLAS