### PR TITLE
Adding compiler options to rmake.py

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ cat <<EOF
 
     --cmake-arg                   Forward the given argument to CMake when configuring the build.
 
-    --compiler </compier/path>    Specify path to host compiler. (e.g. /opt/bin/hipcc)
+    --compiler </compier/path>    Specify path to host compiler. (e.g. /opt/rocm/bin/hipcc)
 
     --custom-target <target>      Specify custom target to link the library against (eg. host, device).
 
@@ -236,7 +236,7 @@ install_packages( )
   if [[ "${build_cuda}" == true ]]; then
     # Ideally, this could be cuda-cublas-dev, but the package name has a version number in it
     library_dependencies_ubuntu+=( "" ) # removed, use --installcuda option to install cuda
-  elif [[ "${build_hip_clang}" == false ]]; then
+  else
     # Custom rocm-dev installation
     if [[ -z ${custom_rocm_dev+foo} ]]; then
       # Install base rocm-dev package unless -v/--rocm-dev flag is passed
@@ -427,7 +427,6 @@ install_prefix=hipblas-install
 build_clients=false
 build_solver=true
 build_cuda=false
-build_hip_clang=true
 build_release=true
 build_relocatable=false
 build_address_sanitizer=false
@@ -497,10 +496,10 @@ while true; do
         build_codecoverage=true
         shift ;;
     --hip-clang)
-        build_hip_clang=true
+        compiler=hipcc
         shift ;;
     --no-hip-clang)
-        build_hip_clang=false
+        compiler=g++
         shift ;;
     --compiler)
         compiler=${2}

--- a/install.sh
+++ b/install.sh
@@ -653,8 +653,6 @@ pushd .
       exit 1
     fi
     cmake_common_options+=("-DBUILD_SHARED_LIBS=OFF")
-    compiler="${rocm_path}/bin/hipcc" #force hipcc for static libs, g++ doesn't work
-    printf "Forcing compiler to hipcc for static library.\n"
   fi
 
   # build type

--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ cat <<EOF
 
     --cmake-arg                   Forward the given argument to CMake when configuring the build.
 
-    --compiler </compier/path>    Specify path to host compiler. (e.g. /opt/rocm/bin/hipcc)
+    --compiler </compiler/path>    Specify path to host compiler. (e.g. /opt/rocm/bin/hipcc)
 
     --custom-target <target>      Specify custom target to link the library against (eg. host, device).
 

--- a/rmake.py
+++ b/rmake.py
@@ -89,10 +89,10 @@ def parse_args():
                         help='Build hipblas as a static library.(optional, default: False). hipblas must be built statically when the used companion rocblas is also static')
 
     parser.add_argument('--hip-clang', dest='use_hipcc_compiler', required=False, default=True, action='store_true',
-                        help='Build hipBLAS using hipcc compiler')
+                        help='Linux only: Build hipBLAS using hipcc compiler.')
 
     parser.add_argument('--no-hip-clang', dest='use_hipcc_compiler', required=False, default=True, action='store_false',
-                        help='Build hipBLAS with g++ compiler instead of hipcc compiler, not currently supported on Windows')
+                        help='Linux only: Build hipBLAS with g++ compiler instead of hipcc compiler.')
 
     parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
                         help='Verbose build (optional, default: False)')
@@ -217,12 +217,10 @@ def config_cmd():
     os.chdir( build_path )
 
     # compiler
-    if args.use_hipcc_compiler:
-        cmake_options.append(f"-DCMAKE_C_COMPILER={rocm_path}/bin/hipcc")
-        cmake_options.append(f"-DCMAKE_CXX_COMPILER={rocm_path}/bin/hipcc")
-    else:
-        if os.name == "nt":
-            print("Currently forcing hip-clang compiler on Windows.")
+    if os.name == "nt":
+        if args.use_hipcc_compiler:
+            cmake_options.append(f"-DCMAKE_C_COMPILER={rocm_path}/bin/hipcc")
+            cmake_options.append(f"-DCMAKE_CXX_COMPILER={rocm_path}/bin/hipcc")
         else:
             cmake_options.append(f"-DCMAKE_C_COMPILER=gcc")
             cmake_options.append(f"-DCMAKE_CXX_COMPILER=g++")

--- a/rmake.py
+++ b/rmake.py
@@ -92,7 +92,7 @@ def parse_args():
                         help='Build hipBLAS using hipcc compiler')
 
     parser.add_argument('--no-hip-clang', dest='use_hipcc_compiler', required=False, default=True, action='store_false',
-                        help='Build hipBLAS with g++ compiler instead of hipcc compiler')
+                        help='Build hipBLAS with g++ compiler instead of hipcc compiler, not currently supported on Windows')
 
     parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
                         help='Verbose build (optional, default: False)')
@@ -221,15 +221,14 @@ def config_cmd():
         cmake_options.append(f"-DCMAKE_C_COMPILER={rocm_path}/bin/hipcc")
         cmake_options.append(f"-DCMAKE_CXX_COMPILER={rocm_path}/bin/hipcc")
     else:
-        cmake_options.append(f"-DCMAKE_C_COMPILER=gcc")
-        cmake_options.append(f"-DCMAKE_CXX_COMPILER=g++")
+        if os.name == "nt":
+            print("Currently forcing hip-clang compiler on Windows.")
+        else:
+            cmake_options.append(f"-DCMAKE_C_COMPILER=gcc")
+            cmake_options.append(f"-DCMAKE_CXX_COMPILER=g++")
 
     if args.static_lib:
         cmake_options.append( f"-DBUILD_SHARED_LIBS=OFF" )
-        # force hipcc for static libs
-        cmake_options.append(f"-DCMAKE_C_COMPILER={rocm_path}/bin/hipcc")
-        cmake_options.append(f"-DCMAKE_CXX_COMPILER={rocm_path}/bin/hipcc")
-        print("Forcing compiler to hipcc for static library.")
 
     if args.relocatable:
         rocm_rpath = os.getenv( 'ROCM_RPATH', "/opt/rocm/lib:/opt/rocm/lib64")

--- a/rmake.py
+++ b/rmake.py
@@ -217,7 +217,7 @@ def config_cmd():
     os.chdir( build_path )
 
     # compiler
-    if os.name == "nt":
+    if os.name != "nt":
         if args.use_hipcc_compiler:
             cmake_options.append(f"-DCMAKE_C_COMPILER={rocm_path}/bin/hipcc")
             cmake_options.append(f"-DCMAKE_CXX_COMPILER={rocm_path}/bin/hipcc")

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -11,11 +11,11 @@ endif()
 
 # relying on env and path for backward compatibility with external recipes
 if (NOT DEFINED ENV{CXX} AND NOT CMAKE_CXX_COMPILER)
-  set(CMAKE_CXX_COMPILER "hipcc")
+  set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc")
 endif()
 
 if (NOT DEFINED ENV{CC} AND NOT CMAKE_C_COMPILER)
-  set(CMAKE_C_COMPILER "hipcc")
+  set(CMAKE_C_COMPILER "${rocm_bin}/hipcc")
 endif()
 
 if (NOT DEFINED ENV{FC} AND NOT CMAKE_Fortran_COMPILER)


### PR DESCRIPTION
- fixes --hip-clang and --no-hip-clang ./install.sh options to use hipcc/g++ accordingly
- adds --hip-clang and --no-hip-clang rmake.py options to use hipcc/g++ accordingly
- uses ROCM_PATH to get hipcc location instead of assuming it's in the path

install.sh defaults to using g++ and rmake.py defaults to using hipcc. I didn't change that in this PR.