### PR TITLE
366827 - Disable file reorg backward compatibility support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
-option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
+option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     ${CMAKE_SOURCE_DIR}/library/include

--- a/install.sh
+++ b/install.sh
@@ -441,7 +441,7 @@ build_static=false
 build_release_debug=false
 build_codecoverage=false
 update_cmake=false
-build_freorg_bkwdcomp=true
+build_freorg_bkwdcomp=false
 declare -a cmake_common_options
 declare -a cmake_client_options
 


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- File Reorg backward compatibility option set to OFF
- Backward Compatibility flag in install script set to false by default.
-
