### PR TITLE
Use new-style includes in samples

### DIFF
--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus

--- a/clients/samples/example_c.c
+++ b/clients/samples/example_c.c
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,8 +21,8 @@
  *
  * ************************************************************************ */
 
-#include "hipblas.h"
 #include "utility.h"
+#include <hipblas/hipblas.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/clients/samples/example_hgemm.cpp
+++ b/clients/samples/example_hgemm.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
  *
  * ************************************************************************ */
 
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include <iostream>
 #include <limits>
 #include <stdio.h>

--- a/clients/samples/example_hgemm_hip_half.cpp
+++ b/clients/samples/example_hgemm_hip_half.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
  *
  * ************************************************************************ */
 
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include <iostream>
 #include <limits>
 #include <stdio.h>

--- a/clients/samples/example_hip_complex_her2.cpp
+++ b/clients/samples/example_hip_complex_her2.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@
 #include <vector>
 
 #define ROCM_MATHLIBS_API_USE_HIP_COMPLEX
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 
 #ifndef CHECK_HIP_ERROR
 #define CHECK_HIP_ERROR(error)                    \

--- a/clients/samples/example_sgemm.cpp
+++ b/clients/samples/example_sgemm.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
  *
  * ************************************************************************ */
 
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include <iostream>
 #include <limits>
 #include <stdio.h>

--- a/clients/samples/example_sgemm_strided_batched.cpp
+++ b/clients/samples/example_sgemm_strided_batched.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
  *
  * ************************************************************************ */
 
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include <iostream>
 #include <limits>
 #include <stdio.h>

--- a/clients/samples/example_sscal.cpp
+++ b/clients/samples/example_sscal.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,8 @@
 #include <stdlib.h>
 #include <vector>
 
-#include "hipblas.h"
 #include "utility.h"
+#include <hipblas/hipblas.h>
 
 /* ============================================================================================ */
 

--- a/clients/samples/example_strmm.cpp
+++ b/clients/samples/example_strmm.cpp
@@ -21,7 +21,7 @@
  *
  * ************************************************************************ */
 
-#include "hipblas.h"
+#include <hipblas/hipblas.h>
 #include <iostream>
 #include <limits>
 #include <math.h> // isnan


### PR DESCRIPTION
Users of hipBLAS should be including the header as <hipblas/hipblas.h>, so it is nice to use that style of include in the samples.