### PR TITLE
Fix --yaml flag for hipblas-bench and hipblas-test

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -47,6 +47,13 @@ def runTestCommand (platform, project)
                 """
 
     platform.runCommand(this, v2TestCommand)
+
+    def yamlTestCommand = """#!/usr/bin/env bash
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release/clients/staging
+                    ${sudo} LD_LIBRARY_PATH=/opt/rocm/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./hipblas-test --gtest_output=xml --gtest_color=yes --yaml hipblas_smoke.yaml
+                """
+    platform.runCommand(this, yamlTestCommand)
     junit "${project.paths.project_build_prefix}/build/release/clients/staging/*.xml"
 }
 

--- a/clients/common/hipblas_gentest.py
+++ b/clients/common/hipblas_gentest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
 
   Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/clients/include/hipblas_common.yaml
+++ b/clients/include/hipblas_common.yaml
@@ -377,6 +377,7 @@ Arguments:
   - batch_count: int
   - fortran: c_bool
   - inplace: c_bool
+  - with_flags: c_bool
   - norm_check: int
   - unit_check: int
   - timing: int
@@ -458,6 +459,7 @@ Defaults:
   batch_count: -1
   fortran: false
   inplace: false
+  with_flags: false
   norm_check: 0
   unit_check: 1
   timing: 0


### PR DESCRIPTION
--yaml flag for hipblas-bench/hipblas-test is likely broken since #647.

With this change `./hipblas-test --yaml hipblas_smoke.yaml` all passed, `./hipblas-bench --yaml hipblas_smoke.yaml` works as well.