### PR TITLE
General cleanup for clang warnings

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -991,34 +991,16 @@ void cblas_iamax<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int
 // amin
 // amin is not implemented in cblas, make local version
 template <typename T>
-double abs_helper(T val)
-{
-    return val < 0 ? -val : val;
-}
-
-template <>
-double abs_helper(hipblasComplex val)
-{
-    return std::abs(val.real()) + std::abs(val.imag());
-}
-
-template <>
-double abs_helper(hipblasDoubleComplex val)
-{
-    return std::abs(val.real()) + std::abs(val.imag());
-}
-
-template <typename T>
 int cblas_iamin_helper(int N, const T* X, int incx)
 {
     int minpos = -1;
     if(N > 0 && incx > 0)
     {
-        auto min = abs_helper(X[0]);
+        auto min = hipblas_abs(X[0]);
         minpos   = 0;
         for(size_t i = 1; i < N; ++i)
         {
-            auto a = abs_helper(X[i * incx]);
+            auto a = hipblas_abs(X[i * incx]);
             if(a < min)
             {
                 min    = a;

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -991,16 +991,34 @@ void cblas_iamax<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int
 // amin
 // amin is not implemented in cblas, make local version
 template <typename T>
+double hipblas_magnitude(T val)
+{
+    return val < 0 ? -val : val;
+}
+
+template <>
+double hipblas_magnitude(hipblasComplex val)
+{
+    return std::abs(val.real()) + std::abs(val.imag());
+}
+
+template <>
+double hipblas_magnitude(hipblasDoubleComplex val)
+{
+    return std::abs(val.real()) + std::abs(val.imag());
+}
+
+template <typename T>
 int cblas_iamin_helper(int N, const T* X, int incx)
 {
     int minpos = -1;
     if(N > 0 && incx > 0)
     {
-        auto min = hipblas_abs(X[0]);
+        auto min = hipblas_magnitude(X[0]);
         minpos   = 0;
         for(size_t i = 1; i < N; ++i)
         {
-            auto a = hipblas_abs(X[i * incx]);
+            auto a = hipblas_magnitude(X[i * incx]);
             if(a < min)
             {
                 min    = a;

--- a/clients/include/blas1/testing_iamax_iamin.hpp
+++ b/clients/include/blas1/testing_iamax_iamin.hpp
@@ -113,8 +113,8 @@ void testing_iamax_iamin(const Arguments& arg, hipblas_iamax_iamin_t<T> func)
         }
         if(arg.norm_check)
         {
-            hipblas_error_host   = std::abs(hipblas_result_host - cpu_result);
-            hipblas_error_device = std::abs(hipblas_result_device - cpu_result);
+            hipblas_error_host   = hipblas_abs(hipblas_result_host - cpu_result);
+            hipblas_error_device = hipblas_abs(hipblas_result_device - cpu_result);
         }
     }
 

--- a/clients/include/blas1/testing_iamax_iamin_batched.hpp
+++ b/clients/include/blas1/testing_iamax_iamin_batched.hpp
@@ -124,10 +124,11 @@ void testing_iamax_iamin_batched(const Arguments& arg, hipblas_iamax_iamin_batch
         {
             for(int b = 0; b < batch_count; b++)
             {
-                hipblas_error_host   = std::max(hipblas_error_host,
-                                              std::abs(hipblas_result_host[b] - cpu_result[b]));
-                hipblas_error_device = std::max(hipblas_error_device,
-                                                std::abs(hipblas_result_device[b] - cpu_result[b]));
+                hipblas_error_host = std::max(
+                    hipblas_error_host, (int)hipblas_abs(hipblas_result_host[b] - cpu_result[b]));
+                hipblas_error_device
+                    = std::max(hipblas_error_device,
+                               (int)hipblas_abs(hipblas_result_device[b] - cpu_result[b]));
             }
         }
     } // end of if unit/norm check

--- a/clients/include/blas1/testing_iamax_iamin_batched.hpp
+++ b/clients/include/blas1/testing_iamax_iamin_batched.hpp
@@ -124,11 +124,10 @@ void testing_iamax_iamin_batched(const Arguments& arg, hipblas_iamax_iamin_batch
         {
             for(int b = 0; b < batch_count; b++)
             {
-                hipblas_error_host = std::max(
-                    hipblas_error_host, (int)hipblas_abs(hipblas_result_host[b] - cpu_result[b]));
-                hipblas_error_device
-                    = std::max(hipblas_error_device,
-                               (int)hipblas_abs(hipblas_result_device[b] - cpu_result[b]));
+                hipblas_error_host   = std::max(hipblas_error_host,
+                                              hipblas_abs(hipblas_result_host[b] - cpu_result[b]));
+                hipblas_error_device = std::max(
+                    hipblas_error_device, hipblas_abs(hipblas_result_device[b] - cpu_result[b]));
             }
         }
     } // end of if unit/norm check

--- a/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
@@ -140,10 +140,11 @@ void testing_iamax_iamin_strided_batched(const Arguments&                       
         {
             for(int b = 0; b < batch_count; b++)
             {
-                hipblas_error_host   = std::max(hipblas_error_host,
-                                              std::abs(hipblas_result_host[b] - cpu_result[b]));
-                hipblas_error_device = std::max(hipblas_error_device,
-                                                std::abs(hipblas_result_device[b] - cpu_result[b]));
+                hipblas_error_host = std::max(
+                    hipblas_error_host, (int)hipblas_abs(hipblas_result_host[b] - cpu_result[b]));
+                hipblas_error_device
+                    = std::max(hipblas_error_device,
+                               (int)hipblas_abs(hipblas_result_device[b] - cpu_result[b]));
             }
         }
     } // end of if unit/norm check

--- a/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
@@ -140,11 +140,10 @@ void testing_iamax_iamin_strided_batched(const Arguments&                       
         {
             for(int b = 0; b < batch_count; b++)
             {
-                hipblas_error_host = std::max(
-                    hipblas_error_host, (int)hipblas_abs(hipblas_result_host[b] - cpu_result[b]));
-                hipblas_error_device
-                    = std::max(hipblas_error_device,
-                               (int)hipblas_abs(hipblas_result_device[b] - cpu_result[b]));
+                hipblas_error_host   = std::max(hipblas_error_host,
+                                              hipblas_abs(hipblas_result_host[b] - cpu_result[b]));
+                hipblas_error_device = std::max(
+                    hipblas_error_device, hipblas_abs(hipblas_result_device[b] - cpu_result[b]));
             }
         }
     } // end of if unit/norm check

--- a/clients/include/blas2/testing_tbsv.hpp
+++ b/clients/include/blas2/testing_tbsv.hpp
@@ -119,7 +119,7 @@ void testing_tbsv(const Arguments& arg)
             hipMemcpy(hx_or_b_1.data(), dx_or_b, sizeof(T) * size_x, hipMemcpyDeviceToHost));
 
         // Calculating error
-        hipblas_error = std::abs(vector_norm_1<T>(N, abs_incx, hx.data(), hx_or_b_1.data()));
+        hipblas_error = hipblas_abs(vector_norm_1<T>(N, abs_incx, hx.data(), hx_or_b_1.data()));
 
         if(arg.unit_check)
         {

--- a/clients/include/blas2/testing_tbsv_batched.hpp
+++ b/clients/include/blas2/testing_tbsv_batched.hpp
@@ -139,7 +139,7 @@ void testing_tbsv_batched(const Arguments& arg)
         // For norm_check/bench, currently taking the cumulative sum of errors over all batches
         for(int b = 0; b < batch_count; b++)
         {
-            hipblas_error = std::abs(vector_norm_1<T>(N, abs_incx, hx[b], hx_or_b[b]));
+            hipblas_error = hipblas_abs(vector_norm_1<T>(N, abs_incx, hx[b], hx_or_b[b]));
             if(arg.unit_check)
             {
                 double tolerance = std::numeric_limits<real_t<T>>::epsilon() * 40 * N;

--- a/clients/include/blas2/testing_tbsv_strided_batched.hpp
+++ b/clients/include/blas2/testing_tbsv_strided_batched.hpp
@@ -169,7 +169,7 @@ void testing_tbsv_strided_batched(const Arguments& arg)
         // For norm_check/bench, currently taking the cumulative sum of errors over all batches
         for(int b = 0; b < batch_count; b++)
         {
-            hipblas_error = std::abs(vector_norm_1<T>(
+            hipblas_error = hipblas_abs(vector_norm_1<T>(
                 N, abs_incx, hx.data() + b * stridex, hx_or_b_1.data() + b * stridex));
             if(arg.unit_check)
             {

--- a/clients/include/blas2/testing_tpsv.hpp
+++ b/clients/include/blas2/testing_tpsv.hpp
@@ -114,7 +114,7 @@ void testing_tpsv(const Arguments& arg)
         for(int j = 0; j < N; j++)
         {
             hA[i + j * N] = AAT[i + j * N];
-            t += std::abs(AAT[i + j * N]);
+            t += hipblas_abs(AAT[i + j * N]);
         }
         hA[i + i * N] = t;
     }
@@ -165,7 +165,7 @@ void testing_tpsv(const Arguments& arg)
             hipMemcpy(hx_or_b_1.data(), dx_or_b, sizeof(T) * size_x, hipMemcpyDeviceToHost));
 
         // Calculating error
-        hipblas_error = std::abs(vector_norm_1<T>(N, abs_incx, hx.data(), hx_or_b_1.data()));
+        hipblas_error = hipblas_abs(vector_norm_1<T>(N, abs_incx, hx.data(), hx_or_b_1.data()));
 
         if(arg.unit_check)
         {

--- a/clients/include/blas2/testing_tpsv_batched.hpp
+++ b/clients/include/blas2/testing_tpsv_batched.hpp
@@ -118,7 +118,7 @@ void testing_tpsv_batched(const Arguments& arg)
             for(int j = 0; j < N; j++)
             {
                 hA[b][i + j * N] = AAT[b][i + j * N];
-                t += std::abs(AAT[b][i + j * N]);
+                t += hipblas_abs(AAT[b][i + j * N]);
             }
             hA[b][i + i * N] = t;
         }
@@ -180,7 +180,7 @@ void testing_tpsv_batched(const Arguments& arg)
         // For norm_check/bench, currently taking the cumulative sum of errors over all batches
         for(int b = 0; b < batch_count; b++)
         {
-            hipblas_error = std::abs(vector_norm_1<T>(N, abs_incx, hx[b], hx_or_b_1[b]));
+            hipblas_error = hipblas_abs(vector_norm_1<T>(N, abs_incx, hx[b], hx_or_b_1[b]));
             if(arg.unit_check)
             {
                 double tolerance = std::numeric_limits<real_t<T>>::epsilon() * 40 * N;

--- a/clients/include/blas2/testing_tpsv_strided_batched.hpp
+++ b/clients/include/blas2/testing_tpsv_strided_batched.hpp
@@ -112,7 +112,7 @@ void testing_tpsv_strided_batched(const Arguments& arg)
             for(int j = 0; j < N; j++)
             {
                 hAb[i + j * N] = AATb[i + j * N];
-                t += std::abs(AATb[i + j * N]);
+                t += hipblas_abs(AATb[i + j * N]);
             }
             hAb[i + i * N] = t;
         }
@@ -169,7 +169,7 @@ void testing_tpsv_strided_batched(const Arguments& arg)
         // For norm_check/bench, currently taking the cumulative sum of errors over all batches
         for(int b = 0; b < batch_count; b++)
         {
-            hipblas_error = std::abs(vector_norm_1<T>(
+            hipblas_error = hipblas_abs(vector_norm_1<T>(
                 N, abs_incx, hx.data() + b * stridex, hx_or_b_1.data() + b * stridex));
             if(arg.unit_check)
             {

--- a/clients/include/blas2/testing_trsv.hpp
+++ b/clients/include/blas2/testing_trsv.hpp
@@ -107,7 +107,7 @@ void testing_trsv(const Arguments& arg)
         for(int j = 0; j < N; j++)
         {
             hA[i + j * lda] = AAT[i + j * lda];
-            t += std::abs(AAT[i + j * lda]);
+            t += hipblas_abs(AAT[i + j * lda]);
         }
         hA[i + i * lda] = t;
     }
@@ -156,7 +156,7 @@ void testing_trsv(const Arguments& arg)
             hipMemcpy(hx_or_b_1.data(), dx_or_b, sizeof(T) * size_x, hipMemcpyDeviceToHost));
 
         // Calculating error
-        hipblas_error = std::abs(vector_norm_1<T>(N, abs_incx, hx.data(), hx_or_b_1.data()));
+        hipblas_error = hipblas_abs(vector_norm_1<T>(N, abs_incx, hx.data(), hx_or_b_1.data()));
 
         if(arg.unit_check)
         {

--- a/clients/include/blas2/testing_trsv_batched.hpp
+++ b/clients/include/blas2/testing_trsv_batched.hpp
@@ -114,7 +114,7 @@ void testing_trsv_batched(const Arguments& arg)
             for(int j = 0; j < N; j++)
             {
                 hA[b][i + j * lda] = AAT[b][i + j * lda];
-                t += std::abs(AAT[b][i + j * lda]);
+                t += hipblas_abs(AAT[b][i + j * lda]);
             }
             hA[b][i + i * lda] = t;
         }
@@ -176,7 +176,7 @@ void testing_trsv_batched(const Arguments& arg)
         // For norm_check/bench, currently taking the cumulative sum of errors over all batches
         for(int b = 0; b < batch_count; b++)
         {
-            hipblas_error = std::abs(vector_norm_1<T>(N, abs_incx, hx[b], hx_or_b_1[b]));
+            hipblas_error = hipblas_abs(vector_norm_1<T>(N, abs_incx, hx[b], hx_or_b_1[b]));
             if(arg.unit_check)
             {
                 double tolerance = std::numeric_limits<real_t<T>>::epsilon() * 40 * N;

--- a/clients/include/blas2/testing_trsv_strided_batched.hpp
+++ b/clients/include/blas2/testing_trsv_strided_batched.hpp
@@ -126,7 +126,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
             for(int j = 0; j < N; j++)
             {
                 hAb[i + j * lda] = AATb[i + j * lda];
-                t += std::abs(AATb[i + j * lda]);
+                t += hipblas_abs(AATb[i + j * lda]);
             }
             hAb[i + i * lda] = t;
         }
@@ -180,7 +180,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
         // For norm_check/bench, currently taking the cumulative sum of errors over all batches
         for(int b = 0; b < batch_count; b++)
         {
-            hipblas_error = std::abs(vector_norm_1<T>(
+            hipblas_error = hipblas_abs(vector_norm_1<T>(
                 N, abs_incx, hx.data() + b * stridex, hx_or_b_1.data() + b * stridex));
             if(arg.unit_check)
             {

--- a/clients/include/blas3/testing_gemm.hpp
+++ b/clients/include/blas3/testing_gemm.hpp
@@ -188,9 +188,10 @@ void testing_gemm(const Arguments& arg)
         }
         if(arg.norm_check)
         {
-            hipblas_error_host = std::abs(norm_check_general<T>('F', M, N, ldc, hC_copy, hC_host));
+            hipblas_error_host
+                = hipblas_abs(norm_check_general<T>('F', M, N, ldc, hC_copy, hC_host));
             hipblas_error_device
-                = std::abs(norm_check_general<T>('F', M, N, ldc, hC_copy, hC_device));
+                = hipblas_abs(norm_check_general<T>('F', M, N, ldc, hC_copy, hC_device));
         }
 
     } // end of if unit/norm check

--- a/clients/include/blas3/testing_syrkx.hpp
+++ b/clients/include/blas3/testing_syrkx.hpp
@@ -131,9 +131,10 @@ void testing_syrkx(const Arguments& arg)
         }
         if(arg.norm_check)
         {
-            hipblas_error_host = std::abs(norm_check_general<T>('F', N, N, ldc, hC_gold, hC_host));
+            hipblas_error_host
+                = hipblas_abs(norm_check_general<T>('F', N, N, ldc, hC_gold, hC_host));
             hipblas_error_device
-                = std::abs(norm_check_general<T>('F', N, N, ldc, hC_gold, hC_device));
+                = hipblas_abs(norm_check_general<T>('F', N, N, ldc, hC_gold, hC_device));
         }
     }
 

--- a/clients/include/blas3/testing_syrkx_strided_batched.hpp
+++ b/clients/include/blas3/testing_syrkx_strided_batched.hpp
@@ -196,9 +196,9 @@ void testing_syrkx_strided_batched(const Arguments& arg)
         }
         if(arg.norm_check)
         {
-            hipblas_error_host = std::abs(
+            hipblas_error_host = hipblas_abs(
                 norm_check_general<T>('F', N, N, ldc, stride_C, hC_gold, hC_host, batch_count));
-            hipblas_error_device = std::abs(
+            hipblas_error_device = hipblas_abs(
                 norm_check_general<T>('F', N, N, ldc, stride_C, hC_gold, hC_device, batch_count));
         }
     }

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -290,9 +290,10 @@ void testing_gemm_ex(const Arguments& arg)
         }
         if(norm_check)
         {
-            hipblas_error_host = std::abs(norm_check_general<To>('F', M, N, ldc, hC_gold, hC_host));
+            hipblas_error_host
+                = hipblas_abs(norm_check_general<To>('F', M, N, ldc, hC_gold, hC_host));
             hipblas_error_device
-                = std::abs(norm_check_general<To>('F', M, N, ldc, hC_gold, hC_device));
+                = hipblas_abs(norm_check_general<To>('F', M, N, ldc, hC_gold, hC_device));
         }
     }
 

--- a/clients/include/complex.hpp
+++ b/clients/include/complex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -194,16 +194,6 @@ namespace std
     inline hipblasDoubleComplex conj(const hipblasDoubleComplex& z)
     {
         return {z.real(), -z.imag()};
-    }
-
-    inline float abs(const hipblasComplex& z)
-    {
-        return abs(reinterpret_cast<const complex<float>&>(z));
-    }
-
-    inline double abs(const hipblasDoubleComplex& z)
-    {
-        return abs(reinterpret_cast<const complex<double>&>(z));
     }
 
     inline float conj(const float& r)

--- a/clients/include/hipblas_datatype2string.hpp
+++ b/clients/include/hipblas_datatype2string.hpp
@@ -133,8 +133,10 @@ inline constexpr auto hipblas_datatype2string(hipblasDatatype_t type)
         return "bf16_r";
     case HIPBLAS_C_16B:
         return "bf16_c";
+#ifndef HIPBLAS_V2
     case HIPBLAS_DATATYPE_INVALID:
         return "invalid";
+#endif
     default:
         // Missing some datatypes for hipDataType with HIPBLAS_V2. Types included
         // here are thorough for our use cases for now, can be expanded on once hipDataType

--- a/clients/include/norm.h
+++ b/clients/include/norm.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,7 @@
 
 #include "hipblas.h"
 #include "hipblas_vector.hpp"
+#include "utility.h"
 
 /* =====================================================================
         Norm check: norm(A-B)/norm(A), evaluate relative error
@@ -169,11 +170,11 @@ double vector_norm_1(int M, int incx, T* hx_gold, T* hx)
     double max_err      = 0.0;
     for(int i = 0; i < M; i++)
     {
-        max_err += std::abs((hx_gold[i * incx] - hx[i * incx]));
-        max_err_scal += std::abs(hx_gold[i * incx]);
+        max_err += hipblas_abs((hx_gold[i * incx] - hx[i * incx]));
+        max_err_scal += hipblas_abs(hx_gold[i * incx]);
     }
 
-    if(std::abs(max_err_scal) < 1e6)
+    if(hipblas_abs(max_err_scal) < 1e6)
         max_err_scal = 1;
 
     return max_err / max_err_scal;

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -184,7 +184,8 @@ inline float half_to_float(hipblasHalf val)
 #endif
 }
 
-// Absolute values
+/* =============================================================================================== */
+/* Absolute values                                                                                 */
 template <typename T>
 inline double hipblas_abs(const T& x)
 {
@@ -211,6 +212,11 @@ inline double hipblas_abs(const hipblasComplex& x)
 inline double hipblas_abs(const hipblasDoubleComplex& x)
 {
     return abs(reinterpret_cast<const std::complex<double>&>(x));
+}
+
+inline int hipblas_abs(const int& x)
+{
+    return x < 0 ? -x : x;
 }
 
 /* =============================================================================================== */

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -184,6 +184,35 @@ inline float half_to_float(hipblasHalf val)
 #endif
 }
 
+// Absolute values
+template <typename T>
+inline double hipblas_abs(const T& x)
+{
+    return x < 0 ? -x : x;
+}
+
+template <>
+inline double hipblas_abs(const hipblasHalf& x)
+{
+    return std::abs(half_to_float(x));
+}
+
+template <>
+inline double hipblas_abs(const hipblasBfloat16& x)
+{
+    return std::abs(bfloat16_to_float(x));
+}
+
+inline double hipblas_abs(const hipblasComplex& x)
+{
+    return abs(reinterpret_cast<const std::complex<float>&>(x));
+}
+
+inline double hipblas_abs(const hipblasDoubleComplex& x)
+{
+    return abs(reinterpret_cast<const std::complex<double>&>(x));
+}
+
 /* =============================================================================================== */
 /* Complex / real helpers.                                                                         */
 template <typename T>
@@ -851,7 +880,7 @@ void prepare_triangular_solve(T* hA, int lda, T* AAT, int N, char char_uplo)
         for(int j = 0; j < N; j++)
         {
             hA[i + j * lda] = AAT[i + j * lda];
-            t += std::abs(AAT[i + j * lda]);
+            t += hipblas_abs(AAT[i + j * lda]);
         }
         hA[i + i * lda] = t;
     }

--- a/library/src/amd_detail/hipblas.cpp
+++ b/library/src/amd_detail/hipblas.cpp
@@ -259,8 +259,10 @@ rocblas_datatype HIPDatatypeToRocblasDatatype_v2(hipDataType type)
 
     case HIP_C_16BF:
         return rocblas_datatype_bf16_c;
+
+    default:
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
-    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_datatype HIPDatatypeToRocblasDatatype(hipblasDatatype_t type)
@@ -314,8 +316,9 @@ rocblas_datatype HIPDatatypeToRocblasDatatype(hipblasDatatype_t type)
 
     case HIPBLAS_C_16B:
         return rocblas_datatype_bf16_c;
+    default:
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
-    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasDatatype_t RocblasDatatypeToHIPDatatype(rocblas_datatype type)
@@ -345,8 +348,9 @@ hipblasDatatype_t RocblasDatatypeToHIPDatatype(rocblas_datatype type)
 
     case rocblas_datatype_f64_c:
         return HIPBLAS_C_64F;
+    default:
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
-    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_gemm_algo HIPGemmAlgoToRocblasGemmAlgo(hipblasGemmAlgo_t algo)
@@ -365,8 +369,9 @@ hipblasGemmAlgo_t RocblasGemmAlgoToHIPGemmAlgo(rocblas_gemm_algo algo)
     {
     case rocblas_gemm_algo_standard:
         return HIPBLAS_GEMM_DEFAULT;
+    default:
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
-    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_gemm_flags HIPGemmFlagsToRocblasGemmFlags(hipblasGemmFlags_t flags)
@@ -383,8 +388,9 @@ rocblas_gemm_flags HIPGemmFlagsToRocblasGemmFlags(hipblasGemmFlags_t flags)
         return rocblas_gemm_flags_check_solution_index;
     case HIPBLAS_GEMM_FLAGS_FP16_ALT_IMPL_RNZ:
         return rocblas_gemm_flags_fp16_alt_impl_rnz;
+    default:
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
-    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 hipblasGemmFlags_t RocblasGemmFlagsToHIPGemmFlags(rocblas_gemm_flags flags)
@@ -401,8 +407,9 @@ hipblasGemmFlags_t RocblasGemmFlagsToHIPGemmFlags(rocblas_gemm_flags flags)
         return HIPBLAS_GEMM_FLAGS_CHECK_SOLUTION_INDEX;
     case rocblas_gemm_flags_fp16_alt_impl_rnz:
         return HIPBLAS_GEMM_FLAGS_FP16_ALT_IMPL_RNZ;
+    default:
+        throw HIPBLAS_STATUS_INVALID_ENUM;
     }
-    throw HIPBLAS_STATUS_INVALID_ENUM;
 }
 
 rocblas_atomics_mode HIPAtomicsModeToRocblasAtomicsMode(hipblasAtomicsMode_t mode)


### PR DESCRIPTION
- Adds hipblas_abs to use instead of std::abs for accurate abs for our half/bf16/complex types.
- Adds default cases in switch statements.

This should clean up hipcc/clang++ build warnings.