### PR TITLE
Cuda yaml test fixes

### DIFF
--- a/clients/gtest/blas1/asum_gtest.yaml
+++ b/clients/gtest/blas1/asum_gtest.yaml
@@ -28,7 +28,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: asum_strided_batched_general
     category: quick
@@ -39,5 +39,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas1/axpy_gtest.yaml
+++ b/clients/gtest/blas1/axpy_gtest.yaml
@@ -35,7 +35,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: axpy_batched_general
     category: quick
@@ -46,7 +46,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: axpy_strided_batched_general
     category: quick
@@ -58,5 +58,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas1/copy_gtest.yaml
+++ b/clients/gtest/blas1/copy_gtest.yaml
@@ -30,7 +30,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: copy_strided_batched_general
     category: quick
@@ -41,5 +41,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas1/dot_gtest.yaml
+++ b/clients/gtest/blas1/dot_gtest.yaml
@@ -32,7 +32,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: dot_batched_general
     category: quick
@@ -43,7 +43,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: dot_strided_batched_general
     category: quick
@@ -55,5 +55,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas1/iamaxmin_gtest.yaml
+++ b/clients/gtest/blas1/iamaxmin_gtest.yaml
@@ -30,7 +30,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: iamaxmin_strided_batched_general
     category: quick
@@ -42,5 +42,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas1/nrm2_gtest.yaml
+++ b/clients/gtest/blas1/nrm2_gtest.yaml
@@ -28,7 +28,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: nrm2_strided_batched_general
     category: quick
@@ -39,5 +39,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas1/rot_gtest.yaml
+++ b/clients/gtest/blas1/rot_gtest.yaml
@@ -33,7 +33,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: rot_strided_batched_general
     category: quick
@@ -45,7 +45,7 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   # rotg, rotmg
   - name: rotg_general
@@ -62,7 +62,7 @@ Tests:
       - rotmg_batched: *single_double_precisions
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: rotg_strided_batched_general
     category: quick
@@ -72,5 +72,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas1/scal_gtest.yaml
+++ b/clients/gtest/blas1/scal_gtest.yaml
@@ -35,7 +35,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: scal_strided_batched_general
     category: quick
@@ -48,5 +48,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas1/swap_gtest.yaml
+++ b/clients/gtest/blas1/swap_gtest.yaml
@@ -30,7 +30,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: swap_strided_batched_general
     category: quick
@@ -41,5 +41,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/gbmv_gtest.yaml
+++ b/clients/gtest/blas2/gbmv_gtest.yaml
@@ -42,7 +42,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: gbmv_strided_batched_general
     category: quick
@@ -55,5 +55,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/gemv_gtest.yaml
+++ b/clients/gtest/blas2/gemv_gtest.yaml
@@ -41,7 +41,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: gemv_strided_batched_general
     category: quick
@@ -54,5 +54,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/ger_gtest.yaml
+++ b/clients/gtest/blas2/ger_gtest.yaml
@@ -41,7 +41,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: ger_strided_batched_general
     category: quick
@@ -55,5 +55,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/hbmv_gtest.yaml
+++ b/clients/gtest/blas2/hbmv_gtest.yaml
@@ -41,7 +41,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: hbmv_strided_batched_general
     category: quick
@@ -54,5 +54,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/hemv_gtest.yaml
+++ b/clients/gtest/blas2/hemv_gtest.yaml
@@ -41,7 +41,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: hemv_strided_batched_general
     category: quick
@@ -54,5 +54,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/her2_gtest.yaml
+++ b/clients/gtest/blas2/her2_gtest.yaml
@@ -43,7 +43,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: her2_strided_batched_general
     category: quick
@@ -56,5 +56,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/her_gtest.yaml
+++ b/clients/gtest/blas2/her_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: her_strided_batched_general
     category: quick
@@ -52,5 +52,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/hpmv_gtest.yaml
+++ b/clients/gtest/blas2/hpmv_gtest.yaml
@@ -40,7 +40,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: hpmv_strided_batched_general
     category: quick
@@ -53,5 +53,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/hpr2_gtest.yaml
+++ b/clients/gtest/blas2/hpr2_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: hpr2_strided_batched_general
     category: quick
@@ -52,5 +52,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/hpr_gtest.yaml
+++ b/clients/gtest/blas2/hpr_gtest.yaml
@@ -35,7 +35,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: hpr_strided_batched_general
     category: quick
@@ -48,5 +48,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/sbmv_gtest.yaml
+++ b/clients/gtest/blas2/sbmv_gtest.yaml
@@ -42,7 +42,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: sbmv_strided_batched_general
     category: quick
@@ -55,5 +55,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/spmv_gtest.yaml
+++ b/clients/gtest/blas2/spmv_gtest.yaml
@@ -40,7 +40,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: spmv_strided_batched_general
     category: quick
@@ -53,5 +53,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/spr2_gtest.yaml
+++ b/clients/gtest/blas2/spr2_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: spr2_strided_batched_general
     category: quick
@@ -52,5 +52,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/spr_gtest.yaml
+++ b/clients/gtest/blas2/spr_gtest.yaml
@@ -35,7 +35,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: spr_strided_batched_general
     category: quick
@@ -48,5 +48,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/spr_gtest.yaml
+++ b/clients/gtest/blas2/spr_gtest.yaml
@@ -18,12 +18,23 @@ Tests:
   - name: spr_general
     category: quick
     function: spr
-    precision: *single_double_precisions_complex_real
+    precision: *single_double_precisions
     uplo: [ 'L', 'U' ]
     alpha: *alpha_range
     N: *N_range
     incx: *incx_range
     api: [ FORTRAN, C ]
+
+  - name: spr_complex_general
+    category: quick
+    function: spr
+    precision: *single_double_precisions_complex
+    uplo: [ 'L', 'U' ]
+    alpha: *alpha_range
+    N: *N_range
+    incx: *incx_range
+    api: [ FORTRAN, C ]
+    backend_flags: AMD
 
   - name: spr_batched_general
     category: quick

--- a/clients/gtest/blas2/symv_gtest.yaml
+++ b/clients/gtest/blas2/symv_gtest.yaml
@@ -44,7 +44,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: symv_strided_batched_general
     category: quick
@@ -57,5 +57,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/syr2_gtest.yaml
+++ b/clients/gtest/blas2/syr2_gtest.yaml
@@ -43,7 +43,7 @@ Tests:
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: syr2_strided_batched_general
     category: quick
@@ -56,5 +56,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/syr_gtest.yaml
+++ b/clients/gtest/blas2/syr_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: syr_strided_batched_general
     category: quick
@@ -52,5 +52,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/tbmv_gtest.yaml
+++ b/clients/gtest/blas2/tbmv_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: tbmv_strided_batched_general
     category: quick
@@ -53,5 +53,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/tbsv_gtest.yaml
+++ b/clients/gtest/blas2/tbsv_gtest.yaml
@@ -40,7 +40,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: tbsv_strided_batched_general
     category: quick
@@ -54,5 +54,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/tpmv_gtest.yaml
+++ b/clients/gtest/blas2/tpmv_gtest.yaml
@@ -35,7 +35,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: tpmv_strided_batched_general
     category: quick
@@ -49,5 +49,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/tpsv_gtest.yaml
+++ b/clients/gtest/blas2/tpsv_gtest.yaml
@@ -35,7 +35,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: tpsv_strided_batched_general
     category: quick
@@ -49,5 +49,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/trmv_gtest.yaml
+++ b/clients/gtest/blas2/trmv_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: trmv_strided_batched_general
     category: quick
@@ -53,5 +53,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas2/trsv_gtest.yaml
+++ b/clients/gtest/blas2/trsv_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: trsv_strided_batched_general
     category: quick
@@ -53,5 +53,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/dgmm_gtest.yaml
+++ b/clients/gtest/blas3/dgmm_gtest.yaml
@@ -32,7 +32,7 @@ Tests:
     incx: *incx_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: dgmm_strided_batched_general
     category: quick
@@ -44,5 +44,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/geam_gtest.yaml
+++ b/clients/gtest/blas3/geam_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: geam_strided_batched_general
     category: quick
@@ -52,5 +52,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/gemm_gtest.yaml
+++ b/clients/gtest/blas3/gemm_gtest.yaml
@@ -39,7 +39,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: gemm_strided_batched_general
     category: quick
@@ -52,5 +52,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/hemm_gtest.yaml
+++ b/clients/gtest/blas3/hemm_gtest.yaml
@@ -36,7 +36,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: hemm_strided_batched_general
     category: quick
@@ -49,5 +49,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/her2k_gtest.yaml
+++ b/clients/gtest/blas3/her2k_gtest.yaml
@@ -38,7 +38,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: her2k_strided_batched_general
     category: quick
@@ -51,5 +51,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/herk_gtest.yaml
+++ b/clients/gtest/blas3/herk_gtest.yaml
@@ -38,7 +38,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: herk_strided_batched_general
     category: quick
@@ -51,5 +51,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/herkx_gtest.yaml
+++ b/clients/gtest/blas3/herkx_gtest.yaml
@@ -38,7 +38,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: herkx_strided_batched_general
     category: quick
@@ -51,5 +51,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/symm_gtest.yaml
+++ b/clients/gtest/blas3/symm_gtest.yaml
@@ -34,7 +34,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: symm_strided_batched_general
     category: quick
@@ -47,5 +47,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/syr2k_gtest.yaml
+++ b/clients/gtest/blas3/syr2k_gtest.yaml
@@ -33,7 +33,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: syr2k_strided_batched_general
     category: quick
@@ -46,5 +46,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/syrk_gtest.yaml
+++ b/clients/gtest/blas3/syrk_gtest.yaml
@@ -33,7 +33,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: syrk_strided_batched_general
     category: quick
@@ -46,5 +46,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/syrkx_gtest.yaml
+++ b/clients/gtest/blas3/syrkx_gtest.yaml
@@ -33,7 +33,7 @@ Tests:
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: syrkx_strided_batched_general
     category: quick
@@ -46,5 +46,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/trmm_gtest.yaml
+++ b/clients/gtest/blas3/trmm_gtest.yaml
@@ -38,7 +38,7 @@ Tests:
     alpha_beta: *alpha_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: trmm_strided_batched_general
     category: quick
@@ -53,5 +53,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/trsm_gtest.yaml
+++ b/clients/gtest/blas3/trsm_gtest.yaml
@@ -38,7 +38,7 @@ Tests:
     alpha_beta: *alpha_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: trsm_strided_batched_general
     category: quick
@@ -53,5 +53,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/trtri_gtest.yaml
+++ b/clients/gtest/blas3/trtri_gtest.yaml
@@ -32,7 +32,7 @@ Tests:
     matrix_size: *size_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 
   - name: trtri_strided_batched_general
     category: quick
@@ -44,5 +44,5 @@ Tests:
     batch_count: *batch_count_range
     stride_scale: [ 1.0, 2.5 ]
     api: [ FORTRAN, C ]
-    hipblas_backend: AMD
+    backend_flags: AMD
 ...

--- a/clients/gtest/blas3/trtri_gtest.yaml
+++ b/clients/gtest/blas3/trtri_gtest.yaml
@@ -22,6 +22,7 @@ Tests:
     diag: [ 'N', 'U' ]
     matrix_size: *size_range
     api: [ FORTRAN, C ]
+    backend_flags: AMD
 
   - name: trtri_batched_general
     category: quick

--- a/clients/gtest/hipblas_gtest_main.cpp
+++ b/clients/gtest/hipblas_gtest_main.cpp
@@ -77,6 +77,8 @@ struct data_driven : public testing::TestWithParam<Arguments>
 
     static bool function_filter(const Arguments& arg)
     {
+        if(!hipblas_client_global_filters(args))
+            return false;
         return true;
     }
 

--- a/clients/gtest/hipblas_gtest_main.cpp
+++ b/clients/gtest/hipblas_gtest_main.cpp
@@ -77,7 +77,7 @@ struct data_driven : public testing::TestWithParam<Arguments>
 
     static bool function_filter(const Arguments& arg)
     {
-        if(!hipblas_client_global_filters(args))
+        if(!hipblas_client_global_filters(arg))
             return false;
         return true;
     }


### PR DESCRIPTION
No cuda CI for develop-6.1 branch, this has fixes that were missed in previous PRs by removing unsupported tests with cuda backend.