### PR TITLE
support multiple rocblas dll files for tests

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -233,7 +233,7 @@ if (WIN32)
     ${HIP_DIR}/bin/amd*.dll
     ${HIP_DIR}/bin/hiprt*.dll
     ${HIP_DIR}/bin/hipinfo.exe
-    ${ROCBLAS_PATH}/bin/rocblas.dll
+    ${ROCBLAS_PATH}/bin/rocblas*.dll
     ${ROCSOLVER_PATH}/bin/rocsolver.dll
     ${CMAKE_SOURCE_DIR}/rtest.*
     C:/Windows/System32/libomp140*.dll


### PR DESCRIPTION
* allows multiple rocblas DLLs to be used in testing