### PR TITLE
Add rocSPARSE dependency to math-ci (#585)

### DIFF
--- a/.jenkins/multicompiler.groovy
+++ b/.jenkins/multicompiler.groovy
@@ -17,7 +17,7 @@ def runCI =
 
     //customize for project
     prj.paths.build_command = buildCommand
-    prj.libraryDependencies = ['rocBLAS-internal', 'rocSOLVER']
+    prj.libraryDependencies = ['rocBLAS-internal', 'rocSPARSE-internal', 'rocSOLVER']
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -17,7 +17,7 @@ def runCI =
 
     //customize for project
     prj.paths.build_command = buildCommand
-    prj.libraryDependencies = ['rocBLAS-internal', 'rocSOLVER']
+    prj.libraryDependencies = ['rocBLAS-internal', 'rocSPARSE-internal', 'rocSOLVER']
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -15,7 +15,7 @@ def runCI =
 
     def prj  = new rocProject('hipBLAS', 'StaticLibrary')
     prj.paths.build_command = './install.sh -cd --static -p /opt/rocm/lib/cmake'
-    prj.libraryDependencies = ['rocBLAS-internal', 'rocSOLVER']
+    prj.libraryDependencies = ['rocBLAS-internal', 'rocSPARSE-internal', 'rocSOLVER']
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)


### PR DESCRIPTION
The rocSOLVER library has added a dependency on rocSPARSE, so it may be required to successfully link with rocSOLVER.

(cherry picked from commit 6888e100ad69e5692643e62a3ffc4f13ede920e0)