### PR TITLE
Fix install when not building hipblas-bench

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -135,13 +135,15 @@ add_custom_command( OUTPUT "${HIPBLAS_GENTEST}"
 
 add_custom_target( hipblas-common DEPENDS "${HIPBLAS_COMMON}" "${HIPBLAS_TEMPLATE}" "${HIPBLAS_SMOKE}" "${HIPBLAS_GENTEST}" )
 
-rocm_install(
-  FILES ${HIPBLAS_COMMON} ${HIPBLAS_TEMPLATE} ${HIPBLAS_SMOKE}
-  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  COMPONENT clients-common
-)
-rocm_install(
-  PROGRAMS ${HIPBLAS_GENTEST}
-  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  COMPONENT clients-common
-)
+if(BUILD_CLIENTS_BENCHMARKS)
+  rocm_install(
+    FILES ${HIPBLAS_COMMON} ${HIPBLAS_TEMPLATE} ${HIPBLAS_SMOKE}
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    COMPONENT clients-common
+  )
+  rocm_install(
+    PROGRAMS ${HIPBLAS_GENTEST}
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    COMPONENT clients-common
+  )
+endif()


### PR DESCRIPTION
The hipblas-common target is only used by hipblas-bench and will therefore not be built during a build of only the library and tests. In that case, the install will fail.

This fixes the error by not installing hipblas-common unless hipblas-bench is to be built.