### PR TITLE
don't copy extra dlls

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -214,7 +214,8 @@ if (WIN32)
     ${LAPACK_DIR}/bin/*.dll
     ${BLIS_DIR}/lib/*.dll
     ${OPENBLAS_DIR}/bin/*.dll
-    ${HIP_DIR}/bin/*.dll
+    ${HIP_DIR}/bin/amd*.dll
+    ${HIP_DIR}/bin/hiprt*.dll
     ${HIP_DIR}/bin/hipinfo.exe
     ${ROCBLAS_PATH}/bin/rocblas.dll
     ${ROCSOLVER_PATH}/bin/rocsolver.dll


### PR DESCRIPTION
* avoids copying in extra rocm math libs which may contaminate local build