### PR TITLE
CI: get dependencies from the same branch

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -10,7 +10,7 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
     {
         project.libraryDependencies.each
         { libraryName ->
-            getDependenciesCommand += auxiliary.getLibrary(libraryName, platform.jenkinsLabel, 'develop', sameOrg)
+            getDependenciesCommand += auxiliary.getLibrary(libraryName, platform.jenkinsLabel, null, sameOrg)
         }
     }
 

--- a/.jenkins/multicompiler.groovy
+++ b/.jenkins/multicompiler.groovy
@@ -17,7 +17,7 @@ def runCI =
 
     //customize for project
     prj.paths.build_command = buildCommand
-    prj.libraryDependencies = ['rocBLAS-internal', 'rocSPARSE-internal', 'rocSOLVER']
+    prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER']
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -17,7 +17,7 @@ def runCI =
 
     //customize for project
     prj.paths.build_command = buildCommand
-    prj.libraryDependencies = ['rocBLAS-internal', 'rocSPARSE-internal', 'rocSOLVER']
+    prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER']
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -15,7 +15,7 @@ def runCI =
 
     def prj  = new rocProject('hipBLAS', 'StaticLibrary')
     prj.paths.build_command = './install.sh -cd --static -p /opt/rocm/lib/cmake'
-    prj.libraryDependencies = ['rocBLAS-internal', 'rocSPARSE-internal', 'rocSOLVER']
+    prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER']
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)


### PR DESCRIPTION
This is impacting release branch testing. CI will try to get dependencies from develop branch of rocBLAS which does not sync with the release branch of hipBLAS. 