### PR TITLE
Updating changelog for rocm 5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
 - updated documentation requirements
 
+### Dependencies
+- dependency rocSOLVER now depends on rocSPARSE
+
 ## (Unreleased) hipBLAS 1.0.0
 ### Changed
 - added const qualifier to hipBLAS functions (swap, sbmv, spmv, symv, trsm) where missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for hipBLAS
 
+## (Unreleased) hipBLAS 1.1.0
+### Changed
+- updated documentation requirements
+
 ## (Unreleased) hipBLAS 1.0.0
 ### Changed
 - added const qualifier to hipBLAS functions (swap, sbmv, spmv, symv, trsm) where missing


### PR DESCRIPTION
Looks like not really any changes for hipBLAS this release.

https://github.com/rocmsoftwareplatform/hipblas/compare/release/rocm-rel-5.6...develop