### PR TITLE
hipComplex Versions of L1 Functions

### DIFF
--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -84,7 +84,12 @@ hipblasStatus_t hipblasAxpy<hipblasComplex>(hipblasHandle_t       handle,
                                             hipblasComplex*       y,
                                             int                   incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCaxpy(
+        handle, n, (const hipComplex*)alpha, (const hipComplex*)x, incx, (hipComplex*)y, incy);
+#else
     return hipblasCaxpy(handle, n, alpha, x, incx, y, incy);
+#endif
 }
 
 template <>
@@ -96,7 +101,17 @@ hipblasStatus_t hipblasAxpy<hipblasDoubleComplex>(hipblasHandle_t             ha
                                                   hipblasDoubleComplex*       y,
                                                   int                         incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZaxpy(handle,
+                        n,
+                        (const hipDoubleComplex*)alpha,
+                        (const hipDoubleComplex*)x,
+                        incx,
+                        (hipDoubleComplex*)y,
+                        incy);
+#else
     return hipblasZaxpy(handle, n, alpha, x, incx, y, incy);
+#endif
 }
 
 // axpy_batched
@@ -149,7 +164,18 @@ hipblasStatus_t hipblasAxpyBatched<hipblasComplex>(hipblasHandle_t             h
                                                    int                         incy,
                                                    int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCaxpyBatched(handle,
+                               n,
+                               (const hipComplex*)alpha,
+                               (const hipComplex* const*)x,
+                               incx,
+                               (hipComplex* const*)y,
+                               incy,
+                               batch_count);
+#else
     return hipblasCaxpyBatched(handle, n, alpha, x, incx, y, incy, batch_count);
+#endif
 }
 
 template <>
@@ -162,7 +188,18 @@ hipblasStatus_t hipblasAxpyBatched<hipblasDoubleComplex>(hipblasHandle_t        
                                                          int                               incy,
                                                          int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZaxpyBatched(handle,
+                               n,
+                               (const hipDoubleComplex*)alpha,
+                               (const hipDoubleComplex* const*)x,
+                               incx,
+                               (hipDoubleComplex* const*)y,
+                               incy,
+                               batch_count);
+#else
     return hipblasZaxpyBatched(handle, n, alpha, x, incx, y, incy, batch_count);
+#endif
 }
 
 // axpy_strided_batched
@@ -226,8 +263,21 @@ hipblasStatus_t hipblasAxpyStridedBatched<hipblasComplex>(hipblasHandle_t       
                                                           hipblasStride         stridey,
                                                           int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCaxpyStridedBatched(handle,
+                                      n,
+                                      (const hipComplex*)alpha,
+                                      (const hipComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (hipComplex*)y,
+                                      incy,
+                                      stridey,
+                                      batch_count);
+#else
     return hipblasCaxpyStridedBatched(
         handle, n, alpha, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 template <>
@@ -242,8 +292,21 @@ hipblasStatus_t hipblasAxpyStridedBatched<hipblasDoubleComplex>(hipblasHandle_t 
                                                                 hipblasStride               stridey,
                                                                 int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZaxpyStridedBatched(handle,
+                                      n,
+                                      (const hipDoubleComplex*)alpha,
+                                      (const hipDoubleComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (hipDoubleComplex*)y,
+                                      incy,
+                                      stridey,
+                                      batch_count);
+#else
     return hipblasZaxpyStridedBatched(
         handle, n, alpha, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 // scal
@@ -10490,7 +10553,12 @@ hipblasStatus_t hipblasAxpy<hipblasComplex, true>(hipblasHandle_t       handle,
                                                   hipblasComplex*       y,
                                                   int                   incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCaxpyFortran(
+        handle, n, (const hipComplex*)alpha, (const hipComplex*)x, incx, (hipComplex*)y, incy);
+#else
     return hipblasCaxpyFortran(handle, n, alpha, x, incx, y, incy);
+#endif
 }
 
 template <>
@@ -10502,7 +10570,17 @@ hipblasStatus_t hipblasAxpy<hipblasDoubleComplex, true>(hipblasHandle_t         
                                                         hipblasDoubleComplex*       y,
                                                         int                         incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZaxpyFortran(handle,
+                               n,
+                               (const hipDoubleComplex*)alpha,
+                               (const hipDoubleComplex*)x,
+                               incx,
+                               (hipDoubleComplex*)y,
+                               incy);
+#else
     return hipblasZaxpyFortran(handle, n, alpha, x, incx, y, incy);
+#endif
 }
 
 // axpy_batched
@@ -10555,7 +10633,18 @@ hipblasStatus_t hipblasAxpyBatched<hipblasComplex, true>(hipblasHandle_t        
                                                          int                         incy,
                                                          int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCaxpyBatchedFortran(handle,
+                                      n,
+                                      (const hipComplex*)alpha,
+                                      (const hipComplex* const*)x,
+                                      incx,
+                                      (hipComplex* const*)y,
+                                      incy,
+                                      batch_count);
+#else
     return hipblasCaxpyBatchedFortran(handle, n, alpha, x, incx, y, incy, batch_count);
+#endif
 }
 
 template <>
@@ -10569,7 +10658,18 @@ hipblasStatus_t
                                                    int                               incy,
                                                    int                               batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZaxpyBatchedFortran(handle,
+                                      n,
+                                      (const hipDoubleComplex*)alpha,
+                                      (const hipDoubleComplex* const*)x,
+                                      incx,
+                                      (hipDoubleComplex* const*)y,
+                                      incy,
+                                      batch_count);
+#else
     return hipblasZaxpyBatchedFortran(handle, n, alpha, x, incx, y, incy, batch_count);
+#endif
 }
 
 // axpy_strided_batched
@@ -10633,8 +10733,21 @@ hipblasStatus_t hipblasAxpyStridedBatched<hipblasComplex, true>(hipblasHandle_t 
                                                                 hipblasStride         stridey,
                                                                 int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCaxpyStridedBatchedFortran(handle,
+                                             n,
+                                             (const hipComplex*)alpha,
+                                             (const hipComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (hipComplex*)y,
+                                             incy,
+                                             stridey,
+                                             batch_count);
+#else
     return hipblasCaxpyStridedBatchedFortran(
         handle, n, alpha, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 template <>
@@ -10650,8 +10763,21 @@ hipblasStatus_t
                                                           hipblasStride               stridey,
                                                           int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZaxpyStridedBatchedFortran(handle,
+                                             n,
+                                             (const hipDoubleComplex*)alpha,
+                                             (const hipDoubleComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (hipDoubleComplex*)y,
+                                             incy,
+                                             stridey,
+                                             batch_count);
+#else
     return hipblasZaxpyStridedBatchedFortran(
         handle, n, alpha, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 // scal

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -328,14 +328,22 @@ template <>
 hipblasStatus_t hipblasScal<hipblasComplex>(
     hipblasHandle_t handle, int n, const hipblasComplex* alpha, hipblasComplex* x, int incx)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCscal(handle, n, (const hipComplex*)alpha, (hipComplex*)x, incx);
+#else
     return hipblasCscal(handle, n, alpha, x, incx);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasScal<hipblasComplex, float>(
     hipblasHandle_t handle, int n, const float* alpha, hipblasComplex* x, int incx)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsscal(handle, n, alpha, (hipComplex*)x, incx);
+#else
     return hipblasCsscal(handle, n, alpha, x, incx);
+#endif
 }
 
 template <>
@@ -345,14 +353,22 @@ hipblasStatus_t hipblasScal<hipblasDoubleComplex>(hipblasHandle_t             ha
                                                   hipblasDoubleComplex*       x,
                                                   int                         incx)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZscal(handle, n, (const hipDoubleComplex*)alpha, (hipDoubleComplex*)x, incx);
+#else
     return hipblasZscal(handle, n, alpha, x, incx);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasScal<hipblasDoubleComplex, double>(
     hipblasHandle_t handle, int n, const double* alpha, hipblasDoubleComplex* x, int incx)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdscal(handle, n, alpha, (hipDoubleComplex*)x, incx);
+#else
     return hipblasZdscal(handle, n, alpha, x, incx);
+#endif
 }
 
 // scal_batched
@@ -382,7 +398,12 @@ hipblasStatus_t hipblasScalBatched<hipblasComplex>(hipblasHandle_t       handle,
                                                    int                   incx,
                                                    int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCscalBatched(
+        handle, n, (const hipComplex*)alpha, (hipComplex* const*)x, incx, batch_count);
+#else
     return hipblasCscalBatched(handle, n, alpha, x, incx, batch_count);
+#endif
 }
 
 template <>
@@ -393,7 +414,12 @@ hipblasStatus_t hipblasScalBatched<hipblasDoubleComplex>(hipblasHandle_t        
                                                          int                         incx,
                                                          int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZscalBatched(
+        handle, n, (const hipDoubleComplex*)alpha, (hipDoubleComplex* const*)x, incx, batch_count);
+#else
     return hipblasZscalBatched(handle, n, alpha, x, incx, batch_count);
+#endif
 }
 
 template <>
@@ -404,7 +430,11 @@ hipblasStatus_t hipblasScalBatched<hipblasComplex, float>(hipblasHandle_t       
                                                           int                   incx,
                                                           int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsscalBatched(handle, n, alpha, (hipComplex* const*)x, incx, batch_count);
+#else
     return hipblasCsscalBatched(handle, n, alpha, x, incx, batch_count);
+#endif
 }
 
 template <>
@@ -415,7 +445,11 @@ hipblasStatus_t hipblasScalBatched<hipblasDoubleComplex, double>(hipblasHandle_t
                                                                  int                         incx,
                                                                  int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdscalBatched(handle, n, alpha, (hipDoubleComplex* const*)x, incx, batch_count);
+#else
     return hipblasZdscalBatched(handle, n, alpha, x, incx, batch_count);
+#endif
 }
 
 // scal_strided_batched
@@ -452,7 +486,12 @@ hipblasStatus_t hipblasScalStridedBatched<hipblasComplex>(hipblasHandle_t       
                                                           hipblasStride         stridex,
                                                           int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCscalStridedBatched(
+        handle, n, (const hipComplex*)alpha, (hipComplex*)x, incx, stridex, batch_count);
+#else
     return hipblasCscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+#endif
 }
 
 template <>
@@ -464,7 +503,17 @@ hipblasStatus_t hipblasScalStridedBatched<hipblasDoubleComplex>(hipblasHandle_t 
                                                                 hipblasStride               stridex,
                                                                 int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZscalStridedBatched(handle,
+                                      n,
+                                      (const hipDoubleComplex*)alpha,
+                                      (hipDoubleComplex*)x,
+                                      incx,
+                                      stridex,
+                                      batch_count);
+#else
     return hipblasZscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+#endif
 }
 
 template <>
@@ -476,7 +525,12 @@ hipblasStatus_t hipblasScalStridedBatched<hipblasComplex, float>(hipblasHandle_t
                                                                  hipblasStride   stridex,
                                                                  int             batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsscalStridedBatched(
+        handle, n, alpha, (hipComplex*)x, incx, stridex, batch_count);
+#else
     return hipblasCsscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+#endif
 }
 
 template <>
@@ -488,7 +542,12 @@ hipblasStatus_t hipblasScalStridedBatched<hipblasDoubleComplex, double>(hipblasH
                                                                         hipblasStride stridex,
                                                                         int           batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdscalStridedBatched(
+        handle, n, alpha, (hipDoubleComplex*)x, incx, stridex, batch_count);
+#else
     return hipblasZdscalStridedBatched(handle, n, alpha, x, incx, stridex, batch_count);
+#endif
 }
 
 //swap
@@ -11151,14 +11210,22 @@ template <>
 hipblasStatus_t hipblasScal<hipblasComplex, hipblasComplex, true>(
     hipblasHandle_t handle, int n, const hipblasComplex* alpha, hipblasComplex* x, int incx)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCscalFortran(handle, n, (const hipComplex*)alpha, (hipComplex*)x, incx);
+#else
     return hipblasCscalFortran(handle, n, alpha, x, incx);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasScal<hipblasComplex, float, true>(
     hipblasHandle_t handle, int n, const float* alpha, hipblasComplex* x, int incx)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsscalFortran(handle, n, alpha, (hipComplex*)x, incx);
+#else
     return hipblasCsscalFortran(handle, n, alpha, x, incx);
+#endif
 }
 
 template <>
@@ -11169,14 +11236,23 @@ hipblasStatus_t
                                                                   hipblasDoubleComplex*       x,
                                                                   int                         incx)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZscalFortran(
+        handle, n, (const hipDoubleComplex*)alpha, (hipDoubleComplex*)x, incx);
+#else
     return hipblasZscalFortran(handle, n, alpha, x, incx);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasScal<hipblasDoubleComplex, double, true>(
     hipblasHandle_t handle, int n, const double* alpha, hipblasDoubleComplex* x, int incx)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdscalFortran(handle, n, alpha, (hipDoubleComplex*)x, incx);
+#else
     return hipblasZdscalFortran(handle, n, alpha, x, incx);
+#endif
 }
 
 // scal_batched
@@ -11207,7 +11283,12 @@ hipblasStatus_t
                                                              int                   incx,
                                                              int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCscalBatchedFortran(
+        handle, n, (const hipComplex*)alpha, (hipComplex* const*)x, incx, batch_count);
+#else
     return hipblasCscalBatchedFortran(handle, n, alpha, x, incx, batch_count);
+#endif
 }
 
 template <>
@@ -11219,7 +11300,12 @@ hipblasStatus_t hipblasScalBatched<hipblasDoubleComplex, hipblasDoubleComplex, t
     int                         incx,
     int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZscalBatchedFortran(
+        handle, n, (const hipDoubleComplex*)alpha, (hipDoubleComplex* const*)x, incx, batch_count);
+#else
     return hipblasZscalBatchedFortran(handle, n, alpha, x, incx, batch_count);
+#endif
 }
 
 template <>
@@ -11230,7 +11316,11 @@ hipblasStatus_t hipblasScalBatched<hipblasComplex, float, true>(hipblasHandle_t 
                                                                 int                   incx,
                                                                 int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsscalBatchedFortran(handle, n, alpha, (hipComplex* const*)x, incx, batch_count);
+#else
     return hipblasCsscalBatchedFortran(handle, n, alpha, x, incx, batch_count);
+#endif
 }
 
 template <>
@@ -11242,7 +11332,12 @@ hipblasStatus_t
                                                            int                         incx,
                                                            int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdscalBatchedFortran(
+        handle, n, alpha, (hipDoubleComplex* const*)x, incx, batch_count);
+#else
     return hipblasZdscalBatchedFortran(handle, n, alpha, x, incx, batch_count);
+#endif
 }
 
 // scal_strided_batched
@@ -11280,7 +11375,12 @@ hipblasStatus_t
                                                                     hipblasStride         stridex,
                                                                     int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCscalStridedBatchedFortran(
+        handle, n, (const hipComplex*)alpha, (hipComplex*)x, incx, stridex, batch_count);
+#else
     return hipblasCscalStridedBatchedFortran(handle, n, alpha, x, incx, stridex, batch_count);
+#endif
 }
 
 template <>
@@ -11293,7 +11393,17 @@ hipblasStatus_t hipblasScalStridedBatched<hipblasDoubleComplex, hipblasDoubleCom
     hipblasStride               stridex,
     int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZscalStridedBatchedFortran(handle,
+                                             n,
+                                             (const hipDoubleComplex*)alpha,
+                                             (hipDoubleComplex*)x,
+                                             incx,
+                                             stridex,
+                                             batch_count);
+#else
     return hipblasZscalStridedBatchedFortran(handle, n, alpha, x, incx, stridex, batch_count);
+#endif
 }
 
 template <>
@@ -11305,7 +11415,12 @@ hipblasStatus_t hipblasScalStridedBatched<hipblasComplex, float, true>(hipblasHa
                                                                        hipblasStride   stridex,
                                                                        int             batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsscalStridedBatchedFortran(
+        handle, n, alpha, (hipComplex*)x, incx, stridex, batch_count);
+#else
     return hipblasCsscalStridedBatchedFortran(handle, n, alpha, x, incx, stridex, batch_count);
+#endif
 }
 
 template <>
@@ -11318,7 +11433,12 @@ hipblasStatus_t
                                                                   hipblasStride         stridex,
                                                                   int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdscalStridedBatchedFortran(
+        handle, n, alpha, (hipDoubleComplex*)x, incx, stridex, batch_count);
+#else
     return hipblasZdscalStridedBatchedFortran(handle, n, alpha, x, incx, stridex, batch_count);
+#endif
 }
 
 //swap

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -2039,14 +2039,22 @@ template <>
 hipblasStatus_t hipblasIamin<hipblasComplex>(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIcamin(handle, n, (const hipComplex*)x, incx, result);
+#else
     return hipblasIcamin(handle, n, x, incx, result);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasIamin<hipblasDoubleComplex>(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIzamin(handle, n, (const hipDoubleComplex*)x, incx, result);
+#else
     return hipblasIzamin(handle, n, x, incx, result);
+#endif
 }
 
 // amin_batched
@@ -2072,7 +2080,11 @@ hipblasStatus_t hipblasIaminBatched<hipblasComplex>(hipblasHandle_t             
                                                     int                         batch_count,
                                                     int*                        result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIcaminBatched(handle, n, (const hipComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasIcaminBatched(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 template <>
@@ -2083,7 +2095,12 @@ hipblasStatus_t hipblasIaminBatched<hipblasDoubleComplex>(hipblasHandle_t       
                                                           int  batch_count,
                                                           int* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIzaminBatched(
+        handle, n, (const hipDoubleComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasIzaminBatched(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 // amin_strided_batched
@@ -2120,7 +2137,12 @@ hipblasStatus_t hipblasIaminStridedBatched<hipblasComplex>(hipblasHandle_t      
                                                            int                   batch_count,
                                                            int*                  result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIcaminStridedBatched(
+        handle, n, (const hipComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasIcaminStridedBatched(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 template <>
@@ -2132,7 +2154,12 @@ hipblasStatus_t hipblasIaminStridedBatched<hipblasDoubleComplex>(hipblasHandle_t
                                                                  int           batch_count,
                                                                  int*          result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIzaminStridedBatched(
+        handle, n, (const hipDoubleComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasIzaminStridedBatched(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 /*
@@ -12426,14 +12453,22 @@ template <>
 hipblasStatus_t hipblasIamin<hipblasComplex, true>(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIcaminFortran(handle, n, (const hipComplex*)x, incx, result);
+#else
     return hipblasIcaminFortran(handle, n, x, incx, result);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasIamin<hipblasDoubleComplex, true>(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIzaminFortran(handle, n, (const hipDoubleComplex*)x, incx, result);
+#else
     return hipblasIzaminFortran(handle, n, x, incx, result);
+#endif
 }
 
 // amin_batched
@@ -12459,7 +12494,12 @@ hipblasStatus_t hipblasIaminBatched<hipblasComplex, true>(hipblasHandle_t       
                                                           int                         batch_count,
                                                           int*                        result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIcaminBatchedFortran(
+        handle, n, (const hipComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasIcaminBatchedFortran(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 template <>
@@ -12471,7 +12511,12 @@ hipblasStatus_t
                                                     int                               batch_count,
                                                     int*                              result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIzaminBatchedFortran(
+        handle, n, (const hipDoubleComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasIzaminBatchedFortran(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 // amin_strided_batched
@@ -12508,7 +12553,12 @@ hipblasStatus_t hipblasIaminStridedBatched<hipblasComplex, true>(hipblasHandle_t
                                                                  int                   batch_count,
                                                                  int*                  result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIcaminStridedBatchedFortran(
+        handle, n, (const hipComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasIcaminStridedBatchedFortran(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 template <>
@@ -12521,7 +12571,12 @@ hipblasStatus_t
                                                            int                         batch_count,
                                                            int*                        result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasIzaminStridedBatchedFortran(
+        handle, n, (const hipDoubleComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasIzaminStridedBatchedFortran(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 /*

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -857,7 +857,12 @@ hipblasStatus_t hipblasDot<hipblasComplex>(hipblasHandle_t       handle,
                                            int                   incy,
                                            hipblasComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotu(
+        handle, n, (const hipComplex*)x, incx, (const hipComplex*)y, incy, (hipComplex*)result);
+#else
     return hipblasCdotu(handle, n, x, incx, y, incy, result);
+#endif
 }
 
 template <>
@@ -869,7 +874,17 @@ hipblasStatus_t hipblasDot<hipblasDoubleComplex>(hipblasHandle_t             han
                                                  int                         incy,
                                                  hipblasDoubleComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotu(handle,
+                        n,
+                        (const hipDoubleComplex*)x,
+                        incx,
+                        (const hipDoubleComplex*)y,
+                        incy,
+                        (hipDoubleComplex*)result);
+#else
     return hipblasZdotu(handle, n, x, incx, y, incy, result);
+#endif
 }
 
 template <>
@@ -881,7 +896,12 @@ hipblasStatus_t hipblasDotc<hipblasComplex>(hipblasHandle_t       handle,
                                             int                   incy,
                                             hipblasComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotc(
+        handle, n, (const hipComplex*)x, incx, (const hipComplex*)y, incy, (hipComplex*)result);
+#else
     return hipblasCdotc(handle, n, x, incx, y, incy, result);
+#endif
 }
 
 template <>
@@ -893,7 +913,17 @@ hipblasStatus_t hipblasDotc<hipblasDoubleComplex>(hipblasHandle_t             ha
                                                   int                         incy,
                                                   hipblasDoubleComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotc(handle,
+                        n,
+                        (const hipDoubleComplex*)x,
+                        incx,
+                        (const hipDoubleComplex*)y,
+                        incy,
+                        (hipDoubleComplex*)result);
+#else
     return hipblasZdotc(handle, n, x, incx, y, incy, result);
+#endif
 }
 
 // dot_batched
@@ -959,7 +989,18 @@ hipblasStatus_t hipblasDotBatched<hipblasComplex>(hipblasHandle_t             ha
                                                   int                         batch_count,
                                                   hipblasComplex*             result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotuBatched(handle,
+                               n,
+                               (const hipComplex* const*)x,
+                               incx,
+                               (const hipComplex* const*)y,
+                               incy,
+                               batch_count,
+                               (hipComplex*)result);
+#else
     return hipblasCdotuBatched(handle, n, x, incx, y, incy, batch_count, result);
+#endif
 }
 
 template <>
@@ -972,7 +1013,18 @@ hipblasStatus_t hipblasDotcBatched<hipblasComplex>(hipblasHandle_t             h
                                                    int                         batch_count,
                                                    hipblasComplex*             result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotcBatched(handle,
+                               n,
+                               (const hipComplex* const*)x,
+                               incx,
+                               (const hipComplex* const*)y,
+                               incy,
+                               batch_count,
+                               (hipComplex*)result);
+#else
     return hipblasCdotcBatched(handle, n, x, incx, y, incy, batch_count, result);
+#endif
 }
 
 template <>
@@ -985,7 +1037,18 @@ hipblasStatus_t hipblasDotBatched<hipblasDoubleComplex>(hipblasHandle_t         
                                                         int                   batch_count,
                                                         hipblasDoubleComplex* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotuBatched(handle,
+                               n,
+                               (const hipDoubleComplex* const*)x,
+                               incx,
+                               (const hipDoubleComplex* const*)y,
+                               incy,
+                               batch_count,
+                               (hipDoubleComplex*)result);
+#else
     return hipblasZdotuBatched(handle, n, x, incx, y, incy, batch_count, result);
+#endif
 }
 
 template <>
@@ -998,7 +1061,18 @@ hipblasStatus_t hipblasDotcBatched<hipblasDoubleComplex>(hipblasHandle_t        
                                                          int                   batch_count,
                                                          hipblasDoubleComplex* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotcBatched(handle,
+                               n,
+                               (const hipDoubleComplex* const*)x,
+                               incx,
+                               (const hipDoubleComplex* const*)y,
+                               incy,
+                               batch_count,
+                               (hipDoubleComplex*)result);
+#else
     return hipblasZdotcBatched(handle, n, x, incx, y, incy, batch_count, result);
+#endif
 }
 
 // dot_strided_batched
@@ -1078,8 +1152,21 @@ hipblasStatus_t hipblasDotStridedBatched<hipblasComplex>(hipblasHandle_t       h
                                                          int                   batch_count,
                                                          hipblasComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotuStridedBatched(handle,
+                                      n,
+                                      (const hipComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (const hipComplex*)y,
+                                      incy,
+                                      stridey,
+                                      batch_count,
+                                      (hipComplex*)result);
+#else
     return hipblasCdotuStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+#endif
 }
 
 template <>
@@ -1094,8 +1181,21 @@ hipblasStatus_t hipblasDotcStridedBatched<hipblasComplex>(hipblasHandle_t       
                                                           int                   batch_count,
                                                           hipblasComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotcStridedBatched(handle,
+                                      n,
+                                      (const hipComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (const hipComplex*)y,
+                                      incy,
+                                      stridey,
+                                      batch_count,
+                                      (hipComplex*)result);
+#else
     return hipblasCdotcStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+#endif
 }
 
 template <>
@@ -1110,8 +1210,21 @@ hipblasStatus_t hipblasDotStridedBatched<hipblasDoubleComplex>(hipblasHandle_t  
                                                                int                   batch_count,
                                                                hipblasDoubleComplex* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotuStridedBatched(handle,
+                                      n,
+                                      (const hipDoubleComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (const hipDoubleComplex*)y,
+                                      incy,
+                                      stridey,
+                                      batch_count,
+                                      (hipDoubleComplex*)result);
+#else
     return hipblasZdotuStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+#endif
 }
 
 template <>
@@ -1126,8 +1239,21 @@ hipblasStatus_t hipblasDotcStridedBatched<hipblasDoubleComplex>(hipblasHandle_t 
                                                                 int                   batch_count,
                                                                 hipblasDoubleComplex* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotcStridedBatched(handle,
+                                      n,
+                                      (const hipDoubleComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (const hipDoubleComplex*)y,
+                                      incy,
+                                      stridey,
+                                      batch_count,
+                                      (hipDoubleComplex*)result);
+#else
     return hipblasZdotcStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+#endif
 }
 
 // asum
@@ -11385,7 +11511,12 @@ hipblasStatus_t hipblasDot<hipblasComplex, true>(hipblasHandle_t       handle,
                                                  int                   incy,
                                                  hipblasComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotuFortran(
+        handle, n, (const hipComplex*)x, incx, (const hipComplex*)y, incy, (hipComplex*)result);
+#else
     return hipblasCdotuFortran(handle, n, x, incx, y, incy, result);
+#endif
 }
 
 template <>
@@ -11397,7 +11528,17 @@ hipblasStatus_t hipblasDot<hipblasDoubleComplex, true>(hipblasHandle_t          
                                                        int                         incy,
                                                        hipblasDoubleComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotuFortran(handle,
+                               n,
+                               (const hipDoubleComplex*)x,
+                               incx,
+                               (const hipDoubleComplex*)y,
+                               incy,
+                               (hipDoubleComplex*)result);
+#else
     return hipblasZdotuFortran(handle, n, x, incx, y, incy, result);
+#endif
 }
 
 template <>
@@ -11409,7 +11550,12 @@ hipblasStatus_t hipblasDotc<hipblasComplex, true>(hipblasHandle_t       handle,
                                                   int                   incy,
                                                   hipblasComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotcFortran(
+        handle, n, (const hipComplex*)x, incx, (const hipComplex*)y, incy, (hipComplex*)result);
+#else
     return hipblasCdotcFortran(handle, n, x, incx, y, incy, result);
+#endif
 }
 
 template <>
@@ -11421,7 +11567,17 @@ hipblasStatus_t hipblasDotc<hipblasDoubleComplex, true>(hipblasHandle_t         
                                                         int                         incy,
                                                         hipblasDoubleComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotcFortran(handle,
+                               n,
+                               (const hipDoubleComplex*)x,
+                               incx,
+                               (const hipDoubleComplex*)y,
+                               incy,
+                               (hipDoubleComplex*)result);
+#else
     return hipblasZdotcFortran(handle, n, x, incx, y, incy, result);
+#endif
 }
 
 // dot_batched
@@ -11487,7 +11643,18 @@ hipblasStatus_t hipblasDotBatched<hipblasComplex, true>(hipblasHandle_t         
                                                         int                         batch_count,
                                                         hipblasComplex*             result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotuBatchedFortran(handle,
+                                      n,
+                                      (const hipComplex* const*)x,
+                                      incx,
+                                      (const hipComplex* const*)y,
+                                      incy,
+                                      batch_count,
+                                      (hipComplex*)result);
+#else
     return hipblasCdotuBatchedFortran(handle, n, x, incx, y, incy, batch_count, result);
+#endif
 }
 
 template <>
@@ -11500,7 +11667,18 @@ hipblasStatus_t hipblasDotcBatched<hipblasComplex, true>(hipblasHandle_t        
                                                          int                         batch_count,
                                                          hipblasComplex*             result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotcBatchedFortran(handle,
+                                      n,
+                                      (const hipComplex* const*)x,
+                                      incx,
+                                      (const hipComplex* const*)y,
+                                      incy,
+                                      batch_count,
+                                      (hipComplex*)result);
+#else
     return hipblasCdotcBatchedFortran(handle, n, x, incx, y, incy, batch_count, result);
+#endif
 }
 
 template <>
@@ -11513,7 +11691,18 @@ hipblasStatus_t hipblasDotBatched<hipblasDoubleComplex, true>(hipblasHandle_t ha
                                                               int                   batch_count,
                                                               hipblasDoubleComplex* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotuBatchedFortran(handle,
+                                      n,
+                                      (const hipDoubleComplex* const*)x,
+                                      incx,
+                                      (const hipDoubleComplex* const*)y,
+                                      incy,
+                                      batch_count,
+                                      (hipDoubleComplex*)result);
+#else
     return hipblasZdotuBatchedFortran(handle, n, x, incx, y, incy, batch_count, result);
+#endif
 }
 
 template <>
@@ -11527,7 +11716,18 @@ hipblasStatus_t
                                                    int                               batch_count,
                                                    hipblasDoubleComplex*             result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotcBatchedFortran(handle,
+                                      n,
+                                      (const hipDoubleComplex* const*)x,
+                                      incx,
+                                      (const hipDoubleComplex* const*)y,
+                                      incy,
+                                      batch_count,
+                                      (hipDoubleComplex*)result);
+#else
     return hipblasZdotcBatchedFortran(handle, n, x, incx, y, incy, batch_count, result);
+#endif
 }
 
 // dot_strided_batched
@@ -11607,8 +11807,21 @@ hipblasStatus_t hipblasDotStridedBatched<hipblasComplex, true>(hipblasHandle_t  
                                                                int                   batch_count,
                                                                hipblasComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotuStridedBatchedFortran(handle,
+                                             n,
+                                             (const hipComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (const hipComplex*)y,
+                                             incy,
+                                             stridey,
+                                             batch_count,
+                                             (hipComplex*)result);
+#else
     return hipblasCdotuStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+#endif
 }
 
 template <>
@@ -11623,8 +11836,21 @@ hipblasStatus_t hipblasDotcStridedBatched<hipblasComplex, true>(hipblasHandle_t 
                                                                 int                   batch_count,
                                                                 hipblasComplex*       result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCdotcStridedBatchedFortran(handle,
+                                             n,
+                                             (const hipComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (const hipComplex*)y,
+                                             incy,
+                                             stridey,
+                                             batch_count,
+                                             (hipComplex*)result);
+#else
     return hipblasCdotcStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+#endif
 }
 
 template <>
@@ -11639,8 +11865,21 @@ hipblasStatus_t hipblasDotStridedBatched<hipblasDoubleComplex, true>(hipblasHand
                                                                      int           batch_count,
                                                                      hipblasDoubleComplex* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotuStridedBatchedFortran(handle,
+                                             n,
+                                             (const hipDoubleComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (const hipDoubleComplex*)y,
+                                             incy,
+                                             stridey,
+                                             batch_count,
+                                             (hipDoubleComplex*)result);
+#else
     return hipblasZdotuStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+#endif
 }
 
 template <>
@@ -11655,8 +11894,21 @@ hipblasStatus_t hipblasDotcStridedBatched<hipblasDoubleComplex, true>(hipblasHan
                                                                       int           batch_count,
                                                                       hipblasDoubleComplex* result)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdotcStridedBatchedFortran(handle,
+                                             n,
+                                             (const hipDoubleComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (const hipDoubleComplex*)y,
+                                             incy,
+                                             stridey,
+                                             batch_count,
+                                             (hipDoubleComplex*)result);
+#else
     return hipblasZdotcStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count, result);
+#endif
 }
 
 // asum

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -1601,7 +1601,12 @@ hipblasStatus_t hipblasRot<hipblasComplex, float>(hipblasHandle_t       handle,
                                                   const float*          c,
                                                   const hipblasComplex* s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrot(
+        handle, n, (hipComplex*)x, incx, (hipComplex*)y, incy, c, (const hipComplex*)s);
+#else
     return hipblasCrot(handle, n, x, incx, y, incy, c, s);
+#endif
 }
 
 template <>
@@ -1614,7 +1619,11 @@ hipblasStatus_t hipblasRot<hipblasComplex, float, float>(hipblasHandle_t handle,
                                                          const float*    c,
                                                          const float*    s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsrot(handle, n, (hipComplex*)x, incx, (hipComplex*)y, incy, c, s);
+#else
     return hipblasCsrot(handle, n, x, incx, y, incy, c, s);
+#endif
 }
 
 template <>
@@ -1627,7 +1636,18 @@ hipblasStatus_t hipblasRot<hipblasDoubleComplex, double>(hipblasHandle_t        
                                                          const double*               c,
                                                          const hipblasDoubleComplex* s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrot(handle,
+                       n,
+                       (hipDoubleComplex*)x,
+                       incx,
+                       (hipDoubleComplex*)y,
+                       incy,
+                       c,
+                       (const hipDoubleComplex*)s);
+#else
     return hipblasZrot(handle, n, x, incx, y, incy, c, s);
+#endif
 }
 
 template <>
@@ -1640,7 +1660,11 @@ hipblasStatus_t hipblasRot<hipblasDoubleComplex, double, double>(hipblasHandle_t
                                                                  const double*         c,
                                                                  const double*         s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdrot(handle, n, (hipDoubleComplex*)x, incx, (hipDoubleComplex*)y, incy, c, s);
+#else
     return hipblasZdrot(handle, n, x, incx, y, incy, c, s);
+#endif
 }
 
 // rot_batched
@@ -1683,7 +1707,19 @@ hipblasStatus_t hipblasRotBatched<hipblasComplex, float>(hipblasHandle_t       h
                                                          const hipblasComplex* s,
                                                          int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotBatched(handle,
+                              n,
+                              (hipComplex* const*)x,
+                              incx,
+                              (hipComplex* const*)y,
+                              incy,
+                              c,
+                              (const hipComplex*)s,
+                              batch_count);
+#else
     return hipblasCrotBatched(handle, n, x, incx, y, incy, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -1697,7 +1733,12 @@ hipblasStatus_t hipblasRotBatched<hipblasComplex, float, float>(hipblasHandle_t 
                                                                 const float*          s,
                                                                 int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsrotBatched(
+        handle, n, (hipComplex* const*)x, incx, (hipComplex* const*)y, incy, c, s, batch_count);
+#else
     return hipblasCsrotBatched(handle, n, x, incx, y, incy, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -1711,7 +1752,19 @@ hipblasStatus_t hipblasRotBatched<hipblasDoubleComplex, double>(hipblasHandle_t 
                                                                 const hipblasDoubleComplex* s,
                                                                 int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotBatched(handle,
+                              n,
+                              (hipDoubleComplex* const*)x,
+                              incx,
+                              (hipDoubleComplex* const*)y,
+                              incy,
+                              c,
+                              (const hipDoubleComplex*)s,
+                              batch_count);
+#else
     return hipblasZrotBatched(handle, n, x, incx, y, incy, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -1726,7 +1779,19 @@ hipblasStatus_t
                                                             const double*               s,
                                                             int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdrotBatched(handle,
+                               n,
+                               (hipDoubleComplex* const*)x,
+                               incx,
+                               (hipDoubleComplex* const*)y,
+                               incy,
+                               c,
+                               s,
+                               batch_count);
+#else
     return hipblasZdrotBatched(handle, n, x, incx, y, incy, c, s, batch_count);
+#endif
 }
 
 // rot_strided_batched
@@ -1777,8 +1842,22 @@ hipblasStatus_t hipblasRotStridedBatched<hipblasComplex, float>(hipblasHandle_t 
                                                                 const hipblasComplex* s,
                                                                 int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotStridedBatched(handle,
+                                     n,
+                                     (hipComplex*)x,
+                                     incx,
+                                     stridex,
+                                     (hipComplex*)y,
+                                     incy,
+                                     stridey,
+                                     c,
+                                     (const hipComplex*)s,
+                                     batch_count);
+#else
     return hipblasCrotStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -1794,8 +1873,13 @@ hipblasStatus_t hipblasRotStridedBatched<hipblasComplex, float, float>(hipblasHa
                                                                        const float*    s,
                                                                        int             batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsrotStridedBatched(
+        handle, n, (hipComplex*)x, incx, stridex, (hipComplex*)y, incy, stridey, c, s, batch_count);
+#else
     return hipblasCsrotStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -1812,8 +1896,22 @@ hipblasStatus_t
                                                            const hipblasDoubleComplex* s,
                                                            int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotStridedBatched(handle,
+                                     n,
+                                     (hipDoubleComplex*)x,
+                                     incx,
+                                     stridex,
+                                     (hipDoubleComplex*)y,
+                                     incy,
+                                     stridey,
+                                     c,
+                                     (const hipDoubleComplex*)s,
+                                     batch_count);
+#else
     return hipblasZrotStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -1830,8 +1928,22 @@ hipblasStatus_t
                                                                    const double*         s,
                                                                    int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdrotStridedBatched(handle,
+                                      n,
+                                      (hipDoubleComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (hipDoubleComplex*)y,
+                                      incy,
+                                      stridey,
+                                      c,
+                                      s,
+                                      batch_count);
+#else
     return hipblasZdrotStridedBatched(
         handle, n, x, incx, stridex, y, incy, stridey, c, s, batch_count);
+#endif
 }
 
 // rotg
@@ -12279,7 +12391,12 @@ hipblasStatus_t hipblasRot<hipblasComplex, float, hipblasComplex, true>(hipblasH
                                                                         const float*    c,
                                                                         const hipblasComplex* s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotFortran(
+        handle, n, (hipComplex*)x, incx, (hipComplex*)y, incy, c, (const hipComplex*)s);
+#else
     return hipblasCrotFortran(handle, n, x, incx, y, incy, c, s);
+#endif
 }
 
 template <>
@@ -12292,7 +12409,11 @@ hipblasStatus_t hipblasRot<hipblasComplex, float, float, true>(hipblasHandle_t h
                                                                const float*    c,
                                                                const float*    s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsrotFortran(handle, n, (hipComplex*)x, incx, (hipComplex*)y, incy, c, s);
+#else
     return hipblasCsrotFortran(handle, n, x, incx, y, incy, c, s);
+#endif
 }
 
 template <>
@@ -12306,7 +12427,18 @@ hipblasStatus_t hipblasRot<hipblasDoubleComplex, double, hipblasDoubleComplex, t
     const double*               c,
     const hipblasDoubleComplex* s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotFortran(handle,
+                              n,
+                              (hipDoubleComplex*)x,
+                              incx,
+                              (hipDoubleComplex*)y,
+                              incy,
+                              c,
+                              (const hipDoubleComplex*)s);
+#else
     return hipblasZrotFortran(handle, n, x, incx, y, incy, c, s);
+#endif
 }
 
 template <>
@@ -12319,7 +12451,12 @@ hipblasStatus_t hipblasRot<hipblasDoubleComplex, double, double, true>(hipblasHa
                                                                        const double*         c,
                                                                        const double*         s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdrotFortran(
+        handle, n, (hipDoubleComplex*)x, incx, (hipDoubleComplex*)y, incy, c, s);
+#else
     return hipblasZdrotFortran(handle, n, x, incx, y, incy, c, s);
+#endif
 }
 
 // rot_batched
@@ -12363,7 +12500,19 @@ hipblasStatus_t
                                                                    const hipblasComplex* s,
                                                                    int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotBatchedFortran(handle,
+                                     n,
+                                     (hipComplex* const*)x,
+                                     incx,
+                                     (hipComplex* const*)y,
+                                     incy,
+                                     c,
+                                     (const hipComplex*)s,
+                                     batch_count);
+#else
     return hipblasCrotBatchedFortran(handle, n, x, incx, y, incy, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -12377,7 +12526,12 @@ hipblasStatus_t hipblasRotBatched<hipblasComplex, float, float, true>(hipblasHan
                                                                       const float*          s,
                                                                       int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsrotBatchedFortran(
+        handle, n, (hipComplex* const*)x, incx, (hipComplex* const*)y, incy, c, s, batch_count);
+#else
     return hipblasCsrotBatchedFortran(handle, n, x, incx, y, incy, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -12392,7 +12546,19 @@ hipblasStatus_t hipblasRotBatched<hipblasDoubleComplex, double, hipblasDoubleCom
     const hipblasDoubleComplex* s,
     int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotBatchedFortran(handle,
+                                     n,
+                                     (hipDoubleComplex* const*)x,
+                                     incx,
+                                     (hipDoubleComplex* const*)y,
+                                     incy,
+                                     c,
+                                     (const hipDoubleComplex*)s,
+                                     batch_count);
+#else
     return hipblasZrotBatchedFortran(handle, n, x, incx, y, incy, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -12407,7 +12573,19 @@ hipblasStatus_t
                                                                   const double*               s,
                                                                   int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdrotBatchedFortran(handle,
+                                      n,
+                                      (hipDoubleComplex* const*)x,
+                                      incx,
+                                      (hipDoubleComplex* const*)y,
+                                      incy,
+                                      c,
+                                      s,
+                                      batch_count);
+#else
     return hipblasZdrotBatchedFortran(handle, n, x, incx, y, incy, c, s, batch_count);
+#endif
 }
 
 // rot_strided_batched
@@ -12459,8 +12637,22 @@ hipblasStatus_t
                                                                           const hipblasComplex* s,
                                                                           int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotStridedBatchedFortran(handle,
+                                            n,
+                                            (hipComplex*)x,
+                                            incx,
+                                            stridex,
+                                            (hipComplex*)y,
+                                            incy,
+                                            stridey,
+                                            c,
+                                            (const hipComplex*)s,
+                                            batch_count);
+#else
     return hipblasCrotStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -12476,8 +12668,13 @@ hipblasStatus_t hipblasRotStridedBatched<hipblasComplex, float, float, true>(hip
                                                                              const float*  s,
                                                                              int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCsrotStridedBatchedFortran(
+        handle, n, (hipComplex*)x, incx, stridex, (hipComplex*)y, incy, stridey, c, s, batch_count);
+#else
     return hipblasCsrotStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -12494,8 +12691,22 @@ hipblasStatus_t hipblasRotStridedBatched<hipblasDoubleComplex, double, hipblasDo
     const hipblasDoubleComplex* s,
     int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotStridedBatchedFortran(handle,
+                                            n,
+                                            (hipDoubleComplex*)x,
+                                            incx,
+                                            stridex,
+                                            (hipDoubleComplex*)y,
+                                            incy,
+                                            stridey,
+                                            c,
+                                            (const hipDoubleComplex*)s,
+                                            batch_count);
+#else
     return hipblasZrotStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -12512,8 +12723,22 @@ hipblasStatus_t
                                                                          const double* s,
                                                                          int           batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZdrotStridedBatchedFortran(handle,
+                                             n,
+                                             (hipDoubleComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (hipDoubleComplex*)y,
+                                             incy,
+                                             stridey,
+                                             c,
+                                             s,
+                                             batch_count);
+#else
     return hipblasZdrotStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, c, s, batch_count);
+#endif
 }
 
 // rotg

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -1964,7 +1964,11 @@ template <>
 hipblasStatus_t hipblasRotg<hipblasComplex, float>(
     hipblasHandle_t handle, hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotg(handle, (hipComplex*)a, (hipComplex*)b, c, (hipComplex*)s);
+#else
     return hipblasCrotg(handle, a, b, c, s);
+#endif
 }
 
 template <>
@@ -1974,7 +1978,12 @@ hipblasStatus_t hipblasRotg<hipblasDoubleComplex, double>(hipblasHandle_t       
                                                           double*               c,
                                                           hipblasDoubleComplex* s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotg(
+        handle, (hipDoubleComplex*)a, (hipDoubleComplex*)b, c, (hipDoubleComplex*)s);
+#else
     return hipblasZrotg(handle, a, b, c, s);
+#endif
 }
 
 // rotg_batched
@@ -2008,7 +2017,16 @@ hipblasStatus_t hipblasRotgBatched<hipblasComplex, float>(hipblasHandle_t       
                                                           hipblasComplex* const s[],
                                                           int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotgBatched(handle,
+                               (hipComplex* const*)a,
+                               (hipComplex* const*)b,
+                               c,
+                               (hipComplex* const*)s,
+                               batch_count);
+#else
     return hipblasCrotgBatched(handle, a, b, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -2019,7 +2037,16 @@ hipblasStatus_t hipblasRotgBatched<hipblasDoubleComplex, double>(hipblasHandle_t
                                                                  hipblasDoubleComplex* const s[],
                                                                  int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotgBatched(handle,
+                               (hipDoubleComplex* const*)a,
+                               (hipDoubleComplex* const*)b,
+                               c,
+                               (hipDoubleComplex* const*)s,
+                               batch_count);
+#else
     return hipblasZrotgBatched(handle, a, b, c, s, batch_count);
+#endif
 }
 
 // rotg_strided_batched
@@ -2067,8 +2094,21 @@ hipblasStatus_t hipblasRotgStridedBatched<hipblasComplex, float>(hipblasHandle_t
                                                                  hipblasStride   strides,
                                                                  int             batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotgStridedBatched(handle,
+                                      (hipComplex*)a,
+                                      stridea,
+                                      (hipComplex*)b,
+                                      strideb,
+                                      c,
+                                      stridec,
+                                      (hipComplex*)s,
+                                      strides,
+                                      batch_count);
+#else
     return hipblasCrotgStridedBatched(
         handle, a, stridea, b, strideb, c, stridec, s, strides, batch_count);
+#endif
 }
 
 template <>
@@ -2083,8 +2123,21 @@ hipblasStatus_t hipblasRotgStridedBatched<hipblasDoubleComplex, double>(hipblasH
                                                                         hipblasStride strides,
                                                                         int           batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotgStridedBatched(handle,
+                                      (hipDoubleComplex*)a,
+                                      stridea,
+                                      (hipDoubleComplex*)b,
+                                      strideb,
+                                      c,
+                                      stridec,
+                                      (hipDoubleComplex*)s,
+                                      strides,
+                                      batch_count);
+#else
     return hipblasZrotgStridedBatched(
         handle, a, stridea, b, strideb, c, stridec, s, strides, batch_count);
+#endif
 }
 
 // rotm
@@ -12760,7 +12813,11 @@ template <>
 hipblasStatus_t hipblasRotg<hipblasComplex, float, true>(
     hipblasHandle_t handle, hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotgFortran(handle, (hipComplex*)a, (hipComplex*)b, c, (hipComplex*)s);
+#else
     return hipblasCrotgFortran(handle, a, b, c, s);
+#endif
 }
 
 template <>
@@ -12770,7 +12827,12 @@ hipblasStatus_t hipblasRotg<hipblasDoubleComplex, double, true>(hipblasHandle_t 
                                                                 double*               c,
                                                                 hipblasDoubleComplex* s)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotgFortran(
+        handle, (hipDoubleComplex*)a, (hipDoubleComplex*)b, c, (hipDoubleComplex*)s);
+#else
     return hipblasZrotgFortran(handle, a, b, c, s);
+#endif
 }
 
 // rotg_batched
@@ -12804,7 +12866,16 @@ hipblasStatus_t hipblasRotgBatched<hipblasComplex, float, true>(hipblasHandle_t 
                                                                 hipblasComplex* const s[],
                                                                 int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotgBatchedFortran(handle,
+                                      (hipComplex* const*)a,
+                                      (hipComplex* const*)b,
+                                      c,
+                                      (hipComplex* const*)s,
+                                      batch_count);
+#else
     return hipblasCrotgBatchedFortran(handle, a, b, c, s, batch_count);
+#endif
 }
 
 template <>
@@ -12816,7 +12887,16 @@ hipblasStatus_t
                                                            hipblasDoubleComplex* const s[],
                                                            int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotgBatchedFortran(handle,
+                                      (hipDoubleComplex* const*)a,
+                                      (hipDoubleComplex* const*)b,
+                                      c,
+                                      (hipDoubleComplex* const*)s,
+                                      batch_count);
+#else
     return hipblasZrotgBatchedFortran(handle, a, b, c, s, batch_count);
+#endif
 }
 
 // rotg_strided_batched
@@ -12864,8 +12944,21 @@ hipblasStatus_t hipblasRotgStridedBatched<hipblasComplex, float, true>(hipblasHa
                                                                        hipblasStride   strides,
                                                                        int             batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCrotgStridedBatchedFortran(handle,
+                                             (hipComplex*)a,
+                                             stridea,
+                                             (hipComplex*)b,
+                                             strideb,
+                                             c,
+                                             stridec,
+                                             (hipComplex*)s,
+                                             strides,
+                                             batch_count);
+#else
     return hipblasCrotgStridedBatchedFortran(
         handle, a, stridea, b, strideb, c, stridec, s, strides, batch_count);
+#endif
 }
 
 template <>
@@ -12881,8 +12974,21 @@ hipblasStatus_t
                                                                   hipblasStride         strides,
                                                                   int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZrotgStridedBatchedFortran(handle,
+                                             (hipDoubleComplex*)a,
+                                             stridea,
+                                             (hipDoubleComplex*)b,
+                                             strideb,
+                                             c,
+                                             stridec,
+                                             (hipDoubleComplex*)s,
+                                             strides,
+                                             batch_count);
+#else
     return hipblasZrotgStridedBatchedFortran(
         handle, a, stridea, b, strideb, c, stridec, s, strides, batch_count);
+#endif
 }
 
 // rotm

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -1431,16 +1431,22 @@ template <>
 hipblasStatus_t hipblasNrm2<hipblasComplex, float>(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScnrm2(handle, n, (const hipComplex*)x, incx, result);
+#else
     return hipblasScnrm2(handle, n, x, incx, result);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasNrm2<hipblasDoubleComplex, double>(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDznrm2(handle, n, (const hipDoubleComplex*)x, incx, result);
+#else
     return hipblasDznrm2(handle, n, x, incx, result);
+#endif
 }
 
 // nrm2_batched
@@ -1472,8 +1478,11 @@ hipblasStatus_t hipblasNrm2Batched<hipblasComplex, float>(hipblasHandle_t       
                                                           int                         batch_count,
                                                           float*                      result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScnrm2Batched(handle, n, (const hipComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasScnrm2Batched(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 template <>
@@ -1485,8 +1494,12 @@ hipblasStatus_t
                                                      int                               batch_count,
                                                      double*                           result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDznrm2Batched(
+        handle, n, (const hipDoubleComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasDznrm2Batched(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 // nrm2_strided_batched
@@ -1525,8 +1538,12 @@ hipblasStatus_t hipblasNrm2StridedBatched<hipblasComplex, float>(hipblasHandle_t
                                                                  int                   batch_count,
                                                                  float*                result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScnrm2StridedBatched(
+        handle, n, (const hipComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasScnrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 template <>
@@ -1539,8 +1556,12 @@ hipblasStatus_t
                                                             int                         batch_count,
                                                             double*                     result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDznrm2StridedBatched(
+        handle, n, (const hipDoubleComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasDznrm2StridedBatched(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 // rot
@@ -12087,16 +12108,22 @@ template <>
 hipblasStatus_t hipblasNrm2<hipblasComplex, float, true>(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScnrm2Fortran(handle, n, (const hipComplex*)x, incx, result);
+#else
     return hipblasScnrm2Fortran(handle, n, x, incx, result);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasNrm2<hipblasDoubleComplex, double, true>(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDznrm2Fortran(handle, n, (const hipDoubleComplex*)x, incx, result);
+#else
     return hipblasDznrm2Fortran(handle, n, x, incx, result);
+#endif
 }
 
 // nrm2_batched
@@ -12128,8 +12155,12 @@ hipblasStatus_t hipblasNrm2Batched<hipblasComplex, float, true>(hipblasHandle_t 
                                                                 int    batch_count,
                                                                 float* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScnrm2BatchedFortran(
+        handle, n, (const hipComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasScnrm2BatchedFortran(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 template <>
@@ -12141,8 +12172,12 @@ hipblasStatus_t
                                                            int     batch_count,
                                                            double* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDznrm2BatchedFortran(
+        handle, n, (const hipDoubleComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasDznrm2BatchedFortran(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 // nrm2_strided_batched
@@ -12181,8 +12216,12 @@ hipblasStatus_t hipblasNrm2StridedBatched<hipblasComplex, float, true>(hipblasHa
                                                                        int           batch_count,
                                                                        float*        result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScnrm2StridedBatchedFortran(
+        handle, n, (const hipComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasScnrm2StridedBatchedFortran(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 template <>
@@ -12195,8 +12234,12 @@ hipblasStatus_t
                                                                   int           batch_count,
                                                                   double*       result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDznrm2StridedBatchedFortran(
+        handle, n, (const hipDoubleComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasDznrm2StridedBatchedFortran(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 // rot

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -639,7 +639,11 @@ template <>
 hipblasStatus_t hipblasCopy<hipblasComplex>(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCcopy(handle, n, (const hipComplex*)x, incx, (hipComplex*)y, incy);
+#else
     return hipblasCcopy(handle, n, x, incx, y, incy);
+#endif
 }
 
 template <>
@@ -650,7 +654,11 @@ hipblasStatus_t hipblasCopy<hipblasDoubleComplex>(hipblasHandle_t             ha
                                                   hipblasDoubleComplex*       y,
                                                   int                         incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZcopy(handle, n, (const hipDoubleComplex*)x, incx, (hipDoubleComplex*)y, incy);
+#else
     return hipblasZcopy(handle, n, x, incx, y, incy);
+#endif
 }
 
 // copy_batched
@@ -687,7 +695,12 @@ hipblasStatus_t hipblasCopyBatched<hipblasComplex>(hipblasHandle_t             h
                                                    int                         incy,
                                                    int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCcopyBatched(
+        handle, n, (const hipComplex* const*)x, incx, (hipComplex* const*)y, incy, batch_count);
+#else
     return hipblasCcopyBatched(handle, n, x, incx, y, incy, batch_count);
+#endif
 }
 
 template <>
@@ -699,7 +712,17 @@ hipblasStatus_t hipblasCopyBatched<hipblasDoubleComplex>(hipblasHandle_t        
                                                          int                               incy,
                                                          int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZcopyBatched(handle,
+                               n,
+                               (const hipDoubleComplex* const*)x,
+                               incx,
+                               (hipDoubleComplex* const*)y,
+                               incy,
+                               batch_count);
+#else
     return hipblasZcopyBatched(handle, n, x, incx, y, incy, batch_count);
+#endif
 }
 
 // copy_strided_batched
@@ -742,7 +765,12 @@ hipblasStatus_t hipblasCopyStridedBatched<hipblasComplex>(hipblasHandle_t       
                                                           hipblasStride         stridey,
                                                           int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCcopyStridedBatched(
+        handle, n, (const hipComplex*)x, incx, stridex, (hipComplex*)y, incy, stridey, batch_count);
+#else
     return hipblasCcopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 template <>
@@ -756,7 +784,19 @@ hipblasStatus_t hipblasCopyStridedBatched<hipblasDoubleComplex>(hipblasHandle_t 
                                                                 hipblasStride               stridey,
                                                                 int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZcopyStridedBatched(handle,
+                                      n,
+                                      (const hipDoubleComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (hipDoubleComplex*)y,
+                                      incy,
+                                      stridey,
+                                      batch_count);
+#else
     return hipblasZcopyStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 // dot
@@ -11121,7 +11161,11 @@ template <>
 hipblasStatus_t hipblasCopy<hipblasComplex, true>(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCcopyFortran(handle, n, (const hipComplex*)x, incx, (hipComplex*)y, incy);
+#else
     return hipblasCcopyFortran(handle, n, x, incx, y, incy);
+#endif
 }
 
 template <>
@@ -11132,7 +11176,12 @@ hipblasStatus_t hipblasCopy<hipblasDoubleComplex, true>(hipblasHandle_t         
                                                         hipblasDoubleComplex*       y,
                                                         int                         incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZcopyFortran(
+        handle, n, (const hipDoubleComplex*)x, incx, (hipDoubleComplex*)y, incy);
+#else
     return hipblasZcopyFortran(handle, n, x, incx, y, incy);
+#endif
 }
 
 // copy_batched
@@ -11169,7 +11218,12 @@ hipblasStatus_t hipblasCopyBatched<hipblasComplex, true>(hipblasHandle_t        
                                                          int                         incy,
                                                          int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCcopyBatchedFortran(
+        handle, n, (const hipComplex* const*)x, incx, (hipComplex* const*)y, incy, batch_count);
+#else
     return hipblasCcopyBatchedFortran(handle, n, x, incx, y, incy, batch_count);
+#endif
 }
 
 template <>
@@ -11182,7 +11236,17 @@ hipblasStatus_t
                                                    int                               incy,
                                                    int                               batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZcopyBatchedFortran(handle,
+                                      n,
+                                      (const hipDoubleComplex* const*)x,
+                                      incx,
+                                      (hipDoubleComplex* const*)y,
+                                      incy,
+                                      batch_count);
+#else
     return hipblasZcopyBatchedFortran(handle, n, x, incx, y, incy, batch_count);
+#endif
 }
 
 // copy_strided_batched
@@ -11227,8 +11291,13 @@ hipblasStatus_t hipblasCopyStridedBatched<hipblasComplex, true>(hipblasHandle_t 
                                                                 hipblasStride         stridey,
                                                                 int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCcopyStridedBatchedFortran(
+        handle, n, (const hipComplex*)x, incx, stridex, (hipComplex*)y, incy, stridey, batch_count);
+#else
     return hipblasCcopyStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 template <>
@@ -11242,8 +11311,20 @@ hipblasStatus_t hipblasCopyStridedBatched<hipblasDoubleComplex, true>(hipblasHan
                                                                       hipblasStride         stridey,
                                                                       int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZcopyStridedBatchedFortran(handle,
+                                             n,
+                                             (const hipDoubleComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (hipDoubleComplex*)y,
+                                             incy,
+                                             stridey,
+                                             batch_count);
+#else
     return hipblasZcopyStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 // dot

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -1048,16 +1048,22 @@ template <>
 hipblasStatus_t hipblasAsum<hipblasComplex, float>(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScasum(handle, n, (const hipComplex*)x, incx, result);
+#else
     return hipblasScasum(handle, n, x, incx, result);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasAsum<hipblasDoubleComplex, double>(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDzasum(handle, n, (const hipDoubleComplex*)x, incx, result);
+#else
     return hipblasDzasum(handle, n, x, incx, result);
+#endif
 }
 
 // asum_batched
@@ -1089,8 +1095,11 @@ hipblasStatus_t hipblasAsumBatched<hipblasComplex, float>(hipblasHandle_t       
                                                           int                         batch_count,
                                                           float*                      result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScasumBatched(handle, n, (const hipComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasScasumBatched(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 template <>
@@ -1102,8 +1111,12 @@ hipblasStatus_t
                                                      int                               batch_count,
                                                      double*                           result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDzasumBatched(
+        handle, n, (const hipDoubleComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasDzasumBatched(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 // asum_strided_batched
@@ -1142,8 +1155,12 @@ hipblasStatus_t hipblasAsumStridedBatched<hipblasComplex, float>(hipblasHandle_t
                                                                  int                   batch_count,
                                                                  float*                result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScasumStridedBatched(
+        handle, n, (const hipComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasScasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 template <>
@@ -1156,8 +1173,12 @@ hipblasStatus_t
                                                             int                         batch_count,
                                                             double*                     result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDzasumStridedBatched(
+        handle, n, (const hipDoubleComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasDzasumStridedBatched(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 // nrm2
@@ -11452,16 +11473,22 @@ template <>
 hipblasStatus_t hipblasAsum<hipblasComplex, float, true>(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScasumFortran(handle, n, (const hipComplex*)x, incx, result);
+#else
     return hipblasScasumFortran(handle, n, x, incx, result);
+#endif
 }
 
 template <>
 hipblasStatus_t hipblasAsum<hipblasDoubleComplex, double, true>(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDzasumFortran(handle, n, (const hipDoubleComplex*)x, incx, result);
+#else
     return hipblasDzasumFortran(handle, n, x, incx, result);
+#endif
 }
 
 // asum_batched
@@ -11493,8 +11520,12 @@ hipblasStatus_t hipblasAsumBatched<hipblasComplex, float, true>(hipblasHandle_t 
                                                                 int    batch_count,
                                                                 float* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScasumBatchedFortran(
+        handle, n, (const hipComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasScasumBatchedFortran(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 template <>
@@ -11506,8 +11537,12 @@ hipblasStatus_t
                                                            int     batch_count,
                                                            double* result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDzasumBatchedFortran(
+        handle, n, (const hipDoubleComplex* const*)x, incx, batch_count, result);
+#else
     return hipblasDzasumBatchedFortran(handle, n, x, incx, batch_count, result);
+#endif
 }
 
 // asum_strided_batched
@@ -11546,8 +11581,12 @@ hipblasStatus_t hipblasAsumStridedBatched<hipblasComplex, float, true>(hipblasHa
                                                                        int           batch_count,
                                                                        float*        result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasScasumStridedBatchedFortran(
+        handle, n, (const hipComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasScasumStridedBatchedFortran(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 template <>
@@ -11560,8 +11599,12 @@ hipblasStatus_t
                                                                   int           batch_count,
                                                                   double*       result)
 {
-
+#ifdef HIPBLAS_V2
+    return hipblasDzasumStridedBatchedFortran(
+        handle, n, (const hipDoubleComplex*)x, incx, stridex, batch_count, result);
+#else
     return hipblasDzasumStridedBatchedFortran(handle, n, x, incx, stridex, batch_count, result);
+#endif
 }
 
 // nrm2

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -569,7 +569,11 @@ template <>
 hipblasStatus_t hipblasSwap<hipblasComplex>(
     hipblasHandle_t handle, int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCswap(handle, n, (hipComplex*)x, incx, (hipComplex*)y, incy);
+#else
     return hipblasCswap(handle, n, x, incx, y, incy);
+#endif
 }
 
 template <>
@@ -580,46 +584,75 @@ hipblasStatus_t hipblasSwap<hipblasDoubleComplex>(hipblasHandle_t       handle,
                                                   hipblasDoubleComplex* y,
                                                   int                   incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZswap(handle, n, (hipDoubleComplex*)x, incx, (hipDoubleComplex*)y, incy);
+#else
     return hipblasZswap(handle, n, x, incx, y, incy);
+#endif
 }
 
 // swap_batched
 template <>
-hipblasStatus_t hipblasSwapBatched<float>(
-    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batch_count)
+hipblasStatus_t hipblasSwapBatched<float>(hipblasHandle_t handle,
+                                          int             n,
+                                          float* const    x[],
+                                          int             incx,
+                                          float* const    y[],
+                                          int             incy,
+                                          int             batch_count)
 {
     return hipblasSswapBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t hipblasSwapBatched<double>(
-    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batch_count)
+hipblasStatus_t hipblasSwapBatched<double>(hipblasHandle_t handle,
+                                           int             n,
+                                           double* const   x[],
+                                           int             incx,
+                                           double* const   y[],
+                                           int             incy,
+                                           int             batch_count)
 {
     return hipblasDswapBatched(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t hipblasSwapBatched<hipblasComplex>(hipblasHandle_t handle,
-                                                   int             n,
-                                                   hipblasComplex* x[],
-                                                   int             incx,
-                                                   hipblasComplex* y[],
-                                                   int             incy,
-                                                   int             batch_count)
+hipblasStatus_t hipblasSwapBatched<hipblasComplex>(hipblasHandle_t       handle,
+                                                   int                   n,
+                                                   hipblasComplex* const x[],
+                                                   int                   incx,
+                                                   hipblasComplex* const y[],
+                                                   int                   incy,
+                                                   int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCswapBatched(
+        handle, n, (hipComplex* const*)x, incx, (hipComplex* const*)y, incy, batch_count);
+#else
     return hipblasCswapBatched(handle, n, x, incx, y, incy, batch_count);
+#endif
 }
 
 template <>
-hipblasStatus_t hipblasSwapBatched<hipblasDoubleComplex>(hipblasHandle_t       handle,
-                                                         int                   n,
-                                                         hipblasDoubleComplex* x[],
-                                                         int                   incx,
-                                                         hipblasDoubleComplex* y[],
-                                                         int                   incy,
-                                                         int                   batch_count)
+hipblasStatus_t hipblasSwapBatched<hipblasDoubleComplex>(hipblasHandle_t             handle,
+                                                         int                         n,
+                                                         hipblasDoubleComplex* const x[],
+                                                         int                         incx,
+                                                         hipblasDoubleComplex* const y[],
+                                                         int                         incy,
+                                                         int                         batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZswapBatched(handle,
+                               n,
+                               (hipDoubleComplex* const*)x,
+                               incx,
+                               (hipDoubleComplex* const*)y,
+                               incy,
+                               batch_count);
+#else
     return hipblasZswapBatched(handle, n, x, incx, y, incy, batch_count);
+#endif
 }
 
 // swap_strided_batched
@@ -662,7 +695,12 @@ hipblasStatus_t hipblasSwapStridedBatched<hipblasComplex>(hipblasHandle_t handle
                                                           hipblasStride   stridey,
                                                           int             batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCswapStridedBatched(
+        handle, n, (hipComplex*)x, incx, stridex, (hipComplex*)y, incy, stridey, batch_count);
+#else
     return hipblasCswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 template <>
@@ -676,7 +714,19 @@ hipblasStatus_t hipblasSwapStridedBatched<hipblasDoubleComplex>(hipblasHandle_t 
                                                                 hipblasStride         stridey,
                                                                 int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZswapStridedBatched(handle,
+                                      n,
+                                      (hipDoubleComplex*)x,
+                                      incx,
+                                      stridex,
+                                      (hipDoubleComplex*)y,
+                                      incy,
+                                      stridey,
+                                      batch_count);
+#else
     return hipblasZswapStridedBatched(handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 // copy
@@ -11460,7 +11510,11 @@ template <>
 hipblasStatus_t hipblasSwap<hipblasComplex, true>(
     hipblasHandle_t handle, int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCswapFortran(handle, n, (hipComplex*)x, incx, (hipComplex*)y, incy);
+#else
     return hipblasCswapFortran(handle, n, x, incx, y, incy);
+#endif
 }
 
 template <>
@@ -11471,46 +11525,75 @@ hipblasStatus_t hipblasSwap<hipblasDoubleComplex, true>(hipblasHandle_t       ha
                                                         hipblasDoubleComplex* y,
                                                         int                   incy)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZswapFortran(handle, n, (hipDoubleComplex*)x, incx, (hipDoubleComplex*)y, incy);
+#else
     return hipblasZswapFortran(handle, n, x, incx, y, incy);
+#endif
 }
 
 // swap_batched
 template <>
-hipblasStatus_t hipblasSwapBatched<float, true>(
-    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batch_count)
+hipblasStatus_t hipblasSwapBatched<float, true>(hipblasHandle_t handle,
+                                                int             n,
+                                                float* const    x[],
+                                                int             incx,
+                                                float* const    y[],
+                                                int             incy,
+                                                int             batch_count)
 {
     return hipblasSswapBatchedFortran(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t hipblasSwapBatched<double, true>(
-    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batch_count)
+hipblasStatus_t hipblasSwapBatched<double, true>(hipblasHandle_t handle,
+                                                 int             n,
+                                                 double* const   x[],
+                                                 int             incx,
+                                                 double* const   y[],
+                                                 int             incy,
+                                                 int             batch_count)
 {
     return hipblasDswapBatchedFortran(handle, n, x, incx, y, incy, batch_count);
 }
 
 template <>
-hipblasStatus_t hipblasSwapBatched<hipblasComplex, true>(hipblasHandle_t handle,
-                                                         int             n,
-                                                         hipblasComplex* x[],
-                                                         int             incx,
-                                                         hipblasComplex* y[],
-                                                         int             incy,
-                                                         int             batch_count)
+hipblasStatus_t hipblasSwapBatched<hipblasComplex, true>(hipblasHandle_t       handle,
+                                                         int                   n,
+                                                         hipblasComplex* const x[],
+                                                         int                   incx,
+                                                         hipblasComplex* const y[],
+                                                         int                   incy,
+                                                         int                   batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCswapBatchedFortran(
+        handle, n, (hipComplex* const*)x, incx, (hipComplex* const*)y, incy, batch_count);
+#else
     return hipblasCswapBatchedFortran(handle, n, x, incx, y, incy, batch_count);
+#endif
 }
 
 template <>
-hipblasStatus_t hipblasSwapBatched<hipblasDoubleComplex, true>(hipblasHandle_t       handle,
-                                                               int                   n,
-                                                               hipblasDoubleComplex* x[],
-                                                               int                   incx,
-                                                               hipblasDoubleComplex* y[],
-                                                               int                   incy,
-                                                               int                   batch_count)
+hipblasStatus_t hipblasSwapBatched<hipblasDoubleComplex, true>(hipblasHandle_t             handle,
+                                                               int                         n,
+                                                               hipblasDoubleComplex* const x[],
+                                                               int                         incx,
+                                                               hipblasDoubleComplex* const y[],
+                                                               int                         incy,
+                                                               int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZswapBatchedFortran(handle,
+                                      n,
+                                      (hipDoubleComplex* const*)x,
+                                      incx,
+                                      (hipDoubleComplex* const*)y,
+                                      incy,
+                                      batch_count);
+#else
     return hipblasZswapBatchedFortran(handle, n, x, incx, y, incy, batch_count);
+#endif
 }
 
 // swap_strided_batched
@@ -11555,8 +11638,13 @@ hipblasStatus_t hipblasSwapStridedBatched<hipblasComplex, true>(hipblasHandle_t 
                                                                 hipblasStride   stridey,
                                                                 int             batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasCswapStridedBatchedFortran(
+        handle, n, (hipComplex*)x, incx, stridex, (hipComplex*)y, incy, stridey, batch_count);
+#else
     return hipblasCswapStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 template <>
@@ -11570,8 +11658,20 @@ hipblasStatus_t hipblasSwapStridedBatched<hipblasDoubleComplex, true>(hipblasHan
                                                                       hipblasStride         stridey,
                                                                       int batch_count)
 {
+#ifdef HIPBLAS_V2
+    return hipblasZswapStridedBatchedFortran(handle,
+                                             n,
+                                             (hipDoubleComplex*)x,
+                                             incx,
+                                             stridex,
+                                             (hipDoubleComplex*)y,
+                                             incy,
+                                             stridey,
+                                             batch_count);
+#else
     return hipblasZswapStridedBatchedFortran(
         handle, n, x, incx, stridex, y, incy, stridey, batch_count);
+#endif
 }
 
 // copy

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -469,6 +469,28 @@ TEST_P(blas1_gtest, copy_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, copy_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_copy<hipblasDoubleComplex>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 #ifndef __HIP_PLATFORM_NVCC__
 
 // copy_batched tests
@@ -524,6 +546,32 @@ TEST_P(blas1_gtest, copy_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, copy_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_copy_batched<hipblasDoubleComplex>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 // copy_strided_batched tests
 TEST_P(blas1_gtest, copy_strided_batched_float)
 {
@@ -555,6 +603,32 @@ TEST_P(blas1_gtest, copy_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_copy_strided_batched<hipblasComplex>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, copy_strided_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_copy_strided_batched<hipblasDoubleComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -1147,6 +1147,28 @@ TEST_P(blas1_gtest, swap_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, swap_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_swap<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 #ifndef __HIP_PLATFORM_NVCC__
 
 // swap_batched tests
@@ -1202,6 +1224,32 @@ TEST_P(blas1_gtest, swap_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, swap_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_swap_batched<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
 // swap_strided_batched tests
 TEST_P(blas1_gtest, swap_strided_batched_float)
 {
@@ -1233,6 +1281,32 @@ TEST_P(blas1_gtest, swap_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_swap_strided_batched<hipblasComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(blas1_gtest, swap_strided_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_swap_strided_batched<hipblasDoubleComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -2029,6 +2029,21 @@ TEST_P(blas1_gtest, rot_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, rot_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rot<hipblasDoubleComplex, double>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+    }
+}
+
 TEST_P(blas1_gtest, rot_float_complex_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -2037,6 +2052,21 @@ TEST_P(blas1_gtest, rot_float_complex_float)
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_rot<hipblasComplex, float, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+    }
+}
+
+TEST_P(blas1_gtest, rot_double_complex_double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rot<hipblasDoubleComplex, double, double>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -2091,6 +2121,28 @@ TEST_P(blas1_gtest, rot_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, rot_batched_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rot_batched<hipblasDoubleComplex, double>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 TEST_P(blas1_gtest, rot_batched_float_complex_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -2099,6 +2151,28 @@ TEST_P(blas1_gtest, rot_batched_float_complex_float)
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_rot_batched<hipblasComplex, float, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, rot_batched_double_complex_double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rot_batched<hipblasDoubleComplex, double, double>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -2158,6 +2232,28 @@ TEST_P(blas1_gtest, rot_strided_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, rot_strided_batched_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rot_strided_batched<hipblasDoubleComplex, double>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 TEST_P(blas1_gtest, rot_strided_batched_float_complex_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -2166,6 +2262,28 @@ TEST_P(blas1_gtest, rot_strided_batched_float_complex_float)
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_rot_strided_batched<hipblasComplex, float, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, rot_strided_batched_double_complex_double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rot_strided_batched<hipblasDoubleComplex, double, double>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -706,6 +706,32 @@ TEST_P(blas1_gtest, scal_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, scal_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_scal<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 TEST_P(blas1_gtest, scal_float_complex_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -714,6 +740,33 @@ TEST_P(blas1_gtest, scal_float_complex_float)
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_scal<hipblasComplex, float>(arg);
+
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, scal_double_complex_double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_scal<hipblasDoubleComplex, double>(arg);
 
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
@@ -798,6 +851,37 @@ TEST_P(blas1_gtest, scal_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, scal_batched_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_scal_batched<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            // for cublas
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
+        }
+    }
+}
+
 TEST_P(blas1_gtest, scal_batched_float_complex_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -806,6 +890,37 @@ TEST_P(blas1_gtest, scal_batched_float_complex_float)
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_scal_batched<hipblasComplex, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            // for cublas
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
+        }
+    }
+}
+
+TEST_P(blas1_gtest, scal_batched_double_complex_double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_scal_batched<hipblasDoubleComplex, double>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {
@@ -892,6 +1007,37 @@ TEST_P(blas1_gtest, scal_strided_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, scal_strided_batched_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_scal_strided_batched<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            // for cublas
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
+        }
+    }
+}
+
 TEST_P(blas1_gtest, scal_strided_batched_float_complex_float)
 {
     // GetParam return a tuple. Tee setup routine unpack the tuple
@@ -900,6 +1046,37 @@ TEST_P(blas1_gtest, scal_strided_batched_float_complex_float)
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_scal_strided_batched<hipblasComplex, float>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            // for cublas
+            EXPECT_EQ(HIPBLAS_STATUS_NOT_SUPPORTED, status);
+        }
+    }
+}
+
+TEST_P(blas1_gtest, scal_strided_batched_double_complex_double)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_scal_strided_batched<hipblasDoubleComplex, double>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -1227,6 +1227,58 @@ TEST_P(blas1_gtest, dotc_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, dotu_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dot<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dotc_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dotc<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 #ifndef __HIP_PLATFORM_NVCC__
 
 // dot_batched tests
@@ -1394,6 +1446,66 @@ TEST_P(blas1_gtest, dotc_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, dotu_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dot_batched<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dotc_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dotc_batched<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
 // dot_strided_batched tests
 TEST_P(blas1_gtest, dot_strided_batched_half)
 {
@@ -1533,6 +1645,66 @@ TEST_P(blas1_gtest, dotc_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_dotc_strided_batched<hipblasComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dotu_strided_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dot_strided_batched<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incy < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status);
+        }
+    }
+}
+
+TEST_P(blas1_gtest, dotc_strided_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_dotc_strided_batched<hipblasDoubleComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -240,6 +240,28 @@ TEST_P(blas1_gtest, axpy_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, axpy_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_axpy<hipblasDoubleComplex>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(!arg.incx || !arg.incy)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 #ifndef __HIP_PLATFORM_NVCC__
 
 // axpy_batched
@@ -295,6 +317,32 @@ TEST_P(blas1_gtest, axpy_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, axpy_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_axpy_batched<hipblasDoubleComplex>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(!arg.incx || !arg.incy)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 // axpy_strided_batched
 TEST_P(blas1_gtest, axpy_strided_batched_float)
 {
@@ -326,6 +374,32 @@ TEST_P(blas1_gtest, axpy_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_axpy_strided_batched<hipblasComplex>(arg);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(!arg.incx || !arg.incy)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, axpy_strided_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_axpy_strided_batched<hipblasDoubleComplex>(arg);
 
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -2323,6 +2323,17 @@ TEST_P(blas1_gtest, rotg_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, rotg_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rotg<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+    }
+}
+
 #ifndef __HIP_PLATFORM_NVCC__
 
 // rotg_batched
@@ -2362,6 +2373,24 @@ TEST_P(blas1_gtest, rotg_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, rotg_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rotg_batched<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 // rotg_strided_batched
 TEST_P(blas1_gtest, rotg_strided_batched_float)
 {
@@ -2385,6 +2414,24 @@ TEST_P(blas1_gtest, rotg_strided_batched_float_complex)
 {
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_rotg_strided_batched<hipblasComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, rotg_strided_batched_double_complex)
+{
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_rotg_strided_batched<hipblasDoubleComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/blas1_gtest.cpp
+++ b/clients/gtest/blas1_gtest.cpp
@@ -1786,6 +1786,32 @@ TEST_P(blas1_gtest, nrm2_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, nrm2_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_nrm2<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 #ifndef __HIP_PLATFORM_NVCC__
 
 // nrm2_batched tests
@@ -1849,6 +1875,36 @@ TEST_P(blas1_gtest, nrm2_batched_float_complex)
     }
 }
 
+TEST_P(blas1_gtest, nrm2_batched_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_nrm2_batched<hipblasDoubleComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
 // nrm2_strided_batched tests
 TEST_P(blas1_gtest, nrm2_strided_batched_float)
 {
@@ -1888,6 +1944,36 @@ TEST_P(blas1_gtest, nrm2_strided_batched_float_complex)
     // while the tuple is non-intuitive.
     Arguments       arg    = setup_blas1_arguments(GetParam());
     hipblasStatus_t status = testing_nrm2_strided_batched<hipblasComplex>(arg);
+    // if not success, then the input argument is problematic, so detect the error message
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        if(arg.N < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.incx < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else if(arg.batch_count < 0)
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_INVALID_VALUE, status);
+        }
+        else
+        {
+            EXPECT_EQ(HIPBLAS_STATUS_SUCCESS, status); // fail
+        }
+    }
+}
+
+TEST_P(blas1_gtest, nrm2_strided_batched_double_complex)
+{
+    // GetParam return a tuple. Tee setup routine unpack the tuple
+    // and initializes arg(Arguments) which will be passed to testing routine
+    // The Arguments data struture have physical meaning associated.
+    // while the tuple is non-intuitive.
+    Arguments       arg    = setup_blas1_arguments(GetParam());
+    hipblasStatus_t status = testing_nrm2_strided_batched<hipblasDoubleComplex>(arg);
     // if not success, then the input argument is problematic, so detect the error message
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -86,7 +86,7 @@ hipblasStatus_t hipblasSwap(hipblasHandle_t handle, int n, T* x, int incx, T* y,
 
 template <typename T, bool FORTRAN = false>
 hipblasStatus_t hipblasSwapBatched(
-    hipblasHandle_t handle, int n, T* x[], int incx, T* y[], int incy, int batch_count);
+    hipblasHandle_t handle, int n, T* const x[], int incx, T* const y[], int incy, int batch_count);
 
 template <typename T, bool FORTRAN = false>
 hipblasStatus_t hipblasSwapStridedBatched(hipblasHandle_t handle,

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -1080,11 +1080,19 @@ hipblasStatus_t
 hipblasStatus_t
     hipblasDnrm2Fortran(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasScnrm2Fortran(
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
+
+hipblasStatus_t hipblasDznrm2Fortran(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
+#else
 hipblasStatus_t hipblasScnrm2Fortran(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result);
 
 hipblasStatus_t hipblasDznrm2Fortran(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result);
+#endif
 
 // nrm2Batched
 hipblasStatus_t hipblasSnrm2BatchedFortran(hipblasHandle_t    handle,
@@ -1101,6 +1109,21 @@ hipblasStatus_t hipblasDnrm2BatchedFortran(hipblasHandle_t     handle,
                                            int                 batch_count,
                                            double*             results);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasScnrm2BatchedFortran(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const hipComplex* const x[],
+                                            int                     incx,
+                                            int                     batch_count,
+                                            float*                  results);
+
+hipblasStatus_t hipblasDznrm2BatchedFortran(hipblasHandle_t               handle,
+                                            int                           n,
+                                            const hipDoubleComplex* const x[],
+                                            int                           incx,
+                                            int                           batch_count,
+                                            double*                       results);
+#else
 hipblasStatus_t hipblasScnrm2BatchedFortran(hipblasHandle_t             handle,
                                             int                         n,
                                             const hipblasComplex* const x[],
@@ -1114,6 +1137,7 @@ hipblasStatus_t hipblasDznrm2BatchedFortran(hipblasHandle_t                   ha
                                             int                               incx,
                                             int                               batch_count,
                                             double*                           results);
+#endif
 
 // nrm2StridedBatched
 hipblasStatus_t hipblasSnrm2StridedBatchedFortran(hipblasHandle_t handle,
@@ -1132,6 +1156,23 @@ hipblasStatus_t hipblasDnrm2StridedBatchedFortran(hipblasHandle_t handle,
                                                   int             batch_count,
                                                   double*         results);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasScnrm2StridedBatchedFortran(hipblasHandle_t   handle,
+                                                   int               n,
+                                                   const hipComplex* x,
+                                                   int               incx,
+                                                   hipblasStride     stridex,
+                                                   int               batch_count,
+                                                   float*            results);
+
+hipblasStatus_t hipblasDznrm2StridedBatchedFortran(hipblasHandle_t         handle,
+                                                   int                     n,
+                                                   const hipDoubleComplex* x,
+                                                   int                     incx,
+                                                   hipblasStride           stridex,
+                                                   int                     batch_count,
+                                                   double*                 results);
+#else
 hipblasStatus_t hipblasScnrm2StridedBatchedFortran(hipblasHandle_t       handle,
                                                    int                   n,
                                                    const hipblasComplex* x,
@@ -1147,6 +1188,7 @@ hipblasStatus_t hipblasDznrm2StridedBatchedFortran(hipblasHandle_t             h
                                                    hipblasStride               stridex,
                                                    int                         batch_count,
                                                    double*                     results);
+#endif
 
 // amax
 hipblasStatus_t

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -1425,6 +1425,43 @@ hipblasStatus_t hipblasDrotFortran(hipblasHandle_t handle,
                                    const double*   c,
                                    const double*   s);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCrotFortran(hipblasHandle_t   handle,
+                                   int               n,
+                                   hipComplex*       x,
+                                   int               incx,
+                                   hipComplex*       y,
+                                   int               incy,
+                                   const float*      c,
+                                   const hipComplex* s);
+
+hipblasStatus_t hipblasCsrotFortran(hipblasHandle_t handle,
+                                    int             n,
+                                    hipComplex*     x,
+                                    int             incx,
+                                    hipComplex*     y,
+                                    int             incy,
+                                    const float*    c,
+                                    const float*    s);
+
+hipblasStatus_t hipblasZrotFortran(hipblasHandle_t         handle,
+                                   int                     n,
+                                   hipDoubleComplex*       x,
+                                   int                     incx,
+                                   hipDoubleComplex*       y,
+                                   int                     incy,
+                                   const double*           c,
+                                   const hipDoubleComplex* s);
+
+hipblasStatus_t hipblasZdrotFortran(hipblasHandle_t   handle,
+                                    int               n,
+                                    hipDoubleComplex* x,
+                                    int               incx,
+                                    hipDoubleComplex* y,
+                                    int               incy,
+                                    const double*     c,
+                                    const double*     s);
+#else
 hipblasStatus_t hipblasCrotFortran(hipblasHandle_t       handle,
                                    int                   n,
                                    hipblasComplex*       x,
@@ -1460,6 +1497,7 @@ hipblasStatus_t hipblasZdrotFortran(hipblasHandle_t       handle,
                                     int                   incy,
                                     const double*         c,
                                     const double*         s);
+#endif
 
 // rotBatched
 hipblasStatus_t hipblasSrotBatchedFortran(hipblasHandle_t handle,
@@ -1482,6 +1520,47 @@ hipblasStatus_t hipblasDrotBatchedFortran(hipblasHandle_t handle,
                                           const double*   s,
                                           int             batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCrotBatchedFortran(hipblasHandle_t   handle,
+                                          int               n,
+                                          hipComplex* const x[],
+                                          int               incx,
+                                          hipComplex* const y[],
+                                          int               incy,
+                                          const float*      c,
+                                          const hipComplex* s,
+                                          int               batch_count);
+
+hipblasStatus_t hipblasCsrotBatchedFortran(hipblasHandle_t   handle,
+                                           int               n,
+                                           hipComplex* const x[],
+                                           int               incx,
+                                           hipComplex* const y[],
+                                           int               incy,
+                                           const float*      c,
+                                           const float*      s,
+                                           int               batch_count);
+
+hipblasStatus_t hipblasZrotBatchedFortran(hipblasHandle_t         handle,
+                                          int                     n,
+                                          hipDoubleComplex* const x[],
+                                          int                     incx,
+                                          hipDoubleComplex* const y[],
+                                          int                     incy,
+                                          const double*           c,
+                                          const hipDoubleComplex* s,
+                                          int                     batch_count);
+
+hipblasStatus_t hipblasZdrotBatchedFortran(hipblasHandle_t         handle,
+                                           int                     n,
+                                           hipDoubleComplex* const x[],
+                                           int                     incx,
+                                           hipDoubleComplex* const y[],
+                                           int                     incy,
+                                           const double*           c,
+                                           const double*           s,
+                                           int                     batch_count);
+#else
 hipblasStatus_t hipblasCrotBatchedFortran(hipblasHandle_t       handle,
                                           int                   n,
                                           hipblasComplex* const x[],
@@ -1521,6 +1600,7 @@ hipblasStatus_t hipblasZdrotBatchedFortran(hipblasHandle_t             handle,
                                            const double*               c,
                                            const double*               s,
                                            int                         batch_count);
+#endif
 
 // rotStridedBatched
 hipblasStatus_t hipblasSrotStridedBatchedFortran(hipblasHandle_t handle,
@@ -1547,6 +1627,55 @@ hipblasStatus_t hipblasDrotStridedBatchedFortran(hipblasHandle_t handle,
                                                  const double*   s,
                                                  int             batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCrotStridedBatchedFortran(hipblasHandle_t   handle,
+                                                 int               n,
+                                                 hipComplex*       x,
+                                                 int               incx,
+                                                 hipblasStride     stride_x,
+                                                 hipComplex*       y,
+                                                 int               incy,
+                                                 hipblasStride     stride_y,
+                                                 const float*      c,
+                                                 const hipComplex* s,
+                                                 int               batch_count);
+
+hipblasStatus_t hipblasCsrotStridedBatchedFortran(hipblasHandle_t handle,
+                                                  int             n,
+                                                  hipComplex*     x,
+                                                  int             incx,
+                                                  hipblasStride   stride_x,
+                                                  hipComplex*     y,
+                                                  int             incy,
+                                                  hipblasStride   stride_y,
+                                                  const float*    c,
+                                                  const float*    s,
+                                                  int             batch_count);
+
+hipblasStatus_t hipblasZrotStridedBatchedFortran(hipblasHandle_t         handle,
+                                                 int                     n,
+                                                 hipDoubleComplex*       x,
+                                                 int                     incx,
+                                                 hipblasStride           stride_x,
+                                                 hipDoubleComplex*       y,
+                                                 int                     incy,
+                                                 hipblasStride           stride_y,
+                                                 const double*           c,
+                                                 const hipDoubleComplex* s,
+                                                 int                     batch_count);
+
+hipblasStatus_t hipblasZdrotStridedBatchedFortran(hipblasHandle_t   handle,
+                                                  int               n,
+                                                  hipDoubleComplex* x,
+                                                  int               incx,
+                                                  hipblasStride     stride_x,
+                                                  hipDoubleComplex* y,
+                                                  int               incy,
+                                                  hipblasStride     stride_y,
+                                                  const double*     c,
+                                                  const double*     s,
+                                                  int               batch_count);
+#else
 hipblasStatus_t hipblasCrotStridedBatchedFortran(hipblasHandle_t       handle,
                                                  int                   n,
                                                  hipblasComplex*       x,
@@ -1594,6 +1723,7 @@ hipblasStatus_t hipblasZdrotStridedBatchedFortran(hipblasHandle_t       handle,
                                                   const double*         c,
                                                   const double*         s,
                                                   int                   batch_count);
+#endif
 
 // rotg
 hipblasStatus_t hipblasSrotgFortran(hipblasHandle_t handle, float* a, float* b, float* c, float* s);

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -79,6 +79,19 @@ hipblasStatus_t
 hipblasStatus_t
     hipblasDscalFortran(hipblasHandle_t handle, int n, const double* alpha, double* x, int incx);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCscalFortran(
+    hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx);
+
+hipblasStatus_t hipblasZscalFortran(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx);
+
+hipblasStatus_t hipblasCsscalFortran(
+    hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx);
+
+hipblasStatus_t hipblasZdscalFortran(
+    hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx);
+#else
 hipblasStatus_t hipblasCscalFortran(
     hipblasHandle_t handle, int n, const hipblasComplex* alpha, hipblasComplex* x, int incx);
 
@@ -93,6 +106,7 @@ hipblasStatus_t hipblasCsscalFortran(
 
 hipblasStatus_t hipblasZdscalFortran(
     hipblasHandle_t handle, int n, const double* alpha, hipblasDoubleComplex* x, int incx);
+#endif
 
 // scalBatched
 hipblasStatus_t hipblasSscalBatchedFortran(
@@ -105,6 +119,35 @@ hipblasStatus_t hipblasDscalBatchedFortran(hipblasHandle_t handle,
                                            int             incx,
                                            int             batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCscalBatchedFortran(hipblasHandle_t   handle,
+                                           int               n,
+                                           const hipComplex* alpha,
+                                           hipComplex* const x[],
+                                           int               incx,
+                                           int               batch_count);
+
+hipblasStatus_t hipblasZscalBatchedFortran(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipDoubleComplex* alpha,
+                                           hipDoubleComplex* const x[],
+                                           int                     incx,
+                                           int                     batch_count);
+
+hipblasStatus_t hipblasCsscalBatchedFortran(hipblasHandle_t   handle,
+                                            int               n,
+                                            const float*      alpha,
+                                            hipComplex* const x[],
+                                            int               incx,
+                                            int               batch_count);
+
+hipblasStatus_t hipblasZdscalBatchedFortran(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const double*           alpha,
+                                            hipDoubleComplex* const x[],
+                                            int                     incx,
+                                            int                     batch_count);
+#else
 hipblasStatus_t hipblasCscalBatchedFortran(hipblasHandle_t       handle,
                                            int                   n,
                                            const hipblasComplex* alpha,
@@ -132,6 +175,7 @@ hipblasStatus_t hipblasZdscalBatchedFortran(hipblasHandle_t             handle,
                                             hipblasDoubleComplex* const x[],
                                             int                         incx,
                                             int                         batch_count);
+#endif
 
 // scalStridedBatched
 hipblasStatus_t hipblasSscalStridedBatchedFortran(hipblasHandle_t handle,
@@ -150,6 +194,39 @@ hipblasStatus_t hipblasDscalStridedBatchedFortran(hipblasHandle_t handle,
                                                   hipblasStride   stride_x,
                                                   int             batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCscalStridedBatchedFortran(hipblasHandle_t   handle,
+                                                  int               n,
+                                                  const hipComplex* alpha,
+                                                  hipComplex*       x,
+                                                  int               incx,
+                                                  hipblasStride     stride_x,
+                                                  int               batch_count);
+
+hipblasStatus_t hipblasZscalStridedBatchedFortran(hipblasHandle_t         handle,
+                                                  int                     n,
+                                                  const hipDoubleComplex* alpha,
+                                                  hipDoubleComplex*       x,
+                                                  int                     incx,
+                                                  hipblasStride           stride_x,
+                                                  int                     batch_count);
+
+hipblasStatus_t hipblasCsscalStridedBatchedFortran(hipblasHandle_t handle,
+                                                   int             n,
+                                                   const float*    alpha,
+                                                   hipComplex*     x,
+                                                   int             incx,
+                                                   hipblasStride   stride_x,
+                                                   int             batch_count);
+
+hipblasStatus_t hipblasZdscalStridedBatchedFortran(hipblasHandle_t   handle,
+                                                   int               n,
+                                                   const double*     alpha,
+                                                   hipDoubleComplex* x,
+                                                   int               incx,
+                                                   hipblasStride     stride_x,
+                                                   int               batch_count);
+#else
 hipblasStatus_t hipblasCscalStridedBatchedFortran(hipblasHandle_t       handle,
                                                   int                   n,
                                                   const hipblasComplex* alpha,
@@ -181,6 +258,7 @@ hipblasStatus_t hipblasZdscalStridedBatchedFortran(hipblasHandle_t       handle,
                                                    int                   incx,
                                                    hipblasStride         stride_x,
                                                    int                   batch_count);
+#endif
 
 // copy
 hipblasStatus_t hipblasScopyFortran(

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -606,6 +606,23 @@ hipblasStatus_t hipblasDaxpyFortran(hipblasHandle_t handle,
                                     double*         y,
                                     const int       incy);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCaxpyFortran(hipblasHandle_t   handle,
+                                    const int         N,
+                                    const hipComplex* alpha,
+                                    const hipComplex* x,
+                                    const int         incx,
+                                    hipComplex*       y,
+                                    const int         incy);
+
+hipblasStatus_t hipblasZaxpyFortran(hipblasHandle_t         handle,
+                                    const int               N,
+                                    const hipDoubleComplex* alpha,
+                                    const hipDoubleComplex* x,
+                                    const int               incx,
+                                    hipDoubleComplex*       y,
+                                    const int               incy);
+#else
 hipblasStatus_t hipblasCaxpyFortran(hipblasHandle_t       handle,
                                     const int             N,
                                     const hipblasComplex* alpha,
@@ -621,6 +638,7 @@ hipblasStatus_t hipblasZaxpyFortran(hipblasHandle_t             handle,
                                     const int                   incx,
                                     hipblasDoubleComplex*       y,
                                     const int                   incy);
+#endif
 
 // axpyBatched
 hipblasStatus_t hipblasHaxpyBatchedFortran(hipblasHandle_t          handle,
@@ -641,15 +659,6 @@ hipblasStatus_t hipblasSaxpyBatchedFortran(hipblasHandle_t    handle,
                                            const int          incy,
                                            const int          batch_count);
 
-hipblasStatus_t hipblasSaxpyBatchedFortran(hipblasHandle_t    handle,
-                                           const int          N,
-                                           const float*       alpha,
-                                           const float* const x[],
-                                           const int          incx,
-                                           float* const       y[],
-                                           const int          incy,
-                                           const int          batch_count);
-
 hipblasStatus_t hipblasDaxpyBatchedFortran(hipblasHandle_t     handle,
                                            const int           N,
                                            const double*       alpha,
@@ -659,6 +668,25 @@ hipblasStatus_t hipblasDaxpyBatchedFortran(hipblasHandle_t     handle,
                                            const int           incy,
                                            const int           batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCaxpyBatchedFortran(hipblasHandle_t         handle,
+                                           const int               N,
+                                           const hipComplex*       alpha,
+                                           const hipComplex* const x[],
+                                           const int               incx,
+                                           hipComplex* const       y[],
+                                           const int               incy,
+                                           const int               batch_count);
+
+hipblasStatus_t hipblasZaxpyBatchedFortran(hipblasHandle_t               handle,
+                                           const int                     N,
+                                           const hipDoubleComplex*       alpha,
+                                           const hipDoubleComplex* const x[],
+                                           const int                     incx,
+                                           hipDoubleComplex* const       y[],
+                                           const int                     incy,
+                                           const int                     batch_count);
+#else
 hipblasStatus_t hipblasCaxpyBatchedFortran(hipblasHandle_t             handle,
                                            const int                   N,
                                            const hipblasComplex*       alpha,
@@ -676,6 +704,7 @@ hipblasStatus_t hipblasZaxpyBatchedFortran(hipblasHandle_t                   han
                                            hipblasDoubleComplex* const       y[],
                                            const int                         incy,
                                            const int                         batch_count);
+#endif
 
 // axpyStridedBatched
 hipblasStatus_t hipblasHaxpyStridedBatchedFortran(hipblasHandle_t     handle,
@@ -711,6 +740,29 @@ hipblasStatus_t hipblasDaxpyStridedBatchedFortran(hipblasHandle_t     handle,
                                                   const hipblasStride stride_y,
                                                   const int           batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCaxpyStridedBatchedFortran(hipblasHandle_t     handle,
+                                                  const int           N,
+                                                  const hipComplex*   alpha,
+                                                  const hipComplex*   x,
+                                                  const int           incx,
+                                                  const hipblasStride stride_x,
+                                                  hipComplex*         y,
+                                                  const int           incy,
+                                                  const hipblasStride stride_y,
+                                                  const int           batch_count);
+
+hipblasStatus_t hipblasZaxpyStridedBatchedFortran(hipblasHandle_t         handle,
+                                                  const int               N,
+                                                  const hipDoubleComplex* alpha,
+                                                  const hipDoubleComplex* x,
+                                                  const int               incx,
+                                                  const hipblasStride     stride_x,
+                                                  hipDoubleComplex*       y,
+                                                  const int               incy,
+                                                  const hipblasStride     stride_y,
+                                                  const int               batch_count);
+#else
 hipblasStatus_t hipblasCaxpyStridedBatchedFortran(hipblasHandle_t       handle,
                                                   const int             N,
                                                   const hipblasComplex* alpha,
@@ -732,6 +784,7 @@ hipblasStatus_t hipblasZaxpyStridedBatchedFortran(hipblasHandle_t             ha
                                                   const int                   incy,
                                                   const hipblasStride         stride_y,
                                                   const int                   batch_count);
+#endif
 
 // asum
 hipblasStatus_t

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -189,6 +189,17 @@ hipblasStatus_t hipblasScopyFortran(
 hipblasStatus_t hipblasDcopyFortran(
     hipblasHandle_t handle, int n, const double* x, int incx, double* y, int incy);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCcopyFortran(
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, hipComplex* y, int incy);
+
+hipblasStatus_t hipblasZcopyFortran(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipDoubleComplex* x,
+                                    int                     incx,
+                                    hipDoubleComplex*       y,
+                                    int                     incy);
+#else
 hipblasStatus_t hipblasCcopyFortran(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, hipblasComplex* y, int incy);
 
@@ -198,6 +209,7 @@ hipblasStatus_t hipblasZcopyFortran(hipblasHandle_t             handle,
                                     int                         incx,
                                     hipblasDoubleComplex*       y,
                                     int                         incy);
+#endif
 
 // copyBatched
 hipblasStatus_t hipblasScopyBatchedFortran(hipblasHandle_t    handle,
@@ -216,6 +228,23 @@ hipblasStatus_t hipblasDcopyBatchedFortran(hipblasHandle_t     handle,
                                            int                 incy,
                                            int                 batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCcopyBatchedFortran(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipComplex* const x[],
+                                           int                     incx,
+                                           hipComplex* const       y[],
+                                           int                     incy,
+                                           int                     batch_count);
+
+hipblasStatus_t hipblasZcopyBatchedFortran(hipblasHandle_t               handle,
+                                           int                           n,
+                                           const hipDoubleComplex* const x[],
+                                           int                           incx,
+                                           hipDoubleComplex* const       y[],
+                                           int                           incy,
+                                           int                           batch_count);
+#else
 hipblasStatus_t hipblasCcopyBatchedFortran(hipblasHandle_t             handle,
                                            int                         n,
                                            const hipblasComplex* const x[],
@@ -231,6 +260,7 @@ hipblasStatus_t hipblasZcopyBatchedFortran(hipblasHandle_t                   han
                                            hipblasDoubleComplex* const       y[],
                                            int                               incy,
                                            int                               batch_count);
+#endif
 
 // copyStridedBatched
 hipblasStatus_t hipblasScopyStridedBatchedFortran(hipblasHandle_t handle,
@@ -253,6 +283,27 @@ hipblasStatus_t hipblasDcopyStridedBatchedFortran(hipblasHandle_t handle,
                                                   hipblasStride   stridey,
                                                   int             batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCcopyStridedBatchedFortran(hipblasHandle_t   handle,
+                                                  int               n,
+                                                  const hipComplex* x,
+                                                  int               incx,
+                                                  hipblasStride     stridex,
+                                                  hipComplex*       y,
+                                                  int               incy,
+                                                  hipblasStride     stridey,
+                                                  int               batch_count);
+
+hipblasStatus_t hipblasZcopyStridedBatchedFortran(hipblasHandle_t         handle,
+                                                  int                     n,
+                                                  const hipDoubleComplex* x,
+                                                  int                     incx,
+                                                  hipblasStride           stridex,
+                                                  hipDoubleComplex*       y,
+                                                  int                     incy,
+                                                  hipblasStride           stridey,
+                                                  int                     batch_count);
+#else
 hipblasStatus_t hipblasCcopyStridedBatchedFortran(hipblasHandle_t       handle,
                                                   int                   n,
                                                   const hipblasComplex* x,
@@ -272,6 +323,7 @@ hipblasStatus_t hipblasZcopyStridedBatchedFortran(hipblasHandle_t             ha
                                                   int                         incy,
                                                   hipblasStride               stridey,
                                                   int                         batch_count);
+#endif
 
 // dot
 hipblasStatus_t hipblasSdotFortran(hipblasHandle_t handle,

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -999,11 +999,19 @@ hipblasStatus_t
 hipblasStatus_t
     hipblasIdaminFortran(hipblasHandle_t handle, int n, const double* x, int incx, int* result);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t
+    hipblasIcaminFortran(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result);
+
+hipblasStatus_t hipblasIzaminFortran(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result);
+#else
 hipblasStatus_t hipblasIcaminFortran(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, int* result);
 
 hipblasStatus_t hipblasIzaminFortran(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result);
+#endif
 
 // aminBatched
 hipblasStatus_t hipblasIsaminBatchedFortran(
@@ -1012,6 +1020,20 @@ hipblasStatus_t hipblasIsaminBatchedFortran(
 hipblasStatus_t hipblasIdaminBatchedFortran(
     hipblasHandle_t handle, int n, const double* const x[], int incx, int batch_count, int* result);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasIcaminBatchedFortran(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const hipComplex* const x[],
+                                            int                     incx,
+                                            int                     batch_count,
+                                            int*                    result);
+hipblasStatus_t hipblasIzaminBatchedFortran(hipblasHandle_t               handle,
+                                            int                           n,
+                                            const hipDoubleComplex* const x[],
+                                            int                           incx,
+                                            int                           batch_count,
+                                            int*                          result);
+#else
 hipblasStatus_t hipblasIcaminBatchedFortran(hipblasHandle_t             handle,
                                             int                         n,
                                             const hipblasComplex* const x[],
@@ -1024,6 +1046,7 @@ hipblasStatus_t hipblasIzaminBatchedFortran(hipblasHandle_t                   ha
                                             int                               incx,
                                             int                               batch_count,
                                             int*                              result);
+#endif
 
 // aminStridedBatched
 hipblasStatus_t hipblasIsaminStridedBatchedFortran(hipblasHandle_t handle,
@@ -1042,6 +1065,23 @@ hipblasStatus_t hipblasIdaminStridedBatchedFortran(hipblasHandle_t handle,
                                                    int             batch_count,
                                                    int*            result);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasIcaminStridedBatchedFortran(hipblasHandle_t   handle,
+                                                   int               n,
+                                                   const hipComplex* x,
+                                                   int               incx,
+                                                   hipblasStride     stridex,
+                                                   int               batch_count,
+                                                   int*              result);
+
+hipblasStatus_t hipblasIzaminStridedBatchedFortran(hipblasHandle_t         handle,
+                                                   int                     n,
+                                                   const hipDoubleComplex* x,
+                                                   int                     incx,
+                                                   hipblasStride           stridex,
+                                                   int                     batch_count,
+                                                   int*                    result);
+#else
 hipblasStatus_t hipblasIcaminStridedBatchedFortran(hipblasHandle_t       handle,
                                                    int                   n,
                                                    const hipblasComplex* x,
@@ -1057,6 +1097,7 @@ hipblasStatus_t hipblasIzaminStridedBatchedFortran(hipblasHandle_t             h
                                                    hipblasStride               stridex,
                                                    int                         batch_count,
                                                    int*                        result);
+#endif
 
 // rot
 hipblasStatus_t hipblasSrotFortran(hipblasHandle_t handle,

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -1731,6 +1731,16 @@ hipblasStatus_t hipblasSrotgFortran(hipblasHandle_t handle, float* a, float* b, 
 hipblasStatus_t
     hipblasDrotgFortran(hipblasHandle_t handle, double* a, double* b, double* c, double* s);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCrotgFortran(
+    hipblasHandle_t handle, hipComplex* a, hipComplex* b, float* c, hipComplex* s);
+
+hipblasStatus_t hipblasZrotgFortran(hipblasHandle_t   handle,
+                                    hipDoubleComplex* a,
+                                    hipDoubleComplex* b,
+                                    double*           c,
+                                    hipDoubleComplex* s);
+#else
 hipblasStatus_t hipblasCrotgFortran(
     hipblasHandle_t handle, hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s);
 
@@ -1739,6 +1749,7 @@ hipblasStatus_t hipblasZrotgFortran(hipblasHandle_t       handle,
                                     hipblasDoubleComplex* b,
                                     double*               c,
                                     hipblasDoubleComplex* s);
+#endif
 
 // rotgBatched
 hipblasStatus_t hipblasSrotgBatchedFortran(hipblasHandle_t handle,
@@ -1755,6 +1766,21 @@ hipblasStatus_t hipblasDrotgBatchedFortran(hipblasHandle_t handle,
                                            double* const   s[],
                                            int             batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCrotgBatchedFortran(hipblasHandle_t   handle,
+                                           hipComplex* const a[],
+                                           hipComplex* const b[],
+                                           float* const      c[],
+                                           hipComplex* const s[],
+                                           int               batch_count);
+
+hipblasStatus_t hipblasZrotgBatchedFortran(hipblasHandle_t         handle,
+                                           hipDoubleComplex* const a[],
+                                           hipDoubleComplex* const b[],
+                                           double* const           c[],
+                                           hipDoubleComplex* const s[],
+                                           int                     batch_count);
+#else
 hipblasStatus_t hipblasCrotgBatchedFortran(hipblasHandle_t       handle,
                                            hipblasComplex* const a[],
                                            hipblasComplex* const b[],
@@ -1768,6 +1794,7 @@ hipblasStatus_t hipblasZrotgBatchedFortran(hipblasHandle_t             handle,
                                            double* const               c[],
                                            hipblasDoubleComplex* const s[],
                                            int                         batch_count);
+#endif
 
 // rotgStridedBatched
 hipblasStatus_t hipblasSrotgStridedBatchedFortran(hipblasHandle_t handle,
@@ -1792,6 +1819,29 @@ hipblasStatus_t hipblasDrotgStridedBatchedFortran(hipblasHandle_t handle,
                                                   hipblasStride   stride_s,
                                                   int             batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCrotgStridedBatchedFortran(hipblasHandle_t handle,
+                                                  hipComplex*     a,
+                                                  hipblasStride   stride_a,
+                                                  hipComplex*     b,
+                                                  hipblasStride   stride_b,
+                                                  float*          c,
+                                                  hipblasStride   stride_c,
+                                                  hipComplex*     s,
+                                                  hipblasStride   stride_s,
+                                                  int             batch_count);
+
+hipblasStatus_t hipblasZrotgStridedBatchedFortran(hipblasHandle_t   handle,
+                                                  hipDoubleComplex* a,
+                                                  hipblasStride     stride_a,
+                                                  hipDoubleComplex* b,
+                                                  hipblasStride     stride_b,
+                                                  double*           c,
+                                                  hipblasStride     stride_c,
+                                                  hipDoubleComplex* s,
+                                                  hipblasStride     stride_s,
+                                                  int               batch_count);
+#else
 hipblasStatus_t hipblasCrotgStridedBatchedFortran(hipblasHandle_t handle,
                                                   hipblasComplex* a,
                                                   hipblasStride   stride_a,
@@ -1813,6 +1863,7 @@ hipblasStatus_t hipblasZrotgStridedBatchedFortran(hipblasHandle_t       handle,
                                                   hipblasDoubleComplex* s,
                                                   hipblasStride         stride_s,
                                                   int                   batch_count);
+#endif
 
 // rotm
 hipblasStatus_t hipblasSrotmFortran(

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -358,6 +358,39 @@ hipblasStatus_t hipblasBfdotFortran(hipblasHandle_t        handle,
                                     int                    incy,
                                     hipblasBfloat16*       result);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCdotuFortran(hipblasHandle_t   handle,
+                                    int               n,
+                                    const hipComplex* x,
+                                    int               incx,
+                                    const hipComplex* y,
+                                    int               incy,
+                                    hipComplex*       result);
+
+hipblasStatus_t hipblasZdotuFortran(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipDoubleComplex* x,
+                                    int                     incx,
+                                    const hipDoubleComplex* y,
+                                    int                     incy,
+                                    hipDoubleComplex*       result);
+
+hipblasStatus_t hipblasCdotcFortran(hipblasHandle_t   handle,
+                                    int               n,
+                                    const hipComplex* x,
+                                    int               incx,
+                                    const hipComplex* y,
+                                    int               incy,
+                                    hipComplex*       result);
+
+hipblasStatus_t hipblasZdotcFortran(hipblasHandle_t         handle,
+                                    int                     n,
+                                    const hipDoubleComplex* x,
+                                    int                     incx,
+                                    const hipDoubleComplex* y,
+                                    int                     incy,
+                                    hipDoubleComplex*       result);
+#else
 hipblasStatus_t hipblasCdotuFortran(hipblasHandle_t       handle,
                                     int                   n,
                                     const hipblasComplex* x,
@@ -389,6 +422,7 @@ hipblasStatus_t hipblasZdotcFortran(hipblasHandle_t             handle,
                                     const hipblasDoubleComplex* y,
                                     int                         incy,
                                     hipblasDoubleComplex*       result);
+#endif
 
 // dotBatched
 hipblasStatus_t hipblasSdotBatchedFortran(hipblasHandle_t    handle,
@@ -427,6 +461,43 @@ hipblasStatus_t hipblasBfdotBatchedFortran(hipblasHandle_t              handle,
                                            int                          batch_count,
                                            hipblasBfloat16*             result);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCdotuBatchedFortran(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipComplex* const x[],
+                                           int                     incx,
+                                           const hipComplex* const y[],
+                                           int                     incy,
+                                           int                     batch_count,
+                                           hipComplex*             result);
+
+hipblasStatus_t hipblasZdotuBatchedFortran(hipblasHandle_t               handle,
+                                           int                           n,
+                                           const hipDoubleComplex* const x[],
+                                           int                           incx,
+                                           const hipDoubleComplex* const y[],
+                                           int                           incy,
+                                           int                           batch_count,
+                                           hipDoubleComplex*             result);
+
+hipblasStatus_t hipblasCdotcBatchedFortran(hipblasHandle_t         handle,
+                                           int                     n,
+                                           const hipComplex* const x[],
+                                           int                     incx,
+                                           const hipComplex* const y[],
+                                           int                     incy,
+                                           int                     batch_count,
+                                           hipComplex*             result);
+
+hipblasStatus_t hipblasZdotcBatchedFortran(hipblasHandle_t               handle,
+                                           int                           n,
+                                           const hipDoubleComplex* const x[],
+                                           int                           incx,
+                                           const hipDoubleComplex* const y[],
+                                           int                           incy,
+                                           int                           batch_count,
+                                           hipDoubleComplex*             result);
+#else
 hipblasStatus_t hipblasCdotuBatchedFortran(hipblasHandle_t             handle,
                                            int                         n,
                                            const hipblasComplex* const x[],
@@ -462,6 +533,7 @@ hipblasStatus_t hipblasZdotcBatchedFortran(hipblasHandle_t                   han
                                            int                               incy,
                                            int                               batch_count,
                                            hipblasDoubleComplex*             result);
+#endif
 
 // dotStridedBatched
 hipblasStatus_t hipblasSdotStridedBatchedFortran(hipblasHandle_t handle,
@@ -508,6 +580,51 @@ hipblasStatus_t hipblasBfdotStridedBatchedFortran(hipblasHandle_t        handle,
                                                   int                    batch_count,
                                                   hipblasBfloat16*       result);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCdotuStridedBatchedFortran(hipblasHandle_t   handle,
+                                                  int               n,
+                                                  const hipComplex* x,
+                                                  int               incx,
+                                                  hipblasStride     stridex,
+                                                  const hipComplex* y,
+                                                  int               incy,
+                                                  hipblasStride     stridey,
+                                                  int               batch_count,
+                                                  hipComplex*       result);
+
+hipblasStatus_t hipblasZdotuStridedBatchedFortran(hipblasHandle_t         handle,
+                                                  int                     n,
+                                                  const hipDoubleComplex* x,
+                                                  int                     incx,
+                                                  hipblasStride           stridex,
+                                                  const hipDoubleComplex* y,
+                                                  int                     incy,
+                                                  hipblasStride           stridey,
+                                                  int                     batch_count,
+                                                  hipDoubleComplex*       result);
+
+hipblasStatus_t hipblasCdotcStridedBatchedFortran(hipblasHandle_t   handle,
+                                                  int               n,
+                                                  const hipComplex* x,
+                                                  int               incx,
+                                                  hipblasStride     stridex,
+                                                  const hipComplex* y,
+                                                  int               incy,
+                                                  hipblasStride     stridey,
+                                                  int               batch_count,
+                                                  hipComplex*       result);
+
+hipblasStatus_t hipblasZdotcStridedBatchedFortran(hipblasHandle_t         handle,
+                                                  int                     n,
+                                                  const hipDoubleComplex* x,
+                                                  int                     incx,
+                                                  hipblasStride           stridex,
+                                                  const hipDoubleComplex* y,
+                                                  int                     incy,
+                                                  hipblasStride           stridey,
+                                                  int                     batch_count,
+                                                  hipDoubleComplex*       result);
+#else
 hipblasStatus_t hipblasCdotuStridedBatchedFortran(hipblasHandle_t       handle,
                                                   int                   n,
                                                   const hipblasComplex* x,
@@ -551,6 +668,7 @@ hipblasStatus_t hipblasZdotcStridedBatchedFortran(hipblasHandle_t             ha
                                                   hipblasStride               stridey,
                                                   int                         batch_count,
                                                   hipblasDoubleComplex*       result);
+#endif
 
 // swap
 hipblasStatus_t

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -755,6 +755,13 @@ hipblasStatus_t
 hipblasStatus_t
     hipblasDswapFortran(hipblasHandle_t handle, int n, double* x, int incx, double* y, int incy);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCswapFortran(
+    hipblasHandle_t handle, int n, hipComplex* x, int incx, hipComplex* y, int incy);
+
+hipblasStatus_t hipblasZswapFortran(
+    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy);
+#else
 hipblasStatus_t hipblasCswapFortran(
     hipblasHandle_t handle, int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy);
 
@@ -764,29 +771,58 @@ hipblasStatus_t hipblasZswapFortran(hipblasHandle_t       handle,
                                     int                   incx,
                                     hipblasDoubleComplex* y,
                                     int                   incy);
+#endif
 
 // swapBatched
-hipblasStatus_t hipblasSswapBatchedFortran(
-    hipblasHandle_t handle, int n, float* x[], int incx, float* y[], int incy, int batch_count);
-
-hipblasStatus_t hipblasDswapBatchedFortran(
-    hipblasHandle_t handle, int n, double* x[], int incx, double* y[], int incy, int batch_count);
-
-hipblasStatus_t hipblasCswapBatchedFortran(hipblasHandle_t handle,
+hipblasStatus_t hipblasSswapBatchedFortran(hipblasHandle_t handle,
                                            int             n,
-                                           hipblasComplex* x[],
+                                           float* const    x[],
                                            int             incx,
-                                           hipblasComplex* y[],
+                                           float* const    y[],
                                            int             incy,
                                            int             batch_count);
 
-hipblasStatus_t hipblasZswapBatchedFortran(hipblasHandle_t       handle,
+hipblasStatus_t hipblasDswapBatchedFortran(hipblasHandle_t handle,
+                                           int             n,
+                                           double* const   x[],
+                                           int             incx,
+                                           double* const   y[],
+                                           int             incy,
+                                           int             batch_count);
+
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCswapBatchedFortran(hipblasHandle_t   handle,
+                                           int               n,
+                                           hipComplex* const x[],
+                                           int               incx,
+                                           hipComplex* const y[],
+                                           int               incy,
+                                           int               batch_count);
+
+hipblasStatus_t hipblasZswapBatchedFortran(hipblasHandle_t         handle,
+                                           int                     n,
+                                           hipDoubleComplex* const x[],
+                                           int                     incx,
+                                           hipDoubleComplex* const y[],
+                                           int                     incy,
+                                           int                     batch_count);
+#else
+hipblasStatus_t hipblasCswapBatchedFortran(hipblasHandle_t       handle,
                                            int                   n,
-                                           hipblasDoubleComplex* x[],
+                                           hipblasComplex* const x[],
                                            int                   incx,
-                                           hipblasDoubleComplex* y[],
+                                           hipblasComplex* const y[],
                                            int                   incy,
                                            int                   batch_count);
+
+hipblasStatus_t hipblasZswapBatchedFortran(hipblasHandle_t             handle,
+                                           int                         n,
+                                           hipblasDoubleComplex* const x[],
+                                           int                         incx,
+                                           hipblasDoubleComplex* const y[],
+                                           int                         incy,
+                                           int                         batch_count);
+#endif
 
 // swapStridedBatched
 hipblasStatus_t hipblasSswapStridedBatchedFortran(hipblasHandle_t handle,
@@ -809,6 +845,27 @@ hipblasStatus_t hipblasDswapStridedBatchedFortran(hipblasHandle_t handle,
                                                   hipblasStride   stridey,
                                                   int             batch_count);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasCswapStridedBatchedFortran(hipblasHandle_t handle,
+                                                  int             n,
+                                                  hipComplex*     x,
+                                                  int             incx,
+                                                  hipblasStride   stridex,
+                                                  hipComplex*     y,
+                                                  int             incy,
+                                                  hipblasStride   stridey,
+                                                  int             batch_count);
+
+hipblasStatus_t hipblasZswapStridedBatchedFortran(hipblasHandle_t   handle,
+                                                  int               n,
+                                                  hipDoubleComplex* x,
+                                                  int               incx,
+                                                  hipblasStride     stridex,
+                                                  hipDoubleComplex* y,
+                                                  int               incy,
+                                                  hipblasStride     stridey,
+                                                  int               batch_count);
+#else
 hipblasStatus_t hipblasCswapStridedBatchedFortran(hipblasHandle_t handle,
                                                   int             n,
                                                   hipblasComplex* x,
@@ -828,6 +885,7 @@ hipblasStatus_t hipblasZswapStridedBatchedFortran(hipblasHandle_t       handle,
                                                   int                   incy,
                                                   hipblasStride         stridey,
                                                   int                   batch_count);
+#endif
 
 // axpy
 hipblasStatus_t hipblasHaxpyFortran(hipblasHandle_t    handle,

--- a/clients/include/hipblas_fortran.hpp
+++ b/clients/include/hipblas_fortran.hpp
@@ -740,11 +740,19 @@ hipblasStatus_t
 hipblasStatus_t
     hipblasDasumFortran(hipblasHandle_t handle, int n, const double* x, int incx, double* result);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasScasumFortran(
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
+
+hipblasStatus_t hipblasDzasumFortran(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
+#else
 hipblasStatus_t hipblasScasumFortran(
     hipblasHandle_t handle, int n, const hipblasComplex* x, int incx, float* result);
 
 hipblasStatus_t hipblasDzasumFortran(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result);
+#endif
 
 // asumBatched
 hipblasStatus_t hipblasSasumBatchedFortran(hipblasHandle_t    handle,
@@ -761,6 +769,21 @@ hipblasStatus_t hipblasDasumBatchedFortran(hipblasHandle_t     handle,
                                            int                 batch_count,
                                            double*             results);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasScasumBatchedFortran(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const hipComplex* const x[],
+                                            int                     incx,
+                                            int                     batch_count,
+                                            float*                  results);
+
+hipblasStatus_t hipblasDzasumBatchedFortran(hipblasHandle_t               handle,
+                                            int                           n,
+                                            const hipDoubleComplex* const x[],
+                                            int                           incx,
+                                            int                           batch_count,
+                                            double*                       results);
+#else
 hipblasStatus_t hipblasScasumBatchedFortran(hipblasHandle_t             handle,
                                             int                         n,
                                             const hipblasComplex* const x[],
@@ -774,6 +797,7 @@ hipblasStatus_t hipblasDzasumBatchedFortran(hipblasHandle_t                   ha
                                             int                               incx,
                                             int                               batch_count,
                                             double*                           results);
+#endif
 
 // asumStridedBatched
 hipblasStatus_t hipblasSasumStridedBatchedFortran(hipblasHandle_t handle,
@@ -792,6 +816,23 @@ hipblasStatus_t hipblasDasumStridedBatchedFortran(hipblasHandle_t handle,
                                                   int             batch_count,
                                                   double*         results);
 
+#ifdef HIPBLAS_V2
+hipblasStatus_t hipblasScasumStridedBatchedFortran(hipblasHandle_t   handle,
+                                                   int               n,
+                                                   const hipComplex* x,
+                                                   int               incx,
+                                                   hipblasStride     stridex,
+                                                   int               batch_count,
+                                                   float*            results);
+
+hipblasStatus_t hipblasDzasumStridedBatchedFortran(hipblasHandle_t         handle,
+                                                   int                     n,
+                                                   const hipDoubleComplex* x,
+                                                   int                     incx,
+                                                   hipblasStride           stridex,
+                                                   int                     batch_count,
+                                                   double*                 results);
+#else
 hipblasStatus_t hipblasScasumStridedBatchedFortran(hipblasHandle_t       handle,
                                                    int                   n,
                                                    const hipblasComplex* x,
@@ -807,6 +848,7 @@ hipblasStatus_t hipblasDzasumStridedBatchedFortran(hipblasHandle_t             h
                                                    hipblasStride               stridex,
                                                    int                         batch_count,
                                                    double*                     results);
+#endif
 
 // nrm2
 hipblasStatus_t

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -2070,6 +2070,38 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotu(hipblasHandle_t             handle,
                                             const hipblasDoubleComplex* y,
                                             int                         incy,
                                             hipblasDoubleComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotc_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               const hipComplex* y,
+                                               int               incy,
+                                               hipComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotu_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               const hipComplex* y,
+                                               int               incy,
+                                               hipComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotc_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               const hipDoubleComplex* y,
+                                               int                     incy,
+                                               hipDoubleComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotu_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               const hipDoubleComplex* y,
+                                               int                     incy,
+                                               hipDoubleComplex*       result);
 //! @}
 
 /*! @{
@@ -2187,6 +2219,42 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t              
                                                    int                               incy,
                                                    int                               batchCount,
                                                    hipblasDoubleComplex*             result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcBatched_v2(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      const hipComplex* const x[],
+                                                      int                     incx,
+                                                      const hipComplex* const y[],
+                                                      int                     incy,
+                                                      int                     batchCount,
+                                                      hipComplex*             result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuBatched_v2(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      const hipComplex* const x[],
+                                                      int                     incx,
+                                                      const hipComplex* const y[],
+                                                      int                     incy,
+                                                      int                     batchCount,
+                                                      hipComplex*             result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcBatched_v2(hipblasHandle_t               handle,
+                                                      int                           n,
+                                                      const hipDoubleComplex* const x[],
+                                                      int                           incx,
+                                                      const hipDoubleComplex* const y[],
+                                                      int                           incy,
+                                                      int                           batchCount,
+                                                      hipDoubleComplex*             result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuBatched_v2(hipblasHandle_t               handle,
+                                                      int                           n,
+                                                      const hipDoubleComplex* const x[],
+                                                      int                           incx,
+                                                      const hipDoubleComplex* const y[],
+                                                      int                           incy,
+                                                      int                           batchCount,
+                                                      hipDoubleComplex*             result);
 //! @}
 
 /*! @{
@@ -2326,6 +2394,50 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t       
                                                           hipblasStride               stridey,
                                                           int                         batchCount,
                                                           hipblasDoubleComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotcStridedBatched_v2(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             const hipComplex* x,
+                                                             int               incx,
+                                                             hipblasStride     stridex,
+                                                             const hipComplex* y,
+                                                             int               incy,
+                                                             hipblasStride     stridey,
+                                                             int               batchCount,
+                                                             hipComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCdotuStridedBatched_v2(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             const hipComplex* x,
+                                                             int               incx,
+                                                             hipblasStride     stridex,
+                                                             const hipComplex* y,
+                                                             int               incy,
+                                                             hipblasStride     stridey,
+                                                             int               batchCount,
+                                                             hipComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotcStridedBatched_v2(hipblasHandle_t         handle,
+                                                             int                     n,
+                                                             const hipDoubleComplex* x,
+                                                             int                     incx,
+                                                             hipblasStride           stridex,
+                                                             const hipDoubleComplex* y,
+                                                             int                     incy,
+                                                             hipblasStride           stridey,
+                                                             int                     batchCount,
+                                                             hipDoubleComplex*       result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuStridedBatched_v2(hipblasHandle_t         handle,
+                                                             int                     n,
+                                                             const hipDoubleComplex* x,
+                                                             int                     incx,
+                                                             hipblasStride           stridex,
+                                                             const hipDoubleComplex* y,
+                                                             int                     incy,
+                                                             hipblasStride           stridey,
+                                                             int                     batchCount,
+                                                             hipDoubleComplex*       result);
 //! @}
 
 /*! @{
@@ -21262,6 +21374,21 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 
 #define hipblasCcopyStridedBatched hipblasCcopyStridedBatched_v2
 #define hipblasZcopyStridedBatched hipblasZcopyStridedBatched_v2
+
+#define hipblasCdotu hipblasCdotu_v2
+#define hipblasCdotc hipblasCdotc_v2
+#define hipblasZdotu hipblasZdotu_v2
+#define hipblasZdotc hipblasZdotc_v2
+
+#define hipblasCdotuBatched hipblasCdotuBatched_v2
+#define hipblasCdotcBatched hipblasCdotcBatched_v2
+#define hipblasZdotuBatched hipblasZdotuBatched_v2
+#define hipblasZdotcBatched hipblasZdotcBatched_v2
+
+#define hipblasCdotuStridedBatched hipblasCdotuStridedBatched_v2
+#define hipblasCdotcStridedBatched hipblasCdotcStridedBatched_v2
+#define hipblasZdotuStridedBatched hipblasZdotuStridedBatched_v2
+#define hipblasZdotcStridedBatched hipblasZdotcStridedBatched_v2
 
 #endif
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -2480,6 +2480,12 @@ HIPBLAS_EXPORT hipblasStatus_t
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasScnrm2_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
 //! @}
 
 /*! @{
@@ -2537,6 +2543,20 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t             
                                                     int                               incx,
                                                     int                               batchCount,
                                                     double*                           result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasScnrm2Batched_v2(hipblasHandle_t         handle,
+                                                       int                     n,
+                                                       const hipComplex* const x[],
+                                                       int                     incx,
+                                                       int                     batchCount,
+                                                       float*                  result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2Batched_v2(hipblasHandle_t               handle,
+                                                       int                           n,
+                                                       const hipDoubleComplex* const x[],
+                                                       int                           incx,
+                                                       int                           batchCount,
+                                                       double*                       result);
 //! @}
 
 /*! @{
@@ -2609,6 +2629,22 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t      
                                                            hipblasStride               stridex,
                                                            int                         batchCount,
                                                            double*                     result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasScnrm2StridedBatched_v2(hipblasHandle_t   handle,
+                                                              int               n,
+                                                              const hipComplex* x,
+                                                              int               incx,
+                                                              hipblasStride     stridex,
+                                                              int               batchCount,
+                                                              float*            result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2StridedBatched_v2(hipblasHandle_t         handle,
+                                                              int                     n,
+                                                              const hipDoubleComplex* x,
+                                                              int                     incx,
+                                                              hipblasStride           stridex,
+                                                              int                     batchCount,
+                                                              double*                 result);
 //! @}
 
 /*! @{
@@ -21389,6 +21425,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 #define hipblasCdotcStridedBatched hipblasCdotcStridedBatched_v2
 #define hipblasZdotuStridedBatched hipblasZdotuStridedBatched_v2
 #define hipblasZdotcStridedBatched hipblasZdotcStridedBatched_v2
+
+#define hipblasScnrm2 hipblasScnrm2_v2
+#define hipblasDznrm2 hipblasDznrm2_v2
+
+#define hipblasScnrm2Batched hipblasScnrm2Batched_v2
+#define hipblasDznrm2Batched hipblasDznrm2Batched_v2
+
+#define hipblasScnrm2StridedBatched hipblasScnrm2StridedBatched_v2
+#define hipblasDznrm2StridedBatched hipblasDznrm2StridedBatched_v2
 
 #endif
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -1251,6 +1251,12 @@ HIPBLAS_EXPORT hipblasStatus_t
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasDzasum(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, double* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasScasum_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDzasum_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result);
 //! @}
 
 /*! @{
@@ -1307,6 +1313,20 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t             
                                                     int                               incx,
                                                     int                               batchCount,
                                                     double*                           result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasScasumBatched_v2(hipblasHandle_t         handle,
+                                                       int                     n,
+                                                       const hipComplex* const x[],
+                                                       int                     incx,
+                                                       int                     batchCount,
+                                                       float*                  result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumBatched_v2(hipblasHandle_t               handle,
+                                                       int                           n,
+                                                       const hipDoubleComplex* const x[],
+                                                       int                           incx,
+                                                       int                           batchCount,
+                                                       double*                       result);
 //! @}
 
 /*! @{
@@ -1377,6 +1397,22 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t      
                                                            hipblasStride               stridex,
                                                            int                         batchCount,
                                                            double*                     result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasScasumStridedBatched_v2(hipblasHandle_t   handle,
+                                                              int               n,
+                                                              const hipComplex* x,
+                                                              int               incx,
+                                                              hipblasStride     stridex,
+                                                              int               batchCount,
+                                                              float*            result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumStridedBatched_v2(hipblasHandle_t         handle,
+                                                              int                     n,
+                                                              const hipDoubleComplex* x,
+                                                              int                     incx,
+                                                              hipblasStride           stridex,
+                                                              int                     batchCount,
+                                                              double*                 result);
 //! @}
 
 /*! @{
@@ -21097,6 +21133,16 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 
 #define hipblasIcaminStridedBatched hipblasIcaminStridedBatched_v2
 #define hipblasIzaminStridedBatched hipblasIzaminStridedBatched_v2
+
+#define hipblasScasum hipblasScasum_v2
+#define hipblasDzasum hipblasDzasum_v2
+
+#define hipblasScasumBatched hipblasScasumBatched_v2
+#define hipblasDzasumBatched hipblasDzasumBatched_v2
+
+#define hipblasScasumStridedBatched hipblasScasumStridedBatched_v2
+#define hipblasDzasumStridedBatched hipblasDzasumStridedBatched_v2
+
 #endif
 
 /*! HIPBLAS Auxiliary API

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -1763,6 +1763,16 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopy(hipblasHandle_t             handle,
                                             int                         incx,
                                             hipblasDoubleComplex*       y,
                                             int                         incy);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCcopy_v2(
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, hipComplex* y, int incy);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZcopy_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               hipDoubleComplex*       y,
+                                               int                     incy);
 //! @}
 
 /*! @{
@@ -1832,6 +1842,22 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t              
                                                    hipblasDoubleComplex* const       y[],
                                                    int                               incy,
                                                    int                               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyBatched_v2(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      const hipComplex* const x[],
+                                                      int                     incx,
+                                                      hipComplex* const       y[],
+                                                      int                     incy,
+                                                      int                     batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyBatched_v2(hipblasHandle_t               handle,
+                                                      int                           n,
+                                                      const hipDoubleComplex* const x[],
+                                                      int                           incx,
+                                                      hipDoubleComplex* const       y[],
+                                                      int                           incy,
+                                                      int                           batchCount);
 //! @}
 
 /*! @{
@@ -1921,6 +1947,26 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t       
                                                           int                         incy,
                                                           hipblasStride               stridey,
                                                           int                         batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCcopyStridedBatched_v2(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             const hipComplex* x,
+                                                             int               incx,
+                                                             hipblasStride     stridex,
+                                                             hipComplex*       y,
+                                                             int               incy,
+                                                             hipblasStride     stridey,
+                                                             int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyStridedBatched_v2(hipblasHandle_t         handle,
+                                                             int                     n,
+                                                             const hipDoubleComplex* x,
+                                                             int                     incx,
+                                                             hipblasStride           stridex,
+                                                             hipDoubleComplex*       y,
+                                                             int                     incy,
+                                                             hipblasStride           stridey,
+                                                             int                     batchCount);
 //! @}
 
 /*! @{
@@ -21207,6 +21253,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 
 #define hipblasCaxpyStridedBatched hipblasCaxpyStridedBatched_v2
 #define hipblasZaxpyStridedBatched hipblasZaxpyStridedBatched_v2
+
+#define hipblasCcopy hipblasCcopy_v2
+#define hipblasZcopy hipblasZcopy_v2
+
+#define hipblasCcopyBatched hipblasCcopyBatched_v2
+#define hipblasZcopyBatched hipblasZcopyBatched_v2
+
+#define hipblasCcopyStridedBatched hipblasCcopyStridedBatched_v2
+#define hipblasZcopyStridedBatched hipblasZcopyStridedBatched_v2
 
 #endif
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -3727,6 +3727,18 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZscal(hipblasHandle_t             handle,
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasZdscal(
     hipblasHandle_t handle, int n, const double* alpha, hipblasDoubleComplex* x, int incx);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCscal_v2(
+    hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasCsscal_v2(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZscal_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdscal_v2(
+    hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx);
 //! @}
 
 /*! @{
@@ -3796,6 +3808,34 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t             
                                                     hipblasDoubleComplex* const x[],
                                                     int                         incx,
                                                     int                         batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCscalBatched_v2(hipblasHandle_t   handle,
+                                                      int               n,
+                                                      const hipComplex* alpha,
+                                                      hipComplex* const x[],
+                                                      int               incx,
+                                                      int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZscalBatched_v2(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      const hipDoubleComplex* alpha,
+                                                      hipDoubleComplex* const x[],
+                                                      int                     incx,
+                                                      int                     batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCsscalBatched_v2(hipblasHandle_t   handle,
+                                                       int               n,
+                                                       const float*      alpha,
+                                                       hipComplex* const x[],
+                                                       int               incx,
+                                                       int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalBatched_v2(hipblasHandle_t         handle,
+                                                       int                     n,
+                                                       const double*           alpha,
+                                                       hipDoubleComplex* const x[],
+                                                       int                     incx,
+                                                       int                     batchCount);
 //! @}
 
 /*! @{
@@ -3880,6 +3920,38 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t      
                                                            int                   incx,
                                                            hipblasStride         stridex,
                                                            int                   batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCscalStridedBatched_v2(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             const hipComplex* alpha,
+                                                             hipComplex*       x,
+                                                             int               incx,
+                                                             hipblasStride     stridex,
+                                                             int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZscalStridedBatched_v2(hipblasHandle_t         handle,
+                                                             int                     n,
+                                                             const hipDoubleComplex* alpha,
+                                                             hipDoubleComplex*       x,
+                                                             int                     incx,
+                                                             hipblasStride           stridex,
+                                                             int                     batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCsscalStridedBatched_v2(hipblasHandle_t handle,
+                                                              int             n,
+                                                              const float*    alpha,
+                                                              hipComplex*     x,
+                                                              int             incx,
+                                                              hipblasStride   stridex,
+                                                              int             batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalStridedBatched_v2(hipblasHandle_t   handle,
+                                                              int               n,
+                                                              const double*     alpha,
+                                                              hipDoubleComplex* x,
+                                                              int               incx,
+                                                              hipblasStride     stridex,
+                                                              int               batchCount);
 //! @}
 
 /*! @{
@@ -21627,6 +21699,21 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 
 #define hipblasCrotgStridedBatched hipblasCrotgStridedBatched_v2
 #define hipblasZrotgStridedBatched hipblasZrotgStridedBatched_v2
+
+#define hipblasCscal hipblasCscal_v2
+#define hipblasCsscal hipblasCsscal_v2
+#define hipblasZscal hipblasZscal_v2
+#define hipblasZdscal hipblasZdscal_v2
+
+#define hipblasCscalBatched hipblasCscalBatched_v2
+#define hipblasCsscalBatched hipblasCsscalBatched_v2
+#define hipblasZscalBatched hipblasZscalBatched_v2
+#define hipblasZdscalBatched hipblasZdscalBatched_v2
+
+#define hipblasCscalStridedBatched hipblasCscalStridedBatched_v2
+#define hipblasCsscalStridedBatched hipblasCsscalStridedBatched_v2
+#define hipblasZscalStridedBatched hipblasZscalStridedBatched_v2
+#define hipblasZdscalStridedBatched hipblasZdscalStridedBatched_v2
 
 #endif
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -3111,6 +3111,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotg(hipblasHandle_t       handle,
                                             hipblasDoubleComplex* b,
                                             double*               c,
                                             hipblasDoubleComplex* s);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasCrotg_v2(hipblasHandle_t handle, hipComplex* a, hipComplex* b, float* c, hipComplex* s);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZrotg_v2(hipblasHandle_t   handle,
+                                               hipDoubleComplex* a,
+                                               hipDoubleComplex* b,
+                                               double*           c,
+                                               hipDoubleComplex* s);
 //! @}
 
 /*! @{
@@ -3169,6 +3178,20 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgBatched(hipblasHandle_t             h
                                                    double* const               c[],
                                                    hipblasDoubleComplex* const s[],
                                                    int                         batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCrotgBatched_v2(hipblasHandle_t   handle,
+                                                      hipComplex* const a[],
+                                                      hipComplex* const b[],
+                                                      float* const      c[],
+                                                      hipComplex* const s[],
+                                                      int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgBatched_v2(hipblasHandle_t         handle,
+                                                      hipDoubleComplex* const a[],
+                                                      hipDoubleComplex* const b[],
+                                                      double* const           c[],
+                                                      hipDoubleComplex* const s[],
+                                                      int                     batchCount);
 //! @}
 
 /*! @{
@@ -3255,6 +3278,28 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgStridedBatched(hipblasHandle_t       
                                                           hipblasDoubleComplex* s,
                                                           hipblasStride         strides,
                                                           int                   batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCrotgStridedBatched_v2(hipblasHandle_t handle,
+                                                             hipComplex*     a,
+                                                             hipblasStride   stridea,
+                                                             hipComplex*     b,
+                                                             hipblasStride   strideb,
+                                                             float*          c,
+                                                             hipblasStride   stridec,
+                                                             hipComplex*     s,
+                                                             hipblasStride   strides,
+                                                             int             batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgStridedBatched_v2(hipblasHandle_t   handle,
+                                                             hipDoubleComplex* a,
+                                                             hipblasStride     stridea,
+                                                             hipDoubleComplex* b,
+                                                             hipblasStride     strideb,
+                                                             double*           c,
+                                                             hipblasStride     stridec,
+                                                             hipDoubleComplex* s,
+                                                             hipblasStride     strides,
+                                                             int               batchCount);
 //! @}
 
 /*! @{
@@ -21573,6 +21618,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 #define hipblasCsrotStridedBatched hipblasCsrotStridedBatched_v2
 #define hipblasZrotStridedBatched hipblasZrotStridedBatched_v2
 #define hipblasZdrotStridedBatched hipblasZdrotStridedBatched_v2
+
+#define hipblasCrotg hipblasCrotg_v2
+#define hipblasZrotg hipblasZrotg_v2
+
+#define hipblasCrotgBatched hipblasCrotgBatched_v2
+#define hipblasZrotgBatched hipblasZrotgBatched_v2
+
+#define hipblasCrotgStridedBatched hipblasCrotgStridedBatched_v2
+#define hipblasZrotgStridedBatched hipblasZrotgStridedBatched_v2
 
 #endif
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -1486,6 +1486,22 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpy(hipblasHandle_t             handle,
                                             int                         incx,
                                             hipblasDoubleComplex*       y,
                                             int                         incy);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCaxpy_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* alpha,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               hipComplex*       y,
+                                               int               incy);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpy_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* alpha,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               hipDoubleComplex*       y,
+                                               int                     incy);
 //! @}
 
 /*! @{
@@ -1565,6 +1581,24 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpyBatched(hipblasHandle_t              
                                                    hipblasDoubleComplex* const       y[],
                                                    int                               incy,
                                                    int                               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCaxpyBatched_v2(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      const hipComplex*       alpha,
+                                                      const hipComplex* const x[],
+                                                      int                     incx,
+                                                      hipComplex* const       y[],
+                                                      int                     incy,
+                                                      int                     batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpyBatched_v2(hipblasHandle_t               handle,
+                                                      int                           n,
+                                                      const hipDoubleComplex*       alpha,
+                                                      const hipDoubleComplex* const x[],
+                                                      int                           incx,
+                                                      hipDoubleComplex* const       y[],
+                                                      int                           incy,
+                                                      int                           batchCount);
 //! @}
 
 /*! @{
@@ -1660,6 +1694,28 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpyStridedBatched(hipblasHandle_t       
                                                           int                         incy,
                                                           hipblasStride               stridey,
                                                           int                         batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCaxpyStridedBatched_v2(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             const hipComplex* alpha,
+                                                             const hipComplex* x,
+                                                             int               incx,
+                                                             hipblasStride     stridex,
+                                                             hipComplex*       y,
+                                                             int               incy,
+                                                             hipblasStride     stridey,
+                                                             int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpyStridedBatched_v2(hipblasHandle_t         handle,
+                                                             int                     n,
+                                                             const hipDoubleComplex* alpha,
+                                                             const hipDoubleComplex* x,
+                                                             int                     incx,
+                                                             hipblasStride           stridex,
+                                                             hipDoubleComplex*       y,
+                                                             int                     incy,
+                                                             hipblasStride           stridey,
+                                                             int                     batchCount);
 //! @}
 
 /*! @{
@@ -21142,6 +21198,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 
 #define hipblasScasumStridedBatched hipblasScasumStridedBatched_v2
 #define hipblasDzasumStridedBatched hipblasDzasumStridedBatched_v2
+
+#define hipblasCaxpy hipblasCaxpy_v2
+#define hipblasZaxpy hipblasZaxpy_v2
+
+#define hipblasCaxpyBatched hipblasCaxpyBatched_v2
+#define hipblasZaxpyBatched hipblasZaxpyBatched_v2
+
+#define hipblasCaxpyStridedBatched hipblasCaxpyStridedBatched_v2
+#define hipblasZaxpyStridedBatched hipblasZaxpyStridedBatched_v2
 
 #endif
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -1059,6 +1059,12 @@ HIPBLAS_EXPORT hipblasStatus_t
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasIzamin(
     hipblasHandle_t handle, int n, const hipblasDoubleComplex* x, int incx, int* result);
+
+HIPBLAS_EXPORT hipblasStatus_t
+    hipblasIcamin_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasIzamin_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result);
 //! @}
 
 /*! @{
@@ -1108,6 +1114,20 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzaminBatched(hipblasHandle_t             
                                                     int                               incx,
                                                     int                               batchCount,
                                                     int*                              result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasIcaminBatched_v2(hipblasHandle_t         handle,
+                                                       int                     n,
+                                                       const hipComplex* const x[],
+                                                       int                     incx,
+                                                       int                     batchCount,
+                                                       int*                    result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasIzaminBatched_v2(hipblasHandle_t               handle,
+                                                       int                           n,
+                                                       const hipDoubleComplex* const x[],
+                                                       int                           incx,
+                                                       int                           batchCount,
+                                                       int*                          result);
 //! @}
 
 /*! @{
@@ -1174,6 +1194,22 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzaminStridedBatched(hipblasHandle_t      
                                                            hipblasStride               stridex,
                                                            int                         batchCount,
                                                            int*                        result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasIcaminStridedBatched_v2(hipblasHandle_t   handle,
+                                                              int               n,
+                                                              const hipComplex* x,
+                                                              int               incx,
+                                                              hipblasStride     stridex,
+                                                              int               batchCount,
+                                                              int*              result);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasIzaminStridedBatched_v2(hipblasHandle_t         handle,
+                                                              int                     n,
+                                                              const hipDoubleComplex* x,
+                                                              int                     incx,
+                                                              hipblasStride           stridex,
+                                                              int                     batchCount,
+                                                              int*                    result);
 //! @}
 
 /*! @{
@@ -21052,6 +21088,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 
 #define hipblasIcamaxStridedBatched hipblasIcamaxStridedBatched_v2
 #define hipblasIzamaxStridedBatched hipblasIzamaxStridedBatched_v2
+
+#define hipblasIcamin hipblasIcamin_v2
+#define hipblasIzamin hipblasIzamin_v2
+
+#define hipblasIcaminBatched hipblasIcaminBatched_v2
+#define hipblasIzaminBatched hipblasIzaminBatched_v2
+
+#define hipblasIcaminStridedBatched hipblasIcaminStridedBatched_v2
+#define hipblasIzaminStridedBatched hipblasIzaminStridedBatched_v2
 #endif
 
 /*! HIPBLAS Auxiliary API

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -3999,6 +3999,12 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswap(hipblasHandle_t       handle,
                                             int                   incx,
                                             hipblasDoubleComplex* y,
                                             int                   incy);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCswap_v2(
+    hipblasHandle_t handle, int n, hipComplex* x, int incx, hipComplex* y, int incy);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZswap_v2(
+    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy);
 //! @}
 
 /*! @{
@@ -4065,6 +4071,22 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswapBatched(hipblasHandle_t             h
                                                    hipblasDoubleComplex* const y[],
                                                    int                         incy,
                                                    int                         batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCswapBatched_v2(hipblasHandle_t   handle,
+                                                      int               n,
+                                                      hipComplex* const x[],
+                                                      int               incx,
+                                                      hipComplex* const y[],
+                                                      int               incy,
+                                                      int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZswapBatched_v2(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      hipDoubleComplex* const x[],
+                                                      int                     incx,
+                                                      hipDoubleComplex* const y[],
+                                                      int                     incy,
+                                                      int                     batchCount);
 //! @}
 
 /*! @{
@@ -4151,6 +4173,26 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t       
                                                           int                   incy,
                                                           hipblasStride         stridey,
                                                           int                   batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCswapStridedBatched_v2(hipblasHandle_t handle,
+                                                             int             n,
+                                                             hipComplex*     x,
+                                                             int             incx,
+                                                             hipblasStride   stridex,
+                                                             hipComplex*     y,
+                                                             int             incy,
+                                                             hipblasStride   stridey,
+                                                             int             batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZswapStridedBatched_v2(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             hipDoubleComplex* x,
+                                                             int               incx,
+                                                             hipblasStride     stridex,
+                                                             hipDoubleComplex* y,
+                                                             int               incy,
+                                                             hipblasStride     stridey,
+                                                             int               batchCount);
 //! @}
 
 /*
@@ -21714,6 +21756,15 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 #define hipblasCsscalStridedBatched hipblasCsscalStridedBatched_v2
 #define hipblasZscalStridedBatched hipblasZscalStridedBatched_v2
 #define hipblasZdscalStridedBatched hipblasZdscalStridedBatched_v2
+
+#define hipblasCswap hipblasCswap_v2
+#define hipblasZswap hipblasZswap_v2
+
+#define hipblasCswapBatched hipblasCswapBatched_v2
+#define hipblasZswapBatched hipblasZswapBatched_v2
+
+#define hipblasCswapStridedBatched hipblasCswapStridedBatched_v2
+#define hipblasZswapStridedBatched hipblasZswapStridedBatched_v2
 
 #endif
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -2733,6 +2733,42 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrot(hipblasHandle_t       handle,
                                             int                   incy,
                                             const double*         c,
                                             const double*         s);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCrot_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              hipComplex*       x,
+                                              int               incx,
+                                              hipComplex*       y,
+                                              int               incy,
+                                              const float*      c,
+                                              const hipComplex* s);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCsrot_v2(hipblasHandle_t handle,
+                                               int             n,
+                                               hipComplex*     x,
+                                               int             incx,
+                                               hipComplex*     y,
+                                               int             incy,
+                                               const float*    c,
+                                               const float*    s);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZrot_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              hipDoubleComplex*       x,
+                                              int                     incx,
+                                              hipDoubleComplex*       y,
+                                              int                     incy,
+                                              const double*           c,
+                                              const hipDoubleComplex* s);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdrot_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               hipDoubleComplex* x,
+                                               int               incx,
+                                               hipDoubleComplex* y,
+                                               int               incy,
+                                               const double*     c,
+                                               const double*     s);
 //! @}
 
 /*! @{
@@ -2830,6 +2866,46 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotBatched(hipblasHandle_t             h
                                                    const double*               c,
                                                    const double*               s,
                                                    int                         batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCrotBatched_v2(hipblasHandle_t   handle,
+                                                     int               n,
+                                                     hipComplex* const x[],
+                                                     int               incx,
+                                                     hipComplex* const y[],
+                                                     int               incy,
+                                                     const float*      c,
+                                                     const hipComplex* s,
+                                                     int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCsrotBatched_v2(hipblasHandle_t   handle,
+                                                      int               n,
+                                                      hipComplex* const x[],
+                                                      int               incx,
+                                                      hipComplex* const y[],
+                                                      int               incy,
+                                                      const float*      c,
+                                                      const float*      s,
+                                                      int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZrotBatched_v2(hipblasHandle_t         handle,
+                                                     int                     n,
+                                                     hipDoubleComplex* const x[],
+                                                     int                     incx,
+                                                     hipDoubleComplex* const y[],
+                                                     int                     incy,
+                                                     const double*           c,
+                                                     const hipDoubleComplex* s,
+                                                     int                     batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotBatched_v2(hipblasHandle_t         handle,
+                                                      int                     n,
+                                                      hipDoubleComplex* const x[],
+                                                      int                     incx,
+                                                      hipDoubleComplex* const y[],
+                                                      int                     incy,
+                                                      const double*           c,
+                                                      const double*           s,
+                                                      int                     batchCount);
 //! @}
 
 /*! @{
@@ -2945,6 +3021,54 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotStridedBatched(hipblasHandle_t       
                                                           const double*         c,
                                                           const double*         s,
                                                           int                   batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCrotStridedBatched_v2(hipblasHandle_t   handle,
+                                                            int               n,
+                                                            hipComplex*       x,
+                                                            int               incx,
+                                                            hipblasStride     stridex,
+                                                            hipComplex*       y,
+                                                            int               incy,
+                                                            hipblasStride     stridey,
+                                                            const float*      c,
+                                                            const hipComplex* s,
+                                                            int               batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasCsrotStridedBatched_v2(hipblasHandle_t handle,
+                                                             int             n,
+                                                             hipComplex*     x,
+                                                             int             incx,
+                                                             hipblasStride   stridex,
+                                                             hipComplex*     y,
+                                                             int             incy,
+                                                             hipblasStride   stridey,
+                                                             const float*    c,
+                                                             const float*    s,
+                                                             int             batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZrotStridedBatched_v2(hipblasHandle_t         handle,
+                                                            int                     n,
+                                                            hipDoubleComplex*       x,
+                                                            int                     incx,
+                                                            hipblasStride           stridex,
+                                                            hipDoubleComplex*       y,
+                                                            int                     incy,
+                                                            hipblasStride           stridey,
+                                                            const double*           c,
+                                                            const hipDoubleComplex* s,
+                                                            int                     batchCount);
+
+HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotStridedBatched_v2(hipblasHandle_t   handle,
+                                                             int               n,
+                                                             hipDoubleComplex* x,
+                                                             int               incx,
+                                                             hipblasStride     stridex,
+                                                             hipDoubleComplex* y,
+                                                             int               incy,
+                                                             hipblasStride     stridey,
+                                                             const double*     c,
+                                                             const double*     s,
+                                                             int               batchCount);
 //! @}
 
 /*! @{
@@ -21434,6 +21558,21 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasScalStridedBatchedEx_v2(hipblasHandle_t ha
 
 #define hipblasScnrm2StridedBatched hipblasScnrm2StridedBatched_v2
 #define hipblasDznrm2StridedBatched hipblasDznrm2StridedBatched_v2
+
+#define hipblasCrot hipblasCrot_v2
+#define hipblasCsrot hipblasCsrot_v2
+#define hipblasZrot hipblasZrot_v2
+#define hipblasZdrot hipblasZdrot_v2
+
+#define hipblasCrotBatched hipblasCrotBatched_v2
+#define hipblasCsrotBatched hipblasCsrotBatched_v2
+#define hipblasZrotBatched hipblasZrotBatched_v2
+#define hipblasZdrotBatched hipblasZdrotBatched_v2
+
+#define hipblasCrotStridedBatched hipblasCrotStridedBatched_v2
+#define hipblasCsrotStridedBatched hipblasCsrotStridedBatched_v2
+#define hipblasZrotStridedBatched hipblasZrotStridedBatched_v2
+#define hipblasZdrotStridedBatched hipblasZdrotStridedBatched_v2
 
 #endif
 

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -4839,6 +4839,57 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasCscal_v2(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cscal(
+        (rocblas_handle)handle, n, (rocblas_float_complex*)alpha, (rocblas_float_complex*)x, incx));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t
+    hipblasCsscal_v2(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx)
+try
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_csscal((rocblas_handle)handle, n, alpha, (rocblas_float_complex*)x, incx));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZscal_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zscal((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_double_complex*)alpha,
+                                                  (rocblas_double_complex*)x,
+                                                  incx));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdscal_v2(
+    hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx)
+try
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_zdscal((rocblas_handle)handle, n, alpha, (rocblas_double_complex*)x, incx));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // scal_batched
 hipblasStatus_t hipblasSscalBatched(
     hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batchCount)
@@ -4926,6 +4977,78 @@ hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t             handle,
                                      hipblasDoubleComplex* const x[],
                                      int                         incx,
                                      int                         batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdscal_batched(
+        (rocblas_handle)handle, n, alpha, (rocblas_double_complex* const*)x, incx, batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCscalBatched_v2(hipblasHandle_t   handle,
+                                       int               n,
+                                       const hipComplex* alpha,
+                                       hipComplex* const x[],
+                                       int               incx,
+                                       int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cscal_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex*)alpha,
+                                                          (rocblas_float_complex* const*)x,
+                                                          incx,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZscalBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipDoubleComplex* alpha,
+                                       hipDoubleComplex* const x[],
+                                       int                     incx,
+                                       int                     batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zscal_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex*)alpha,
+                                                          (rocblas_double_complex* const*)x,
+                                                          incx,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCsscalBatched_v2(hipblasHandle_t   handle,
+                                        int               n,
+                                        const float*      alpha,
+                                        hipComplex* const x[],
+                                        int               incx,
+                                        int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_csscal_batched(
+        (rocblas_handle)handle, n, alpha, (rocblas_float_complex* const*)x, incx, batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdscalBatched_v2(hipblasHandle_t         handle,
+                                        int                     n,
+                                        const double*           alpha,
+                                        hipDoubleComplex* const x[],
+                                        int                     incx,
+                                        int                     batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zdscal_batched(
@@ -5039,6 +5162,84 @@ hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t       handle,
                                             int                   incx,
                                             hipblasStride         stridex,
                                             int                   batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdscal_strided_batched(
+        (rocblas_handle)handle, n, alpha, (rocblas_double_complex*)x, incx, stridex, batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCscalStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* alpha,
+                                              hipComplex*       x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cscal_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)alpha,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZscalStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* alpha,
+                                              hipDoubleComplex*       x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              int                     batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zscal_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)alpha,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCsscalStridedBatched_v2(hipblasHandle_t handle,
+                                               int             n,
+                                               const float*    alpha,
+                                               hipComplex*     x,
+                                               int             incx,
+                                               hipblasStride   stridex,
+                                               int             batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_csscal_strided_batched(
+        (rocblas_handle)handle, n, alpha, (rocblas_float_complex*)x, incx, stridex, batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdscalStridedBatched_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const double*     alpha,
+                                               hipDoubleComplex* x,
+                                               int               incx,
+                                               hipblasStride     stridex,
+                                               int               batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zdscal_strided_batched(

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -2453,6 +2453,94 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t hipblasCdotc_v2(hipblasHandle_t   handle,
+                                int               n,
+                                const hipComplex* x,
+                                int               incx,
+                                const hipComplex* y,
+                                int               incy,
+                                hipComplex*       result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cdotc((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_float_complex*)x,
+                                                  incx,
+                                                  (rocblas_float_complex*)y,
+                                                  incy,
+                                                  (rocblas_float_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCdotu_v2(hipblasHandle_t   handle,
+                                int               n,
+                                const hipComplex* x,
+                                int               incx,
+                                const hipComplex* y,
+                                int               incy,
+                                hipComplex*       result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cdotu((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_float_complex*)x,
+                                                  incx,
+                                                  (rocblas_float_complex*)y,
+                                                  incy,
+                                                  (rocblas_float_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdotc_v2(hipblasHandle_t         handle,
+                                int                     n,
+                                const hipDoubleComplex* x,
+                                int                     incx,
+                                const hipDoubleComplex* y,
+                                int                     incy,
+                                hipDoubleComplex*       result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdotc((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_double_complex*)x,
+                                                  incx,
+                                                  (rocblas_double_complex*)y,
+                                                  incy,
+                                                  (rocblas_double_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdotu_v2(hipblasHandle_t         handle,
+                                int                     n,
+                                const hipDoubleComplex* x,
+                                int                     incx,
+                                const hipDoubleComplex* y,
+                                int                     incy,
+                                hipDoubleComplex*       result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdotu((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_double_complex*)x,
+                                                  incx,
+                                                  (rocblas_double_complex*)y,
+                                                  incy,
+                                                  (rocblas_double_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // dot_batched
 hipblasStatus_t hipblasHdotBatched(hipblasHandle_t          handle,
                                    int                      n,
@@ -2618,6 +2706,102 @@ hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t                   handle,
                                     int                               incy,
                                     int                               batchCount,
                                     hipblasDoubleComplex*             result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdotu_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          batchCount,
+                                                          (rocblas_double_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCdotcBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipComplex* const x[],
+                                       int                     incx,
+                                       const hipComplex* const y[],
+                                       int                     incy,
+                                       int                     batchCount,
+                                       hipComplex*             result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cdotc_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          batchCount,
+                                                          (rocblas_float_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCdotuBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipComplex* const x[],
+                                       int                     incx,
+                                       const hipComplex* const y[],
+                                       int                     incy,
+                                       int                     batchCount,
+                                       hipComplex*             result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cdotu_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          batchCount,
+                                                          (rocblas_float_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdotcBatched_v2(hipblasHandle_t               handle,
+                                       int                           n,
+                                       const hipDoubleComplex* const x[],
+                                       int                           incx,
+                                       const hipDoubleComplex* const y[],
+                                       int                           incy,
+                                       int                           batchCount,
+                                       hipDoubleComplex*             result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdotc_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          batchCount,
+                                                          (rocblas_double_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdotuBatched_v2(hipblasHandle_t               handle,
+                                       int                           n,
+                                       const hipDoubleComplex* const x[],
+                                       int                           incx,
+                                       const hipDoubleComplex* const y[],
+                                       int                           incy,
+                                       int                           batchCount,
+                                       hipDoubleComplex*             result)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zdotu_batched((rocblas_handle)handle,
@@ -2825,6 +3009,118 @@ hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t             handle,
                                            hipblasStride               stridey,
                                            int                         batchCount,
                                            hipblasDoubleComplex*       result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdotu_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount,
+                                                                  (rocblas_double_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCdotcStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              const hipComplex* y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount,
+                                              hipComplex*       result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cdotc_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount,
+                                                                  (rocblas_float_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCdotuStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              const hipComplex* y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount,
+                                              hipComplex*       result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cdotu_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount,
+                                                                  (rocblas_float_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdotcStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              const hipDoubleComplex* y,
+                                              int                     incy,
+                                              hipblasStride           stridey,
+                                              int                     batchCount,
+                                              hipDoubleComplex*       result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdotc_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount,
+                                                                  (rocblas_double_complex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdotuStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              const hipDoubleComplex* y,
+                                              int                     incy,
+                                              hipblasStride           stridey,
+                                              int                     batchCount,
+                                              hipDoubleComplex*       result)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zdotu_strided_batched((rocblas_handle)handle,

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -965,6 +965,30 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasIcamin_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result)
+try
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_icamin((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasIzamin_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result)
+try
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_izamin((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // amin_batched
 hipblasStatus_t hipblasIsaminBatched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, int* result)
@@ -1012,6 +1036,38 @@ hipblasStatus_t hipblasIzaminBatched(hipblasHandle_t                   handle,
                                      int                               incx,
                                      int                               batchCount,
                                      int*                              result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_izamin_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex* const*)x, incx, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasIcaminBatched_v2(hipblasHandle_t         handle,
+                                        int                     n,
+                                        const hipComplex* const x[],
+                                        int                     incx,
+                                        int                     batchCount,
+                                        int*                    result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_icamin_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex* const*)x, incx, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasIzaminBatched_v2(hipblasHandle_t               handle,
+                                        int                           n,
+                                        const hipDoubleComplex* const x[],
+                                        int                           incx,
+                                        int                           batchCount,
+                                        int*                          result)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_izamin_batched(
@@ -1081,6 +1137,40 @@ hipblasStatus_t hipblasIzaminStridedBatched(hipblasHandle_t             handle,
                                             hipblasStride               stridex,
                                             int                         batchCount,
                                             int*                        result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_izamin_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasIcaminStridedBatched_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               hipblasStride     stridex,
+                                               int               batchCount,
+                                               int*              result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_icamin_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasIzaminStridedBatched_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               hipblasStride           stridex,
+                                               int                     batchCount,
+                                               int*                    result)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_izamin_strided_batched(

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -4218,6 +4218,39 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasCrotg_v2(hipblasHandle_t handle, hipComplex* a, hipComplex* b, float* c, hipComplex* s)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_crotg((rocblas_handle)handle,
+                                                  (rocblas_float_complex*)a,
+                                                  (rocblas_float_complex*)b,
+                                                  c,
+                                                  (rocblas_float_complex*)s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZrotg_v2(hipblasHandle_t   handle,
+                                hipDoubleComplex* a,
+                                hipDoubleComplex* b,
+                                double*           c,
+                                hipDoubleComplex* s)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zrotg((rocblas_handle)handle,
+                                                  (rocblas_double_complex*)a,
+                                                  (rocblas_double_complex*)b,
+                                                  c,
+                                                  (rocblas_double_complex*)s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // rotg_batched
 hipblasStatus_t hipblasSrotgBatched(hipblasHandle_t handle,
                                     float* const    a[],
@@ -4277,6 +4310,46 @@ hipblasStatus_t hipblasZrotgBatched(hipblasHandle_t             handle,
                                     double* const               c[],
                                     hipblasDoubleComplex* const s[],
                                     int                         batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zrotg_batched((rocblas_handle)handle,
+                                                          (rocblas_double_complex**)a,
+                                                          (rocblas_double_complex**)b,
+                                                          c,
+                                                          (rocblas_double_complex**)s,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCrotgBatched_v2(hipblasHandle_t   handle,
+                                       hipComplex* const a[],
+                                       hipComplex* const b[],
+                                       float* const      c[],
+                                       hipComplex* const s[],
+                                       int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_crotg_batched((rocblas_handle)handle,
+                                                          (rocblas_float_complex**)a,
+                                                          (rocblas_float_complex**)b,
+                                                          c,
+                                                          (rocblas_float_complex**)s,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZrotgBatched_v2(hipblasHandle_t         handle,
+                                       hipDoubleComplex* const a[],
+                                       hipDoubleComplex* const b[],
+                                       double* const           c[],
+                                       hipDoubleComplex* const s[],
+                                       int                     batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zrotg_batched((rocblas_handle)handle,
@@ -4370,6 +4443,62 @@ hipblasStatus_t hipblasZrotgStridedBatched(hipblasHandle_t       handle,
                                            hipblasDoubleComplex* s,
                                            hipblasStride         stride_s,
                                            int                   batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zrotg_strided_batched((rocblas_handle)handle,
+                                                                  (rocblas_double_complex*)a,
+                                                                  stride_a,
+                                                                  (rocblas_double_complex*)b,
+                                                                  stride_b,
+                                                                  c,
+                                                                  stride_c,
+                                                                  (rocblas_double_complex*)s,
+                                                                  stride_s,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCrotgStridedBatched_v2(hipblasHandle_t handle,
+                                              hipComplex*     a,
+                                              hipblasStride   stride_a,
+                                              hipComplex*     b,
+                                              hipblasStride   stride_b,
+                                              float*          c,
+                                              hipblasStride   stride_c,
+                                              hipComplex*     s,
+                                              hipblasStride   stride_s,
+                                              int             batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_crotg_strided_batched((rocblas_handle)handle,
+                                                                  (rocblas_float_complex*)a,
+                                                                  stride_a,
+                                                                  (rocblas_float_complex*)b,
+                                                                  stride_b,
+                                                                  c,
+                                                                  stride_c,
+                                                                  (rocblas_float_complex*)s,
+                                                                  stride_s,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZrotgStridedBatched_v2(hipblasHandle_t   handle,
+                                              hipDoubleComplex* a,
+                                              hipblasStride     stride_a,
+                                              hipDoubleComplex* b,
+                                              hipblasStride     stride_b,
+                                              double*           c,
+                                              hipblasStride     stride_c,
+                                              hipDoubleComplex* s,
+                                              hipblasStride     stride_s,
+                                              int               batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zrotg_strided_batched((rocblas_handle)handle,

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -1543,6 +1543,50 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t hipblasCaxpy_v2(hipblasHandle_t   handle,
+                                int               n,
+                                const hipComplex* alpha,
+                                const hipComplex* x,
+                                int               incx,
+                                hipComplex*       y,
+                                int               incy)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_caxpy((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_float_complex*)alpha,
+                                                  (rocblas_float_complex*)x,
+                                                  incx,
+                                                  (rocblas_float_complex*)y,
+                                                  incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZaxpy_v2(hipblasHandle_t         handle,
+                                int                     n,
+                                const hipDoubleComplex* alpha,
+                                const hipDoubleComplex* x,
+                                int                     incx,
+                                hipDoubleComplex*       y,
+                                int                     incy)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zaxpy((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_double_complex*)alpha,
+                                                  (rocblas_double_complex*)x,
+                                                  incx,
+                                                  (rocblas_double_complex*)y,
+                                                  incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // axpy_batched
 hipblasStatus_t hipblasHaxpyBatched(hipblasHandle_t          handle,
                                     int                      n,
@@ -1636,6 +1680,54 @@ hipblasStatus_t hipblasZaxpyBatched(hipblasHandle_t                   handle,
                                     hipblasDoubleComplex* const       y[],
                                     int                               incy,
                                     int                               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zaxpy_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex*)alpha,
+                                                          (rocblas_double_complex* const*)x,
+                                                          incx,
+                                                          (rocblas_double_complex* const*)y,
+                                                          incy,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCaxpyBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipComplex*       alpha,
+                                       const hipComplex* const x[],
+                                       int                     incx,
+                                       hipComplex* const       y[],
+                                       int                     incy,
+                                       int                     batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_caxpy_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex*)alpha,
+                                                          (rocblas_float_complex* const*)x,
+                                                          incx,
+                                                          (rocblas_float_complex* const*)y,
+                                                          incy,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZaxpyBatched_v2(hipblasHandle_t               handle,
+                                       int                           n,
+                                       const hipDoubleComplex*       alpha,
+                                       const hipDoubleComplex* const x[],
+                                       int                           incx,
+                                       hipDoubleComplex* const       y[],
+                                       int                           incy,
+                                       int                           batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zaxpy_batched((rocblas_handle)handle,
@@ -1759,6 +1851,62 @@ hipblasStatus_t hipblasZaxpyStridedBatched(hipblasHandle_t             handle,
                                            int                         incy,
                                            hipblasStride               stridey,
                                            int                         batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zaxpy_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)alpha,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCaxpyStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* alpha,
+                                              const hipComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              hipComplex*       y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_caxpy_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)alpha,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZaxpyStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* alpha,
+                                              const hipDoubleComplex* x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              hipDoubleComplex*       y,
+                                              int                     incy,
+                                              hipblasStride           stridey,
+                                              int                     batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zaxpy_strided_batched((rocblas_handle)handle,

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -1984,6 +1984,42 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t hipblasCcopy_v2(
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, hipComplex* y, int incy)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_ccopy((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_float_complex*)x,
+                                                  incx,
+                                                  (rocblas_float_complex*)y,
+                                                  incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZcopy_v2(hipblasHandle_t         handle,
+                                int                     n,
+                                const hipDoubleComplex* x,
+                                int                     incx,
+                                hipDoubleComplex*       y,
+                                int                     incy)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zcopy((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_double_complex*)x,
+                                                  incx,
+                                                  (rocblas_double_complex*)y,
+                                                  incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // copy_batched
 hipblasStatus_t hipblasScopyBatched(hipblasHandle_t    handle,
                                     int                n,
@@ -2048,6 +2084,50 @@ hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t                   handle,
                                     hipblasDoubleComplex* const       y[],
                                     int                               incy,
                                     int                               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zcopy_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCcopyBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipComplex* const x[],
+                                       int                     incx,
+                                       hipComplex* const       y[],
+                                       int                     incy,
+                                       int                     batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_ccopy_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZcopyBatched_v2(hipblasHandle_t               handle,
+                                       int                           n,
+                                       const hipDoubleComplex* const x[],
+                                       int                           incx,
+                                       hipDoubleComplex* const       y[],
+                                       int                           incy,
+                                       int                           batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zcopy_batched((rocblas_handle)handle,
@@ -2137,6 +2217,58 @@ hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t             handle,
                                            int                         incy,
                                            hipblasStride               stridey,
                                            int                         batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zcopy_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCcopyStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              hipComplex*       y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_ccopy_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZcopyStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              hipDoubleComplex*       y,
+                                              int                     incy,
+                                              hipblasStride           stridey,
+                                              int                     batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zcopy_strided_batched((rocblas_handle)handle,

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -3185,6 +3185,30 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasScnrm2_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+try
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_scnrm2((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasDznrm2_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+try
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_dznrm2((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // nrm2_batched
 hipblasStatus_t hipblasSnrm2Batched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
@@ -3236,6 +3260,38 @@ hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t                   handle,
                                      int                               incx,
                                      int                               batchCount,
                                      double*                           result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_dznrm2_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex* const*)x, incx, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasScnrm2Batched_v2(hipblasHandle_t         handle,
+                                        int                     n,
+                                        const hipComplex* const x[],
+                                        int                     incx,
+                                        int                     batchCount,
+                                        float*                  result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_scnrm2_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex* const*)x, incx, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasDznrm2Batched_v2(hipblasHandle_t               handle,
+                                        int                           n,
+                                        const hipDoubleComplex* const x[],
+                                        int                           incx,
+                                        int                           batchCount,
+                                        double*                       result)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_dznrm2_batched(
@@ -3305,6 +3361,40 @@ hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t             handle,
                                             hipblasStride               stridex,
                                             int                         batchCount,
                                             double*                     result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_dznrm2_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasScnrm2StridedBatched_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               hipblasStride     stridex,
+                                               int               batchCount,
+                                               float*            result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_scnrm2_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasDznrm2StridedBatched_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               hipblasStride           stridex,
+                                               int                     batchCount,
+                                               double*                 result)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_dznrm2_strided_batched(

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -1227,6 +1227,30 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasScasum_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+try
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_scasum((rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasDzasum_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+try
+{
+    return rocBLASStatusToHIPStatus(
+        rocblas_dzasum((rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // asum_batched
 hipblasStatus_t hipblasSasumBatched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
@@ -1278,6 +1302,38 @@ hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t                   handle,
                                      int                               incx,
                                      int                               batchCount,
                                      double*                           result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_dzasum_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex* const*)x, incx, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasScasumBatched_v2(hipblasHandle_t         handle,
+                                        int                     n,
+                                        const hipComplex* const x[],
+                                        int                     incx,
+                                        int                     batchCount,
+                                        float*                  result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_scasum_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex* const*)x, incx, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasDzasumBatched_v2(hipblasHandle_t               handle,
+                                        int                           n,
+                                        const hipDoubleComplex* const x[],
+                                        int                           incx,
+                                        int                           batchCount,
+                                        double*                       result)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_dzasum_batched(
@@ -1347,6 +1403,40 @@ hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t             handle,
                                             hipblasStride               stridex,
                                             int                         batchCount,
                                             double*                     result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_dzasum_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_double_complex*)x, incx, stridex, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasScasumStridedBatched_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               hipblasStride     stridex,
+                                               int               batchCount,
+                                               float*            result)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_scasum_strided_batched(
+        (rocblas_handle)handle, n, (rocblas_float_complex*)x, incx, stridex, batchCount, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasDzasumStridedBatched_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               hipblasStride           stridex,
+                                               int                     batchCount,
+                                               double*                 result)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_dzasum_strided_batched(

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -3538,6 +3538,102 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t hipblasCrot_v2(hipblasHandle_t   handle,
+                               int               n,
+                               hipComplex*       x,
+                               int               incx,
+                               hipComplex*       y,
+                               int               incy,
+                               const float*      c,
+                               const hipComplex* s)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_crot((rocblas_handle)handle,
+                                                 n,
+                                                 (rocblas_float_complex*)x,
+                                                 incx,
+                                                 (rocblas_float_complex*)y,
+                                                 incy,
+                                                 c,
+                                                 (rocblas_float_complex*)s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCsrot_v2(hipblasHandle_t handle,
+                                int             n,
+                                hipComplex*     x,
+                                int             incx,
+                                hipComplex*     y,
+                                int             incy,
+                                const float*    c,
+                                const float*    s)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_csrot((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_float_complex*)x,
+                                                  incx,
+                                                  (rocblas_float_complex*)y,
+                                                  incy,
+                                                  c,
+                                                  s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZrot_v2(hipblasHandle_t         handle,
+                               int                     n,
+                               hipDoubleComplex*       x,
+                               int                     incx,
+                               hipDoubleComplex*       y,
+                               int                     incy,
+                               const double*           c,
+                               const hipDoubleComplex* s)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zrot((rocblas_handle)handle,
+                                                 n,
+                                                 (rocblas_double_complex*)x,
+                                                 incx,
+                                                 (rocblas_double_complex*)y,
+                                                 incy,
+                                                 c,
+                                                 (rocblas_double_complex*)s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdrot_v2(hipblasHandle_t   handle,
+                                int               n,
+                                hipDoubleComplex* x,
+                                int               incx,
+                                hipDoubleComplex* y,
+                                int               incy,
+                                const double*     c,
+                                const double*     s)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdrot((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_double_complex*)x,
+                                                  incx,
+                                                  (rocblas_double_complex*)y,
+                                                  incy,
+                                                  c,
+                                                  s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // rot_batched
 hipblasStatus_t hipblasSrotBatched(hipblasHandle_t handle,
                                    int             n,
@@ -3664,6 +3760,110 @@ hipblasStatus_t hipblasZdrotBatched(hipblasHandle_t             handle,
                                     const double*               c,
                                     const double*               s,
                                     int                         batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdrot_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          c,
+                                                          s,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCrotBatched_v2(hipblasHandle_t   handle,
+                                      int               n,
+                                      hipComplex* const x[],
+                                      int               incx,
+                                      hipComplex* const y[],
+                                      int               incy,
+                                      const float*      c,
+                                      const hipComplex* s,
+                                      int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_crot_batched((rocblas_handle)handle,
+                                                         n,
+                                                         (rocblas_float_complex**)x,
+                                                         incx,
+                                                         (rocblas_float_complex**)y,
+                                                         incy,
+                                                         c,
+                                                         (rocblas_float_complex*)s,
+                                                         batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCsrotBatched_v2(hipblasHandle_t   handle,
+                                       int               n,
+                                       hipComplex* const x[],
+                                       int               incx,
+                                       hipComplex* const y[],
+                                       int               incy,
+                                       const float*      c,
+                                       const float*      s,
+                                       int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_csrot_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          c,
+                                                          s,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZrotBatched_v2(hipblasHandle_t         handle,
+                                      int                     n,
+                                      hipDoubleComplex* const x[],
+                                      int                     incx,
+                                      hipDoubleComplex* const y[],
+                                      int                     incy,
+                                      const double*           c,
+                                      const hipDoubleComplex* s,
+                                      int                     batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zrot_batched((rocblas_handle)handle,
+                                                         n,
+                                                         (rocblas_double_complex**)x,
+                                                         incx,
+                                                         (rocblas_double_complex**)y,
+                                                         incy,
+                                                         c,
+                                                         (rocblas_double_complex*)s,
+                                                         batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdrotBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       hipDoubleComplex* const x[],
+                                       int                     incx,
+                                       hipDoubleComplex* const y[],
+                                       int                     incy,
+                                       const double*           c,
+                                       const double*           s,
+                                       int                     batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zdrot_batched((rocblas_handle)handle,
@@ -3825,6 +4025,126 @@ hipblasStatus_t hipblasZdrotStridedBatched(hipblasHandle_t       handle,
                                            const double*         c,
                                            const double*         s,
                                            int                   batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zdrot_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  c,
+                                                                  s,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCrotStridedBatched_v2(hipblasHandle_t   handle,
+                                             int               n,
+                                             hipComplex*       x,
+                                             int               incx,
+                                             hipblasStride     stridex,
+                                             hipComplex*       y,
+                                             int               incy,
+                                             hipblasStride     stridey,
+                                             const float*      c,
+                                             const hipComplex* s,
+                                             int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_crot_strided_batched((rocblas_handle)handle,
+                                                                 n,
+                                                                 (rocblas_float_complex*)x,
+                                                                 incx,
+                                                                 stridex,
+                                                                 (rocblas_float_complex*)y,
+                                                                 incy,
+                                                                 stridey,
+                                                                 c,
+                                                                 (rocblas_float_complex*)s,
+                                                                 batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCsrotStridedBatched_v2(hipblasHandle_t handle,
+                                              int             n,
+                                              hipComplex*     x,
+                                              int             incx,
+                                              hipblasStride   stridex,
+                                              hipComplex*     y,
+                                              int             incy,
+                                              hipblasStride   stridey,
+                                              const float*    c,
+                                              const float*    s,
+                                              int             batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_csrot_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  c,
+                                                                  s,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZrotStridedBatched_v2(hipblasHandle_t         handle,
+                                             int                     n,
+                                             hipDoubleComplex*       x,
+                                             int                     incx,
+                                             hipblasStride           stridex,
+                                             hipDoubleComplex*       y,
+                                             int                     incy,
+                                             hipblasStride           stridey,
+                                             const double*           c,
+                                             const hipDoubleComplex* s,
+                                             int                     batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zrot_strided_batched((rocblas_handle)handle,
+                                                                 n,
+                                                                 (rocblas_double_complex*)x,
+                                                                 incx,
+                                                                 stridex,
+                                                                 (rocblas_double_complex*)y,
+                                                                 incy,
+                                                                 stridey,
+                                                                 c,
+                                                                 (rocblas_double_complex*)s,
+                                                                 batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdrotStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              hipDoubleComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              hipDoubleComplex* y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              const double*     c,
+                                              const double*     s,
+                                              int               batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zdrot_strided_batched((rocblas_handle)handle,

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -5308,6 +5308,38 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasCswap_v2(hipblasHandle_t handle, int n, hipComplex* x, int incx, hipComplex* y, int incy)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cswap((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_float_complex*)x,
+                                                  incx,
+                                                  (rocblas_float_complex*)y,
+                                                  incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZswap_v2(
+    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zswap((rocblas_handle)handle,
+                                                  n,
+                                                  (rocblas_double_complex*)x,
+                                                  incx,
+                                                  (rocblas_double_complex*)y,
+                                                  incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // swap_batched
 hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle,
                                     int             n,
@@ -5372,6 +5404,50 @@ hipblasStatus_t hipblasZswapBatched(hipblasHandle_t             handle,
                                     hipblasDoubleComplex* const y[],
                                     int                         incy,
                                     int                         batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zswap_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_double_complex**)x,
+                                                          incx,
+                                                          (rocblas_double_complex**)y,
+                                                          incy,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCswapBatched_v2(hipblasHandle_t   handle,
+                                       int               n,
+                                       hipComplex* const x[],
+                                       int               incx,
+                                       hipComplex* const y[],
+                                       int               incy,
+                                       int               batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cswap_batched((rocblas_handle)handle,
+                                                          n,
+                                                          (rocblas_float_complex**)x,
+                                                          incx,
+                                                          (rocblas_float_complex**)y,
+                                                          incy,
+                                                          batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZswapBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       hipDoubleComplex* const x[],
+                                       int                     incx,
+                                       hipDoubleComplex* const y[],
+                                       int                     incy,
+                                       int                     batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zswap_batched((rocblas_handle)handle,
@@ -5461,6 +5537,58 @@ hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t       handle,
                                            int                   incy,
                                            hipblasStride         stridey,
                                            int                   batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_zswap_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_double_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_double_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCswapStridedBatched_v2(hipblasHandle_t handle,
+                                              int             n,
+                                              hipComplex*     x,
+                                              int             incx,
+                                              hipblasStride   stridex,
+                                              hipComplex*     y,
+                                              int             incy,
+                                              hipblasStride   stridey,
+                                              int             batchCount)
+try
+{
+    return rocBLASStatusToHIPStatus(rocblas_cswap_strided_batched((rocblas_handle)handle,
+                                                                  n,
+                                                                  (rocblas_float_complex*)x,
+                                                                  incx,
+                                                                  stridex,
+                                                                  (rocblas_float_complex*)y,
+                                                                  incy,
+                                                                  stridey,
+                                                                  batchCount));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZswapStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              hipDoubleComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              hipDoubleComplex* y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount)
 try
 {
     return rocBLASStatusToHIPStatus(rocblas_zswap_strided_batched((rocblas_handle)handle,

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -2535,6 +2535,84 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t hipblasCrot_v2(hipblasHandle_t   handle,
+                               int               n,
+                               hipComplex*       x,
+                               int               incx,
+                               hipComplex*       y,
+                               int               incy,
+                               const float*      c,
+                               const hipComplex* s)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasCrot(
+        (cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy, c, (cuComplex*)s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCsrot_v2(hipblasHandle_t handle,
+                                int             n,
+                                hipComplex*     x,
+                                int             incx,
+                                hipComplex*     y,
+                                int             incy,
+                                const float*    c,
+                                const float*    s)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasCsrot((cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy, c, s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZrot_v2(hipblasHandle_t         handle,
+                               int                     n,
+                               hipDoubleComplex*       x,
+                               int                     incx,
+                               hipDoubleComplex*       y,
+                               int                     incy,
+                               const double*           c,
+                               const hipDoubleComplex* s)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasZrot((cublasHandle_t)handle,
+                                                 n,
+                                                 (cuDoubleComplex*)x,
+                                                 incx,
+                                                 (cuDoubleComplex*)y,
+                                                 incy,
+                                                 c,
+                                                 (cuDoubleComplex*)s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdrot_v2(hipblasHandle_t   handle,
+                                int               n,
+                                hipDoubleComplex* x,
+                                int               incx,
+                                hipDoubleComplex* y,
+                                int               incy,
+                                const double*     c,
+                                const double*     s)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasZdrot(
+        (cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, (cuDoubleComplex*)y, incy, c, s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // rot_batched
 hipblasStatus_t hipblasSrotBatched(hipblasHandle_t handle,
                                    int             n,
@@ -2610,6 +2688,58 @@ hipblasStatus_t hipblasZdrotBatched(hipblasHandle_t             handle,
                                     const double*               c,
                                     const double*               s,
                                     int                         batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCrotBatched_v2(hipblasHandle_t   handle,
+                                      int               n,
+                                      hipComplex* const x[],
+                                      int               incx,
+                                      hipComplex* const y[],
+                                      int               incy,
+                                      const float*      c,
+                                      const hipComplex* s,
+                                      int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCsrotBatched_v2(hipblasHandle_t   handle,
+                                       int               n,
+                                       hipComplex* const x[],
+                                       int               incx,
+                                       hipComplex* const y[],
+                                       int               incy,
+                                       const float*      c,
+                                       const float*      s,
+                                       int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZrotBatched_v2(hipblasHandle_t         handle,
+                                      int                     n,
+                                      hipDoubleComplex* const x[],
+                                      int                     incx,
+                                      hipDoubleComplex* const y[],
+                                      int                     incy,
+                                      const double*           c,
+                                      const hipDoubleComplex* s,
+                                      int                     batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdrotBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       hipDoubleComplex* const x[],
+                                       int                     incx,
+                                       hipDoubleComplex* const y[],
+                                       int                     incy,
+                                       const double*           c,
+                                       const double*           s,
+                                       int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -2701,6 +2831,66 @@ hipblasStatus_t hipblasZdrotStridedBatched(hipblasHandle_t       handle,
                                            const double*         c,
                                            const double*         s,
                                            int                   batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCrotStridedBatched_v2(hipblasHandle_t   handle,
+                                             int               n,
+                                             hipComplex*       x,
+                                             int               incx,
+                                             hipblasStride     stridex,
+                                             hipComplex*       y,
+                                             int               incy,
+                                             hipblasStride     stridey,
+                                             const float*      c,
+                                             const hipComplex* s,
+                                             int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCsrotStridedBatched_v2(hipblasHandle_t handle,
+                                              int             n,
+                                              hipComplex*     x,
+                                              int             incx,
+                                              hipblasStride   stridex,
+                                              hipComplex*     y,
+                                              int             incy,
+                                              hipblasStride   stridey,
+                                              const float*    c,
+                                              const float*    s,
+                                              int             batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZrotStridedBatched_v2(hipblasHandle_t         handle,
+                                             int                     n,
+                                             hipDoubleComplex*       x,
+                                             int                     incx,
+                                             hipblasStride           stridex,
+                                             hipDoubleComplex*       y,
+                                             int                     incy,
+                                             hipblasStride           stridey,
+                                             const double*           c,
+                                             const hipDoubleComplex* s,
+                                             int                     batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdrotStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              hipDoubleComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              hipDoubleComplex* y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              const double*     c,
+                                              const double*     s,
+                                              int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -3657,6 +3657,30 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasCswap_v2(hipblasHandle_t handle, int n, hipComplex* x, int incx, hipComplex* y, int incy)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasCswap((cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZswap_v2(
+    hipblasHandle_t handle, int n, hipDoubleComplex* x, int incx, hipDoubleComplex* y, int incy)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasZswap(
+        (cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, (cuDoubleComplex*)y, incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // swap_batched
 hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle,
                                     int             n,
@@ -3698,6 +3722,28 @@ hipblasStatus_t hipblasZswapBatched(hipblasHandle_t             handle,
                                     hipblasDoubleComplex* const y[],
                                     int                         incy,
                                     int                         batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCswapBatched_v2(hipblasHandle_t   handle,
+                                       int               n,
+                                       hipComplex* const x[],
+                                       int               incx,
+                                       hipComplex* const y[],
+                                       int               incy,
+                                       int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZswapBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       hipDoubleComplex* const x[],
+                                       int                     incx,
+                                       hipDoubleComplex* const y[],
+                                       int                     incy,
+                                       int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -3751,6 +3797,32 @@ hipblasStatus_t hipblasZswapStridedBatched(hipblasHandle_t       handle,
                                            int                   incy,
                                            hipblasStride         stridey,
                                            int                   batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCswapStridedBatched_v2(hipblasHandle_t handle,
+                                              int             n,
+                                              hipComplex*     x,
+                                              int             incx,
+                                              hipblasStride   stridex,
+                                              hipComplex*     y,
+                                              int             incy,
+                                              hipblasStride   stridey,
+                                              int             batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZswapStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              hipDoubleComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              hipDoubleComplex* y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -1227,6 +1227,45 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t hipblasCaxpy_v2(hipblasHandle_t   handle,
+                                int               n,
+                                const hipComplex* alpha,
+                                const hipComplex* x,
+                                int               incx,
+                                hipComplex*       y,
+                                int               incy)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasCaxpy(
+        (cublasHandle_t)handle, n, (cuComplex*)alpha, (cuComplex*)x, incx, (cuComplex*)y, incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZaxpy_v2(hipblasHandle_t         handle,
+                                int                     n,
+                                const hipDoubleComplex* alpha,
+                                const hipDoubleComplex* x,
+                                int                     incx,
+                                hipDoubleComplex*       y,
+                                int                     incy)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasZaxpy((cublasHandle_t)handle,
+                                                  n,
+                                                  (cuDoubleComplex*)alpha,
+                                                  (cuDoubleComplex*)x,
+                                                  incx,
+                                                  (cuDoubleComplex*)y,
+                                                  incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // axpy_batched
 hipblasStatus_t hipblasHaxpyBatched(hipblasHandle_t          handle,
                                     int                      n,
@@ -1292,6 +1331,30 @@ hipblasStatus_t hipblasZaxpyBatched(hipblasHandle_t                   handle,
                                     hipblasDoubleComplex* const       y[],
                                     int                               incy,
                                     int                               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCaxpyBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipComplex*       alpha,
+                                       const hipComplex* const x[],
+                                       int                     incx,
+                                       hipComplex* const       y[],
+                                       int                     incy,
+                                       int                     batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZaxpyBatched_v2(hipblasHandle_t               handle,
+                                       int                           n,
+                                       const hipDoubleComplex*       alpha,
+                                       const hipDoubleComplex* const x[],
+                                       int                           incx,
+                                       hipDoubleComplex* const       y[],
+                                       int                           incy,
+                                       int                           batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -1363,6 +1426,34 @@ hipblasStatus_t hipblasZaxpyStridedBatched(hipblasHandle_t             handle,
                                            int                         incy,
                                            hipblasStride               stridey,
                                            int                         batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCaxpyStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* alpha,
+                                              const hipComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              hipComplex*       y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZaxpyStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* alpha,
+                                              const hipDoubleComplex* x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              hipDoubleComplex*       y,
+                                              int                     incy,
+                                              hipblasStride           stridey,
+                                              int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -2272,6 +2272,30 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasScnrm2_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasScnrm2((cublasHandle_t)handle, n, (cuComplex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasDznrm2_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasDznrm2((cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // nrm2_batched
 hipblasStatus_t hipblasSnrm2Batched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
@@ -2305,6 +2329,26 @@ hipblasStatus_t hipblasDznrm2Batched(hipblasHandle_t                   handle,
                                      int                               incx,
                                      int                               batchCount,
                                      double*                           result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasScnrm2Batched_v2(hipblasHandle_t         handle,
+                                        int                     n,
+                                        const hipComplex* const x[],
+                                        int                     incx,
+                                        int                     batchCount,
+                                        float*                  result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDznrm2Batched_v2(hipblasHandle_t               handle,
+                                        int                           n,
+                                        const hipDoubleComplex* const x[],
+                                        int                           incx,
+                                        int                           batchCount,
+                                        double*                       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -2350,6 +2394,28 @@ hipblasStatus_t hipblasDznrm2StridedBatched(hipblasHandle_t             handle,
                                             hipblasStride               stridex,
                                             int                         batchCount,
                                             double*                     result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasScnrm2StridedBatched_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               hipblasStride     stridex,
+                                               int               batchCount,
+                                               float*            result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDznrm2StridedBatched_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               hipblasStride           stridex,
+                                               int                     batchCount,
+                                               double*                 result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -802,6 +802,30 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasIcamin_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, int* result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasIcamin((cublasHandle_t)handle, n, (cuComplex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasIzamin_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, int* result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasIzamin((cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // amin_batched
 hipblasStatus_t hipblasIsaminBatched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, int* result)
@@ -831,6 +855,26 @@ hipblasStatus_t hipblasIzaminBatched(hipblasHandle_t                   handle,
                                      int                               incx,
                                      int                               batchCount,
                                      int*                              result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasIcaminBatched_v2(hipblasHandle_t         handle,
+                                        int                     n,
+                                        const hipComplex* const x[],
+                                        int                     incx,
+                                        int                     batchCount,
+                                        int*                    result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasIzaminBatched_v2(hipblasHandle_t               handle,
+                                        int                           n,
+                                        const hipDoubleComplex* const x[],
+                                        int                           incx,
+                                        int                           batchCount,
+                                        int*                          result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -876,6 +920,28 @@ hipblasStatus_t hipblasIzaminStridedBatched(hipblasHandle_t             handle,
                                             hipblasStride               stridex,
                                             int                         batchCount,
                                             int*                        result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasIcaminStridedBatched_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               hipblasStride     stridex,
+                                               int               batchCount,
+                                               int*              result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasIzaminStridedBatched_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               hipblasStride           stridex,
+                                               int                     batchCount,
+                                               int*                    result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -3349,6 +3349,54 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasCscal_v2(hipblasHandle_t handle, int n, const hipComplex* alpha, hipComplex* x, int incx)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasCscal((cublasHandle_t)handle, n, (cuComplex*)alpha, (cuComplex*)x, incx));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t
+    hipblasCsscal_v2(hipblasHandle_t handle, int n, const float* alpha, hipComplex* x, int incx)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasCsscal((cublasHandle_t)handle, n, alpha, (cuComplex*)x, incx));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZscal_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* alpha, hipDoubleComplex* x, int incx)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasZscal((cublasHandle_t)handle, n, (cuDoubleComplex*)alpha, (cuDoubleComplex*)x, incx));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdscal_v2(
+    hipblasHandle_t handle, int n, const double* alpha, hipDoubleComplex* x, int incx)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasZdscal((cublasHandle_t)handle, n, alpha, (cuDoubleComplex*)x, incx));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // scal_batched
 hipblasStatus_t hipblasSscalBatched(
     hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batchCount)
@@ -3404,6 +3452,46 @@ hipblasStatus_t hipblasZdscalBatched(hipblasHandle_t             handle,
                                      hipblasDoubleComplex* const x[],
                                      int                         incx,
                                      int                         batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCscalBatched_v2(hipblasHandle_t   handle,
+                                       int               n,
+                                       const hipComplex* alpha,
+                                       hipComplex* const x[],
+                                       int               incx,
+                                       int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZscalBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipDoubleComplex* alpha,
+                                       hipDoubleComplex* const x[],
+                                       int                     incx,
+                                       int                     batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCsscalBatched_v2(hipblasHandle_t   handle,
+                                        int               n,
+                                        const float*      alpha,
+                                        hipComplex* const x[],
+                                        int               incx,
+                                        int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdscalBatched_v2(hipblasHandle_t         handle,
+                                        int                     n,
+                                        const double*           alpha,
+                                        hipDoubleComplex* const x[],
+                                        int                     incx,
+                                        int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -3471,6 +3559,50 @@ hipblasStatus_t hipblasZdscalStridedBatched(hipblasHandle_t       handle,
                                             int                   incx,
                                             hipblasStride         stridex,
                                             int                   batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCscalStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* alpha,
+                                              hipComplex*       x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZscalStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* alpha,
+                                              hipDoubleComplex*       x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              int                     batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCsscalStridedBatched_v2(hipblasHandle_t handle,
+                                               int             n,
+                                               const float*    alpha,
+                                               hipComplex*     x,
+                                               int             incx,
+                                               hipblasStride   stridex,
+                                               int             batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdscalStridedBatched_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const double*     alpha,
+                                               hipDoubleComplex* x,
+                                               int               incx,
+                                               hipblasStride     stridex,
+                                               int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -1509,6 +1509,34 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t hipblasCcopy_v2(
+    hipblasHandle_t handle, int n, const hipComplex* x, int incx, hipComplex* y, int incy)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasCcopy((cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZcopy_v2(hipblasHandle_t         handle,
+                                int                     n,
+                                const hipDoubleComplex* x,
+                                int                     incx,
+                                hipDoubleComplex*       y,
+                                int                     incy)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasZcopy(
+        (cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, (cuDoubleComplex*)y, incy));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // copy_batched
 hipblasStatus_t hipblasScopyBatched(hipblasHandle_t    handle,
                                     int                n,
@@ -1550,6 +1578,28 @@ hipblasStatus_t hipblasZcopyBatched(hipblasHandle_t                   handle,
                                     hipblasDoubleComplex* const       y[],
                                     int                               incy,
                                     int                               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCcopyBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipComplex* const x[],
+                                       int                     incx,
+                                       hipComplex* const       y[],
+                                       int                     incy,
+                                       int                     batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZcopyBatched_v2(hipblasHandle_t               handle,
+                                       int                           n,
+                                       const hipDoubleComplex* const x[],
+                                       int                           incx,
+                                       hipDoubleComplex* const       y[],
+                                       int                           incy,
+                                       int                           batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -1603,6 +1653,32 @@ hipblasStatus_t hipblasZcopyStridedBatched(hipblasHandle_t             handle,
                                            int                         incy,
                                            hipblasStride               stridey,
                                            int                         batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCcopyStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              hipComplex*       y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZcopyStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              hipDoubleComplex*       y,
+                                              int                     incy,
+                                              hipblasStride           stridey,
+                                              int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -2943,6 +2943,33 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasCrotg_v2(hipblasHandle_t handle, hipComplex* a, hipComplex* b, float* c, hipComplex* s)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasCrotg((cublasHandle_t)handle, (cuComplex*)a, (cuComplex*)b, c, (cuComplex*)s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZrotg_v2(hipblasHandle_t   handle,
+                                hipDoubleComplex* a,
+                                hipDoubleComplex* b,
+                                double*           c,
+                                hipDoubleComplex* s)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasZrotg(
+        (cublasHandle_t)handle, (cuDoubleComplex*)a, (cuDoubleComplex*)b, c, (cuDoubleComplex*)s));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // rotg_batchced
 hipblasStatus_t hipblasSrotgBatched(hipblasHandle_t handle,
                                     float* const    a[],
@@ -2980,6 +3007,26 @@ hipblasStatus_t hipblasZrotgBatched(hipblasHandle_t             handle,
                                     double* const               c[],
                                     hipblasDoubleComplex* const s[],
                                     int                         batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCrotgBatched_v2(hipblasHandle_t   handle,
+                                       hipComplex* const a[],
+                                       hipComplex* const b[],
+                                       float* const      c[],
+                                       hipComplex* const s[],
+                                       int               batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZrotgBatched_v2(hipblasHandle_t         handle,
+                                       hipDoubleComplex* const a[],
+                                       hipDoubleComplex* const b[],
+                                       double* const           c[],
+                                       hipDoubleComplex* const s[],
+                                       int                     batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -3037,6 +3084,34 @@ hipblasStatus_t hipblasZrotgStridedBatched(hipblasHandle_t       handle,
                                            hipblasDoubleComplex* s,
                                            hipblasStride         stride_s,
                                            int                   batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCrotgStridedBatched_v2(hipblasHandle_t handle,
+                                              hipComplex*     a,
+                                              hipblasStride   stride_a,
+                                              hipComplex*     b,
+                                              hipblasStride   stride_b,
+                                              float*          c,
+                                              hipblasStride   stride_c,
+                                              hipComplex*     s,
+                                              hipblasStride   stride_s,
+                                              int             batchCount)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZrotgStridedBatched_v2(hipblasHandle_t   handle,
+                                              hipDoubleComplex* a,
+                                              hipblasStride     stride_a,
+                                              hipDoubleComplex* b,
+                                              hipblasStride     stride_b,
+                                              double*           c,
+                                              hipblasStride     stride_c,
+                                              hipDoubleComplex* s,
+                                              hipblasStride     stride_s,
+                                              int               batchCount)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -1818,6 +1818,84 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t hipblasCdotc_v2(hipblasHandle_t   handle,
+                                int               n,
+                                const hipComplex* x,
+                                int               incx,
+                                const hipComplex* y,
+                                int               incy,
+                                hipComplex*       result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasCdotc(
+        (cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy, (cuComplex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasCdotu_v2(hipblasHandle_t   handle,
+                                int               n,
+                                const hipComplex* x,
+                                int               incx,
+                                const hipComplex* y,
+                                int               incy,
+                                hipComplex*       result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasCdotu(
+        (cublasHandle_t)handle, n, (cuComplex*)x, incx, (cuComplex*)y, incy, (cuComplex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdotc_v2(hipblasHandle_t         handle,
+                                int                     n,
+                                const hipDoubleComplex* x,
+                                int                     incx,
+                                const hipDoubleComplex* y,
+                                int                     incy,
+                                hipDoubleComplex*       result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasZdotc((cublasHandle_t)handle,
+                                                  n,
+                                                  (cuDoubleComplex*)x,
+                                                  incx,
+                                                  (cuDoubleComplex*)y,
+                                                  incy,
+                                                  (cuDoubleComplex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasZdotu_v2(hipblasHandle_t         handle,
+                                int                     n,
+                                const hipDoubleComplex* x,
+                                int                     incx,
+                                const hipDoubleComplex* y,
+                                int                     incy,
+                                hipDoubleComplex*       result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(cublasZdotu((cublasHandle_t)handle,
+                                                  n,
+                                                  (cuDoubleComplex*)x,
+                                                  incx,
+                                                  (cuDoubleComplex*)y,
+                                                  incy,
+                                                  (cuDoubleComplex*)result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // dot_batched
 hipblasStatus_t hipblasHdotBatched(hipblasHandle_t          handle,
                                    int                      n,
@@ -1931,6 +2009,54 @@ hipblasStatus_t hipblasZdotuBatched(hipblasHandle_t                   handle,
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
+hipblasStatus_t hipblasCdotcBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipComplex* const x[],
+                                       int                     incx,
+                                       const hipComplex* const y[],
+                                       int                     incy,
+                                       int                     batchCount,
+                                       hipComplex*             result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCdotuBatched_v2(hipblasHandle_t         handle,
+                                       int                     n,
+                                       const hipComplex* const x[],
+                                       int                     incx,
+                                       const hipComplex* const y[],
+                                       int                     incy,
+                                       int                     batchCount,
+                                       hipComplex*             result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdotcBatched_v2(hipblasHandle_t               handle,
+                                       int                           n,
+                                       const hipDoubleComplex* const x[],
+                                       int                           incx,
+                                       const hipDoubleComplex* const y[],
+                                       int                           incy,
+                                       int                           batchCount,
+                                       hipDoubleComplex*             result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdotuBatched_v2(hipblasHandle_t               handle,
+                                       int                           n,
+                                       const hipDoubleComplex* const x[],
+                                       int                           incx,
+                                       const hipDoubleComplex* const y[],
+                                       int                           incy,
+                                       int                           batchCount,
+                                       hipDoubleComplex*             result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
 // dot_strided_batched
 hipblasStatus_t hipblasHdotStridedBatched(hipblasHandle_t    handle,
                                           int                n,
@@ -2040,6 +2166,62 @@ hipblasStatus_t hipblasZdotuStridedBatched(hipblasHandle_t             handle,
                                            hipblasStride               stridey,
                                            int                         batchCount,
                                            hipblasDoubleComplex*       result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCdotcStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              const hipComplex* y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount,
+                                              hipComplex*       result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasCdotuStridedBatched_v2(hipblasHandle_t   handle,
+                                              int               n,
+                                              const hipComplex* x,
+                                              int               incx,
+                                              hipblasStride     stridex,
+                                              const hipComplex* y,
+                                              int               incy,
+                                              hipblasStride     stridey,
+                                              int               batchCount,
+                                              hipComplex*       result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdotcStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              const hipDoubleComplex* y,
+                                              int                     incy,
+                                              hipblasStride           stridey,
+                                              int                     batchCount,
+                                              hipDoubleComplex*       result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasZdotuStridedBatched_v2(hipblasHandle_t         handle,
+                                              int                     n,
+                                              const hipDoubleComplex* x,
+                                              int                     incx,
+                                              hipblasStride           stridex,
+                                              const hipDoubleComplex* y,
+                                              int                     incy,
+                                              hipblasStride           stridey,
+                                              int                     batchCount,
+                                              hipDoubleComplex*       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -992,6 +992,30 @@ catch(...)
     return exception_to_hipblas_status();
 }
 
+hipblasStatus_t
+    hipblasScasum_v2(hipblasHandle_t handle, int n, const hipComplex* x, int incx, float* result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasScasum((cublasHandle_t)handle, n, (cuComplex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
+hipblasStatus_t hipblasDzasum_v2(
+    hipblasHandle_t handle, int n, const hipDoubleComplex* x, int incx, double* result)
+try
+{
+    return hipCUBLASStatusToHIPStatus(
+        cublasDzasum((cublasHandle_t)handle, n, (cuDoubleComplex*)x, incx, result));
+}
+catch(...)
+{
+    return exception_to_hipblas_status();
+}
+
 // asum_batched
 hipblasStatus_t hipblasSasumBatched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result)
@@ -1032,6 +1056,26 @@ hipblasStatus_t hipblasDzasumBatched(hipblasHandle_t                   handle,
                                      int                               incx,
                                      int                               batchCount,
                                      double*                           result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasScasumBatched_v2(hipblasHandle_t         handle,
+                                        int                     n,
+                                        const hipComplex* const x[],
+                                        int                     incx,
+                                        int                     batchCount,
+                                        float*                  result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDzasumBatched_v2(hipblasHandle_t               handle,
+                                        int                           n,
+                                        const hipDoubleComplex* const x[],
+                                        int                           incx,
+                                        int                           batchCount,
+                                        double*                       result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
@@ -1077,6 +1121,28 @@ hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t             handle,
                                             hipblasStride               stridex,
                                             int                         batchCount,
                                             double*                     result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
+                                            int               n,
+                                            const hipComplex* x,
+                                            int               incx,
+                                            hipblasStride     stridex,
+                                            int               batchCount,
+                                            float*            result)
+{
+    return HIPBLAS_STATUS_NOT_SUPPORTED;
+}
+
+hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
+                                            int                     n,
+                                            const hipDoubleComplex* x,
+                                            int                     incx,
+                                            hipblasStride           stridex,
+                                            int                     batchCount,
+                                            double*                 result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }

--- a/library/src/nvidia_detail/hipblas.cpp
+++ b/library/src/nvidia_detail/hipblas.cpp
@@ -1125,24 +1125,24 @@ hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t             handle,
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasScasumStridedBatched(hipblasHandle_t   handle,
-                                            int               n,
-                                            const hipComplex* x,
-                                            int               incx,
-                                            hipblasStride     stridex,
-                                            int               batchCount,
-                                            float*            result)
+hipblasStatus_t hipblasScasumStridedBatched_v2(hipblasHandle_t   handle,
+                                               int               n,
+                                               const hipComplex* x,
+                                               int               incx,
+                                               hipblasStride     stridex,
+                                               int               batchCount,
+                                               float*            result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }
 
-hipblasStatus_t hipblasDzasumStridedBatched(hipblasHandle_t         handle,
-                                            int                     n,
-                                            const hipDoubleComplex* x,
-                                            int                     incx,
-                                            hipblasStride           stridex,
-                                            int                     batchCount,
-                                            double*                 result)
+hipblasStatus_t hipblasDzasumStridedBatched_v2(hipblasHandle_t         handle,
+                                               int                     n,
+                                               const hipDoubleComplex* x,
+                                               int                     incx,
+                                               hipblasStride           stridex,
+                                               int                     batchCount,
+                                               double*                 result)
 {
     return HIPBLAS_STATUS_NOT_SUPPORTED;
 }


### PR DESCRIPTION
Adding hipComplex/hipDoubleComplex version for all L1 functions.

Details:
- hipblas_template_specialization.cpp changes: We're using hipblasComplex types for clients, so need to cast to hipComplex well calling hipblas.h API when using HIPBLAS_V2 define.
- blas1_gtest.cpp changes: adding tests for single/double complex precisions
- hipblas_fortran.hpp changes: client-side C++ interface for Fortran interface, changes needed to use new API for HIPBLAS_V2 changes for minimal code changes in test infrastructure. No changes made in actual .f90/.mod files
- hipblas.h changes: introduce new _v2 API, add `#define` when HIPBLAS_V2 is defined