### PR TITLE
Enabling and adding bad-arg tests for rocsolver

### DIFF
--- a/clients/gtest/solver/gels_gtest.cpp
+++ b/clients/gtest/solver/gels_gtest.cpp
@@ -114,10 +114,16 @@ namespace
         {
             if(!strcmp(arg.function, "gels"))
                 testing_gels<T>(arg);
+            else if(!strcmp(arg.function, "gels_bad_arg"))
+                testing_gels_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "gels_batched"))
                 testing_gels_batched<T>(arg);
+            else if(!strcmp(arg.function, "gels_batched_bad_arg"))
+                testing_gels_batched_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "gels_strided_batched"))
                 testing_gels_strided_batched<T>(arg);
+            else if(!strcmp(arg.function, "gels_strided_batched_bad_arg"))
+                testing_gels_strided_batched_bad_arg<T>(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }

--- a/clients/gtest/solver/gels_gtest.yaml
+++ b/clients/gtest/solver/gels_gtest.yaml
@@ -65,5 +65,6 @@ Tests:
       - gels_batched_bad_arg
     precision: *single_double_precisions_complex_real
     api: [ FORTRAN, C ]
+    bad_arg_all: false
     backend_flags: NVIDIA
 ...

--- a/clients/gtest/solver/gels_gtest.yaml
+++ b/clients/gtest/solver/gels_gtest.yaml
@@ -48,4 +48,22 @@ Tests:
     stride_scale: [ 2.0 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
+
+  - name: gels_bad_arg
+    category: quick
+    function:
+      - gels_bad_arg
+      - gels_batched_bad_arg
+      - gels_strided_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: AMD
+
+  - name: gels_bad_arg
+    category: quick
+    function:
+      - gels_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: NVIDIA
 ...

--- a/clients/gtest/solver/geqrf_gtest.cpp
+++ b/clients/gtest/solver/geqrf_gtest.cpp
@@ -114,10 +114,16 @@ namespace
         {
             if(!strcmp(arg.function, "geqrf"))
                 testing_geqrf<T>(arg);
+            else if(!strcmp(arg.function, "geqrf_bad_arg"))
+                testing_geqrf_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "geqrf_batched"))
                 testing_geqrf_batched<T>(arg);
+            else if(!strcmp(arg.function, "geqrf_batched_bad_arg"))
+                testing_geqrf_batched_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "geqrf_strided_batched"))
                 testing_geqrf_strided_batched<T>(arg);
+            else if(!strcmp(arg.function, "geqrf_strided_batched_bad_arg"))
+                testing_geqrf_strided_batched_bad_arg<T>(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }

--- a/clients/gtest/solver/geqrf_gtest.yaml
+++ b/clients/gtest/solver/geqrf_gtest.yaml
@@ -52,5 +52,6 @@ Tests:
       - geqrf_batched_bad_arg
     precision: *single_double_precisions_complex_real
     api: [ FORTRAN, C ]
+    bad_arg_all: false
     backend_flags: NVIDIA
 ...

--- a/clients/gtest/solver/geqrf_gtest.yaml
+++ b/clients/gtest/solver/geqrf_gtest.yaml
@@ -35,4 +35,22 @@ Tests:
     stride_scale: [ 2.0 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
+
+  - name: geqrf_bad_arg
+    category: quick
+    function:
+      - geqrf_bad_arg
+      - geqrf_batched_bad_arg
+      - geqrf_strided_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: AMD
+
+  - name: geqrf_bad_arg
+    category: quick
+    function:
+      - geqrf_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: NVIDIA
 ...

--- a/clients/gtest/solver/getrf_gtest.cpp
+++ b/clients/gtest/solver/getrf_gtest.cpp
@@ -73,17 +73,22 @@ namespace
             switch(GETRF_TYPE)
             {
             case GETRF:
-                return !strcmp(arg.function, "getrf");
+                return !strcmp(arg.function, "getrf") || !strcmp(arg.function, "getrf_bad_arg");
             case GETRF_BATCHED:
-                return !strcmp(arg.function, "getrf_batched");
+                return !strcmp(arg.function, "getrf_batched")
+                       || !strcmp(arg.function, "getrf_batched_bad_arg");
             case GETRF_STRIDED_BATCHED:
-                return !strcmp(arg.function, "getrf_strided_batched");
+                return !strcmp(arg.function, "getrf_strided_batched")
+                       || !strcmp(arg.function, "getrf_strided_batched_bad_arg");
             case GETRF_NPVT:
-                return !strcmp(arg.function, "getrf_npvt");
+                return !strcmp(arg.function, "getrf_npvt")
+                       || !strcmp(arg.function, "getrf_npvt_bad_arg");
             case GETRF_NPVT_BATCHED:
-                return !strcmp(arg.function, "getrf_npvt_batched");
+                return !strcmp(arg.function, "getrf_npvt_batched")
+                       || !strcmp(arg.function, "getrf_npvt_batched_bad_arg");
             case GETRF_NPVT_STRIDED_BATCHED:
-                return !strcmp(arg.function, "getrf_npvt_strided_batched");
+                return !strcmp(arg.function, "getrf_npvt_strided_batched")
+                       || !strcmp(arg.function, "getrf_npvt_strided_batched_bad_arg");
             }
             return false;
         }
@@ -130,16 +135,28 @@ namespace
         {
             if(!strcmp(arg.function, "getrf"))
                 testing_getrf<T>(arg);
+            else if(!strcmp(arg.function, "getrf_bad_arg"))
+                testing_getrf_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "getrf_batched"))
                 testing_getrf_batched<T>(arg);
+            else if(!strcmp(arg.function, "getrf_batched_bad_arg"))
+                testing_getrf_batched_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "getrf_strided_batched"))
                 testing_getrf_strided_batched<T>(arg);
+            else if(!strcmp(arg.function, "getrf_strided_batched_bad_arg"))
+                testing_getrf_strided_batched_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "getrf_npvt"))
                 testing_getrf_npvt<T>(arg);
+            else if(!strcmp(arg.function, "getrf_npvt_bad_arg"))
+                testing_getrf_npvt_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "getrf_npvt_batched"))
                 testing_getrf_npvt_batched<T>(arg);
+            else if(!strcmp(arg.function, "getrf_npvt_batched_bad_arg"))
+                testing_getrf_npvt_batched_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "getrf_npvt_strided_batched"))
                 testing_getrf_npvt_strided_batched<T>(arg);
+            else if(!strcmp(arg.function, "getrf_npvt_strided_batched_bad_arg"))
+                testing_getrf_npvt_strided_batched_bad_arg<T>(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }

--- a/clients/gtest/solver/getrf_gtest.yaml
+++ b/clients/gtest/solver/getrf_gtest.yaml
@@ -59,5 +59,6 @@ Tests:
       - getrf_npvt_batched_bad_arg
     precision: *single_double_precisions_complex_real
     api: [ FORTRAN, C ]
+    bad_arg_all: false
     backend_flags: NVIDIA
 ...

--- a/clients/gtest/solver/getrf_gtest.yaml
+++ b/clients/gtest/solver/getrf_gtest.yaml
@@ -38,4 +38,26 @@ Tests:
     stride_scale: [ 2.0 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
+
+  - name: getrf_bad_arg
+    category: quick
+    function:
+      - getrf_bad_arg
+      - getrf_npvt_bad_arg
+      - getrf_batched_bad_arg
+      - getrf_npvt_batched_bad_arg
+      - getrf_strided_batched_bad_arg
+      - getrf_npvt_strided_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: AMD
+
+  - name: getrf_bad_arg
+    category: quick
+    function:
+      - getrf_batched_bad_arg
+      - getrf_npvt_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: NVIDIA
 ...

--- a/clients/gtest/solver/getri_gtest.cpp
+++ b/clients/gtest/solver/getri_gtest.cpp
@@ -65,9 +65,11 @@ namespace
             switch(GETRI_TYPE)
             {
             case GETRI_BATCHED:
-                return !strcmp(arg.function, "getri_batched");
+                return !strcmp(arg.function, "getri_batched")
+                       || !strcmp(arg.function, "getri_batched_bad_arg");
             case GETRI_NPVT_BATCHED:
-                return !strcmp(arg.function, "getri_npvt_batched");
+                return !strcmp(arg.function, "getri_npvt_batched")
+                       || !strcmp(arg.function, "getri_npvt_batched_bad_arg");
             }
             return false;
         }
@@ -106,8 +108,12 @@ namespace
         {
             if(!strcmp(arg.function, "getri_batched"))
                 testing_getri_batched<T>(arg);
+            else if(!strcmp(arg.function, "getri_batched_bad_arg"))
+                testing_getri_batched_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "getri_npvt_batched"))
                 testing_getri_npvt_batched<T>(arg);
+            else if(!strcmp(arg.function, "getri_npvt_batched_bad_arg"))
+                testing_getri_npvt_batched_bad_arg<T>(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }

--- a/clients/gtest/solver/getri_gtest.yaml
+++ b/clients/gtest/solver/getri_gtest.yaml
@@ -18,4 +18,13 @@ Tests:
     matrix_size: *size_range
     batch_count: *batch_count_range
     api: [ FORTRAN, C ]
+
+  - name: getri_bad_arg
+    category: quick
+    function:
+      - getri_batched_bad_arg
+      - getri_npvt_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: AMD
 ...

--- a/clients/gtest/solver/getrs_gtest.cpp
+++ b/clients/gtest/solver/getrs_gtest.cpp
@@ -114,10 +114,16 @@ namespace
         {
             if(!strcmp(arg.function, "getrs"))
                 testing_getrs<T>(arg);
+            else if(!strcmp(arg.function, "getrs_bad_arg"))
+                testing_getrs_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "getrs_batched"))
                 testing_getrs_batched<T>(arg);
+            else if(!strcmp(arg.function, "getrs_batched_bad_arg"))
+                testing_getrs_batched_bad_arg<T>(arg);
             else if(!strcmp(arg.function, "getrs_strided_batched"))
                 testing_getrs_strided_batched<T>(arg);
+            else if(!strcmp(arg.function, "getrs_strided_batched_bad_arg"))
+                testing_getrs_strided_batched_bad_arg<T>(arg);
             else
                 FAIL() << "Internal error: Test called with unknown function: " << arg.function;
         }

--- a/clients/gtest/solver/getrs_gtest.yaml
+++ b/clients/gtest/solver/getrs_gtest.yaml
@@ -35,4 +35,22 @@ Tests:
     stride_scale: [ 2.0 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
+
+  - name: getrs_bad_arg
+    category: quick
+    function:
+      - getrs_bad_arg
+      - getrs_batched_bad_arg
+      - getrs_strided_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: AMD
+
+  - name: getrs_bad_arg
+    category: quick
+    function:
+      - getrs_batched_bad_arg
+    precision: *single_double_precisions_complex_real
+    api: [ FORTRAN, C ]
+    backend_flags: NVIDIA
 ...

--- a/clients/gtest/solver/getrs_gtest.yaml
+++ b/clients/gtest/solver/getrs_gtest.yaml
@@ -52,5 +52,6 @@ Tests:
       - getrs_batched_bad_arg
     precision: *single_double_precisions_complex_real
     api: [ FORTRAN, C ]
+    bad_arg_all: false
     backend_flags: NVIDIA
 ...

--- a/clients/include/solver/testing_gels_batched.hpp
+++ b/clients/include/solver/testing_gels_batched.hpp
@@ -72,17 +72,14 @@ void testing_gels_batched_bad_arg(const Arguments& arg)
 
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(
-            handle, opBad, M, N, nrhs, dAp, lda, dBp, ldb, &info, dInfo, batchCount),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -1;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
-
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGelsBatchedFn(
             handle, opN, -1, N, nrhs, dAp, lda, dBp, ldb, &info, dInfo, batchCount),
         HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -2;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
+
+    if(arg.bad_arg_all)
+    {
+        expectedInfo = -2; // cublas gets -1
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+    }
 
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(
@@ -94,57 +91,45 @@ void testing_gels_batched_bad_arg(const Arguments& arg)
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(handle, opN, M, N, -1, dAp, lda, dBp, ldb, &info, dInfo, batchCount),
         HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -4;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
 
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGelsBatchedFn(
-            handle, opN, M, N, nrhs, nullptr, lda, dBp, ldb, &info, dInfo, batchCount),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -5;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
+    if(arg.bad_arg_all)
+    {
+        expectedInfo = -4; // cublas gets -2
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+    }
 
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(
             handle, opN, M, N, nrhs, dAp, M - 1, dBp, ldb, &info, dInfo, batchCount),
         HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -6;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
 
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGelsBatchedFn(
-            handle, opN, M, N, nrhs, dAp, lda, nullptr, ldb, &info, dInfo, batchCount),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -7;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
+    if(arg.bad_arg_all)
+    {
+        expectedInfo = -6; // cublas gets -5
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+    }
 
     // Explicit values to check for ldb < M and ldb < N
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(
-            handle, opN, 100, 200, nrhs, dAp, lda, dBp, 199, &info, dInfo, batchCount),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -8;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
-
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGelsBatchedFn(
             handle, opN, 200, 100, nrhs, dAp, 201, dBp, 199, &info, dInfo, batchCount),
         HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -8;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
 
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGelsBatchedFn(
-            handle, opN, M, N, nrhs, dAp, lda, dBp, ldb, &info, nullptr, batchCount),
-        HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -10;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
+    if(arg.bad_arg_all)
+    {
+        expectedInfo = -8; // cublas gets -7
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+    }
 
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(handle, opN, M, N, nrhs, dAp, lda, dBp, ldb, &info, dInfo, -1),
         HIPBLAS_STATUS_INVALID_VALUE);
-    expectedInfo = -11;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
+
+    if(arg.bad_arg_all)
+    {
+        expectedInfo = -11; // cublas gets -8
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+    }
 
     // If M == 0 || N == 0, A can be nullptr
     EXPECT_HIPBLAS_STATUS(
@@ -157,14 +142,6 @@ void testing_gels_batched_bad_arg(const Arguments& arg)
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(
             handle, opN, M, 0, nrhs, nullptr, lda, dBp, ldb, &info, dInfo, batchCount),
-        HIPBLAS_STATUS_SUCCESS);
-    expectedInfo = 0;
-    unit_check_general(1, 1, 1, &expectedInfo, &info);
-
-    // If nrhs == 0, B can be nullptr
-    EXPECT_HIPBLAS_STATUS(
-        hipblasGelsBatchedFn(
-            handle, opN, M, N, 0, dAp, lda, nullptr, ldb, &info, dInfo, batchCount),
         HIPBLAS_STATUS_SUCCESS);
     expectedInfo = 0;
     unit_check_general(1, 1, 1, &expectedInfo, &info);
@@ -183,6 +160,53 @@ void testing_gels_batched_bad_arg(const Arguments& arg)
         HIPBLAS_STATUS_SUCCESS);
     expectedInfo = 0;
     unit_check_general(1, 1, 1, &expectedInfo, &info);
+
+    if(arg.bad_arg_all)
+    {
+        // cuBLAS returns HIPBLAS_STATUS_NOT_SUPPORTED for these cases, not checking  for now.
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGelsBatchedFn(
+                handle, opBad, M, N, nrhs, dAp, lda, dBp, ldb, &info, dInfo, batchCount),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        expectedInfo = -1;
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGelsBatchedFn(
+                handle, opN, M, N, nrhs, nullptr, lda, dBp, ldb, &info, dInfo, batchCount),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        expectedInfo = -5;
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGelsBatchedFn(
+                handle, opN, M, N, nrhs, dAp, lda, nullptr, ldb, &info, dInfo, batchCount),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        expectedInfo = -7;
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGelsBatchedFn(
+                handle, opN, 100, 200, nrhs, dAp, lda, dBp, 199, &info, dInfo, batchCount),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        expectedInfo = -8;
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGelsBatchedFn(
+                handle, opN, M, N, nrhs, dAp, lda, dBp, ldb, &info, nullptr, batchCount),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        expectedInfo = -10;
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+
+        // If nrhs == 0, B can be nullptr
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGelsBatchedFn(
+                handle, opN, M, N, 0, dAp, lda, nullptr, ldb, &info, dInfo, batchCount),
+            HIPBLAS_STATUS_SUCCESS);
+        expectedInfo = 0;
+        unit_check_general(1, 1, 1, &expectedInfo, &info);
+    }
 }
 
 template <typename T>

--- a/clients/include/solver/testing_getrf.hpp
+++ b/clients/include/solver/testing_getrf.hpp
@@ -36,6 +36,44 @@ inline void testname_getrf(const Arguments& arg, std::string& name)
 }
 
 template <typename T>
+void testing_getrf_bad_arg(const Arguments& arg)
+{
+    bool FORTRAN        = arg.fortran;
+    auto hipblasGetrfFn = FORTRAN ? hipblasGetrf<T, true> : hipblasGetrf<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    int64_t            N         = 101;
+    int64_t            M         = N;
+    int64_t            lda       = 102;
+    int64_t            A_size    = N * lda;
+    int64_t            Ipiv_size = std::min(M, N);
+
+    device_vector<T>   dA(A_size);
+    device_vector<int> dIpiv(Ipiv_size);
+    device_vector<int> dInfo(1);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(nullptr, N, dA, lda, dIpiv, dInfo),
+                          HIPBLAS_STATUS_NOT_INITIALIZED);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(handle, -1, dA, lda, dIpiv, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(handle, N, dA, N - 1, dIpiv, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    // If N == 0, A and ipiv can be nullptr
+    CHECK_HIPBLAS_ERROR(hipblasGetrfFn(handle, 0, nullptr, lda, nullptr, dInfo));
+
+    if(arg.bad_arg_all)
+    {
+        EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(handle, N, nullptr, lda, dIpiv, dInfo),
+                              HIPBLAS_STATUS_INVALID_VALUE);
+        EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(handle, N, dA, lda, dIpiv, nullptr),
+                              HIPBLAS_STATUS_INVALID_VALUE);
+    }
+}
+
+template <typename T>
 void testing_getrf(const Arguments& arg)
 {
     using U             = real_t<T>;

--- a/clients/include/solver/testing_getrf_batched.hpp
+++ b/clients/include/solver/testing_getrf_batched.hpp
@@ -36,6 +36,56 @@ inline void testname_getrf_batched(const Arguments& arg, std::string& name)
 }
 
 template <typename T>
+void testing_getrf_batched_bad_arg(const Arguments& arg)
+{
+    bool FORTRAN = arg.fortran;
+    auto hipblasGetrfBatchedFn
+        = FORTRAN ? hipblasGetrfBatched<T, true> : hipblasGetrfBatched<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    int64_t            N           = 101;
+    int64_t            M           = N;
+    int64_t            lda         = 102;
+    int64_t            batch_count = 2;
+    int64_t            A_size      = N * lda;
+    int64_t            Ipiv_size   = std::min(M, N) * batch_count;
+
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_vector<int>     dIpiv(Ipiv_size);
+    device_vector<int>     dInfo(batch_count);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfBatchedFn(nullptr, N, dA.ptr_on_device(), lda, dIpiv, dInfo, batch_count),
+        HIPBLAS_STATUS_NOT_INITIALIZED);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfBatchedFn(handle, -1, dA.ptr_on_device(), lda, dIpiv, dInfo, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfBatchedFn(handle, N, dA.ptr_on_device(), N - 1, dIpiv, dInfo, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfBatchedFn(handle, N, dA.ptr_on_device(), lda, dIpiv, dInfo, -1),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    // If N == 0, A and ipiv can be nullptr. rocSolver doesn't allow nullptr with batch_count == 0
+    CHECK_HIPBLAS_ERROR(
+        hipblasGetrfBatchedFn(handle, 0, nullptr, lda, nullptr, dInfo, batch_count));
+
+    if(arg.bad_arg_all)
+    {
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGetrfBatchedFn(handle, N, nullptr, lda, dIpiv, dInfo, batch_count),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGetrfBatchedFn(handle, N, dA.ptr_on_device(), lda, dIpiv, nullptr, batch_count),
+            HIPBLAS_STATUS_INVALID_VALUE);
+    }
+}
+
+template <typename T>
 void testing_getrf_batched(const Arguments& arg)
 {
     using U      = real_t<T>;
@@ -77,7 +127,7 @@ void testing_getrf_batched(const Arguments& arg)
     double             gpu_time_used, hipblas_error;
     hipblasLocalHandle handle(arg);
 
-    // Initial hA on CPU
+    // Initialize hA on CPU
     hipblas_init(hA, true);
     for(int b = 0; b < batch_count; b++)
     {

--- a/clients/include/solver/testing_getrf_npvt.hpp
+++ b/clients/include/solver/testing_getrf_npvt.hpp
@@ -36,6 +36,39 @@ inline void testname_getrf_npvt(const Arguments& arg, std::string& name)
 }
 
 template <typename T>
+void testing_getrf_npvt_bad_arg(const Arguments& arg)
+{
+    bool FORTRAN        = arg.fortran;
+    auto hipblasGetrfFn = FORTRAN ? hipblasGetrf<T, true> : hipblasGetrf<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    int64_t            N      = 101;
+    int64_t            M      = N;
+    int64_t            lda    = 102;
+    int64_t            A_size = N * lda;
+
+    device_vector<T>   dA(A_size);
+    device_vector<int> dInfo(1);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(nullptr, N, dA, lda, nullptr, dInfo),
+                          HIPBLAS_STATUS_NOT_INITIALIZED);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(handle, -1, dA, lda, nullptr, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(handle, N, dA, N - 1, nullptr, dInfo),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    if(arg.bad_arg_all)
+    {
+        EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(handle, N, nullptr, lda, nullptr, dInfo),
+                              HIPBLAS_STATUS_INVALID_VALUE);
+        EXPECT_HIPBLAS_STATUS(hipblasGetrfFn(handle, N, dA, lda, nullptr, nullptr),
+                              HIPBLAS_STATUS_INVALID_VALUE);
+    }
+}
+
+template <typename T>
 void testing_getrf_npvt(const Arguments& arg)
 {
     using U             = real_t<T>;

--- a/clients/include/solver/testing_getrf_npvt_strided_batched.hpp
+++ b/clients/include/solver/testing_getrf_npvt_strided_batched.hpp
@@ -37,6 +37,50 @@ inline void testname_getrf_npvt_strided_batched(const Arguments& arg, std::strin
 }
 
 template <typename T>
+void testing_getrf_npvt_strided_batched_bad_arg(const Arguments& arg)
+{
+    bool FORTRAN = arg.fortran;
+    auto hipblasGetrfStridedBatchedFn
+        = FORTRAN ? hipblasGetrfStridedBatched<T, true> : hipblasGetrfStridedBatched<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    int64_t            N           = 101;
+    int64_t            M           = N;
+    int64_t            lda         = 102;
+    int64_t            batch_count = 2;
+    hipblasStride      strideA     = N * lda;
+
+    device_vector<T>   dA(strideA * batch_count);
+    device_vector<int> dInfo(batch_count);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfStridedBatchedFn(nullptr, N, dA, lda, strideA, nullptr, 0, dInfo, batch_count),
+        HIPBLAS_STATUS_NOT_INITIALIZED);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfStridedBatchedFn(handle, -1, dA, lda, strideA, nullptr, 0, dInfo, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfStridedBatchedFn(handle, N, dA, N - 1, strideA, nullptr, 0, dInfo, batch_count),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfStridedBatchedFn(handle, N, dA, lda, strideA, nullptr, 0, dInfo, -1),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    if(arg.bad_arg_all)
+    {
+        EXPECT_HIPBLAS_STATUS(hipblasGetrfStridedBatchedFn(
+                                  handle, N, nullptr, lda, strideA, nullptr, 0, dInfo, batch_count),
+                              HIPBLAS_STATUS_INVALID_VALUE);
+        EXPECT_HIPBLAS_STATUS(hipblasGetrfStridedBatchedFn(
+                                  handle, N, dA, lda, strideA, nullptr, 0, nullptr, batch_count),
+                              HIPBLAS_STATUS_INVALID_VALUE);
+    }
+}
+
+template <typename T>
 void testing_getrf_npvt_strided_batched(const Arguments& arg)
 {
     using U      = real_t<T>;

--- a/clients/include/solver/testing_getrf_strided_batched.hpp
+++ b/clients/include/solver/testing_getrf_strided_batched.hpp
@@ -37,6 +37,58 @@ inline void testname_getrf_strided_batched(const Arguments& arg, std::string& na
 }
 
 template <typename T>
+void testing_getrf_strided_batched_bad_arg(const Arguments& arg)
+{
+    bool FORTRAN = arg.fortran;
+    auto hipblasGetrfStridedBatchedFn
+        = FORTRAN ? hipblasGetrfStridedBatched<T, true> : hipblasGetrfStridedBatched<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    int64_t            N           = 101;
+    int64_t            M           = N;
+    int64_t            lda         = 102;
+    int64_t            batch_count = 2;
+    hipblasStride      strideA     = N * lda;
+    hipblasStride      strideP     = std::min(M, N);
+
+    device_vector<T>   dA(strideA * batch_count);
+    device_vector<int> dIpiv(strideP * batch_count);
+    device_vector<int> dInfo(batch_count);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfStridedBatchedFn(
+                              nullptr, N, dA, lda, strideA, dIpiv, strideP, dInfo, batch_count),
+                          HIPBLAS_STATUS_NOT_INITIALIZED);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfStridedBatchedFn(
+                              handle, -1, dA, lda, strideA, dIpiv, strideP, dInfo, batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetrfStridedBatchedFn(
+                              handle, N, dA, N - 1, strideA, dIpiv, strideP, dInfo, batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetrfStridedBatchedFn(handle, N, dA, lda, strideA, dIpiv, strideP, dInfo, -1),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    // If N == 0 || batch_count == 0, A and ipiv can be nullptr. rocSolver doesn't allow nullptr with batch_count == 0
+    CHECK_HIPBLAS_ERROR(hipblasGetrfStridedBatchedFn(
+        handle, 0, nullptr, lda, strideA, nullptr, strideP, dInfo, batch_count));
+
+    if(arg.bad_arg_all)
+    {
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGetrfStridedBatchedFn(
+                handle, N, nullptr, lda, strideA, dIpiv, strideP, dInfo, batch_count),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGetrfStridedBatchedFn(
+                handle, N, dA, lda, strideA, dIpiv, strideP, nullptr, batch_count),
+            HIPBLAS_STATUS_INVALID_VALUE);
+    }
+}
+
+template <typename T>
 void testing_getrf_strided_batched(const Arguments& arg)
 {
     using U      = real_t<T>;

--- a/clients/include/solver/testing_getri_npvt_batched.hpp
+++ b/clients/include/solver/testing_getri_npvt_batched.hpp
@@ -36,6 +36,96 @@ inline void testname_getri_npvt_batched(const Arguments& arg, std::string& name)
 }
 
 template <typename T>
+void testing_getri_npvt_batched_bad_arg(const Arguments& arg)
+{
+    bool FORTRAN = arg.fortran;
+    auto hipblasGetriBatchedFn
+        = FORTRAN ? hipblasGetriBatched<T, true> : hipblasGetriBatched<T, false>;
+
+    hipblasLocalHandle handle(arg);
+    int64_t            N           = 101;
+    int64_t            M           = N;
+    int64_t            lda         = 102;
+    int64_t            batch_count = 2;
+    int64_t            A_size      = N * lda;
+
+    device_batch_vector<T> dA(A_size, 1, batch_count);
+    device_batch_vector<T> dC(A_size, 1, batch_count);
+    device_vector<int>     dInfo(batch_count);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetriBatchedFn(nullptr,
+                                                N,
+                                                dA.ptr_on_device(),
+                                                lda,
+                                                nullptr,
+                                                dC.ptr_on_device(),
+                                                lda,
+                                                dInfo,
+                                                batch_count),
+                          HIPBLAS_STATUS_NOT_INITIALIZED);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetriBatchedFn(handle,
+                                                -1,
+                                                dA.ptr_on_device(),
+                                                lda,
+                                                nullptr,
+                                                dC.ptr_on_device(),
+                                                lda,
+                                                dInfo,
+                                                batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetriBatchedFn(handle,
+                                                N,
+                                                dA.ptr_on_device(),
+                                                N - 1,
+                                                nullptr,
+                                                dC.ptr_on_device(),
+                                                lda,
+                                                dInfo,
+                                                batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(hipblasGetriBatchedFn(handle,
+                                                N,
+                                                dA.ptr_on_device(),
+                                                lda,
+                                                nullptr,
+                                                dC.ptr_on_device(),
+                                                N - 1,
+                                                dInfo,
+                                                batch_count),
+                          HIPBLAS_STATUS_INVALID_VALUE);
+
+    EXPECT_HIPBLAS_STATUS(
+        hipblasGetriBatchedFn(
+            handle, N, dA.ptr_on_device(), lda, nullptr, dC.ptr_on_device(), lda, dInfo, -1),
+        HIPBLAS_STATUS_INVALID_VALUE);
+
+    if(arg.bad_arg_all)
+    {
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGetriBatchedFn(
+                handle, N, nullptr, lda, nullptr, dC.ptr_on_device(), lda, dInfo, batch_count),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        EXPECT_HIPBLAS_STATUS(
+            hipblasGetriBatchedFn(
+                handle, N, dA.ptr_on_device(), lda, nullptr, nullptr, lda, dInfo, batch_count),
+            HIPBLAS_STATUS_INVALID_VALUE);
+        EXPECT_HIPBLAS_STATUS(hipblasGetriBatchedFn(handle,
+                                                    N,
+                                                    dA.ptr_on_device(),
+                                                    lda,
+                                                    nullptr,
+                                                    dC.ptr_on_device(),
+                                                    lda,
+                                                    nullptr,
+                                                    batch_count),
+                              HIPBLAS_STATUS_INVALID_VALUE);
+    }
+}
+
+template <typename T>
 void testing_getri_npvt_batched(const Arguments& arg)
 {
     using U      = real_t<T>;


### PR DESCRIPTION
Should be the final PR in the bad-arg saga.

There already existed some bad-arg tests for solver, but weren't enabled in the yaml files.

Note some strange behaviour with cuBLAS backend for gels, doesn't seem to make sense for me so left those tests out for now.