### PR TITLE
[5.7.0 docs] Set min rocm-docs-core version to 0.24.0

### DIFF
--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core==0.22.0
+rocm-docs-core>=0.24.0

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -92,7 +92,7 @@ requests==2.31.0
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==0.22.0
+rocm-docs-core>=0.24.0
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb


### PR DESCRIPTION
Summary of proposed changes:
- Set min doc requirements: rocm-docs-core version 0.24.0  for 5.7.0
