### PR TITLE
change cblas helpers use ref_ prefix as reference

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -212,12 +212,12 @@ void zsymv_(char*                 uplo,
 
 // axpy
 template <>
-void cblas_axpy<hipblasBfloat16, hipblasBfloat16>(int                    n,
-                                                  const hipblasBfloat16  alpha,
-                                                  const hipblasBfloat16* x,
-                                                  int                    incx,
-                                                  hipblasBfloat16*       y,
-                                                  int                    incy)
+void ref_axpy<hipblasBfloat16, hipblasBfloat16>(int                    n,
+                                                const hipblasBfloat16  alpha,
+                                                const hipblasBfloat16* x,
+                                                int                    incx,
+                                                hipblasBfloat16*       y,
+                                                int                    incy)
 {
     size_t             abs_incx = incx >= 0 ? incx : -incx;
     size_t             abs_incy = incy >= 0 ? incy : -incy;
@@ -239,7 +239,7 @@ void cblas_axpy<hipblasBfloat16, hipblasBfloat16>(int                    n,
 }
 
 template <>
-void cblas_axpy<float, hipblasBfloat16>(
+void ref_axpy<float, hipblasBfloat16>(
     int n, const float alpha, const hipblasBfloat16* x, int incx, hipblasBfloat16* y, int incy)
 {
     size_t             abs_incx = incx >= 0 ? incx : -incx;
@@ -262,7 +262,7 @@ void cblas_axpy<float, hipblasBfloat16>(
 }
 
 template <>
-void cblas_axpy<hipblasHalf, hipblasHalf>(
+void ref_axpy<hipblasHalf, hipblasHalf>(
     int n, const hipblasHalf alpha, const hipblasHalf* x, int incx, hipblasHalf* y, int incy)
 {
     size_t             abs_incx = incx >= 0 ? incx : -incx;
@@ -285,7 +285,7 @@ void cblas_axpy<hipblasHalf, hipblasHalf>(
 }
 
 template <>
-void cblas_axpy<float, hipblasHalf>(
+void ref_axpy<float, hipblasHalf>(
     int n, const float alpha, const hipblasHalf* x, int incx, hipblasHalf* y, int incy)
 {
     size_t             abs_incx = incx >= 0 ? incx : -incx;
@@ -308,44 +308,43 @@ void cblas_axpy<float, hipblasHalf>(
 }
 
 template <>
-void cblas_axpy<float, float>(
-    int n, const float alpha, const float* x, int incx, float* y, int incy)
+void ref_axpy<float, float>(int n, const float alpha, const float* x, int incx, float* y, int incy)
 {
     cblas_saxpy(n, alpha, x, incx, y, incy);
 }
 
 template <>
-void cblas_axpy<double, double>(
+void ref_axpy<double, double>(
     int n, const double alpha, const double* x, int incx, double* y, int incy)
 {
     cblas_daxpy(n, alpha, x, incx, y, incy);
 }
 
 template <>
-void cblas_axpy<hipblasComplex, hipblasComplex>(int                   n,
-                                                const hipblasComplex  alpha,
-                                                const hipblasComplex* x,
-                                                int                   incx,
-                                                hipblasComplex*       y,
-                                                int                   incy)
+void ref_axpy<hipblasComplex, hipblasComplex>(int                   n,
+                                              const hipblasComplex  alpha,
+                                              const hipblasComplex* x,
+                                              int                   incx,
+                                              hipblasComplex*       y,
+                                              int                   incy)
 {
     cblas_caxpy(n, &alpha, x, incx, y, incy);
 }
 
 template <>
-void cblas_axpy<hipblasDoubleComplex, hipblasDoubleComplex>(int                         n,
-                                                            const hipblasDoubleComplex  alpha,
-                                                            const hipblasDoubleComplex* x,
-                                                            int                         incx,
-                                                            hipblasDoubleComplex*       y,
-                                                            int                         incy)
+void ref_axpy<hipblasDoubleComplex, hipblasDoubleComplex>(int                         n,
+                                                          const hipblasDoubleComplex  alpha,
+                                                          const hipblasDoubleComplex* x,
+                                                          int                         incx,
+                                                          hipblasDoubleComplex*       y,
+                                                          int                         incy)
 {
     cblas_zaxpy(n, &alpha, x, incx, y, incy);
 }
 
 // scal
 template <>
-void cblas_scal<hipblasHalf>(int n, const hipblasHalf alpha, hipblasHalf* x, int incx)
+void ref_scal<hipblasHalf>(int n, const hipblasHalf alpha, hipblasHalf* x, int incx)
 {
     if(n <= 0 || incx <= 0)
         return;
@@ -362,7 +361,7 @@ void cblas_scal<hipblasHalf>(int n, const hipblasHalf alpha, hipblasHalf* x, int
 }
 
 template <>
-void cblas_scal<hipblasBfloat16>(int n, const hipblasBfloat16 alpha, hipblasBfloat16* x, int incx)
+void ref_scal<hipblasBfloat16>(int n, const hipblasBfloat16 alpha, hipblasBfloat16* x, int incx)
 {
     if(n <= 0 || incx <= 0)
         return;
@@ -379,7 +378,7 @@ void cblas_scal<hipblasBfloat16>(int n, const hipblasBfloat16 alpha, hipblasBflo
 }
 
 template <>
-void cblas_scal<hipblasHalf, float>(int n, const float alpha, hipblasHalf* x, int incx)
+void ref_scal<hipblasHalf, float>(int n, const float alpha, hipblasHalf* x, int incx)
 {
     if(n <= 0 || incx <= 0)
         return;
@@ -396,7 +395,7 @@ void cblas_scal<hipblasHalf, float>(int n, const float alpha, hipblasHalf* x, in
 }
 
 template <>
-void cblas_scal<hipblasBfloat16, float>(int n, const float alpha, hipblasBfloat16* x, int incx)
+void ref_scal<hipblasBfloat16, float>(int n, const float alpha, hipblasBfloat16* x, int incx)
 {
     if(n <= 0 || incx <= 0)
         return;
@@ -413,68 +412,68 @@ void cblas_scal<hipblasBfloat16, float>(int n, const float alpha, hipblasBfloat1
 }
 
 template <>
-void cblas_scal<float>(int n, const float alpha, float* x, int incx)
+void ref_scal<float>(int n, const float alpha, float* x, int incx)
 {
     cblas_sscal(n, alpha, x, incx);
 }
 
 template <>
-void cblas_scal<double>(int n, const double alpha, double* x, int incx)
+void ref_scal<double>(int n, const double alpha, double* x, int incx)
 {
     cblas_dscal(n, alpha, x, incx);
 }
 
 template <>
-void cblas_scal<hipblasComplex>(int n, const hipblasComplex alpha, hipblasComplex* x, int incx)
+void ref_scal<hipblasComplex>(int n, const hipblasComplex alpha, hipblasComplex* x, int incx)
 {
     cblas_cscal(n, &alpha, x, incx);
 }
 
 template <>
-void cblas_scal<hipblasComplex, float>(int n, const float alpha, hipblasComplex* x, int incx)
+void ref_scal<hipblasComplex, float>(int n, const float alpha, hipblasComplex* x, int incx)
 {
     cblas_csscal(n, alpha, x, incx);
 }
 
 template <>
-void cblas_scal<hipblasDoubleComplex>(int                        n,
-                                      const hipblasDoubleComplex alpha,
-                                      hipblasDoubleComplex*      x,
-                                      int                        incx)
+void ref_scal<hipblasDoubleComplex>(int                        n,
+                                    const hipblasDoubleComplex alpha,
+                                    hipblasDoubleComplex*      x,
+                                    int                        incx)
 {
     cblas_zscal(n, &alpha, x, incx);
 }
 
 template <>
-void cblas_scal<hipblasDoubleComplex, double>(int                   n,
-                                              const double          alpha,
-                                              hipblasDoubleComplex* x,
-                                              int                   incx)
+void ref_scal<hipblasDoubleComplex, double>(int                   n,
+                                            const double          alpha,
+                                            hipblasDoubleComplex* x,
+                                            int                   incx)
 {
     cblas_zdscal(n, alpha, x, incx);
 }
 
 // copy
 template <>
-void cblas_copy<float>(int n, float* x, int incx, float* y, int incy)
+void ref_copy<float>(int n, float* x, int incx, float* y, int incy)
 {
     cblas_scopy(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_copy<double>(int n, double* x, int incx, double* y, int incy)
+void ref_copy<double>(int n, double* x, int incx, double* y, int incy)
 {
     cblas_dcopy(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_copy<hipblasComplex>(int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
+void ref_copy<hipblasComplex>(int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     cblas_ccopy(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_copy<hipblasDoubleComplex>(
+void ref_copy<hipblasDoubleComplex>(
     int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy)
 {
     cblas_zcopy(n, x, incx, y, incy);
@@ -482,25 +481,25 @@ void cblas_copy<hipblasDoubleComplex>(
 
 // swap
 template <>
-void cblas_swap<float>(int n, float* x, int incx, float* y, int incy)
+void ref_swap<float>(int n, float* x, int incx, float* y, int incy)
 {
     cblas_sswap(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_swap<double>(int n, double* x, int incx, double* y, int incy)
+void ref_swap<double>(int n, double* x, int incx, double* y, int incy)
 {
     cblas_dswap(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_swap<hipblasComplex>(int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
+void ref_swap<hipblasComplex>(int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy)
 {
     cblas_cswap(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_swap<hipblasDoubleComplex>(
+void ref_swap<hipblasDoubleComplex>(
     int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy)
 {
     cblas_zswap(n, x, incx, y, incy);
@@ -508,7 +507,7 @@ void cblas_swap<hipblasDoubleComplex>(
 
 // dot
 template <>
-void cblas_dot<hipblasHalf>(
+void ref_dot<hipblasHalf>(
     int n, const hipblasHalf* x, int incx, const hipblasHalf* y, int incy, hipblasHalf* result)
 {
     size_t             abs_incx = incx >= 0 ? incx : -incx;
@@ -525,12 +524,12 @@ void cblas_dot<hipblasHalf>(
 }
 
 template <>
-void cblas_dot<hipblasBfloat16>(int                    n,
-                                const hipblasBfloat16* x,
-                                int                    incx,
-                                const hipblasBfloat16* y,
-                                int                    incy,
-                                hipblasBfloat16*       result)
+void ref_dot<hipblasBfloat16>(int                    n,
+                              const hipblasBfloat16* x,
+                              int                    incx,
+                              const hipblasBfloat16* y,
+                              int                    incy,
+                              hipblasBfloat16*       result)
 {
     size_t             abs_incx = incx >= 0 ? incx : -incx;
     size_t             abs_incy = incy >= 0 ? incy : -incy;
@@ -546,101 +545,98 @@ void cblas_dot<hipblasBfloat16>(int                    n,
 }
 
 template <>
-void cblas_dot<float>(int n, const float* x, int incx, const float* y, int incy, float* result)
+void ref_dot<float>(int n, const float* x, int incx, const float* y, int incy, float* result)
 {
     *result = cblas_sdot(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_dot<double>(int n, const double* x, int incx, const double* y, int incy, double* result)
+void ref_dot<double>(int n, const double* x, int incx, const double* y, int incy, double* result)
 {
     *result = cblas_ddot(n, x, incx, y, incy);
 }
 
 template <>
-void cblas_dot<hipblasComplex>(int                   n,
-                               const hipblasComplex* x,
-                               int                   incx,
-                               const hipblasComplex* y,
-                               int                   incy,
-                               hipblasComplex*       result)
+void ref_dot<hipblasComplex>(int                   n,
+                             const hipblasComplex* x,
+                             int                   incx,
+                             const hipblasComplex* y,
+                             int                   incy,
+                             hipblasComplex*       result)
 {
     cblas_cdotu_sub(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dot<hipblasDoubleComplex>(int                         n,
-                                     const hipblasDoubleComplex* x,
-                                     int                         incx,
-                                     const hipblasDoubleComplex* y,
-                                     int                         incy,
-                                     hipblasDoubleComplex*       result)
+void ref_dot<hipblasDoubleComplex>(int                         n,
+                                   const hipblasDoubleComplex* x,
+                                   int                         incx,
+                                   const hipblasDoubleComplex* y,
+                                   int                         incy,
+                                   hipblasDoubleComplex*       result)
 {
     cblas_zdotu_sub(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dotc<hipblasHalf>(
+void ref_dotc<hipblasHalf>(
     int n, const hipblasHalf* x, int incx, const hipblasHalf* y, int incy, hipblasHalf* result)
 {
     // Not complex - call regular dot.
-    cblas_dot(n, x, incx, y, incy, result);
+    ref_dot(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dotc<hipblasBfloat16>(int                    n,
-                                 const hipblasBfloat16* x,
-                                 int                    incx,
-                                 const hipblasBfloat16* y,
-                                 int                    incy,
-                                 hipblasBfloat16*       result)
+void ref_dotc<hipblasBfloat16>(int                    n,
+                               const hipblasBfloat16* x,
+                               int                    incx,
+                               const hipblasBfloat16* y,
+                               int                    incy,
+                               hipblasBfloat16*       result)
 {
     // Not complex - call regular dot.
-    cblas_dot(n, x, incx, y, incy, result);
+    ref_dot(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dotc<float>(int n, const float* x, int incx, const float* y, int incy, float* result)
+void ref_dotc<float>(int n, const float* x, int incx, const float* y, int incy, float* result)
 {
     // Not complex - call regular dot.
-    cblas_dot(n, x, incx, y, incy, result);
+    ref_dot(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dotc<double>(int n, const double* x, int incx, const double* y, int incy, double* result)
+void ref_dotc<double>(int n, const double* x, int incx, const double* y, int incy, double* result)
 {
     // Not complex - call regular dot.
-    cblas_dot(n, x, incx, y, incy, result);
+    ref_dot(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dotc<hipblasComplex>(int                   n,
-                                const hipblasComplex* x,
-                                int                   incx,
-                                const hipblasComplex* y,
-                                int                   incy,
-                                hipblasComplex*       result)
+void ref_dotc<hipblasComplex>(int                   n,
+                              const hipblasComplex* x,
+                              int                   incx,
+                              const hipblasComplex* y,
+                              int                   incy,
+                              hipblasComplex*       result)
 {
     cblas_cdotc_sub(n, x, incx, y, incy, result);
 }
 
 template <>
-void cblas_dotc<hipblasDoubleComplex>(int                         n,
-                                      const hipblasDoubleComplex* x,
-                                      int                         incx,
-                                      const hipblasDoubleComplex* y,
-                                      int                         incy,
-                                      hipblasDoubleComplex*       result)
+void ref_dotc<hipblasDoubleComplex>(int                         n,
+                                    const hipblasDoubleComplex* x,
+                                    int                         incx,
+                                    const hipblasDoubleComplex* y,
+                                    int                         incy,
+                                    hipblasDoubleComplex*       result)
 {
     cblas_zdotc_sub(n, x, incx, y, incy, result);
 }
 
 // nrm2
 template <>
-void cblas_nrm2<hipblasHalf, hipblasHalf>(int                n,
-                                          const hipblasHalf* x,
-                                          int                incx,
-                                          hipblasHalf*       result)
+void ref_nrm2<hipblasHalf, hipblasHalf>(int n, const hipblasHalf* x, int incx, hipblasHalf* result)
 {
     if(n <= 0 || incx <= 0)
         return;
@@ -654,10 +650,10 @@ void cblas_nrm2<hipblasHalf, hipblasHalf>(int                n,
 }
 
 template <>
-void cblas_nrm2<hipblasBfloat16, hipblasBfloat16>(int                    n,
-                                                  const hipblasBfloat16* x,
-                                                  int                    incx,
-                                                  hipblasBfloat16*       result)
+void ref_nrm2<hipblasBfloat16, hipblasBfloat16>(int                    n,
+                                                const hipblasBfloat16* x,
+                                                int                    incx,
+                                                hipblasBfloat16*       result)
 {
     if(n <= 0 || incx <= 0)
         return;
@@ -671,28 +667,28 @@ void cblas_nrm2<hipblasBfloat16, hipblasBfloat16>(int                    n,
 }
 
 template <>
-void cblas_nrm2<float, float>(int n, const float* x, int incx, float* result)
+void ref_nrm2<float, float>(int n, const float* x, int incx, float* result)
 {
     *result = cblas_snrm2(n, x, incx);
 }
 
 template <>
-void cblas_nrm2<double, double>(int n, const double* x, int incx, double* result)
+void ref_nrm2<double, double>(int n, const double* x, int incx, double* result)
 {
     *result = cblas_dnrm2(n, x, incx);
 }
 
 template <>
-void cblas_nrm2<hipblasComplex, float>(int n, const hipblasComplex* x, int incx, float* result)
+void ref_nrm2<hipblasComplex, float>(int n, const hipblasComplex* x, int incx, float* result)
 {
     *result = cblas_scnrm2(n, x, incx);
 }
 
 template <>
-void cblas_nrm2<hipblasDoubleComplex, double>(int                         n,
-                                              const hipblasDoubleComplex* x,
-                                              int                         incx,
-                                              double*                     result)
+void ref_nrm2<hipblasDoubleComplex, double>(int                         n,
+                                            const hipblasDoubleComplex* x,
+                                            int                         incx,
+                                            double*                     result)
 {
     *result = cblas_dznrm2(n, x, incx);
 }
@@ -737,7 +733,7 @@ void zrotg_(hipblasDoubleComplex* a, hipblasDoubleComplex* b, double* c, hipblas
 
 // rot
 template <>
-void cblas_rot<hipblasHalf>(
+void ref_rot<hipblasHalf>(
     int n, hipblasHalf* x, int incx, hipblasHalf* y, int incy, hipblasHalf c, hipblasHalf s)
 {
     size_t abs_incx = incx >= 0 ? incx : -incx;
@@ -770,13 +766,13 @@ void cblas_rot<hipblasHalf>(
 }
 
 template <>
-void cblas_rot<hipblasBfloat16>(int              n,
-                                hipblasBfloat16* x,
-                                int              incx,
-                                hipblasBfloat16* y,
-                                int              incy,
-                                hipblasBfloat16  c,
-                                hipblasBfloat16  s)
+void ref_rot<hipblasBfloat16>(int              n,
+                              hipblasBfloat16* x,
+                              int              incx,
+                              hipblasBfloat16* y,
+                              int              incy,
+                              hipblasBfloat16  c,
+                              hipblasBfloat16  s)
 {
     size_t abs_incx = incx >= 0 ? incx : -incx;
     size_t abs_incy = incy >= 0 ? incy : -incy;
@@ -808,71 +804,71 @@ void cblas_rot<hipblasBfloat16>(int              n,
 }
 
 template <>
-void cblas_rot<float>(int n, float* x, int incx, float* y, int incy, float c, float s)
+void ref_rot<float>(int n, float* x, int incx, float* y, int incy, float c, float s)
 {
     cblas_srot(n, x, incx, y, incy, c, s);
 }
 
 template <>
-void cblas_rot<double>(int n, double* x, int incx, double* y, int incy, double c, double s)
+void ref_rot<double>(int n, double* x, int incx, double* y, int incy, double c, double s)
 {
     cblas_drot(n, x, incx, y, incy, c, s);
 }
 
 template <>
-void cblas_rot<hipblasComplex>(int             n,
-                               hipblasComplex* x,
-                               int             incx,
-                               hipblasComplex* y,
-                               int             incy,
-                               hipblasComplex  c,
-                               hipblasComplex  s)
+void ref_rot<hipblasComplex>(int             n,
+                             hipblasComplex* x,
+                             int             incx,
+                             hipblasComplex* y,
+                             int             incy,
+                             hipblasComplex  c,
+                             hipblasComplex  s)
 {
     float c_real = std::real(c);
     crot_(&n, x, &incx, y, &incy, &c_real, &s);
 }
 
 template <>
-void cblas_rot<hipblasComplex, float>(
+void ref_rot<hipblasComplex, float>(
     int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy, float c, hipblasComplex s)
 {
     crot_(&n, x, &incx, y, &incy, &c, &s);
 }
 
 template <>
-void cblas_rot<hipblasComplex, float, float>(
+void ref_rot<hipblasComplex, float, float>(
     int n, hipblasComplex* x, int incx, hipblasComplex* y, int incy, float c, float s)
 {
     csrot_(&n, x, &incx, y, &incy, &c, &s);
 }
 
 template <>
-void cblas_rot<hipblasDoubleComplex>(int                   n,
-                                     hipblasDoubleComplex* x,
-                                     int                   incx,
-                                     hipblasDoubleComplex* y,
-                                     int                   incy,
-                                     hipblasDoubleComplex  c,
-                                     hipblasDoubleComplex  s)
+void ref_rot<hipblasDoubleComplex>(int                   n,
+                                   hipblasDoubleComplex* x,
+                                   int                   incx,
+                                   hipblasDoubleComplex* y,
+                                   int                   incy,
+                                   hipblasDoubleComplex  c,
+                                   hipblasDoubleComplex  s)
 {
     double c_real = std::real(c);
     zrot_(&n, x, &incx, y, &incy, &c_real, &s);
 }
 
 template <>
-void cblas_rot<hipblasDoubleComplex, double>(int                   n,
-                                             hipblasDoubleComplex* x,
-                                             int                   incx,
-                                             hipblasDoubleComplex* y,
-                                             int                   incy,
-                                             double                c,
-                                             hipblasDoubleComplex  s)
+void ref_rot<hipblasDoubleComplex, double>(int                   n,
+                                           hipblasDoubleComplex* x,
+                                           int                   incx,
+                                           hipblasDoubleComplex* y,
+                                           int                   incy,
+                                           double                c,
+                                           hipblasDoubleComplex  s)
 {
     zrot_(&n, x, &incx, y, &incy, &c, &s);
 }
 
 template <>
-void cblas_rot<hipblasDoubleComplex, double, double>(
+void ref_rot<hipblasDoubleComplex, double, double>(
     int n, hipblasDoubleComplex* x, int incx, hipblasDoubleComplex* y, int incy, double c, double s)
 {
     zdrot_(&n, x, &incx, y, &incy, &c, &s);
@@ -880,110 +876,110 @@ void cblas_rot<hipblasDoubleComplex, double, double>(
 
 // rotg
 template <>
-void cblas_rotg<float>(float* a, float* b, float* c, float* s)
+void ref_rotg<float>(float* a, float* b, float* c, float* s)
 {
     cblas_srotg(a, b, c, s);
 }
 
 template <>
-void cblas_rotg<double>(double* a, double* b, double* c, double* s)
+void ref_rotg<double>(double* a, double* b, double* c, double* s)
 {
     cblas_drotg(a, b, c, s);
 }
 
 template <>
-void cblas_rotg<hipblasComplex, float>(hipblasComplex* a,
-                                       hipblasComplex* b,
-                                       float*          c,
-                                       hipblasComplex* s)
+void ref_rotg<hipblasComplex, float>(hipblasComplex* a,
+                                     hipblasComplex* b,
+                                     float*          c,
+                                     hipblasComplex* s)
 {
     crotg_(a, b, c, s);
 }
 
 template <>
-void cblas_rotg<hipblasDoubleComplex, double>(hipblasDoubleComplex* a,
-                                              hipblasDoubleComplex* b,
-                                              double*               c,
-                                              hipblasDoubleComplex* s)
+void ref_rotg<hipblasDoubleComplex, double>(hipblasDoubleComplex* a,
+                                            hipblasDoubleComplex* b,
+                                            double*               c,
+                                            hipblasDoubleComplex* s)
 {
     zrotg_(a, b, c, s);
 }
 
 // rotm
 template <>
-void cblas_rotm<float>(int n, float* x, int incx, float* y, int incy, float* param)
+void ref_rotm<float>(int n, float* x, int incx, float* y, int incy, float* param)
 {
     cblas_srotm(n, x, incx, y, incy, param);
 }
 
 template <>
-void cblas_rotm<double>(int n, double* x, int incx, double* y, int incy, double* param)
+void ref_rotm<double>(int n, double* x, int incx, double* y, int incy, double* param)
 {
     cblas_drotm(n, x, incx, y, incy, param);
 }
 
 // rotmg
 template <>
-void cblas_rotmg<float>(float* d1, float* d2, float* x1, float* y1, float* param)
+void ref_rotmg<float>(float* d1, float* d2, float* x1, float* y1, float* param)
 {
     cblas_srotmg(d1, d2, x1, *y1, param);
 }
 
 template <>
-void cblas_rotmg<double>(double* d1, double* d2, double* x1, double* y1, double* param)
+void ref_rotmg<double>(double* d1, double* d2, double* x1, double* y1, double* param)
 {
     cblas_drotmg(d1, d2, x1, *y1, param);
 }
 
 // asum
 template <>
-void cblas_asum<float, float>(int n, const float* x, int incx, float* result)
+void ref_asum<float, float>(int n, const float* x, int incx, float* result)
 {
     *result = cblas_sasum(n, x, incx);
 }
 
 template <>
-void cblas_asum<double, double>(int n, const double* x, int incx, double* result)
+void ref_asum<double, double>(int n, const double* x, int incx, double* result)
 {
     *result = cblas_dasum(n, x, incx);
 }
 
 template <>
-void cblas_asum<hipblasComplex, float>(int n, const hipblasComplex* x, int incx, float* result)
+void ref_asum<hipblasComplex, float>(int n, const hipblasComplex* x, int incx, float* result)
 {
     *result = cblas_scasum(n, x, incx);
 }
 
 template <>
-void cblas_asum<hipblasDoubleComplex, double>(int                         n,
-                                              const hipblasDoubleComplex* x,
-                                              int                         incx,
-                                              double*                     result)
+void ref_asum<hipblasDoubleComplex, double>(int                         n,
+                                            const hipblasDoubleComplex* x,
+                                            int                         incx,
+                                            double*                     result)
 {
     *result = cblas_dzasum(n, x, incx);
 }
 
 // amax
 template <>
-void cblas_iamax<float>(int n, const float* x, int incx, int* result)
+void ref_iamax<float>(int n, const float* x, int incx, int* result)
 {
     *result = (int)cblas_isamax(n, x, incx);
 }
 
 template <>
-void cblas_iamax<double>(int n, const double* x, int incx, int* result)
+void ref_iamax<double>(int n, const double* x, int incx, int* result)
 {
     *result = (int)cblas_idamax(n, x, incx);
 }
 
 template <>
-void cblas_iamax<hipblasComplex>(int n, const hipblasComplex* x, int incx, int* result)
+void ref_iamax<hipblasComplex>(int n, const hipblasComplex* x, int incx, int* result)
 {
     *result = (int)cblas_icamax(n, x, incx);
 }
 
 template <>
-void cblas_iamax<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int incx, int* result)
+void ref_iamax<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
     *result = (int)cblas_izamax(n, x, incx);
 }
@@ -1009,7 +1005,7 @@ double hipblas_magnitude(hipblasDoubleComplex val)
 }
 
 template <typename T>
-int cblas_iamin_helper(int N, const T* X, int incx)
+int ref_iamin_helper(int N, const T* X, int incx)
 {
     int minpos = -1;
     if(N > 0 && incx > 0)
@@ -1030,27 +1026,27 @@ int cblas_iamin_helper(int N, const T* X, int incx)
 }
 
 template <>
-void cblas_iamin<float>(int n, const float* x, int incx, int* result)
+void ref_iamin<float>(int n, const float* x, int incx, int* result)
 {
-    *result = (int)cblas_iamin_helper(n, x, incx);
+    *result = (int)ref_iamin_helper(n, x, incx);
 }
 
 template <>
-void cblas_iamin<double>(int n, const double* x, int incx, int* result)
+void ref_iamin<double>(int n, const double* x, int incx, int* result)
 {
-    *result = (int)cblas_iamin_helper(n, x, incx);
+    *result = (int)ref_iamin_helper(n, x, incx);
 }
 
 template <>
-void cblas_iamin<hipblasComplex>(int n, const hipblasComplex* x, int incx, int* result)
+void ref_iamin<hipblasComplex>(int n, const hipblasComplex* x, int incx, int* result)
 {
-    *result = (int)cblas_iamin_helper(n, x, incx);
+    *result = (int)ref_iamin_helper(n, x, incx);
 }
 
 template <>
-void cblas_iamin<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int incx, int* result)
+void ref_iamin<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int incx, int* result)
 {
-    *result = (int)cblas_iamin_helper(n, x, incx);
+    *result = (int)ref_iamin_helper(n, x, incx);
 }
 
 /*
@@ -1061,19 +1057,19 @@ void cblas_iamin<hipblasDoubleComplex>(int n, const hipblasDoubleComplex* x, int
 
 // gbmv
 template <>
-void cblas_gbmv<float>(hipblasOperation_t transA,
-                       int                m,
-                       int                n,
-                       int                kl,
-                       int                ku,
-                       float              alpha,
-                       float*             A,
-                       int                lda,
-                       float*             x,
-                       int                incx,
-                       float              beta,
-                       float*             y,
-                       int                incy)
+void ref_gbmv<float>(hipblasOperation_t transA,
+                     int                m,
+                     int                n,
+                     int                kl,
+                     int                ku,
+                     float              alpha,
+                     float*             A,
+                     int                lda,
+                     float*             x,
+                     int                incx,
+                     float              beta,
+                     float*             y,
+                     int                incy)
 {
     cblas_sgbmv(CblasColMajor,
                 (CBLAS_TRANSPOSE)transA,
@@ -1092,19 +1088,19 @@ void cblas_gbmv<float>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gbmv<double>(hipblasOperation_t transA,
-                        int                m,
-                        int                n,
-                        int                kl,
-                        int                ku,
-                        double             alpha,
-                        double*            A,
-                        int                lda,
-                        double*            x,
-                        int                incx,
-                        double             beta,
-                        double*            y,
-                        int                incy)
+void ref_gbmv<double>(hipblasOperation_t transA,
+                      int                m,
+                      int                n,
+                      int                kl,
+                      int                ku,
+                      double             alpha,
+                      double*            A,
+                      int                lda,
+                      double*            x,
+                      int                incx,
+                      double             beta,
+                      double*            y,
+                      int                incy)
 {
     cblas_dgbmv(CblasColMajor,
                 (CBLAS_TRANSPOSE)transA,
@@ -1123,19 +1119,19 @@ void cblas_gbmv<double>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gbmv<hipblasComplex>(hipblasOperation_t transA,
-                                int                m,
-                                int                n,
-                                int                kl,
-                                int                ku,
-                                hipblasComplex     alpha,
-                                hipblasComplex*    A,
-                                int                lda,
-                                hipblasComplex*    x,
-                                int                incx,
-                                hipblasComplex     beta,
-                                hipblasComplex*    y,
-                                int                incy)
+void ref_gbmv<hipblasComplex>(hipblasOperation_t transA,
+                              int                m,
+                              int                n,
+                              int                kl,
+                              int                ku,
+                              hipblasComplex     alpha,
+                              hipblasComplex*    A,
+                              int                lda,
+                              hipblasComplex*    x,
+                              int                incx,
+                              hipblasComplex     beta,
+                              hipblasComplex*    y,
+                              int                incy)
 {
     cblas_cgbmv(CblasColMajor,
                 (CBLAS_TRANSPOSE)transA,
@@ -1154,19 +1150,19 @@ void cblas_gbmv<hipblasComplex>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gbmv<hipblasDoubleComplex>(hipblasOperation_t    transA,
-                                      int                   m,
-                                      int                   n,
-                                      int                   kl,
-                                      int                   ku,
-                                      hipblasDoubleComplex  alpha,
-                                      hipblasDoubleComplex* A,
-                                      int                   lda,
-                                      hipblasDoubleComplex* x,
-                                      int                   incx,
-                                      hipblasDoubleComplex  beta,
-                                      hipblasDoubleComplex* y,
-                                      int                   incy)
+void ref_gbmv<hipblasDoubleComplex>(hipblasOperation_t    transA,
+                                    int                   m,
+                                    int                   n,
+                                    int                   kl,
+                                    int                   ku,
+                                    hipblasDoubleComplex  alpha,
+                                    hipblasDoubleComplex* A,
+                                    int                   lda,
+                                    hipblasDoubleComplex* x,
+                                    int                   incx,
+                                    hipblasDoubleComplex  beta,
+                                    hipblasDoubleComplex* y,
+                                    int                   incy)
 {
     cblas_zgbmv(CblasColMajor,
                 (CBLAS_TRANSPOSE)transA,
@@ -1186,68 +1182,68 @@ void cblas_gbmv<hipblasDoubleComplex>(hipblasOperation_t    transA,
 
 // gemv
 template <>
-void cblas_gemv<float>(hipblasOperation_t transA,
-                       int                m,
-                       int                n,
-                       float              alpha,
-                       float*             A,
-                       int                lda,
-                       float*             x,
-                       int                incx,
-                       float              beta,
-                       float*             y,
-                       int                incy)
+void ref_gemv<float>(hipblasOperation_t transA,
+                     int                m,
+                     int                n,
+                     float              alpha,
+                     float*             A,
+                     int                lda,
+                     float*             x,
+                     int                incx,
+                     float              beta,
+                     float*             y,
+                     int                incy)
 {
     cblas_sgemv(
         CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
-void cblas_gemv<double>(hipblasOperation_t transA,
-                        int                m,
-                        int                n,
-                        double             alpha,
-                        double*            A,
-                        int                lda,
-                        double*            x,
-                        int                incx,
-                        double             beta,
-                        double*            y,
-                        int                incy)
+void ref_gemv<double>(hipblasOperation_t transA,
+                      int                m,
+                      int                n,
+                      double             alpha,
+                      double*            A,
+                      int                lda,
+                      double*            x,
+                      int                incx,
+                      double             beta,
+                      double*            y,
+                      int                incy)
 {
     cblas_dgemv(
         CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
-void cblas_gemv<hipblasComplex>(hipblasOperation_t transA,
-                                int                m,
-                                int                n,
-                                hipblasComplex     alpha,
-                                hipblasComplex*    A,
-                                int                lda,
-                                hipblasComplex*    x,
-                                int                incx,
-                                hipblasComplex     beta,
-                                hipblasComplex*    y,
-                                int                incy)
+void ref_gemv<hipblasComplex>(hipblasOperation_t transA,
+                              int                m,
+                              int                n,
+                              hipblasComplex     alpha,
+                              hipblasComplex*    A,
+                              int                lda,
+                              hipblasComplex*    x,
+                              int                incx,
+                              hipblasComplex     beta,
+                              hipblasComplex*    y,
+                              int                incy)
 {
     cblas_cgemv(
         CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 template <>
-void cblas_gemv<hipblasDoubleComplex>(hipblasOperation_t    transA,
-                                      int                   m,
-                                      int                   n,
-                                      hipblasDoubleComplex  alpha,
-                                      hipblasDoubleComplex* A,
-                                      int                   lda,
-                                      hipblasDoubleComplex* x,
-                                      int                   incx,
-                                      hipblasDoubleComplex  beta,
-                                      hipblasDoubleComplex* y,
-                                      int                   incy)
+void ref_gemv<hipblasDoubleComplex>(hipblasOperation_t    transA,
+                                    int                   m,
+                                    int                   n,
+                                    hipblasDoubleComplex  alpha,
+                                    hipblasDoubleComplex* A,
+                                    int                   lda,
+                                    hipblasDoubleComplex* x,
+                                    int                   incx,
+                                    hipblasDoubleComplex  beta,
+                                    hipblasDoubleComplex* y,
+                                    int                   incy)
 {
     cblas_zgemv(
         CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, &alpha, A, lda, x, incx, &beta, y, incy);
@@ -1255,362 +1251,362 @@ void cblas_gemv<hipblasDoubleComplex>(hipblasOperation_t    transA,
 
 // ger
 template <>
-void cblas_ger<float, false>(
+void ref_ger<float, false>(
     int m, int n, float alpha, float* x, int incx, float* y, int incy, float* A, int lda)
 {
     cblas_sger(CblasColMajor, m, n, alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_ger<double, false>(
+void ref_ger<double, false>(
     int m, int n, double alpha, double* x, int incx, double* y, int incy, double* A, int lda)
 {
     cblas_dger(CblasColMajor, m, n, alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_ger<hipblasComplex, false>(int             m,
-                                      int             n,
-                                      hipblasComplex  alpha,
-                                      hipblasComplex* x,
-                                      int             incx,
-                                      hipblasComplex* y,
-                                      int             incy,
-                                      hipblasComplex* A,
-                                      int             lda)
+void ref_ger<hipblasComplex, false>(int             m,
+                                    int             n,
+                                    hipblasComplex  alpha,
+                                    hipblasComplex* x,
+                                    int             incx,
+                                    hipblasComplex* y,
+                                    int             incy,
+                                    hipblasComplex* A,
+                                    int             lda)
 {
     cblas_cgeru(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_ger<hipblasComplex, true>(int             m,
-                                     int             n,
-                                     hipblasComplex  alpha,
-                                     hipblasComplex* x,
-                                     int             incx,
-                                     hipblasComplex* y,
-                                     int             incy,
-                                     hipblasComplex* A,
-                                     int             lda)
+void ref_ger<hipblasComplex, true>(int             m,
+                                   int             n,
+                                   hipblasComplex  alpha,
+                                   hipblasComplex* x,
+                                   int             incx,
+                                   hipblasComplex* y,
+                                   int             incy,
+                                   hipblasComplex* A,
+                                   int             lda)
 {
     cblas_cgerc(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_ger<hipblasDoubleComplex, false>(int                   m,
-                                            int                   n,
-                                            hipblasDoubleComplex  alpha,
-                                            hipblasDoubleComplex* x,
-                                            int                   incx,
-                                            hipblasDoubleComplex* y,
-                                            int                   incy,
-                                            hipblasDoubleComplex* A,
-                                            int                   lda)
+void ref_ger<hipblasDoubleComplex, false>(int                   m,
+                                          int                   n,
+                                          hipblasDoubleComplex  alpha,
+                                          hipblasDoubleComplex* x,
+                                          int                   incx,
+                                          hipblasDoubleComplex* y,
+                                          int                   incy,
+                                          hipblasDoubleComplex* A,
+                                          int                   lda)
 {
     cblas_zgeru(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_ger<hipblasDoubleComplex, true>(int                   m,
-                                           int                   n,
-                                           hipblasDoubleComplex  alpha,
-                                           hipblasDoubleComplex* x,
-                                           int                   incx,
-                                           hipblasDoubleComplex* y,
-                                           int                   incy,
-                                           hipblasDoubleComplex* A,
-                                           int                   lda)
+void ref_ger<hipblasDoubleComplex, true>(int                   m,
+                                         int                   n,
+                                         hipblasDoubleComplex  alpha,
+                                         hipblasDoubleComplex* x,
+                                         int                   incx,
+                                         hipblasDoubleComplex* y,
+                                         int                   incy,
+                                         hipblasDoubleComplex* A,
+                                         int                   lda)
 {
     cblas_zgerc(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 // hbmv
 template <>
-void cblas_hbmv<hipblasComplex>(hipblasFillMode_t uplo,
-                                int               n,
-                                int               k,
-                                hipblasComplex    alpha,
-                                hipblasComplex*   A,
-                                int               lda,
-                                hipblasComplex*   x,
-                                int               incx,
-                                hipblasComplex    beta,
-                                hipblasComplex*   y,
-                                int               incy)
+void ref_hbmv<hipblasComplex>(hipblasFillMode_t uplo,
+                              int               n,
+                              int               k,
+                              hipblasComplex    alpha,
+                              hipblasComplex*   A,
+                              int               lda,
+                              hipblasComplex*   x,
+                              int               incx,
+                              hipblasComplex    beta,
+                              hipblasComplex*   y,
+                              int               incy)
 {
     cblas_chbmv(CblasColMajor, (CBLAS_UPLO)uplo, n, k, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 template <>
-void cblas_hbmv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
-                                      int                   n,
-                                      int                   k,
-                                      hipblasDoubleComplex  alpha,
-                                      hipblasDoubleComplex* A,
-                                      int                   lda,
-                                      hipblasDoubleComplex* x,
-                                      int                   incx,
-                                      hipblasDoubleComplex  beta,
-                                      hipblasDoubleComplex* y,
-                                      int                   incy)
+void ref_hbmv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+                                    int                   n,
+                                    int                   k,
+                                    hipblasDoubleComplex  alpha,
+                                    hipblasDoubleComplex* A,
+                                    int                   lda,
+                                    hipblasDoubleComplex* x,
+                                    int                   incx,
+                                    hipblasDoubleComplex  beta,
+                                    hipblasDoubleComplex* y,
+                                    int                   incy)
 {
     cblas_zhbmv(CblasColMajor, (CBLAS_UPLO)uplo, n, k, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 // hemv
 template <>
-void cblas_hemv<hipblasComplex>(hipblasFillMode_t uplo,
-                                int               n,
-                                hipblasComplex    alpha,
-                                hipblasComplex*   A,
-                                int               lda,
-                                hipblasComplex*   x,
-                                int               incx,
-                                hipblasComplex    beta,
-                                hipblasComplex*   y,
-                                int               incy)
+void ref_hemv<hipblasComplex>(hipblasFillMode_t uplo,
+                              int               n,
+                              hipblasComplex    alpha,
+                              hipblasComplex*   A,
+                              int               lda,
+                              hipblasComplex*   x,
+                              int               incx,
+                              hipblasComplex    beta,
+                              hipblasComplex*   y,
+                              int               incy)
 {
     cblas_chemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 template <>
-void cblas_hemv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
-                                      int                   n,
-                                      hipblasDoubleComplex  alpha,
-                                      hipblasDoubleComplex* A,
-                                      int                   lda,
-                                      hipblasDoubleComplex* x,
-                                      int                   incx,
-                                      hipblasDoubleComplex  beta,
-                                      hipblasDoubleComplex* y,
-                                      int                   incy)
+void ref_hemv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+                                    int                   n,
+                                    hipblasDoubleComplex  alpha,
+                                    hipblasDoubleComplex* A,
+                                    int                   lda,
+                                    hipblasDoubleComplex* x,
+                                    int                   incx,
+                                    hipblasDoubleComplex  beta,
+                                    hipblasDoubleComplex* y,
+                                    int                   incy)
 {
     cblas_zhemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 // her
 template <>
-void cblas_her<hipblasComplex, float>(hipblasFillMode_t uplo,
-                                      int               n,
-                                      float             alpha,
-                                      hipblasComplex*   x,
-                                      int               incx,
-                                      hipblasComplex*   A,
-                                      int               lda)
+void ref_her<hipblasComplex, float>(hipblasFillMode_t uplo,
+                                    int               n,
+                                    float             alpha,
+                                    hipblasComplex*   x,
+                                    int               incx,
+                                    hipblasComplex*   A,
+                                    int               lda)
 {
     cblas_cher(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
 }
 
 template <>
-void cblas_her<hipblasDoubleComplex, double>(hipblasFillMode_t     uplo,
-                                             int                   n,
-                                             double                alpha,
-                                             hipblasDoubleComplex* x,
-                                             int                   incx,
-                                             hipblasDoubleComplex* A,
-                                             int                   lda)
+void ref_her<hipblasDoubleComplex, double>(hipblasFillMode_t     uplo,
+                                           int                   n,
+                                           double                alpha,
+                                           hipblasDoubleComplex* x,
+                                           int                   incx,
+                                           hipblasDoubleComplex* A,
+                                           int                   lda)
 {
     cblas_zher(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
 }
 
 // her2
 template <>
-void cblas_her2<hipblasComplex>(hipblasFillMode_t uplo,
-                                int               n,
-                                hipblasComplex    alpha,
-                                hipblasComplex*   x,
-                                int               incx,
-                                hipblasComplex*   y,
-                                int               incy,
-                                hipblasComplex*   A,
-                                int               lda)
+void ref_her2<hipblasComplex>(hipblasFillMode_t uplo,
+                              int               n,
+                              hipblasComplex    alpha,
+                              hipblasComplex*   x,
+                              int               incx,
+                              hipblasComplex*   y,
+                              int               incy,
+                              hipblasComplex*   A,
+                              int               lda)
 {
     cblas_cher2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_her2<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
-                                      int                   n,
-                                      hipblasDoubleComplex  alpha,
-                                      hipblasDoubleComplex* x,
-                                      int                   incx,
-                                      hipblasDoubleComplex* y,
-                                      int                   incy,
-                                      hipblasDoubleComplex* A,
-                                      int                   lda)
+void ref_her2<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+                                    int                   n,
+                                    hipblasDoubleComplex  alpha,
+                                    hipblasDoubleComplex* x,
+                                    int                   incx,
+                                    hipblasDoubleComplex* y,
+                                    int                   incy,
+                                    hipblasDoubleComplex* A,
+                                    int                   lda)
 {
     cblas_zher2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 // hpmv
 template <>
-void cblas_hpmv<hipblasComplex>(hipblasFillMode_t uplo,
-                                int               n,
-                                hipblasComplex    alpha,
-                                hipblasComplex*   AP,
-                                hipblasComplex*   x,
-                                int               incx,
-                                hipblasComplex    beta,
-                                hipblasComplex*   y,
-                                int               incy)
+void ref_hpmv<hipblasComplex>(hipblasFillMode_t uplo,
+                              int               n,
+                              hipblasComplex    alpha,
+                              hipblasComplex*   AP,
+                              hipblasComplex*   x,
+                              int               incx,
+                              hipblasComplex    beta,
+                              hipblasComplex*   y,
+                              int               incy)
 {
     cblas_chpmv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, AP, x, incx, &beta, y, incy);
 }
 
 template <>
-void cblas_hpmv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
-                                      int                   n,
-                                      hipblasDoubleComplex  alpha,
-                                      hipblasDoubleComplex* AP,
-                                      hipblasDoubleComplex* x,
-                                      int                   incx,
-                                      hipblasDoubleComplex  beta,
-                                      hipblasDoubleComplex* y,
-                                      int                   incy)
+void ref_hpmv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+                                    int                   n,
+                                    hipblasDoubleComplex  alpha,
+                                    hipblasDoubleComplex* AP,
+                                    hipblasDoubleComplex* x,
+                                    int                   incx,
+                                    hipblasDoubleComplex  beta,
+                                    hipblasDoubleComplex* y,
+                                    int                   incy)
 {
     cblas_zhpmv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, AP, x, incx, &beta, y, incy);
 }
 
 // hpr
 template <>
-void cblas_hpr(
+void ref_hpr(
     hipblasFillMode_t uplo, int n, float alpha, hipblasComplex* x, int incx, hipblasComplex* AP)
 {
     cblas_chpr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, AP);
 }
 
 template <>
-void cblas_hpr(hipblasFillMode_t     uplo,
-               int                   n,
-               double                alpha,
-               hipblasDoubleComplex* x,
-               int                   incx,
-               hipblasDoubleComplex* AP)
+void ref_hpr(hipblasFillMode_t     uplo,
+             int                   n,
+             double                alpha,
+             hipblasDoubleComplex* x,
+             int                   incx,
+             hipblasDoubleComplex* AP)
 {
     cblas_zhpr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, AP);
 }
 
 // hpr2
 template <>
-void cblas_hpr2(hipblasFillMode_t uplo,
-                int               n,
-                hipblasComplex    alpha,
-                hipblasComplex*   x,
-                int               incx,
-                hipblasComplex*   y,
-                int               incy,
-                hipblasComplex*   AP)
+void ref_hpr2(hipblasFillMode_t uplo,
+              int               n,
+              hipblasComplex    alpha,
+              hipblasComplex*   x,
+              int               incx,
+              hipblasComplex*   y,
+              int               incy,
+              hipblasComplex*   AP)
 {
     cblas_chpr2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, AP);
 }
 
 template <>
-void cblas_hpr2(hipblasFillMode_t     uplo,
-                int                   n,
-                hipblasDoubleComplex  alpha,
-                hipblasDoubleComplex* x,
-                int                   incx,
-                hipblasDoubleComplex* y,
-                int                   incy,
-                hipblasDoubleComplex* AP)
+void ref_hpr2(hipblasFillMode_t     uplo,
+              int                   n,
+              hipblasDoubleComplex  alpha,
+              hipblasDoubleComplex* x,
+              int                   incx,
+              hipblasDoubleComplex* y,
+              int                   incy,
+              hipblasDoubleComplex* AP)
 {
     cblas_zhpr2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, AP);
 }
 
 // sbmv
 template <>
-void cblas_sbmv(hipblasFillMode_t uplo,
-                int               n,
-                int               k,
-                float             alpha,
-                float*            A,
-                int               lda,
-                float*            x,
-                int               incx,
-                float             beta,
-                float*            y,
-                int               incy)
+void ref_sbmv(hipblasFillMode_t uplo,
+              int               n,
+              int               k,
+              float             alpha,
+              float*            A,
+              int               lda,
+              float*            x,
+              int               incx,
+              float             beta,
+              float*            y,
+              int               incy)
 {
     cblas_ssbmv(CblasColMajor, (CBLAS_UPLO)uplo, n, k, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
-void cblas_sbmv(hipblasFillMode_t uplo,
-                int               n,
-                int               k,
-                double            alpha,
-                double*           A,
-                int               lda,
-                double*           x,
-                int               incx,
-                double            beta,
-                double*           y,
-                int               incy)
+void ref_sbmv(hipblasFillMode_t uplo,
+              int               n,
+              int               k,
+              double            alpha,
+              double*           A,
+              int               lda,
+              double*           x,
+              int               incx,
+              double            beta,
+              double*           y,
+              int               incy)
 {
     cblas_dsbmv(CblasColMajor, (CBLAS_UPLO)uplo, n, k, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 // spmv
 template <>
-void cblas_spmv(hipblasFillMode_t uplo,
-                int               n,
-                float             alpha,
-                float*            AP,
-                float*            x,
-                int               incx,
-                float             beta,
-                float*            y,
-                int               incy)
+void ref_spmv(hipblasFillMode_t uplo,
+              int               n,
+              float             alpha,
+              float*            AP,
+              float*            x,
+              int               incx,
+              float             beta,
+              float*            y,
+              int               incy)
 {
     cblas_sspmv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, AP, x, incx, beta, y, incy);
 }
 
 template <>
-void cblas_spmv(hipblasFillMode_t uplo,
-                int               n,
-                double            alpha,
-                double*           AP,
-                double*           x,
-                int               incx,
-                double            beta,
-                double*           y,
-                int               incy)
+void ref_spmv(hipblasFillMode_t uplo,
+              int               n,
+              double            alpha,
+              double*           AP,
+              double*           x,
+              int               incx,
+              double            beta,
+              double*           y,
+              int               incy)
 {
     cblas_dspmv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, AP, x, incx, beta, y, incy);
 }
 
 // spr
 template <>
-void cblas_spr(hipblasFillMode_t uplo, int n, float alpha, float* x, int incx, float* AP)
+void ref_spr(hipblasFillMode_t uplo, int n, float alpha, float* x, int incx, float* AP)
 {
     cblas_sspr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, AP);
 }
 
 template <>
-void cblas_spr(hipblasFillMode_t uplo, int n, double alpha, double* x, int incx, double* AP)
+void ref_spr(hipblasFillMode_t uplo, int n, double alpha, double* x, int incx, double* AP)
 {
     cblas_dspr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, AP);
 }
 
 template <>
-void cblas_spr(hipblasFillMode_t uplo,
-               int               n,
-               hipblasComplex    alpha,
-               hipblasComplex*   x,
-               int               incx,
-               hipblasComplex*   AP)
+void ref_spr(hipblasFillMode_t uplo,
+             int               n,
+             hipblasComplex    alpha,
+             hipblasComplex*   x,
+             int               incx,
+             hipblasComplex*   AP)
 {
     char u = uplo == HIPBLAS_FILL_MODE_UPPER ? 'U' : 'L';
     cspr_(&u, &n, &alpha, x, &incx, AP);
 }
 
 template <>
-void cblas_spr(hipblasFillMode_t     uplo,
-               int                   n,
-               hipblasDoubleComplex  alpha,
-               hipblasDoubleComplex* x,
-               int                   incx,
-               hipblasDoubleComplex* AP)
+void ref_spr(hipblasFillMode_t     uplo,
+             int                   n,
+             hipblasDoubleComplex  alpha,
+             hipblasDoubleComplex* x,
+             int                   incx,
+             hipblasDoubleComplex* AP)
 {
     char u = uplo == HIPBLAS_FILL_MODE_UPPER ? 'U' : 'L';
     zspr_(&u, &n, &alpha, x, &incx, AP);
@@ -1618,83 +1614,83 @@ void cblas_spr(hipblasFillMode_t     uplo,
 
 // spr2
 template <>
-void cblas_spr2(
+void ref_spr2(
     hipblasFillMode_t uplo, int n, float alpha, float* x, int incx, float* y, int incy, float* AP)
 {
     cblas_sspr2(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, y, incy, AP);
 }
 
 template <>
-void cblas_spr2(hipblasFillMode_t uplo,
-                int               n,
-                double            alpha,
-                double*           x,
-                int               incx,
-                double*           y,
-                int               incy,
-                double*           AP)
+void ref_spr2(hipblasFillMode_t uplo,
+              int               n,
+              double            alpha,
+              double*           x,
+              int               incx,
+              double*           y,
+              int               incy,
+              double*           AP)
 {
     cblas_dspr2(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, y, incy, AP);
 }
 
 // symv
 template <>
-void cblas_symv(hipblasFillMode_t uplo,
-                int               n,
-                float             alpha,
-                float*            A,
-                int               lda,
-                float*            x,
-                int               incx,
-                float             beta,
-                float*            y,
-                int               incy)
+void ref_symv(hipblasFillMode_t uplo,
+              int               n,
+              float             alpha,
+              float*            A,
+              int               lda,
+              float*            x,
+              int               incx,
+              float             beta,
+              float*            y,
+              int               incy)
 {
     cblas_ssymv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
-void cblas_symv(hipblasFillMode_t uplo,
-                int               n,
-                double            alpha,
-                double*           A,
-                int               lda,
-                double*           x,
-                int               incx,
-                double            beta,
-                double*           y,
-                int               incy)
+void ref_symv(hipblasFillMode_t uplo,
+              int               n,
+              double            alpha,
+              double*           A,
+              int               lda,
+              double*           x,
+              int               incx,
+              double            beta,
+              double*           y,
+              int               incy)
 {
     cblas_dsymv(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, A, lda, x, incx, beta, y, incy);
 }
 
 template <>
-void cblas_symv(hipblasFillMode_t uplo,
-                int               n,
-                hipblasComplex    alpha,
-                hipblasComplex*   A,
-                int               lda,
-                hipblasComplex*   x,
-                int               incx,
-                hipblasComplex    beta,
-                hipblasComplex*   y,
-                int               incy)
+void ref_symv(hipblasFillMode_t uplo,
+              int               n,
+              hipblasComplex    alpha,
+              hipblasComplex*   A,
+              int               lda,
+              hipblasComplex*   x,
+              int               incx,
+              hipblasComplex    beta,
+              hipblasComplex*   y,
+              int               incy)
 {
     char u = uplo == HIPBLAS_FILL_MODE_UPPER ? 'U' : 'L';
     csymv_(&u, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
 }
 
 template <>
-void cblas_symv(hipblasFillMode_t     uplo,
-                int                   n,
-                hipblasDoubleComplex  alpha,
-                hipblasDoubleComplex* A,
-                int                   lda,
-                hipblasDoubleComplex* x,
-                int                   incx,
-                hipblasDoubleComplex  beta,
-                hipblasDoubleComplex* y,
-                int                   incy)
+void ref_symv(hipblasFillMode_t     uplo,
+              int                   n,
+              hipblasDoubleComplex  alpha,
+              hipblasDoubleComplex* A,
+              int                   lda,
+              hipblasDoubleComplex* x,
+              int                   incx,
+              hipblasDoubleComplex  beta,
+              hipblasDoubleComplex* y,
+              int                   incy)
 {
     char u = uplo == HIPBLAS_FILL_MODE_UPPER ? 'U' : 'L';
     zsymv_(&u, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy);
@@ -1702,40 +1698,40 @@ void cblas_symv(hipblasFillMode_t     uplo,
 
 // syr
 template <>
-void cblas_syr<float>(
+void ref_syr<float>(
     hipblasFillMode_t uplo, int n, float alpha, float* x, int incx, float* A, int lda)
 {
     cblas_ssyr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
 }
 
 template <>
-void cblas_syr<double>(
+void ref_syr<double>(
     hipblasFillMode_t uplo, int n, double alpha, double* x, int incx, double* A, int lda)
 {
     cblas_dsyr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
 }
 
 template <>
-void cblas_syr<hipblasComplex>(hipblasFillMode_t uplo,
-                               int               n,
-                               hipblasComplex    alpha,
-                               hipblasComplex*   x,
-                               int               incx,
-                               hipblasComplex*   A,
-                               int               lda)
+void ref_syr<hipblasComplex>(hipblasFillMode_t uplo,
+                             int               n,
+                             hipblasComplex    alpha,
+                             hipblasComplex*   x,
+                             int               incx,
+                             hipblasComplex*   A,
+                             int               lda)
 {
     char u = uplo == HIPBLAS_FILL_MODE_UPPER ? 'U' : 'L';
     csyr_(&u, &n, &alpha, x, &incx, A, &lda);
 }
 
 template <>
-void cblas_syr<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
-                                     int                   n,
-                                     hipblasDoubleComplex  alpha,
-                                     hipblasDoubleComplex* x,
-                                     int                   incx,
-                                     hipblasDoubleComplex* A,
-                                     int                   lda)
+void ref_syr<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+                                   int                   n,
+                                   hipblasDoubleComplex  alpha,
+                                   hipblasDoubleComplex* x,
+                                   int                   incx,
+                                   hipblasDoubleComplex* A,
+                                   int                   lda)
 {
     char u = uplo == HIPBLAS_FILL_MODE_UPPER ? 'U' : 'L';
     zsyr_(&u, &n, &alpha, x, &incx, A, &lda);
@@ -1744,7 +1740,7 @@ void cblas_syr<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
 // syr2
 // No complex version of syr2 - make a local implementation
 template <typename T>
-void cblas_syr2_local(
+void ref_syr2_local(
     hipblasFillMode_t uplo, int n, T alpha, T* xa, int incx, T* ya, int incy, T* A, int lda)
 {
     if(n <= 0)
@@ -1772,64 +1768,64 @@ void cblas_syr2_local(
 }
 
 template <>
-void cblas_syr2(hipblasFillMode_t uplo,
-                int               n,
-                float             alpha,
-                float*            x,
-                int               incx,
-                float*            y,
-                int               incy,
-                float*            A,
-                int               lda)
+void ref_syr2(hipblasFillMode_t uplo,
+              int               n,
+              float             alpha,
+              float*            x,
+              int               incx,
+              float*            y,
+              int               incy,
+              float*            A,
+              int               lda)
 {
     cblas_ssyr2(CblasColMajor, CBLAS_UPLO(uplo), n, alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_syr2(hipblasFillMode_t uplo,
-                int               n,
-                double            alpha,
-                double*           x,
-                int               incx,
-                double*           y,
-                int               incy,
-                double*           A,
-                int               lda)
+void ref_syr2(hipblasFillMode_t uplo,
+              int               n,
+              double            alpha,
+              double*           x,
+              int               incx,
+              double*           y,
+              int               incy,
+              double*           A,
+              int               lda)
 {
     cblas_dsyr2(CblasColMajor, CBLAS_UPLO(uplo), n, alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_syr2(hipblasFillMode_t uplo,
-                int               n,
-                hipblasComplex    alpha,
-                hipblasComplex*   x,
-                int               incx,
-                hipblasComplex*   y,
-                int               incy,
-                hipblasComplex*   A,
-                int               lda)
+void ref_syr2(hipblasFillMode_t uplo,
+              int               n,
+              hipblasComplex    alpha,
+              hipblasComplex*   x,
+              int               incx,
+              hipblasComplex*   y,
+              int               incy,
+              hipblasComplex*   A,
+              int               lda)
 {
-    cblas_syr2_local(uplo, n, alpha, x, incx, y, incy, A, lda);
+    ref_syr2_local(uplo, n, alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void cblas_syr2(hipblasFillMode_t     uplo,
-                int                   n,
-                hipblasDoubleComplex  alpha,
-                hipblasDoubleComplex* x,
-                int                   incx,
-                hipblasDoubleComplex* y,
-                int                   incy,
-                hipblasDoubleComplex* A,
-                int                   lda)
+void ref_syr2(hipblasFillMode_t     uplo,
+              int                   n,
+              hipblasDoubleComplex  alpha,
+              hipblasDoubleComplex* x,
+              int                   incx,
+              hipblasDoubleComplex* y,
+              int                   incy,
+              hipblasDoubleComplex* A,
+              int                   lda)
 {
-    cblas_syr2_local(uplo, n, alpha, x, incx, y, incy, A, lda);
+    ref_syr2_local(uplo, n, alpha, x, incx, y, incy, A, lda);
 }
 
 // potrf
 template <>
-int cblas_potrf(char uplo, int m, float* A, int lda)
+int ref_potrf(char uplo, int m, float* A, int lda)
 {
     int info;
     spotrf_(&uplo, &m, A, &lda, &info);
@@ -1837,7 +1833,7 @@ int cblas_potrf(char uplo, int m, float* A, int lda)
 }
 
 template <>
-int cblas_potrf(char uplo, int m, double* A, int lda)
+int ref_potrf(char uplo, int m, double* A, int lda)
 {
     int info;
     dpotrf_(&uplo, &m, A, &lda, &info);
@@ -1845,7 +1841,7 @@ int cblas_potrf(char uplo, int m, double* A, int lda)
 }
 
 template <>
-int cblas_potrf(char uplo, int m, hipblasComplex* A, int lda)
+int ref_potrf(char uplo, int m, hipblasComplex* A, int lda)
 {
     int info;
     cpotrf_(&uplo, &m, A, &lda, &info);
@@ -1853,7 +1849,7 @@ int cblas_potrf(char uplo, int m, hipblasComplex* A, int lda)
 }
 
 template <>
-int cblas_potrf(char uplo, int m, hipblasDoubleComplex* A, int lda)
+int ref_potrf(char uplo, int m, hipblasDoubleComplex* A, int lda)
 {
     int info;
     zpotrf_(&uplo, &m, A, &lda, &info);
@@ -1862,15 +1858,15 @@ int cblas_potrf(char uplo, int m, hipblasDoubleComplex* A, int lda)
 
 // tbmv
 template <>
-void cblas_tbmv<float>(hipblasFillMode_t  uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int                m,
-                       int                k,
-                       const float*       A,
-                       int                lda,
-                       float*             x,
-                       int                incx)
+void ref_tbmv<float>(hipblasFillMode_t  uplo,
+                     hipblasOperation_t transA,
+                     hipblasDiagType_t  diag,
+                     int                m,
+                     int                k,
+                     const float*       A,
+                     int                lda,
+                     float*             x,
+                     int                incx)
 {
     cblas_stbmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -1885,15 +1881,15 @@ void cblas_tbmv<float>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_tbmv<double>(hipblasFillMode_t  uplo,
-                        hipblasOperation_t transA,
-                        hipblasDiagType_t  diag,
-                        int                m,
-                        int                k,
-                        const double*      A,
-                        int                lda,
-                        double*            x,
-                        int                incx)
+void ref_tbmv<double>(hipblasFillMode_t  uplo,
+                      hipblasOperation_t transA,
+                      hipblasDiagType_t  diag,
+                      int                m,
+                      int                k,
+                      const double*      A,
+                      int                lda,
+                      double*            x,
+                      int                incx)
 {
     cblas_dtbmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -1908,15 +1904,15 @@ void cblas_tbmv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_tbmv<hipblasComplex>(hipblasFillMode_t     uplo,
-                                hipblasOperation_t    transA,
-                                hipblasDiagType_t     diag,
-                                int                   m,
-                                int                   k,
-                                const hipblasComplex* A,
-                                int                   lda,
-                                hipblasComplex*       x,
-                                int                   incx)
+void ref_tbmv<hipblasComplex>(hipblasFillMode_t     uplo,
+                              hipblasOperation_t    transA,
+                              hipblasDiagType_t     diag,
+                              int                   m,
+                              int                   k,
+                              const hipblasComplex* A,
+                              int                   lda,
+                              hipblasComplex*       x,
+                              int                   incx)
 {
     cblas_ctbmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -1931,15 +1927,15 @@ void cblas_tbmv<hipblasComplex>(hipblasFillMode_t     uplo,
 }
 
 template <>
-void cblas_tbmv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
-                                      hipblasOperation_t          transA,
-                                      hipblasDiagType_t           diag,
-                                      int                         m,
-                                      int                         k,
-                                      const hipblasDoubleComplex* A,
-                                      int                         lda,
-                                      hipblasDoubleComplex*       x,
-                                      int                         incx)
+void ref_tbmv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
+                                    hipblasOperation_t          transA,
+                                    hipblasDiagType_t           diag,
+                                    int                         m,
+                                    int                         k,
+                                    const hipblasDoubleComplex* A,
+                                    int                         lda,
+                                    hipblasDoubleComplex*       x,
+                                    int                         incx)
 {
     cblas_ztbmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -1955,15 +1951,15 @@ void cblas_tbmv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
 
 // tbsv
 template <>
-void cblas_tbsv<float>(hipblasFillMode_t  uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int                m,
-                       int                k,
-                       const float*       A,
-                       int                lda,
-                       float*             x,
-                       int                incx)
+void ref_tbsv<float>(hipblasFillMode_t  uplo,
+                     hipblasOperation_t transA,
+                     hipblasDiagType_t  diag,
+                     int                m,
+                     int                k,
+                     const float*       A,
+                     int                lda,
+                     float*             x,
+                     int                incx)
 {
     cblas_stbsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -1978,15 +1974,15 @@ void cblas_tbsv<float>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_tbsv<double>(hipblasFillMode_t  uplo,
-                        hipblasOperation_t transA,
-                        hipblasDiagType_t  diag,
-                        int                m,
-                        int                k,
-                        const double*      A,
-                        int                lda,
-                        double*            x,
-                        int                incx)
+void ref_tbsv<double>(hipblasFillMode_t  uplo,
+                      hipblasOperation_t transA,
+                      hipblasDiagType_t  diag,
+                      int                m,
+                      int                k,
+                      const double*      A,
+                      int                lda,
+                      double*            x,
+                      int                incx)
 {
     cblas_dtbsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2001,15 +1997,15 @@ void cblas_tbsv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_tbsv<hipblasComplex>(hipblasFillMode_t     uplo,
-                                hipblasOperation_t    transA,
-                                hipblasDiagType_t     diag,
-                                int                   m,
-                                int                   k,
-                                const hipblasComplex* A,
-                                int                   lda,
-                                hipblasComplex*       x,
-                                int                   incx)
+void ref_tbsv<hipblasComplex>(hipblasFillMode_t     uplo,
+                              hipblasOperation_t    transA,
+                              hipblasDiagType_t     diag,
+                              int                   m,
+                              int                   k,
+                              const hipblasComplex* A,
+                              int                   lda,
+                              hipblasComplex*       x,
+                              int                   incx)
 {
     cblas_ctbsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2024,15 +2020,15 @@ void cblas_tbsv<hipblasComplex>(hipblasFillMode_t     uplo,
 }
 
 template <>
-void cblas_tbsv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
-                                      hipblasOperation_t          transA,
-                                      hipblasDiagType_t           diag,
-                                      int                         m,
-                                      int                         k,
-                                      const hipblasDoubleComplex* A,
-                                      int                         lda,
-                                      hipblasDoubleComplex*       x,
-                                      int                         incx)
+void ref_tbsv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
+                                    hipblasOperation_t          transA,
+                                    hipblasDiagType_t           diag,
+                                    int                         m,
+                                    int                         k,
+                                    const hipblasDoubleComplex* A,
+                                    int                         lda,
+                                    hipblasDoubleComplex*       x,
+                                    int                         incx)
 {
     cblas_ztbsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2048,52 +2044,52 @@ void cblas_tbsv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
 
 // tpmv
 template <>
-void cblas_tpmv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                const float*       A,
-                float*             x,
-                int                incx)
+void ref_tpmv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              const float*       A,
+              float*             x,
+              int                incx)
 {
     cblas_stpmv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), m, A, x, incx);
 }
 
 template <>
-void cblas_tpmv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                const double*      A,
-                double*            x,
-                int                incx)
+void ref_tpmv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              const double*      A,
+              double*            x,
+              int                incx)
 {
     cblas_dtpmv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), m, A, x, incx);
 }
 
 template <>
-void cblas_tpmv(hipblasFillMode_t     uplo,
-                hipblasOperation_t    transA,
-                hipblasDiagType_t     diag,
-                int                   m,
-                const hipblasComplex* A,
-                hipblasComplex*       x,
-                int                   incx)
+void ref_tpmv(hipblasFillMode_t     uplo,
+              hipblasOperation_t    transA,
+              hipblasDiagType_t     diag,
+              int                   m,
+              const hipblasComplex* A,
+              hipblasComplex*       x,
+              int                   incx)
 {
     cblas_ctpmv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), m, A, x, incx);
 }
 
 template <>
-void cblas_tpmv(hipblasFillMode_t           uplo,
-                hipblasOperation_t          transA,
-                hipblasDiagType_t           diag,
-                int                         m,
-                const hipblasDoubleComplex* A,
-                hipblasDoubleComplex*       x,
-                int                         incx)
+void ref_tpmv(hipblasFillMode_t           uplo,
+              hipblasOperation_t          transA,
+              hipblasDiagType_t           diag,
+              int                         m,
+              const hipblasDoubleComplex* A,
+              hipblasDoubleComplex*       x,
+              int                         incx)
 {
     cblas_ztpmv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), m, A, x, incx);
@@ -2101,52 +2097,52 @@ void cblas_tpmv(hipblasFillMode_t           uplo,
 
 // tpsv
 template <>
-void cblas_tpsv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                n,
-                const float*       AP,
-                float*             x,
-                int                incx)
+void ref_tpsv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                n,
+              const float*       AP,
+              float*             x,
+              int                incx)
 {
     cblas_stpsv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), n, AP, x, incx);
 }
 
 template <>
-void cblas_tpsv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                n,
-                const double*      AP,
-                double*            x,
-                int                incx)
+void ref_tpsv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                n,
+              const double*      AP,
+              double*            x,
+              int                incx)
 {
     cblas_dtpsv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), n, AP, x, incx);
 }
 
 template <>
-void cblas_tpsv(hipblasFillMode_t     uplo,
-                hipblasOperation_t    transA,
-                hipblasDiagType_t     diag,
-                int                   n,
-                const hipblasComplex* AP,
-                hipblasComplex*       x,
-                int                   incx)
+void ref_tpsv(hipblasFillMode_t     uplo,
+              hipblasOperation_t    transA,
+              hipblasDiagType_t     diag,
+              int                   n,
+              const hipblasComplex* AP,
+              hipblasComplex*       x,
+              int                   incx)
 {
     cblas_ctpsv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), n, AP, x, incx);
 }
 
 template <>
-void cblas_tpsv(hipblasFillMode_t           uplo,
-                hipblasOperation_t          transA,
-                hipblasDiagType_t           diag,
-                int                         n,
-                const hipblasDoubleComplex* AP,
-                hipblasDoubleComplex*       x,
-                int                         incx)
+void ref_tpsv(hipblasFillMode_t           uplo,
+              hipblasOperation_t          transA,
+              hipblasDiagType_t           diag,
+              int                         n,
+              const hipblasDoubleComplex* AP,
+              hipblasDoubleComplex*       x,
+              int                         incx)
 {
     cblas_ztpsv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), n, AP, x, incx);
@@ -2154,14 +2150,14 @@ void cblas_tpsv(hipblasFillMode_t           uplo,
 
 // trmv
 template <>
-void cblas_trmv<float>(hipblasFillMode_t  uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int                m,
-                       const float*       A,
-                       int                lda,
-                       float*             x,
-                       int                incx)
+void ref_trmv<float>(hipblasFillMode_t  uplo,
+                     hipblasOperation_t transA,
+                     hipblasDiagType_t  diag,
+                     int                m,
+                     const float*       A,
+                     int                lda,
+                     float*             x,
+                     int                incx)
 {
     cblas_strmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2175,14 +2171,14 @@ void cblas_trmv<float>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_trmv<double>(hipblasFillMode_t  uplo,
-                        hipblasOperation_t transA,
-                        hipblasDiagType_t  diag,
-                        int                m,
-                        const double*      A,
-                        int                lda,
-                        double*            x,
-                        int                incx)
+void ref_trmv<double>(hipblasFillMode_t  uplo,
+                      hipblasOperation_t transA,
+                      hipblasDiagType_t  diag,
+                      int                m,
+                      const double*      A,
+                      int                lda,
+                      double*            x,
+                      int                incx)
 {
     cblas_dtrmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2196,14 +2192,14 @@ void cblas_trmv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_trmv<hipblasComplex>(hipblasFillMode_t     uplo,
-                                hipblasOperation_t    transA,
-                                hipblasDiagType_t     diag,
-                                int                   m,
-                                const hipblasComplex* A,
-                                int                   lda,
-                                hipblasComplex*       x,
-                                int                   incx)
+void ref_trmv<hipblasComplex>(hipblasFillMode_t     uplo,
+                              hipblasOperation_t    transA,
+                              hipblasDiagType_t     diag,
+                              int                   m,
+                              const hipblasComplex* A,
+                              int                   lda,
+                              hipblasComplex*       x,
+                              int                   incx)
 {
     cblas_ctrmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2217,14 +2213,14 @@ void cblas_trmv<hipblasComplex>(hipblasFillMode_t     uplo,
 }
 
 template <>
-void cblas_trmv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
-                                      hipblasOperation_t          transA,
-                                      hipblasDiagType_t           diag,
-                                      int                         m,
-                                      const hipblasDoubleComplex* A,
-                                      int                         lda,
-                                      hipblasDoubleComplex*       x,
-                                      int                         incx)
+void ref_trmv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
+                                    hipblasOperation_t          transA,
+                                    hipblasDiagType_t           diag,
+                                    int                         m,
+                                    const hipblasDoubleComplex* A,
+                                    int                         lda,
+                                    hipblasDoubleComplex*       x,
+                                    int                         incx)
 {
     cblas_ztrmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2239,15 +2235,15 @@ void cblas_trmv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
 
 // trsv
 template <>
-void cblas_trsv<float>(hipblasHandle_t    handle,
-                       hipblasFillMode_t  uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int                m,
-                       const float*       A,
-                       int                lda,
-                       float*             x,
-                       int                incx)
+void ref_trsv<float>(hipblasHandle_t    handle,
+                     hipblasFillMode_t  uplo,
+                     hipblasOperation_t transA,
+                     hipblasDiagType_t  diag,
+                     int                m,
+                     const float*       A,
+                     int                lda,
+                     float*             x,
+                     int                incx)
 {
     cblas_strsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2261,15 +2257,15 @@ void cblas_trsv<float>(hipblasHandle_t    handle,
 }
 
 template <>
-void cblas_trsv<double>(hipblasHandle_t    handle,
-                        hipblasFillMode_t  uplo,
-                        hipblasOperation_t transA,
-                        hipblasDiagType_t  diag,
-                        int                m,
-                        const double*      A,
-                        int                lda,
-                        double*            x,
-                        int                incx)
+void ref_trsv<double>(hipblasHandle_t    handle,
+                      hipblasFillMode_t  uplo,
+                      hipblasOperation_t transA,
+                      hipblasDiagType_t  diag,
+                      int                m,
+                      const double*      A,
+                      int                lda,
+                      double*            x,
+                      int                incx)
 {
     cblas_dtrsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2283,15 +2279,15 @@ void cblas_trsv<double>(hipblasHandle_t    handle,
 }
 
 template <>
-void cblas_trsv<hipblasComplex>(hipblasHandle_t       handle,
-                                hipblasFillMode_t     uplo,
-                                hipblasOperation_t    transA,
-                                hipblasDiagType_t     diag,
-                                int                   m,
-                                const hipblasComplex* A,
-                                int                   lda,
-                                hipblasComplex*       x,
-                                int                   incx)
+void ref_trsv<hipblasComplex>(hipblasHandle_t       handle,
+                              hipblasFillMode_t     uplo,
+                              hipblasOperation_t    transA,
+                              hipblasDiagType_t     diag,
+                              int                   m,
+                              const hipblasComplex* A,
+                              int                   lda,
+                              hipblasComplex*       x,
+                              int                   incx)
 {
     cblas_ctrsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2305,15 +2301,15 @@ void cblas_trsv<hipblasComplex>(hipblasHandle_t       handle,
 }
 
 template <>
-void cblas_trsv<hipblasDoubleComplex>(hipblasHandle_t             handle,
-                                      hipblasFillMode_t           uplo,
-                                      hipblasOperation_t          transA,
-                                      hipblasDiagType_t           diag,
-                                      int                         m,
-                                      const hipblasDoubleComplex* A,
-                                      int                         lda,
-                                      hipblasDoubleComplex*       x,
-                                      int                         incx)
+void ref_trsv<hipblasDoubleComplex>(hipblasHandle_t             handle,
+                                    hipblasFillMode_t           uplo,
+                                    hipblasOperation_t          transA,
+                                    hipblasDiagType_t           diag,
+                                    int                         m,
+                                    const hipblasDoubleComplex* A,
+                                    int                         lda,
+                                    hipblasDoubleComplex*       x,
+                                    int                         incx)
 {
     cblas_ztrsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2333,18 +2329,18 @@ void cblas_trsv<hipblasDoubleComplex>(hipblasHandle_t             handle,
  */
 
 template <typename T>
-void cblas_geam_helper(hipblasOperation_t transA,
-                       hipblasOperation_t transB,
-                       int                M,
-                       int                N,
-                       T                  alpha,
-                       T*                 A,
-                       int                lda,
-                       T                  beta,
-                       T*                 B,
-                       int                ldb,
-                       T*                 C,
-                       int                ldc)
+void ref_geam_helper(hipblasOperation_t transA,
+                     hipblasOperation_t transB,
+                     int                M,
+                     int                N,
+                     T                  alpha,
+                     T*                 A,
+                     int                lda,
+                     T                  beta,
+                     T*                 B,
+                     int                ldb,
+                     T*                 C,
+                     int                ldc)
 {
     int inc1_A = transA == HIPBLAS_OP_N ? 1 : lda;
     int inc2_A = transA == HIPBLAS_OP_N ? lda : 1;
@@ -2368,88 +2364,88 @@ void cblas_geam_helper(hipblasOperation_t transA,
 
 // geam
 template <>
-void cblas_geam(hipblasOperation_t transa,
-                hipblasOperation_t transb,
-                int                m,
-                int                n,
-                float*             alpha,
-                float*             A,
-                int                lda,
-                float*             beta,
-                float*             B,
-                int                ldb,
-                float*             C,
-                int                ldc)
+void ref_geam(hipblasOperation_t transa,
+              hipblasOperation_t transb,
+              int                m,
+              int                n,
+              float*             alpha,
+              float*             A,
+              int                lda,
+              float*             beta,
+              float*             B,
+              int                ldb,
+              float*             C,
+              int                ldc)
 {
-    return cblas_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
+    return ref_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
 }
 
 template <>
-void cblas_geam(hipblasOperation_t transa,
-                hipblasOperation_t transb,
-                int                m,
-                int                n,
-                double*            alpha,
-                double*            A,
-                int                lda,
-                double*            beta,
-                double*            B,
-                int                ldb,
-                double*            C,
-                int                ldc)
+void ref_geam(hipblasOperation_t transa,
+              hipblasOperation_t transb,
+              int                m,
+              int                n,
+              double*            alpha,
+              double*            A,
+              int                lda,
+              double*            beta,
+              double*            B,
+              int                ldb,
+              double*            C,
+              int                ldc)
 {
-    return cblas_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
+    return ref_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
 }
 
 template <>
-void cblas_geam(hipblasOperation_t transa,
-                hipblasOperation_t transb,
-                int                m,
-                int                n,
-                hipblasComplex*    alpha,
-                hipblasComplex*    A,
-                int                lda,
-                hipblasComplex*    beta,
-                hipblasComplex*    B,
-                int                ldb,
-                hipblasComplex*    C,
-                int                ldc)
+void ref_geam(hipblasOperation_t transa,
+              hipblasOperation_t transb,
+              int                m,
+              int                n,
+              hipblasComplex*    alpha,
+              hipblasComplex*    A,
+              int                lda,
+              hipblasComplex*    beta,
+              hipblasComplex*    B,
+              int                ldb,
+              hipblasComplex*    C,
+              int                ldc)
 {
-    return cblas_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
+    return ref_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
 }
 
 template <>
-void cblas_geam(hipblasOperation_t    transa,
-                hipblasOperation_t    transb,
-                int                   m,
-                int                   n,
-                hipblasDoubleComplex* alpha,
-                hipblasDoubleComplex* A,
-                int                   lda,
-                hipblasDoubleComplex* beta,
-                hipblasDoubleComplex* B,
-                int                   ldb,
-                hipblasDoubleComplex* C,
-                int                   ldc)
+void ref_geam(hipblasOperation_t    transa,
+              hipblasOperation_t    transb,
+              int                   m,
+              int                   n,
+              hipblasDoubleComplex* alpha,
+              hipblasDoubleComplex* A,
+              int                   lda,
+              hipblasDoubleComplex* beta,
+              hipblasDoubleComplex* B,
+              int                   ldb,
+              hipblasDoubleComplex* C,
+              int                   ldc)
 {
-    return cblas_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
+    return ref_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
 }
 
 // gemm
 template <>
-void cblas_gemm<hipblasHalf>(hipblasOperation_t transA,
-                             hipblasOperation_t transB,
-                             int                m,
-                             int                n,
-                             int                k,
-                             hipblasHalf        alpha,
-                             hipblasHalf*       A,
-                             int                lda,
-                             hipblasHalf*       B,
-                             int                ldb,
-                             hipblasHalf        beta,
-                             hipblasHalf*       C,
-                             int                ldc)
+void ref_gemm<hipblasHalf>(hipblasOperation_t transA,
+                           hipblasOperation_t transB,
+                           int                m,
+                           int                n,
+                           int                k,
+                           hipblasHalf        alpha,
+                           hipblasHalf*       A,
+                           int                lda,
+                           hipblasHalf*       B,
+                           int                ldb,
+                           hipblasHalf        beta,
+                           hipblasHalf*       C,
+                           int                ldc)
 {
     // cblas does not support hipblasHalf, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -2501,19 +2497,19 @@ void cblas_gemm<hipblasHalf>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<hipblasHalf, hipblasHalf, float>(hipblasOperation_t transA,
-                                                 hipblasOperation_t transB,
-                                                 int                m,
-                                                 int                n,
-                                                 int                k,
-                                                 float              alpha,
-                                                 hipblasHalf*       A,
-                                                 int                lda,
-                                                 hipblasHalf*       B,
-                                                 int                ldb,
-                                                 float              beta,
-                                                 hipblasHalf*       C,
-                                                 int                ldc)
+void ref_gemm<hipblasHalf, hipblasHalf, float>(hipblasOperation_t transA,
+                                               hipblasOperation_t transB,
+                                               int                m,
+                                               int                n,
+                                               int                k,
+                                               float              alpha,
+                                               hipblasHalf*       A,
+                                               int                lda,
+                                               hipblasHalf*       B,
+                                               int                ldb,
+                                               float              beta,
+                                               hipblasHalf*       C,
+                                               int                ldc)
 {
     // cblas does not support hipblasHalf, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -2563,19 +2559,19 @@ void cblas_gemm<hipblasHalf, hipblasHalf, float>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<hipblasHalf, float, float>(hipblasOperation_t transA,
-                                           hipblasOperation_t transB,
-                                           int                m,
-                                           int                n,
-                                           int                k,
-                                           float              alpha,
-                                           hipblasHalf*       A,
-                                           int                lda,
-                                           hipblasHalf*       B,
-                                           int                ldb,
-                                           float              beta,
-                                           float*             C,
-                                           int                ldc)
+void ref_gemm<hipblasHalf, float, float>(hipblasOperation_t transA,
+                                         hipblasOperation_t transB,
+                                         int                m,
+                                         int                n,
+                                         int                k,
+                                         float              alpha,
+                                         hipblasHalf*       A,
+                                         int                lda,
+                                         hipblasHalf*       B,
+                                         int                ldb,
+                                         float              beta,
+                                         float*             C,
+                                         int                ldc)
 {
     // cblas does not support hipblasHalf, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -2614,19 +2610,19 @@ void cblas_gemm<hipblasHalf, float, float>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<hipblasBfloat16, hipblasBfloat16, float>(hipblasOperation_t transA,
-                                                         hipblasOperation_t transB,
-                                                         int                m,
-                                                         int                n,
-                                                         int                k,
-                                                         float              alpha,
-                                                         hipblasBfloat16*   A,
-                                                         int                lda,
-                                                         hipblasBfloat16*   B,
-                                                         int                ldb,
-                                                         float              beta,
-                                                         hipblasBfloat16*   C,
-                                                         int                ldc)
+void ref_gemm<hipblasBfloat16, hipblasBfloat16, float>(hipblasOperation_t transA,
+                                                       hipblasOperation_t transB,
+                                                       int                m,
+                                                       int                n,
+                                                       int                k,
+                                                       float              alpha,
+                                                       hipblasBfloat16*   A,
+                                                       int                lda,
+                                                       hipblasBfloat16*   B,
+                                                       int                ldb,
+                                                       float              beta,
+                                                       hipblasBfloat16*   C,
+                                                       int                ldc)
 {
     // cblas does not support hipblasBfloat16, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -2676,19 +2672,19 @@ void cblas_gemm<hipblasBfloat16, hipblasBfloat16, float>(hipblasOperation_t tran
 }
 
 template <>
-void cblas_gemm<hipblasBfloat16, float, float>(hipblasOperation_t transA,
-                                               hipblasOperation_t transB,
-                                               int                m,
-                                               int                n,
-                                               int                k,
-                                               float              alpha,
-                                               hipblasBfloat16*   A,
-                                               int                lda,
-                                               hipblasBfloat16*   B,
-                                               int                ldb,
-                                               float              beta,
-                                               float*             C,
-                                               int                ldc)
+void ref_gemm<hipblasBfloat16, float, float>(hipblasOperation_t transA,
+                                             hipblasOperation_t transB,
+                                             int                m,
+                                             int                n,
+                                             int                k,
+                                             float              alpha,
+                                             hipblasBfloat16*   A,
+                                             int                lda,
+                                             hipblasBfloat16*   B,
+                                             int                ldb,
+                                             float              beta,
+                                             float*             C,
+                                             int                ldc)
 {
     // cblas does not support hipblasBfloat16, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
@@ -2727,19 +2723,19 @@ void cblas_gemm<hipblasBfloat16, float, float>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<float>(hipblasOperation_t transA,
-                       hipblasOperation_t transB,
-                       int                m,
-                       int                n,
-                       int                k,
-                       float              alpha,
-                       float*             A,
-                       int                lda,
-                       float*             B,
-                       int                ldb,
-                       float              beta,
-                       float*             C,
-                       int                ldc)
+void ref_gemm<float>(hipblasOperation_t transA,
+                     hipblasOperation_t transB,
+                     int                m,
+                     int                n,
+                     int                k,
+                     float              alpha,
+                     float*             A,
+                     int                lda,
+                     float*             B,
+                     int                ldb,
+                     float              beta,
+                     float*             C,
+                     int                ldc)
 {
     // just directly cast, since transA, transB are integers in the enum
     // printf("transA: hipblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
@@ -2760,19 +2756,19 @@ void cblas_gemm<float>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<double>(hipblasOperation_t transA,
-                        hipblasOperation_t transB,
-                        int                m,
-                        int                n,
-                        int                k,
-                        double             alpha,
-                        double*            A,
-                        int                lda,
-                        double*            B,
-                        int                ldb,
-                        double             beta,
-                        double*            C,
-                        int                ldc)
+void ref_gemm<double>(hipblasOperation_t transA,
+                      hipblasOperation_t transB,
+                      int                m,
+                      int                n,
+                      int                k,
+                      double             alpha,
+                      double*            A,
+                      int                lda,
+                      double*            B,
+                      int                ldb,
+                      double             beta,
+                      double*            C,
+                      int                ldc)
 {
     cblas_dgemm(CblasColMajor,
                 (CBLAS_TRANSPOSE)transA,
@@ -2791,19 +2787,19 @@ void cblas_gemm<double>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<hipblasComplex>(hipblasOperation_t transA,
-                                hipblasOperation_t transB,
-                                int                m,
-                                int                n,
-                                int                k,
-                                hipblasComplex     alpha,
-                                hipblasComplex*    A,
-                                int                lda,
-                                hipblasComplex*    B,
-                                int                ldb,
-                                hipblasComplex     beta,
-                                hipblasComplex*    C,
-                                int                ldc)
+void ref_gemm<hipblasComplex>(hipblasOperation_t transA,
+                              hipblasOperation_t transB,
+                              int                m,
+                              int                n,
+                              int                k,
+                              hipblasComplex     alpha,
+                              hipblasComplex*    A,
+                              int                lda,
+                              hipblasComplex*    B,
+                              int                ldb,
+                              hipblasComplex     beta,
+                              hipblasComplex*    C,
+                              int                ldc)
 {
     //just directly cast, since transA, transB are integers in the enum
     cblas_cgemm(CblasColMajor,
@@ -2823,19 +2819,19 @@ void cblas_gemm<hipblasComplex>(hipblasOperation_t transA,
 }
 
 template <>
-void cblas_gemm<hipblasDoubleComplex>(hipblasOperation_t    transA,
-                                      hipblasOperation_t    transB,
-                                      int                   m,
-                                      int                   n,
-                                      int                   k,
-                                      hipblasDoubleComplex  alpha,
-                                      hipblasDoubleComplex* A,
-                                      int                   lda,
-                                      hipblasDoubleComplex* B,
-                                      int                   ldb,
-                                      hipblasDoubleComplex  beta,
-                                      hipblasDoubleComplex* C,
-                                      int                   ldc)
+void ref_gemm<hipblasDoubleComplex>(hipblasOperation_t    transA,
+                                    hipblasOperation_t    transB,
+                                    int                   m,
+                                    int                   n,
+                                    int                   k,
+                                    hipblasDoubleComplex  alpha,
+                                    hipblasDoubleComplex* A,
+                                    int                   lda,
+                                    hipblasDoubleComplex* B,
+                                    int                   ldb,
+                                    hipblasDoubleComplex  beta,
+                                    hipblasDoubleComplex* C,
+                                    int                   ldc)
 {
     cblas_zgemm(CblasColMajor,
                 (CBLAS_TRANSPOSE)transA,
@@ -2854,19 +2850,19 @@ void cblas_gemm<hipblasDoubleComplex>(hipblasOperation_t    transA,
 }
 
 template <>
-void cblas_gemm<int8_t, int32_t, int32_t>(hipblasOperation_t transA,
-                                          hipblasOperation_t transB,
-                                          int                m,
-                                          int                n,
-                                          int                k,
-                                          int32_t            alpha,
-                                          int8_t*            A,
-                                          int                lda,
-                                          int8_t*            B,
-                                          int                ldb,
-                                          int32_t            beta,
-                                          int32_t*           C,
-                                          int                ldc)
+void ref_gemm<int8_t, int32_t, int32_t>(hipblasOperation_t transA,
+                                        hipblasOperation_t transB,
+                                        int                m,
+                                        int                n,
+                                        int                k,
+                                        int32_t            alpha,
+                                        int8_t*            A,
+                                        int                lda,
+                                        int8_t*            B,
+                                        int                ldb,
+                                        int32_t            beta,
+                                        int32_t*           C,
+                                        int                ldc)
 {
     double alpha_double = static_cast<double>(alpha);
     double beta_double  = static_cast<double>(beta);
@@ -2913,18 +2909,18 @@ void cblas_gemm<int8_t, int32_t, int32_t>(hipblasOperation_t transA,
 
 // hemm
 template <>
-void cblas_hemm(hipblasSideMode_t side,
-                hipblasFillMode_t uplo,
-                int               m,
-                int               n,
-                hipblasComplex    alpha,
-                hipblasComplex*   A,
-                int               lda,
-                hipblasComplex*   B,
-                int               ldb,
-                hipblasComplex    beta,
-                hipblasComplex*   C,
-                int               ldc)
+void ref_hemm(hipblasSideMode_t side,
+              hipblasFillMode_t uplo,
+              int               m,
+              int               n,
+              hipblasComplex    alpha,
+              hipblasComplex*   A,
+              int               lda,
+              hipblasComplex*   B,
+              int               ldb,
+              hipblasComplex    beta,
+              hipblasComplex*   C,
+              int               ldc)
 {
     cblas_chemm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -2942,18 +2938,18 @@ void cblas_hemm(hipblasSideMode_t side,
 }
 
 template <>
-void cblas_hemm(hipblasSideMode_t     side,
-                hipblasFillMode_t     uplo,
-                int                   m,
-                int                   n,
-                hipblasDoubleComplex  alpha,
-                hipblasDoubleComplex* A,
-                int                   lda,
-                hipblasDoubleComplex* B,
-                int                   ldb,
-                hipblasDoubleComplex  beta,
-                hipblasDoubleComplex* C,
-                int                   ldc)
+void ref_hemm(hipblasSideMode_t     side,
+              hipblasFillMode_t     uplo,
+              int                   m,
+              int                   n,
+              hipblasDoubleComplex  alpha,
+              hipblasDoubleComplex* A,
+              int                   lda,
+              hipblasDoubleComplex* B,
+              int                   ldb,
+              hipblasDoubleComplex  beta,
+              hipblasDoubleComplex* C,
+              int                   ldc)
 {
     cblas_zhemm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -2972,16 +2968,16 @@ void cblas_hemm(hipblasSideMode_t     side,
 
 // herk
 template <>
-void cblas_herk(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                int                n,
-                int                k,
-                float              alpha,
-                hipblasComplex*    A,
-                int                lda,
-                float              beta,
-                hipblasComplex*    C,
-                int                ldc)
+void ref_herk(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              int                n,
+              int                k,
+              float              alpha,
+              hipblasComplex*    A,
+              int                lda,
+              float              beta,
+              hipblasComplex*    C,
+              int                ldc)
 {
     cblas_cherk(CblasColMajor,
                 (CBLAS_UPLO)uplo,
@@ -2997,16 +2993,16 @@ void cblas_herk(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_herk(hipblasFillMode_t     uplo,
-                hipblasOperation_t    transA,
-                int                   n,
-                int                   k,
-                double                alpha,
-                hipblasDoubleComplex* A,
-                int                   lda,
-                double                beta,
-                hipblasDoubleComplex* C,
-                int                   ldc)
+void ref_herk(hipblasFillMode_t     uplo,
+              hipblasOperation_t    transA,
+              int                   n,
+              int                   k,
+              double                alpha,
+              hipblasDoubleComplex* A,
+              int                   lda,
+              double                beta,
+              hipblasDoubleComplex* C,
+              int                   ldc)
 {
     cblas_zherk(CblasColMajor,
                 (CBLAS_UPLO)uplo,
@@ -3023,18 +3019,18 @@ void cblas_herk(hipblasFillMode_t     uplo,
 
 // herkx
 template <typename T, typename U>
-void cblas_herkx_local(hipblasFillMode_t  uplo,
-                       hipblasOperation_t transA,
-                       int                n,
-                       int                k,
-                       T                  alpha,
-                       T*                 A,
-                       int                lda,
-                       T*                 B,
-                       int                ldb,
-                       U                  beta,
-                       T*                 C,
-                       int                ldc)
+void ref_herkx_local(hipblasFillMode_t  uplo,
+                     hipblasOperation_t transA,
+                     int                n,
+                     int                k,
+                     T                  alpha,
+                     T*                 A,
+                     int                lda,
+                     T*                 B,
+                     int                ldb,
+                     U                  beta,
+                     T*                 C,
+                     int                ldc)
 {
 
     if(n <= 0 || (beta == 1 && (k == 0 || alpha == T(0.0))))
@@ -3106,53 +3102,53 @@ void cblas_herkx_local(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_herkx(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 hipblasComplex     alpha,
-                 hipblasComplex*    A,
-                 int                lda,
-                 hipblasComplex*    B,
-                 int                ldb,
-                 float              beta,
-                 hipblasComplex*    C,
-                 int                ldc)
+void ref_herkx(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               hipblasComplex     alpha,
+               hipblasComplex*    A,
+               int                lda,
+               hipblasComplex*    B,
+               int                ldb,
+               float              beta,
+               hipblasComplex*    C,
+               int                ldc)
 {
-    cblas_herkx_local(uplo, transA, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+    ref_herkx_local(uplo, transA, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 template <>
-void cblas_herkx(hipblasFillMode_t     uplo,
-                 hipblasOperation_t    transA,
-                 int                   n,
-                 int                   k,
-                 hipblasDoubleComplex  alpha,
-                 hipblasDoubleComplex* A,
-                 int                   lda,
-                 hipblasDoubleComplex* B,
-                 int                   ldb,
-                 double                beta,
-                 hipblasDoubleComplex* C,
-                 int                   ldc)
+void ref_herkx(hipblasFillMode_t     uplo,
+               hipblasOperation_t    transA,
+               int                   n,
+               int                   k,
+               hipblasDoubleComplex  alpha,
+               hipblasDoubleComplex* A,
+               int                   lda,
+               hipblasDoubleComplex* B,
+               int                   ldb,
+               double                beta,
+               hipblasDoubleComplex* C,
+               int                   ldc)
 {
-    cblas_herkx_local(uplo, transA, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+    ref_herkx_local(uplo, transA, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
 }
 
 // her2k
 template <>
-void cblas_her2k(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 hipblasComplex     alpha,
-                 hipblasComplex*    A,
-                 int                lda,
-                 hipblasComplex*    B,
-                 int                ldb,
-                 float              beta,
-                 hipblasComplex*    C,
-                 int                ldc)
+void ref_her2k(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               hipblasComplex     alpha,
+               hipblasComplex*    A,
+               int                lda,
+               hipblasComplex*    B,
+               int                ldb,
+               float              beta,
+               hipblasComplex*    C,
+               int                ldc)
 {
     cblas_cher2k(CblasColMajor,
                  (CBLAS_UPLO)uplo,
@@ -3170,18 +3166,18 @@ void cblas_her2k(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_her2k(hipblasFillMode_t     uplo,
-                 hipblasOperation_t    transA,
-                 int                   n,
-                 int                   k,
-                 hipblasDoubleComplex  alpha,
-                 hipblasDoubleComplex* A,
-                 int                   lda,
-                 hipblasDoubleComplex* B,
-                 int                   ldb,
-                 double                beta,
-                 hipblasDoubleComplex* C,
-                 int                   ldc)
+void ref_her2k(hipblasFillMode_t     uplo,
+               hipblasOperation_t    transA,
+               int                   n,
+               int                   k,
+               hipblasDoubleComplex  alpha,
+               hipblasDoubleComplex* A,
+               int                   lda,
+               hipblasDoubleComplex* B,
+               int                   ldb,
+               double                beta,
+               hipblasDoubleComplex* C,
+               int                   ldc)
 {
     cblas_zher2k(CblasColMajor,
                  (CBLAS_UPLO)uplo,
@@ -3200,18 +3196,18 @@ void cblas_her2k(hipblasFillMode_t     uplo,
 
 // symm
 template <>
-void cblas_symm(hipblasSideMode_t side,
-                hipblasFillMode_t uplo,
-                int               m,
-                int               n,
-                float             alpha,
-                float*            A,
-                int               lda,
-                float*            B,
-                int               ldb,
-                float             beta,
-                float*            C,
-                int               ldc)
+void ref_symm(hipblasSideMode_t side,
+              hipblasFillMode_t uplo,
+              int               m,
+              int               n,
+              float             alpha,
+              float*            A,
+              int               lda,
+              float*            B,
+              int               ldb,
+              float             beta,
+              float*            C,
+              int               ldc)
 {
     cblas_ssymm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3229,18 +3225,18 @@ void cblas_symm(hipblasSideMode_t side,
 }
 
 template <>
-void cblas_symm(hipblasSideMode_t side,
-                hipblasFillMode_t uplo,
-                int               m,
-                int               n,
-                double            alpha,
-                double*           A,
-                int               lda,
-                double*           B,
-                int               ldb,
-                double            beta,
-                double*           C,
-                int               ldc)
+void ref_symm(hipblasSideMode_t side,
+              hipblasFillMode_t uplo,
+              int               m,
+              int               n,
+              double            alpha,
+              double*           A,
+              int               lda,
+              double*           B,
+              int               ldb,
+              double            beta,
+              double*           C,
+              int               ldc)
 {
     cblas_dsymm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3258,18 +3254,18 @@ void cblas_symm(hipblasSideMode_t side,
 }
 
 template <>
-void cblas_symm(hipblasSideMode_t side,
-                hipblasFillMode_t uplo,
-                int               m,
-                int               n,
-                hipblasComplex    alpha,
-                hipblasComplex*   A,
-                int               lda,
-                hipblasComplex*   B,
-                int               ldb,
-                hipblasComplex    beta,
-                hipblasComplex*   C,
-                int               ldc)
+void ref_symm(hipblasSideMode_t side,
+              hipblasFillMode_t uplo,
+              int               m,
+              int               n,
+              hipblasComplex    alpha,
+              hipblasComplex*   A,
+              int               lda,
+              hipblasComplex*   B,
+              int               ldb,
+              hipblasComplex    beta,
+              hipblasComplex*   C,
+              int               ldc)
 {
     cblas_csymm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3287,18 +3283,18 @@ void cblas_symm(hipblasSideMode_t side,
 }
 
 template <>
-void cblas_symm(hipblasSideMode_t     side,
-                hipblasFillMode_t     uplo,
-                int                   m,
-                int                   n,
-                hipblasDoubleComplex  alpha,
-                hipblasDoubleComplex* A,
-                int                   lda,
-                hipblasDoubleComplex* B,
-                int                   ldb,
-                hipblasDoubleComplex  beta,
-                hipblasDoubleComplex* C,
-                int                   ldc)
+void ref_symm(hipblasSideMode_t     side,
+              hipblasFillMode_t     uplo,
+              int                   m,
+              int                   n,
+              hipblasDoubleComplex  alpha,
+              hipblasDoubleComplex* A,
+              int                   lda,
+              hipblasDoubleComplex* B,
+              int                   ldb,
+              hipblasDoubleComplex  beta,
+              hipblasDoubleComplex* C,
+              int                   ldc)
 {
     cblas_zsymm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3317,16 +3313,16 @@ void cblas_symm(hipblasSideMode_t     side,
 
 // syrk
 template <>
-void cblas_syrk(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                int                n,
-                int                k,
-                float              alpha,
-                float*             A,
-                int                lda,
-                float              beta,
-                float*             C,
-                int                ldc)
+void ref_syrk(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              int                n,
+              int                k,
+              float              alpha,
+              float*             A,
+              int                lda,
+              float              beta,
+              float*             C,
+              int                ldc)
 {
     cblas_ssyrk(CblasColMajor,
                 (CBLAS_UPLO)uplo,
@@ -3342,16 +3338,16 @@ void cblas_syrk(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_syrk(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                int                n,
-                int                k,
-                double             alpha,
-                double*            A,
-                int                lda,
-                double             beta,
-                double*            C,
-                int                ldc)
+void ref_syrk(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              int                n,
+              int                k,
+              double             alpha,
+              double*            A,
+              int                lda,
+              double             beta,
+              double*            C,
+              int                ldc)
 {
     cblas_dsyrk(CblasColMajor,
                 (CBLAS_UPLO)uplo,
@@ -3367,16 +3363,16 @@ void cblas_syrk(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_syrk(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                int                n,
-                int                k,
-                hipblasComplex     alpha,
-                hipblasComplex*    A,
-                int                lda,
-                hipblasComplex     beta,
-                hipblasComplex*    C,
-                int                ldc)
+void ref_syrk(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              int                n,
+              int                k,
+              hipblasComplex     alpha,
+              hipblasComplex*    A,
+              int                lda,
+              hipblasComplex     beta,
+              hipblasComplex*    C,
+              int                ldc)
 {
     cblas_csyrk(CblasColMajor,
                 (CBLAS_UPLO)uplo,
@@ -3392,16 +3388,16 @@ void cblas_syrk(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_syrk(hipblasFillMode_t     uplo,
-                hipblasOperation_t    transA,
-                int                   n,
-                int                   k,
-                hipblasDoubleComplex  alpha,
-                hipblasDoubleComplex* A,
-                int                   lda,
-                hipblasDoubleComplex  beta,
-                hipblasDoubleComplex* C,
-                int                   ldc)
+void ref_syrk(hipblasFillMode_t     uplo,
+              hipblasOperation_t    transA,
+              int                   n,
+              int                   k,
+              hipblasDoubleComplex  alpha,
+              hipblasDoubleComplex* A,
+              int                   lda,
+              hipblasDoubleComplex  beta,
+              hipblasDoubleComplex* C,
+              int                   ldc)
 {
     cblas_zsyrk(CblasColMajor,
                 (CBLAS_UPLO)uplo,
@@ -3418,18 +3414,18 @@ void cblas_syrk(hipblasFillMode_t     uplo,
 
 // syr2k
 template <>
-void cblas_syr2k(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 float              alpha,
-                 float*             A,
-                 int                lda,
-                 float*             B,
-                 int                ldb,
-                 float              beta,
-                 float*             C,
-                 int                ldc)
+void ref_syr2k(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               float              alpha,
+               float*             A,
+               int                lda,
+               float*             B,
+               int                ldb,
+               float              beta,
+               float*             C,
+               int                ldc)
 {
     cblas_ssyr2k(CblasColMajor,
                  (CBLAS_UPLO)uplo,
@@ -3447,18 +3443,18 @@ void cblas_syr2k(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_syr2k(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 double             alpha,
-                 double*            A,
-                 int                lda,
-                 double*            B,
-                 int                ldb,
-                 double             beta,
-                 double*            C,
-                 int                ldc)
+void ref_syr2k(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               double             alpha,
+               double*            A,
+               int                lda,
+               double*            B,
+               int                ldb,
+               double             beta,
+               double*            C,
+               int                ldc)
 {
     cblas_dsyr2k(CblasColMajor,
                  (CBLAS_UPLO)uplo,
@@ -3476,18 +3472,18 @@ void cblas_syr2k(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_syr2k(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 hipblasComplex     alpha,
-                 hipblasComplex*    A,
-                 int                lda,
-                 hipblasComplex*    B,
-                 int                ldb,
-                 hipblasComplex     beta,
-                 hipblasComplex*    C,
-                 int                ldc)
+void ref_syr2k(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               hipblasComplex     alpha,
+               hipblasComplex*    A,
+               int                lda,
+               hipblasComplex*    B,
+               int                ldb,
+               hipblasComplex     beta,
+               hipblasComplex*    C,
+               int                ldc)
 {
     cblas_csyr2k(CblasColMajor,
                  (CBLAS_UPLO)uplo,
@@ -3505,18 +3501,18 @@ void cblas_syr2k(hipblasFillMode_t  uplo,
 }
 
 template <>
-void cblas_syr2k(hipblasFillMode_t     uplo,
-                 hipblasOperation_t    transA,
-                 int                   n,
-                 int                   k,
-                 hipblasDoubleComplex  alpha,
-                 hipblasDoubleComplex* A,
-                 int                   lda,
-                 hipblasDoubleComplex* B,
-                 int                   ldb,
-                 hipblasDoubleComplex  beta,
-                 hipblasDoubleComplex* C,
-                 int                   ldc)
+void ref_syr2k(hipblasFillMode_t     uplo,
+               hipblasOperation_t    transA,
+               int                   n,
+               int                   k,
+               hipblasDoubleComplex  alpha,
+               hipblasDoubleComplex* A,
+               int                   lda,
+               hipblasDoubleComplex* B,
+               int                   ldb,
+               hipblasDoubleComplex  beta,
+               hipblasDoubleComplex* C,
+               int                   ldc)
 {
     cblas_zsyr2k(CblasColMajor,
                  (CBLAS_UPLO)uplo,
@@ -3538,17 +3534,17 @@ void cblas_syr2k(hipblasFillMode_t     uplo,
 
 // trsm
 template <>
-void cblas_trsm<float>(hipblasSideMode_t  side,
-                       hipblasFillMode_t  uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int                m,
-                       int                n,
-                       float              alpha,
-                       const float*       A,
-                       int                lda,
-                       float*             B,
-                       int                ldb)
+void ref_trsm<float>(hipblasSideMode_t  side,
+                     hipblasFillMode_t  uplo,
+                     hipblasOperation_t transA,
+                     hipblasDiagType_t  diag,
+                     int                m,
+                     int                n,
+                     float              alpha,
+                     const float*       A,
+                     int                lda,
+                     float*             B,
+                     int                ldb)
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_strsm(CblasColMajor,
@@ -3566,17 +3562,17 @@ void cblas_trsm<float>(hipblasSideMode_t  side,
 }
 
 template <>
-void cblas_trsm<double>(hipblasSideMode_t  side,
-                        hipblasFillMode_t  uplo,
-                        hipblasOperation_t transA,
-                        hipblasDiagType_t  diag,
-                        int                m,
-                        int                n,
-                        double             alpha,
-                        const double*      A,
-                        int                lda,
-                        double*            B,
-                        int                ldb)
+void ref_trsm<double>(hipblasSideMode_t  side,
+                      hipblasFillMode_t  uplo,
+                      hipblasOperation_t transA,
+                      hipblasDiagType_t  diag,
+                      int                m,
+                      int                n,
+                      double             alpha,
+                      const double*      A,
+                      int                lda,
+                      double*            B,
+                      int                ldb)
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_dtrsm(CblasColMajor,
@@ -3594,17 +3590,17 @@ void cblas_trsm<double>(hipblasSideMode_t  side,
 }
 
 template <>
-void cblas_trsm<hipblasComplex>(hipblasSideMode_t     side,
-                                hipblasFillMode_t     uplo,
-                                hipblasOperation_t    transA,
-                                hipblasDiagType_t     diag,
-                                int                   m,
-                                int                   n,
-                                hipblasComplex        alpha,
-                                const hipblasComplex* A,
-                                int                   lda,
-                                hipblasComplex*       B,
-                                int                   ldb)
+void ref_trsm<hipblasComplex>(hipblasSideMode_t     side,
+                              hipblasFillMode_t     uplo,
+                              hipblasOperation_t    transA,
+                              hipblasDiagType_t     diag,
+                              int                   m,
+                              int                   n,
+                              hipblasComplex        alpha,
+                              const hipblasComplex* A,
+                              int                   lda,
+                              hipblasComplex*       B,
+                              int                   ldb)
 {
     cblas_ctrsm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3621,17 +3617,17 @@ void cblas_trsm<hipblasComplex>(hipblasSideMode_t     side,
 }
 
 template <>
-void cblas_trsm<hipblasDoubleComplex>(hipblasSideMode_t           side,
-                                      hipblasFillMode_t           uplo,
-                                      hipblasOperation_t          transA,
-                                      hipblasDiagType_t           diag,
-                                      int                         m,
-                                      int                         n,
-                                      hipblasDoubleComplex        alpha,
-                                      const hipblasDoubleComplex* A,
-                                      int                         lda,
-                                      hipblasDoubleComplex*       B,
-                                      int                         ldb)
+void ref_trsm<hipblasDoubleComplex>(hipblasSideMode_t           side,
+                                    hipblasFillMode_t           uplo,
+                                    hipblasOperation_t          transA,
+                                    hipblasDiagType_t           diag,
+                                    int                         m,
+                                    int                         n,
+                                    hipblasDoubleComplex        alpha,
+                                    const hipblasDoubleComplex* A,
+                                    int                         lda,
+                                    hipblasDoubleComplex*       B,
+                                    int                         ldb)
 {
     cblas_ztrsm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3649,7 +3645,7 @@ void cblas_trsm<hipblasDoubleComplex>(hipblasSideMode_t           side,
 
 // trtri
 template <>
-int cblas_trtri<float>(char uplo, char diag, int n, float* A, int lda)
+int ref_trtri<float>(char uplo, char diag, int n, float* A, int lda)
 {
     // just directly cast, since transA, transB are integers in the enum
     // printf("transA: hipblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
@@ -3659,7 +3655,7 @@ int cblas_trtri<float>(char uplo, char diag, int n, float* A, int lda)
 }
 
 template <>
-int cblas_trtri<double>(char uplo, char diag, int n, double* A, int lda)
+int ref_trtri<double>(char uplo, char diag, int n, double* A, int lda)
 {
     // just directly cast, since transA, transB are integers in the enum
     // printf("transA: hipblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
@@ -3669,7 +3665,7 @@ int cblas_trtri<double>(char uplo, char diag, int n, double* A, int lda)
 }
 
 template <>
-int cblas_trtri<hipblasComplex>(char uplo, char diag, int n, hipblasComplex* A, int lda)
+int ref_trtri<hipblasComplex>(char uplo, char diag, int n, hipblasComplex* A, int lda)
 {
     // just directly cast, since transA, transB are integers in the enum
     // printf("transA: hipblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
@@ -3679,7 +3675,7 @@ int cblas_trtri<hipblasComplex>(char uplo, char diag, int n, hipblasComplex* A, 
 }
 
 template <>
-int cblas_trtri<hipblasDoubleComplex>(char uplo, char diag, int n, hipblasDoubleComplex* A, int lda)
+int ref_trtri<hipblasDoubleComplex>(char uplo, char diag, int n, hipblasDoubleComplex* A, int lda)
 {
     // just directly cast, since transA, transB are integers in the enum
     // printf("transA: hipblas =%d, cblas=%d\n", transA, (CBLAS_TRANSPOSE)transA );
@@ -3690,17 +3686,17 @@ int cblas_trtri<hipblasDoubleComplex>(char uplo, char diag, int n, hipblasDouble
 
 // trmm
 template <>
-void cblas_trmm<float>(hipblasSideMode_t  side,
-                       hipblasFillMode_t  uplo,
-                       hipblasOperation_t transA,
-                       hipblasDiagType_t  diag,
-                       int                m,
-                       int                n,
-                       float              alpha,
-                       const float*       A,
-                       int                lda,
-                       float*             B,
-                       int                ldb)
+void ref_trmm<float>(hipblasSideMode_t  side,
+                     hipblasFillMode_t  uplo,
+                     hipblasOperation_t transA,
+                     hipblasDiagType_t  diag,
+                     int                m,
+                     int                n,
+                     float              alpha,
+                     const float*       A,
+                     int                lda,
+                     float*             B,
+                     int                ldb)
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_strmm(CblasColMajor,
@@ -3718,17 +3714,17 @@ void cblas_trmm<float>(hipblasSideMode_t  side,
 }
 
 template <>
-void cblas_trmm<double>(hipblasSideMode_t  side,
-                        hipblasFillMode_t  uplo,
-                        hipblasOperation_t transA,
-                        hipblasDiagType_t  diag,
-                        int                m,
-                        int                n,
-                        double             alpha,
-                        const double*      A,
-                        int                lda,
-                        double*            B,
-                        int                ldb)
+void ref_trmm<double>(hipblasSideMode_t  side,
+                      hipblasFillMode_t  uplo,
+                      hipblasOperation_t transA,
+                      hipblasDiagType_t  diag,
+                      int                m,
+                      int                n,
+                      double             alpha,
+                      const double*      A,
+                      int                lda,
+                      double*            B,
+                      int                ldb)
 {
     // just directly cast, since transA, transB are integers in the enum
     cblas_dtrmm(CblasColMajor,
@@ -3746,17 +3742,17 @@ void cblas_trmm<double>(hipblasSideMode_t  side,
 }
 
 template <>
-void cblas_trmm<hipblasComplex>(hipblasSideMode_t     side,
-                                hipblasFillMode_t     uplo,
-                                hipblasOperation_t    transA,
-                                hipblasDiagType_t     diag,
-                                int                   m,
-                                int                   n,
-                                hipblasComplex        alpha,
-                                const hipblasComplex* A,
-                                int                   lda,
-                                hipblasComplex*       B,
-                                int                   ldb)
+void ref_trmm<hipblasComplex>(hipblasSideMode_t     side,
+                              hipblasFillMode_t     uplo,
+                              hipblasOperation_t    transA,
+                              hipblasDiagType_t     diag,
+                              int                   m,
+                              int                   n,
+                              hipblasComplex        alpha,
+                              const hipblasComplex* A,
+                              int                   lda,
+                              hipblasComplex*       B,
+                              int                   ldb)
 {
     cblas_ctrmm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3773,17 +3769,17 @@ void cblas_trmm<hipblasComplex>(hipblasSideMode_t     side,
 }
 
 template <>
-void cblas_trmm<hipblasDoubleComplex>(hipblasSideMode_t           side,
-                                      hipblasFillMode_t           uplo,
-                                      hipblasOperation_t          transA,
-                                      hipblasDiagType_t           diag,
-                                      int                         m,
-                                      int                         n,
-                                      hipblasDoubleComplex        alpha,
-                                      const hipblasDoubleComplex* A,
-                                      int                         lda,
-                                      hipblasDoubleComplex*       B,
-                                      int                         ldb)
+void ref_trmm<hipblasDoubleComplex>(hipblasSideMode_t           side,
+                                    hipblasFillMode_t           uplo,
+                                    hipblasOperation_t          transA,
+                                    hipblasDiagType_t           diag,
+                                    int                         m,
+                                    int                         n,
+                                    hipblasDoubleComplex        alpha,
+                                    const hipblasDoubleComplex* A,
+                                    int                         lda,
+                                    hipblasDoubleComplex*       B,
+                                    int                         ldb)
 {
     cblas_ztrmm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3801,7 +3797,7 @@ void cblas_trmm<hipblasDoubleComplex>(hipblasSideMode_t           side,
 
 // getrf
 template <>
-int cblas_getrf<float>(int m, int n, float* A, int lda, int* ipiv)
+int ref_getrf<float>(int m, int n, float* A, int lda, int* ipiv)
 {
     int info;
     sgetrf_(&m, &n, A, &lda, ipiv, &info);
@@ -3809,7 +3805,7 @@ int cblas_getrf<float>(int m, int n, float* A, int lda, int* ipiv)
 }
 
 template <>
-int cblas_getrf<double>(int m, int n, double* A, int lda, int* ipiv)
+int ref_getrf<double>(int m, int n, double* A, int lda, int* ipiv)
 {
     int info;
     dgetrf_(&m, &n, A, &lda, ipiv, &info);
@@ -3817,7 +3813,7 @@ int cblas_getrf<double>(int m, int n, double* A, int lda, int* ipiv)
 }
 
 template <>
-int cblas_getrf<hipblasComplex>(int m, int n, hipblasComplex* A, int lda, int* ipiv)
+int ref_getrf<hipblasComplex>(int m, int n, hipblasComplex* A, int lda, int* ipiv)
 {
     int info;
     cgetrf_(&m, &n, A, &lda, ipiv, &info);
@@ -3825,7 +3821,7 @@ int cblas_getrf<hipblasComplex>(int m, int n, hipblasComplex* A, int lda, int* i
 }
 
 template <>
-int cblas_getrf<hipblasDoubleComplex>(int m, int n, hipblasDoubleComplex* A, int lda, int* ipiv)
+int ref_getrf<hipblasDoubleComplex>(int m, int n, hipblasDoubleComplex* A, int lda, int* ipiv)
 {
     int info;
     zgetrf_(&m, &n, A, &lda, ipiv, &info);
@@ -3834,7 +3830,7 @@ int cblas_getrf<hipblasDoubleComplex>(int m, int n, hipblasDoubleComplex* A, int
 
 // getrs
 template <>
-int cblas_getrs<float>(char trans, int n, int nrhs, float* A, int lda, int* ipiv, float* B, int ldb)
+int ref_getrs<float>(char trans, int n, int nrhs, float* A, int lda, int* ipiv, float* B, int ldb)
 {
     int info;
     sgetrs_(&trans, &n, &nrhs, A, &lda, ipiv, B, &ldb, &info);
@@ -3842,7 +3838,7 @@ int cblas_getrs<float>(char trans, int n, int nrhs, float* A, int lda, int* ipiv
 }
 
 template <>
-int cblas_getrs<double>(
+int ref_getrs<double>(
     char trans, int n, int nrhs, double* A, int lda, int* ipiv, double* B, int ldb)
 {
     int info;
@@ -3851,7 +3847,7 @@ int cblas_getrs<double>(
 }
 
 template <>
-int cblas_getrs<hipblasComplex>(
+int ref_getrs<hipblasComplex>(
     char trans, int n, int nrhs, hipblasComplex* A, int lda, int* ipiv, hipblasComplex* B, int ldb)
 {
     int info;
@@ -3860,14 +3856,14 @@ int cblas_getrs<hipblasComplex>(
 }
 
 template <>
-int cblas_getrs<hipblasDoubleComplex>(char                  trans,
-                                      int                   n,
-                                      int                   nrhs,
-                                      hipblasDoubleComplex* A,
-                                      int                   lda,
-                                      int*                  ipiv,
-                                      hipblasDoubleComplex* B,
-                                      int                   ldb)
+int ref_getrs<hipblasDoubleComplex>(char                  trans,
+                                    int                   n,
+                                    int                   nrhs,
+                                    hipblasDoubleComplex* A,
+                                    int                   lda,
+                                    int*                  ipiv,
+                                    hipblasDoubleComplex* B,
+                                    int                   ldb)
 {
     int info;
     zgetrs_(&trans, &n, &nrhs, A, &lda, ipiv, B, &ldb, &info);
@@ -3876,7 +3872,7 @@ int cblas_getrs<hipblasDoubleComplex>(char                  trans,
 
 // getri
 template <>
-int cblas_getri<float>(int n, float* A, int lda, int* ipiv, float* work, int lwork)
+int ref_getri<float>(int n, float* A, int lda, int* ipiv, float* work, int lwork)
 {
     int info;
     sgetri_(&n, A, &lda, ipiv, work, &lwork, &info);
@@ -3884,7 +3880,7 @@ int cblas_getri<float>(int n, float* A, int lda, int* ipiv, float* work, int lwo
 }
 
 template <>
-int cblas_getri<double>(int n, double* A, int lda, int* ipiv, double* work, int lwork)
+int ref_getri<double>(int n, double* A, int lda, int* ipiv, double* work, int lwork)
 {
     int info;
     dgetri_(&n, A, &lda, ipiv, work, &lwork, &info);
@@ -3892,7 +3888,7 @@ int cblas_getri<double>(int n, double* A, int lda, int* ipiv, double* work, int 
 }
 
 template <>
-int cblas_getri<hipblasComplex>(
+int ref_getri<hipblasComplex>(
     int n, hipblasComplex* A, int lda, int* ipiv, hipblasComplex* work, int lwork)
 {
     int info;
@@ -3901,7 +3897,7 @@ int cblas_getri<hipblasComplex>(
 }
 
 template <>
-int cblas_getri<hipblasDoubleComplex>(
+int ref_getri<hipblasDoubleComplex>(
     int n, hipblasDoubleComplex* A, int lda, int* ipiv, hipblasDoubleComplex* work, int lwork)
 {
     int info;
@@ -3911,7 +3907,7 @@ int cblas_getri<hipblasDoubleComplex>(
 
 // geqrf
 template <>
-int cblas_geqrf<float>(int m, int n, float* A, int lda, float* tau, float* work, int lwork)
+int ref_geqrf<float>(int m, int n, float* A, int lda, float* tau, float* work, int lwork)
 {
     int info;
     sgeqrf_(&m, &n, A, &lda, tau, work, &lwork, &info);
@@ -3919,14 +3915,14 @@ int cblas_geqrf<float>(int m, int n, float* A, int lda, float* tau, float* work,
 }
 
 template <>
-int cblas_geqrf<double>(int m, int n, double* A, int lda, double* tau, double* work, int lwork)
+int ref_geqrf<double>(int m, int n, double* A, int lda, double* tau, double* work, int lwork)
 {
     int info;
     dgeqrf_(&m, &n, A, &lda, tau, work, &lwork, &info);
     return info;
 }
 template <>
-int cblas_geqrf<hipblasComplex>(
+int ref_geqrf<hipblasComplex>(
     int m, int n, hipblasComplex* A, int lda, hipblasComplex* tau, hipblasComplex* work, int lwork)
 {
     int info;
@@ -3935,13 +3931,13 @@ int cblas_geqrf<hipblasComplex>(
 }
 
 template <>
-int cblas_geqrf<hipblasDoubleComplex>(int                   m,
-                                      int                   n,
-                                      hipblasDoubleComplex* A,
-                                      int                   lda,
-                                      hipblasDoubleComplex* tau,
-                                      hipblasDoubleComplex* work,
-                                      int                   lwork)
+int ref_geqrf<hipblasDoubleComplex>(int                   m,
+                                    int                   n,
+                                    hipblasDoubleComplex* A,
+                                    int                   lda,
+                                    hipblasDoubleComplex* tau,
+                                    hipblasDoubleComplex* work,
+                                    int                   lwork)
 {
     int info;
     zgeqrf_(&m, &n, A, &lda, tau, work, &lwork, &info);
@@ -3950,16 +3946,16 @@ int cblas_geqrf<hipblasDoubleComplex>(int                   m,
 
 // gels
 template <>
-int cblas_gels<float>(char   trans,
-                      int    m,
-                      int    n,
-                      int    nrhs,
-                      float* A,
-                      int    lda,
-                      float* B,
-                      int    ldb,
-                      float* work,
-                      int    lwork)
+int ref_gels<float>(char   trans,
+                    int    m,
+                    int    n,
+                    int    nrhs,
+                    float* A,
+                    int    lda,
+                    float* B,
+                    int    ldb,
+                    float* work,
+                    int    lwork)
 {
     int info;
     sgels_(&trans, &m, &n, &nrhs, A, &lda, B, &ldb, work, &lwork, &info);
@@ -3967,16 +3963,16 @@ int cblas_gels<float>(char   trans,
 }
 
 template <>
-int cblas_gels<double>(char    trans,
-                       int     m,
-                       int     n,
-                       int     nrhs,
-                       double* A,
-                       int     lda,
-                       double* B,
-                       int     ldb,
-                       double* work,
-                       int     lwork)
+int ref_gels<double>(char    trans,
+                     int     m,
+                     int     n,
+                     int     nrhs,
+                     double* A,
+                     int     lda,
+                     double* B,
+                     int     ldb,
+                     double* work,
+                     int     lwork)
 {
     int info;
     dgels_(&trans, &m, &n, &nrhs, A, &lda, B, &ldb, work, &lwork, &info);
@@ -3984,16 +3980,16 @@ int cblas_gels<double>(char    trans,
 }
 
 template <>
-int cblas_gels<hipblasComplex>(char            trans,
-                               int             m,
-                               int             n,
-                               int             nrhs,
-                               hipblasComplex* A,
-                               int             lda,
-                               hipblasComplex* B,
-                               int             ldb,
-                               hipblasComplex* work,
-                               int             lwork)
+int ref_gels<hipblasComplex>(char            trans,
+                             int             m,
+                             int             n,
+                             int             nrhs,
+                             hipblasComplex* A,
+                             int             lda,
+                             hipblasComplex* B,
+                             int             ldb,
+                             hipblasComplex* work,
+                             int             lwork)
 {
     int info;
     cgels_(&trans, &m, &n, &nrhs, A, &lda, B, &ldb, work, &lwork, &info);
@@ -4001,16 +3997,16 @@ int cblas_gels<hipblasComplex>(char            trans,
 }
 
 template <>
-int cblas_gels<hipblasDoubleComplex>(char                  trans,
-                                     int                   m,
-                                     int                   n,
-                                     int                   nrhs,
-                                     hipblasDoubleComplex* A,
-                                     int                   lda,
-                                     hipblasDoubleComplex* B,
-                                     int                   ldb,
-                                     hipblasDoubleComplex* work,
-                                     int                   lwork)
+int ref_gels<hipblasDoubleComplex>(char                  trans,
+                                   int                   m,
+                                   int                   n,
+                                   int                   nrhs,
+                                   hipblasDoubleComplex* A,
+                                   int                   lda,
+                                   hipblasDoubleComplex* B,
+                                   int                   ldb,
+                                   hipblasDoubleComplex* work,
+                                   int                   lwork)
 {
     int info;
     zgels_(&trans, &m, &n, &nrhs, A, &lda, B, &ldb, work, &lwork, &info);

--- a/clients/include/blas1/testing_asum.hpp
+++ b/clients/include/blas1/testing_asum.hpp
@@ -136,7 +136,7 @@ void testing_asum(const Arguments& arg)
                     CPU BLAS
         =================================================================== */
 
-        cblas_asum<T, Tr>(N, hx.data(), incx, &cpu_result);
+        ref_asum<T, Tr>(N, hx.data(), incx, &cpu_result);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas1/testing_asum_batched.hpp
+++ b/clients/include/blas1/testing_asum_batched.hpp
@@ -149,7 +149,7 @@ void testing_asum_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_asum<T, Tr>(N, hx[b], incx, &(h_cpu_result[b]));
+            ref_asum<T, Tr>(N, hx[b], incx, &(h_cpu_result[b]));
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_asum_strided_batched.hpp
+++ b/clients/include/blas1/testing_asum_strided_batched.hpp
@@ -157,7 +157,7 @@ void testing_asum_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_asum<T, Tr>(N, hx.data() + b * stridex, incx, &cpu_result[b]);
+            ref_asum<T, Tr>(N, hx.data() + b * stridex, incx, &cpu_result[b]);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_axpy.hpp
+++ b/clients/include/blas1/testing_axpy.hpp
@@ -172,7 +172,7 @@ void testing_axpy(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_axpy<T>(N, alpha, hx_cpu.data(), incx, hy_cpu.data(), incy);
+        ref_axpy<T>(N, alpha, hx_cpu.data(), incx, hy_cpu.data(), incy);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas1/testing_axpy_batched.hpp
+++ b/clients/include/blas1/testing_axpy_batched.hpp
@@ -186,7 +186,7 @@ void testing_axpy_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_axpy<T>(N, alpha, hx_cpu[b], incx, hy_cpu[b], incy);
+            ref_axpy<T>(N, alpha, hx_cpu[b], incx, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas1/testing_axpy_strided_batched.hpp
+++ b/clients/include/blas1/testing_axpy_strided_batched.hpp
@@ -197,7 +197,7 @@ void testing_axpy_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_axpy<T>(
+            ref_axpy<T>(
                 N, alpha, hx_cpu.data() + b * stridex, incx, hy_cpu.data() + b * stridey, incy);
         }
 

--- a/clients/include/blas1/testing_copy.hpp
+++ b/clients/include/blas1/testing_copy.hpp
@@ -129,7 +129,7 @@ void testing_copy(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_copy<T>(N, hx_cpu.data(), incx, hy_cpu.data(), incy);
+        ref_copy<T>(N, hx_cpu.data(), incx, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas1/testing_copy_batched.hpp
+++ b/clients/include/blas1/testing_copy_batched.hpp
@@ -125,7 +125,7 @@ void testing_copy_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_copy<T>(N, hx_cpu[b], incx, hy_cpu[b], incy);
+            ref_copy<T>(N, hx_cpu[b], incx, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas1/testing_copy_strided_batched.hpp
+++ b/clients/include/blas1/testing_copy_strided_batched.hpp
@@ -143,7 +143,7 @@ void testing_copy_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_copy<T>(N, hx_cpu.data() + b * stridex, incx, hy_cpu.data() + b * stridey, incy);
+            ref_copy<T>(N, hx_cpu.data() + b * stridex, incx, hy_cpu.data() + b * stridey, incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas1/testing_dot.hpp
+++ b/clients/include/blas1/testing_dot.hpp
@@ -165,7 +165,7 @@ void testing_dot(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx.data(), incx, hy.data(), incy, &cpu_result);
+        (CONJ ? ref_dotc<T> : ref_dot<T>)(N, hx.data(), incx, hy.data(), incy, &cpu_result);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas1/testing_dot_batched.hpp
+++ b/clients/include/blas1/testing_dot_batched.hpp
@@ -186,7 +186,7 @@ void testing_dot_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N, hx[b], incx, hy[b], incy, &(h_cpu_result[b]));
+            (CONJ ? ref_dotc<T> : ref_dot<T>)(N, hx[b], incx, hy[b], incy, &(h_cpu_result[b]));
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_dot_strided_batched.hpp
+++ b/clients/include/blas1/testing_dot_strided_batched.hpp
@@ -218,12 +218,12 @@ void testing_dot_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            (CONJ ? cblas_dotc<T> : cblas_dot<T>)(N,
-                                                  hx.data() + b * stridex,
-                                                  incx,
-                                                  hy.data() + b * stridey,
-                                                  incy,
-                                                  &h_cpu_result[b]);
+            (CONJ ? ref_dotc<T> : ref_dot<T>)(N,
+                                              hx.data() + b * stridex,
+                                              incx,
+                                              hy.data() + b * stridey,
+                                              incy,
+                                              &h_cpu_result[b]);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_iamax_iamin.hpp
+++ b/clients/include/blas1/testing_iamax_iamin.hpp
@@ -204,7 +204,7 @@ void testing_iamax(const Arguments& arg)
     bool FORTRAN        = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasIamaxFn = FORTRAN ? hipblasIamax<T, true> : hipblasIamax<T, false>;
 
-    testing_iamax_iamin<T, cblas_iamax<T>>(arg, hipblasIamaxFn);
+    testing_iamax_iamin<T, ref_iamax<T>>(arg, hipblasIamaxFn);
 }
 
 inline void testname_iamin(const Arguments& arg, std::string& name)
@@ -218,5 +218,5 @@ void testing_iamin(const Arguments& arg)
     bool FORTRAN        = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasIaminFn = FORTRAN ? hipblasIamin<T, true> : hipblasIamin<T, false>;
 
-    testing_iamax_iamin<T, cblas_iamin<T>>(arg, hipblasIamin<T>);
+    testing_iamax_iamin<T, ref_iamin<T>>(arg, hipblasIamin<T>);
 }

--- a/clients/include/blas1/testing_iamax_iamin_batched.hpp
+++ b/clients/include/blas1/testing_iamax_iamin_batched.hpp
@@ -218,7 +218,7 @@ void testing_iamax_batched(const Arguments& arg)
     auto hipblasIamaxBatchedFn
         = FORTRAN ? hipblasIamaxBatched<T, true> : hipblasIamaxBatched<T, false>;
 
-    testing_iamax_iamin_batched<T, cblas_iamax<T>>(arg, hipblasIamaxBatchedFn);
+    testing_iamax_iamin_batched<T, ref_iamax<T>>(arg, hipblasIamaxBatchedFn);
 }
 
 inline void testname_iamin_batched(const Arguments& arg, std::string& name)
@@ -233,5 +233,5 @@ void testing_iamin_batched(const Arguments& arg)
     auto hipblasIaminBatchedFn
         = FORTRAN ? hipblasIaminBatched<T, true> : hipblasIaminBatched<T, false>;
 
-    testing_iamax_iamin_batched<T, cblas_iamin<T>>(arg, hipblasIaminBatchedFn);
+    testing_iamax_iamin_batched<T, ref_iamin<T>>(arg, hipblasIaminBatchedFn);
 }

--- a/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
@@ -234,7 +234,7 @@ void testing_iamax_strided_batched(const Arguments& arg)
     auto hipblasIamaxStridedBatchedFn
         = FORTRAN ? hipblasIamaxStridedBatched<T, true> : hipblasIamaxStridedBatched<T, false>;
 
-    testing_iamax_iamin_strided_batched<T, cblas_iamax<T>>(arg, hipblasIamaxStridedBatchedFn);
+    testing_iamax_iamin_strided_batched<T, ref_iamax<T>>(arg, hipblasIamaxStridedBatchedFn);
 }
 
 inline void testname_iamin_strided_batched(const Arguments& arg, std::string& name)
@@ -249,5 +249,5 @@ void testing_iamin_strided_batched(const Arguments& arg)
     auto hipblasIaminStridedBatchedFn
         = FORTRAN ? hipblasIaminStridedBatched<T, true> : hipblasIaminStridedBatched<T, false>;
 
-    testing_iamax_iamin_strided_batched<T, cblas_iamin<T>>(arg, hipblasIaminStridedBatchedFn);
+    testing_iamax_iamin_strided_batched<T, ref_iamin<T>>(arg, hipblasIaminStridedBatchedFn);
 }

--- a/clients/include/blas1/testing_nrm2.hpp
+++ b/clients/include/blas1/testing_nrm2.hpp
@@ -134,7 +134,7 @@ void testing_nrm2(const Arguments& arg)
                     CPU BLAS
         =================================================================== */
 
-        cblas_nrm2<T, Tr>(N, hx.data(), incx, &cpu_result);
+        ref_nrm2<T, Tr>(N, hx.data(), incx, &cpu_result);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas1/testing_nrm2_batched.hpp
+++ b/clients/include/blas1/testing_nrm2_batched.hpp
@@ -148,7 +148,7 @@ void testing_nrm2_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_nrm2<T, Tr>(N, hx[b], incx, &(h_cpu_result[b]));
+            ref_nrm2<T, Tr>(N, hx[b], incx, &(h_cpu_result[b]));
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_nrm2_strided_batched.hpp
+++ b/clients/include/blas1/testing_nrm2_strided_batched.hpp
@@ -157,7 +157,7 @@ void testing_nrm2_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_nrm2<T, Tr>(N, hx.data() + b * stridex, incx, &(h_cpu_result[b]));
+            ref_nrm2<T, Tr>(N, hx.data() + b * stridex, incx, &(h_cpu_result[b]));
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_rot.hpp
+++ b/clients/include/blas1/testing_rot.hpp
@@ -128,7 +128,7 @@ void testing_rot(const Arguments& arg)
     host_vector<T> cx = hx;
     host_vector<T> cy = hy;
 
-    cblas_rot<T, U, V>(N, cx.data(), incx, cy.data(), incy, *hc, *hs);
+    ref_rot<T, U, V>(N, cx.data(), incx, cy.data(), incy, *hc, *hs);
 
     if(arg.unit_check || arg.norm_check)
     {

--- a/clients/include/blas1/testing_rot_batched.hpp
+++ b/clients/include/blas1/testing_rot_batched.hpp
@@ -129,12 +129,12 @@ void testing_rot_batched(const Arguments& arg)
     cx.copy_from(hx);
     cy.copy_from(hy);
 
-    // cblas_rotg<T, U>(cx, cy, hc, hs);
+    // ref_rotg<T, U>(cx, cy, hc, hs);
     // cx[0] = hx[0];
     // cy[0] = hy[0];
     for(int b = 0; b < batch_count; b++)
     {
-        cblas_rot<T, U, V>(N, cx[b], incx, cy[b], incy, *hc, *hs);
+        ref_rot<T, U, V>(N, cx[b], incx, cy[b], incy, *hc, *hs);
     }
 
     if(arg.unit_check || arg.norm_check)

--- a/clients/include/blas1/testing_rot_strided_batched.hpp
+++ b/clients/include/blas1/testing_rot_strided_batched.hpp
@@ -162,12 +162,12 @@ void testing_rot_strided_batched(const Arguments& arg)
     // CPU BLAS reference data
     host_vector<T> cx = hx;
     host_vector<T> cy = hy;
-    // cblas_rotg<T, U>(cx, cy, hc, hs);
+    // ref_rotg<T, U>(cx, cy, hc, hs);
     // cx[0] = hx[0];
     // cy[0] = hy[0];
     for(int b = 0; b < batch_count; b++)
     {
-        cblas_rot<T, U, V>(
+        ref_rot<T, U, V>(
             N, cx.data() + b * stride_x, incx, cy.data() + b * stride_y, incy, *hc, *hs);
     }
 

--- a/clients/include/blas1/testing_rotg.hpp
+++ b/clients/include/blas1/testing_rotg.hpp
@@ -124,7 +124,7 @@ void testing_rotg(const Arguments& arg)
         CHECK_HIP_ERROR(hipMemcpy(rc, dc, sizeof(U), hipMemcpyDeviceToHost));
         CHECK_HIP_ERROR(hipMemcpy(rs, ds, sizeof(T), hipMemcpyDeviceToHost));
 
-        cblas_rotg<T, U>(ca, cb, cc, cs);
+        ref_rotg<T, U>(ca, cb, cc, cs);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas1/testing_rotg_batched.hpp
+++ b/clients/include/blas1/testing_rotg_batched.hpp
@@ -152,7 +152,7 @@ void testing_rotg_batched(const Arguments& arg)
         // CBLAS
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_rotg<T, U>(ca[b], cb[b], cc[b], cs[b]);
+            ref_rotg<T, U>(ca[b], cb[b], cc[b], cs[b]);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_rotg_strided_batched.hpp
+++ b/clients/include/blas1/testing_rotg_strided_batched.hpp
@@ -159,10 +159,10 @@ void testing_rotg_strided_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_rotg<T, U>(ca.data() + b * stride_a,
-                             cb.data() + b * stride_b,
-                             cc.data() + b * stride_c,
-                             cs.data() + b * stride_s);
+            ref_rotg<T, U>(ca.data() + b * stride_a,
+                           cb.data() + b * stride_b,
+                           cc.data() + b * stride_c,
+                           cs.data() + b * stride_s);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_rotm.hpp
+++ b/clients/include/blas1/testing_rotm.hpp
@@ -130,7 +130,7 @@ void testing_rotm(const Arguments& arg)
     hipblas_init_vector(hdata, arg, 4, 1, 0, 1, hipblas_client_alpha_sets_nan, false);
 
     // CPU BLAS reference data
-    cblas_rotmg<T>(&hdata[0], &hdata[1], &hdata[2], &hdata[3], hparam);
+    ref_rotmg<T>(&hdata[0], &hdata[1], &hdata[2], &hdata[3], hparam);
     const int FLAG_COUNT        = 4;
     const T   FLAGS[FLAG_COUNT] = {-1, 0, 1, -2};
     for(int i = 0; i < FLAG_COUNT; ++i)
@@ -140,7 +140,7 @@ void testing_rotm(const Arguments& arg)
             hparam[0]         = FLAGS[i];
             host_vector<T> cx = hx;
             host_vector<T> cy = hy;
-            cblas_rotm<T>(N, cx, incx, cy, incy, hparam);
+            ref_rotm<T>(N, cx, incx, cy, incy, hparam);
 
             // Test host
             {

--- a/clients/include/blas1/testing_rotm_batched.hpp
+++ b/clients/include/blas1/testing_rotm_batched.hpp
@@ -120,7 +120,7 @@ void testing_rotm_batched(const Arguments& arg)
 
     for(int b = 0; b < batch_count; b++)
     {
-        cblas_rotmg<T>(&hdata[b][0], &hdata[b][1], &hdata[b][2], &hdata[b][3], hparam[b]);
+        ref_rotmg<T>(&hdata[b][0], &hdata[b][1], &hdata[b][2], &hdata[b][3], hparam[b]);
     }
 
     constexpr int FLAG_COUNT        = 4;
@@ -160,7 +160,7 @@ void testing_rotm_batched(const Arguments& arg)
             for(int b = 0; b < batch_count; b++)
             {
                 // CPU BLAS reference data
-                cblas_rotm<T>(N, cx[b], incx, cy[b], incy, hparam[b]);
+                ref_rotm<T>(N, cx[b], incx, cy[b], incy, hparam[b]);
             }
 
             if(arg.unit_check)

--- a/clients/include/blas1/testing_rotm_strided_batched.hpp
+++ b/clients/include/blas1/testing_rotm_strided_batched.hpp
@@ -189,11 +189,11 @@ void testing_rotm_strided_batched(const Arguments& arg)
     hipblas_init_vector(hdata, arg, 4, 1, 4, batch_count, hipblas_client_alpha_sets_nan, false);
 
     for(int b = 0; b < batch_count; b++)
-        cblas_rotmg<T>(hdata + b * 4,
-                       hdata + b * 4 + 1,
-                       hdata + b * 4 + 2,
-                       hdata + b * 4 + 3,
-                       hparam + b * stride_param);
+        ref_rotmg<T>(hdata + b * 4,
+                     hdata + b * 4 + 1,
+                     hdata + b * 4 + 2,
+                     hdata + b * 4 + 3,
+                     hparam + b * stride_param);
 
     constexpr int FLAG_COUNT        = 4;
     const T       FLAGS[FLAG_COUNT] = {-1, 0, 1, -2};
@@ -234,7 +234,7 @@ void testing_rotm_strided_batched(const Arguments& arg)
             // CPU BLAS reference data
             for(int b = 0; b < batch_count; b++)
             {
-                cblas_rotm<T>(
+                ref_rotm<T>(
                     N, cx + b * stride_x, incx, cy + b * stride_y, incy, hparam + b * stride_param);
             }
 

--- a/clients/include/blas1/testing_rotmg.hpp
+++ b/clients/include/blas1/testing_rotmg.hpp
@@ -103,7 +103,7 @@ void testing_rotmg(const Arguments& arg)
         CHECK_HIP_ERROR(hipMemcpy(hparams_d, dparams, 9 * sizeof(T), hipMemcpyDeviceToHost));
 
         // CPU BLAS
-        cblas_rotmg<T>(&cparams[0], &cparams[1], &cparams[2], &cparams[3], &cparams[4]);
+        ref_rotmg<T>(&cparams[0], &cparams[1], &cparams[2], &cparams[3], &cparams[4]);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas1/testing_rotmg_batched.hpp
+++ b/clients/include/blas1/testing_rotmg_batched.hpp
@@ -162,7 +162,7 @@ void testing_rotmg_batched(const Arguments& arg)
         // CBLAS
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_rotmg<T>(cd1[b], cd2[b], cx1[b], cy1[b], cparams[b]);
+            ref_rotmg<T>(cd1[b], cd2[b], cx1[b], cy1[b], cparams[b]);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_rotmg_strided_batched.hpp
+++ b/clients/include/blas1/testing_rotmg_strided_batched.hpp
@@ -254,11 +254,11 @@ void testing_rotmg_strided_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_rotmg<T>(cd1 + b * stride_d1,
-                           cd2 + b * stride_d2,
-                           cx1 + b * stride_x1,
-                           cy1 + b * stride_y1,
-                           cparams + b * stride_param);
+            ref_rotmg<T>(cd1 + b * stride_d1,
+                         cd2 + b * stride_d2,
+                         cx1 + b * stride_x1,
+                         cy1 + b * stride_y1,
+                         cparams + b * stride_param);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_scal.hpp
+++ b/clients/include/blas1/testing_scal.hpp
@@ -125,7 +125,7 @@ void testing_scal(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_scal<T, U>(N, alpha, hz.data(), incx);
+        ref_scal<T, U>(N, alpha, hz.data(), incx);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas1/testing_scal_batched.hpp
+++ b/clients/include/blas1/testing_scal_batched.hpp
@@ -130,7 +130,7 @@ void testing_scal_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_scal<T, U>(N, alpha, hz[b], incx);
+            ref_scal<T, U>(N, alpha, hz[b], incx);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas1/testing_scal_strided_batched.hpp
+++ b/clients/include/blas1/testing_scal_strided_batched.hpp
@@ -139,7 +139,7 @@ void testing_scal_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_scal<T, U>(N, alpha, hz.data() + b * stridex, incx);
+            ref_scal<T, U>(N, alpha, hz.data() + b * stridex, incx);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas1/testing_swap.hpp
+++ b/clients/include/blas1/testing_swap.hpp
@@ -133,7 +133,7 @@ void testing_swap(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_swap<T>(N, hx.data(), incx, hy.data(), incy);
+        ref_swap<T>(N, hx.data(), incx, hy.data(), incy);
 
         if(unit_check)
         {

--- a/clients/include/blas1/testing_swap_batched.hpp
+++ b/clients/include/blas1/testing_swap_batched.hpp
@@ -129,7 +129,7 @@ void testing_swap_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_swap<T>(N, hx_cpu[b], incx, hy_cpu[b], incy);
+            ref_swap<T>(N, hx_cpu[b], incx, hy_cpu[b], incy);
         }
 
         if(unit_check)

--- a/clients/include/blas1/testing_swap_strided_batched.hpp
+++ b/clients/include/blas1/testing_swap_strided_batched.hpp
@@ -146,7 +146,7 @@ void testing_swap_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_swap<T>(N, hx.data() + b * stridex, incx, hy.data() + b * stridey, incy);
+            ref_swap<T>(N, hx.data() + b * stridex, incx, hy.data() + b * stridey, incy);
         }
 
         if(unit_check)

--- a/clients/include/blas2/testing_gbmv.hpp
+++ b/clients/include/blas2/testing_gbmv.hpp
@@ -343,19 +343,19 @@ void testing_gbmv(const Arguments& arg)
            CPU BLAS
         =================================================================== */
 
-        cblas_gbmv<T>(transA,
-                      M,
-                      N,
-                      KL,
-                      KU,
-                      h_alpha,
-                      hA.data(),
-                      lda,
-                      hx.data(),
-                      incx,
-                      h_beta,
-                      hy_cpu.data(),
-                      incy);
+        ref_gbmv<T>(transA,
+                    M,
+                    N,
+                    KL,
+                    KU,
+                    h_alpha,
+                    hA.data(),
+                    lda,
+                    hx.data(),
+                    incx,
+                    h_beta,
+                    hy_cpu.data(),
+                    incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_gbmv_batched.hpp
+++ b/clients/include/blas2/testing_gbmv_batched.hpp
@@ -447,7 +447,7 @@ void testing_gbmv_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_gbmv<T>(
+            ref_gbmv<T>(
                 transA, M, N, KL, KU, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 

--- a/clients/include/blas2/testing_gbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_gbmv_strided_batched.hpp
@@ -515,19 +515,19 @@ void testing_gbmv_strided_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_gbmv<T>(transA,
-                          M,
-                          N,
-                          KL,
-                          KU,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hx.data() + b * stride_x,
-                          incx,
-                          h_beta,
-                          hy_cpu.data() + b * stride_y,
-                          incy);
+            ref_gbmv<T>(transA,
+                        M,
+                        N,
+                        KL,
+                        KU,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hx.data() + b * stride_x,
+                        incx,
+                        h_beta,
+                        hy_cpu.data() + b * stride_y,
+                        incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_gemv.hpp
+++ b/clients/include/blas2/testing_gemv.hpp
@@ -249,7 +249,7 @@ void testing_gemv(const Arguments& arg)
            CPU BLAS
         =================================================================== */
 
-        cblas_gemv<T>(
+        ref_gemv<T>(
             transA, M, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_gemv_batched.hpp
+++ b/clients/include/blas2/testing_gemv_batched.hpp
@@ -399,7 +399,7 @@ void testing_gemv_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_gemv<T>(transA, M, N, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
+            ref_gemv<T>(transA, M, N, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_gemv_strided_batched.hpp
+++ b/clients/include/blas2/testing_gemv_strided_batched.hpp
@@ -462,17 +462,17 @@ void testing_gemv_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_gemv<T>(transA,
-                          M,
-                          N,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hx.data() + b * stride_x,
-                          incx,
-                          h_beta,
-                          hy_cpu.data() + b * stride_y,
-                          incy);
+            ref_gemv<T>(transA,
+                        M,
+                        N,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hx.data() + b * stride_x,
+                        incx,
+                        h_beta,
+                        hy_cpu.data() + b * stride_y,
+                        incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_ger.hpp
+++ b/clients/include/blas2/testing_ger.hpp
@@ -189,7 +189,7 @@ void testing_ger(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_ger<T, CONJ>(M, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data(), lda);
+        ref_ger<T, CONJ>(M, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data(), lda);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_ger_batched.hpp
+++ b/clients/include/blas2/testing_ger_batched.hpp
@@ -258,7 +258,7 @@ void testing_ger_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_ger<T, CONJ>(M, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b], lda);
+            ref_ger<T, CONJ>(M, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b], lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_ger_strided_batched.hpp
+++ b/clients/include/blas2/testing_ger_strided_batched.hpp
@@ -335,15 +335,15 @@ void testing_ger_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_ger<T, CONJ>(M,
-                               N,
-                               h_alpha,
-                               hx.data() + b * stride_x,
-                               incx,
-                               hy.data() + b * stride_y,
-                               incy,
-                               hA_cpu.data() + b * stride_A,
-                               lda);
+            ref_ger<T, CONJ>(M,
+                             N,
+                             h_alpha,
+                             hx.data() + b * stride_x,
+                             incx,
+                             hy.data() + b * stride_y,
+                             incy,
+                             hA_cpu.data() + b * stride_A,
+                             lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hbmv.hpp
+++ b/clients/include/blas2/testing_hbmv.hpp
@@ -232,7 +232,7 @@ void testing_hbmv(const Arguments& arg)
            CPU BLAS
         =================================================================== */
 
-        cblas_hbmv<T>(
+        ref_hbmv<T>(
             uplo, N, K, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hbmv_batched.hpp
+++ b/clients/include/blas2/testing_hbmv_batched.hpp
@@ -384,7 +384,7 @@ void testing_hbmv_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hbmv<T>(uplo, N, K, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
+            ref_hbmv<T>(uplo, N, K, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hbmv_strided_batched.hpp
@@ -452,17 +452,17 @@ void testing_hbmv_strided_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hbmv<T>(uplo,
-                          N,
-                          K,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hx.data() + b * stride_x,
-                          incx,
-                          h_beta,
-                          hy_cpu.data() + b * stride_y,
-                          incy);
+            ref_hbmv<T>(uplo,
+                        N,
+                        K,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hx.data() + b * stride_x,
+                        incx,
+                        h_beta,
+                        hy_cpu.data() + b * stride_y,
+                        incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hemv.hpp
+++ b/clients/include/blas2/testing_hemv.hpp
@@ -225,8 +225,7 @@ void testing_hemv(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_hemv<T>(
-            uplo, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
+        ref_hemv<T>(uplo, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_hemv_batched.hpp
+++ b/clients/include/blas2/testing_hemv_batched.hpp
@@ -353,7 +353,7 @@ void testing_hemv_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hemv<T>(uplo, N, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
+            ref_hemv<T>(uplo, N, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hemv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hemv_strided_batched.hpp
@@ -435,16 +435,16 @@ void testing_hemv_strided_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hemv<T>(uplo,
-                          N,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hx.data() + b * stride_x,
-                          incx,
-                          h_beta,
-                          hy_cpu.data() + b * stride_y,
-                          incy);
+            ref_hemv<T>(uplo,
+                        N,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hx.data() + b * stride_x,
+                        incx,
+                        h_beta,
+                        hy_cpu.data() + b * stride_y,
+                        incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_her.hpp
+++ b/clients/include/blas2/testing_her.hpp
@@ -180,7 +180,7 @@ void testing_her(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_her<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data(), lda);
+        ref_her<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data(), lda);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_her2.hpp
+++ b/clients/include/blas2/testing_her2.hpp
@@ -196,7 +196,7 @@ void testing_her2(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_her2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data(), lda);
+        ref_her2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data(), lda);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_her2_batched.hpp
+++ b/clients/include/blas2/testing_her2_batched.hpp
@@ -281,7 +281,7 @@ void testing_her2_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b], lda);
+            ref_her2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b], lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_her2_strided_batched.hpp
+++ b/clients/include/blas2/testing_her2_strided_batched.hpp
@@ -376,15 +376,15 @@ void testing_her2_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her2<T>(uplo,
-                          N,
-                          h_alpha,
-                          hx.data() + b * stride_x,
-                          incx,
-                          hy.data() + b * stride_y,
-                          incy,
-                          hA_cpu.data() + b * stride_A,
-                          lda);
+            ref_her2<T>(uplo,
+                        N,
+                        h_alpha,
+                        hx.data() + b * stride_x,
+                        incx,
+                        hy.data() + b * stride_y,
+                        incy,
+                        hA_cpu.data() + b * stride_A,
+                        lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_her_batched.hpp
+++ b/clients/include/blas2/testing_her_batched.hpp
@@ -235,7 +235,7 @@ void testing_her_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b], lda);
+            ref_her<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b], lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_her_strided_batched.hpp
+++ b/clients/include/blas2/testing_her_strided_batched.hpp
@@ -223,13 +223,13 @@ void testing_her_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her<T>(uplo,
-                         N,
-                         h_alpha,
-                         hx.data() + b * stride_x,
-                         incx,
-                         hA_cpu.data() + b * stride_A,
-                         lda);
+            ref_her<T>(uplo,
+                       N,
+                       h_alpha,
+                       hx.data() + b * stride_x,
+                       incx,
+                       hA_cpu.data() + b * stride_A,
+                       lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hpmv.hpp
+++ b/clients/include/blas2/testing_hpmv.hpp
@@ -212,7 +212,7 @@ void testing_hpmv(const Arguments& arg)
            CPU BLAS
         =================================================================== */
 
-        cblas_hpmv<T>(uplo, N, h_alpha, hA.data(), hx.data(), incx, h_beta, hy_cpu.data(), incy);
+        ref_hpmv<T>(uplo, N, h_alpha, hA.data(), hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_hpmv_batched.hpp
+++ b/clients/include/blas2/testing_hpmv_batched.hpp
@@ -318,7 +318,7 @@ void testing_hpmv_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpmv<T>(uplo, N, h_alpha, hA[b], hx[b], incx, h_beta, hy_cpu[b], incy);
+            ref_hpmv<T>(uplo, N, h_alpha, hA[b], hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hpmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hpmv_strided_batched.hpp
@@ -417,15 +417,15 @@ void testing_hpmv_strided_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpmv<T>(uplo,
-                          N,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          hx.data() + b * stride_x,
-                          incx,
-                          h_beta,
-                          hy_cpu.data() + b * stride_y,
-                          incy);
+            ref_hpmv<T>(uplo,
+                        N,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        hx.data() + b * stride_x,
+                        incx,
+                        h_beta,
+                        hy_cpu.data() + b * stride_y,
+                        incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hpr.hpp
+++ b/clients/include/blas2/testing_hpr.hpp
@@ -176,7 +176,7 @@ void testing_hpr(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_hpr<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data());
+        ref_hpr<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data());
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_hpr2.hpp
+++ b/clients/include/blas2/testing_hpr2.hpp
@@ -193,7 +193,7 @@ void testing_hpr2(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_hpr2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data());
+        ref_hpr2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data());
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_hpr2_batched.hpp
+++ b/clients/include/blas2/testing_hpr2_batched.hpp
@@ -271,7 +271,7 @@ void testing_hpr2_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpr2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b]);
+            ref_hpr2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hpr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_hpr2_strided_batched.hpp
@@ -355,14 +355,14 @@ void testing_hpr2_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpr2<T>(uplo,
-                          N,
-                          h_alpha,
-                          hx.data() + b * stride_x,
-                          incx,
-                          hy.data() + b * stride_y,
-                          incy,
-                          hA_cpu.data() + b * stride_A);
+            ref_hpr2<T>(uplo,
+                        N,
+                        h_alpha,
+                        hx.data() + b * stride_x,
+                        incx,
+                        hy.data() + b * stride_y,
+                        incy,
+                        hA_cpu.data() + b * stride_A);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hpr_batched.hpp
+++ b/clients/include/blas2/testing_hpr_batched.hpp
@@ -216,7 +216,7 @@ void testing_hpr_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpr<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b]);
+            ref_hpr<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_hpr_strided_batched.hpp
+++ b/clients/include/blas2/testing_hpr_strided_batched.hpp
@@ -220,7 +220,7 @@ void testing_hpr_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hpr<T>(
+            ref_hpr<T>(
                 uplo, N, h_alpha, hx.data() + b * stride_x, incx, hA_cpu.data() + b * stride_A);
         }
 

--- a/clients/include/blas2/testing_sbmv.hpp
+++ b/clients/include/blas2/testing_sbmv.hpp
@@ -232,7 +232,7 @@ void testing_sbmv(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_sbmv<T>(
+        ref_sbmv<T>(
             uplo, N, K, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_sbmv_batched.hpp
+++ b/clients/include/blas2/testing_sbmv_batched.hpp
@@ -386,7 +386,7 @@ void testing_sbmv_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_sbmv<T>(uplo, N, K, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
+            ref_sbmv<T>(uplo, N, K, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_sbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_sbmv_strided_batched.hpp
@@ -450,17 +450,17 @@ void testing_sbmv_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_sbmv<T>(uplo,
-                          N,
-                          K,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hx.data() + b * stride_x,
-                          incx,
-                          h_beta,
-                          hy_cpu.data() + b * stride_y,
-                          incy);
+            ref_sbmv<T>(uplo,
+                        N,
+                        K,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hx.data() + b * stride_x,
+                        incx,
+                        h_beta,
+                        hy_cpu.data() + b * stride_y,
+                        incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_spmv.hpp
+++ b/clients/include/blas2/testing_spmv.hpp
@@ -214,7 +214,7 @@ void testing_spmv(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_spmv<T>(uplo, N, h_alpha, hA.data(), hx.data(), incx, h_beta, hy_cpu.data(), incy);
+        ref_spmv<T>(uplo, N, h_alpha, hA.data(), hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_spmv_batched.hpp
+++ b/clients/include/blas2/testing_spmv_batched.hpp
@@ -316,7 +316,7 @@ void testing_spmv_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_spmv<T>(uplo, N, h_alpha, hA[b], hx[b], incx, h_beta, hy_cpu[b], incy);
+            ref_spmv<T>(uplo, N, h_alpha, hA[b], hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_spmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_spmv_strided_batched.hpp
@@ -414,15 +414,15 @@ void testing_spmv_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_spmv<T>(uplo,
-                          N,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          hx.data() + b * stride_x,
-                          incx,
-                          h_beta,
-                          hy_cpu.data() + b * stride_y,
-                          incy);
+            ref_spmv<T>(uplo,
+                        N,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        hx.data() + b * stride_x,
+                        incx,
+                        h_beta,
+                        hy_cpu.data() + b * stride_y,
+                        incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_spr.hpp
+++ b/clients/include/blas2/testing_spr.hpp
@@ -173,7 +173,7 @@ void testing_spr(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_spr<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data());
+        ref_spr<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data());
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_spr2.hpp
+++ b/clients/include/blas2/testing_spr2.hpp
@@ -191,7 +191,7 @@ void testing_spr2(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_spr2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data());
+        ref_spr2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data());
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_spr2_batched.hpp
+++ b/clients/include/blas2/testing_spr2_batched.hpp
@@ -273,7 +273,7 @@ void testing_spr2_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_spr2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b]);
+            ref_spr2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_spr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_spr2_strided_batched.hpp
@@ -353,14 +353,14 @@ void testing_spr2_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_spr2<T>(uplo,
-                          N,
-                          h_alpha,
-                          hx.data() + b * stridex,
-                          incx,
-                          hy.data() + b * stridey,
-                          incy,
-                          hA_cpu.data() + b * strideA);
+            ref_spr2<T>(uplo,
+                        N,
+                        h_alpha,
+                        hx.data() + b * stridex,
+                        incx,
+                        hy.data() + b * stridey,
+                        incy,
+                        hA_cpu.data() + b * strideA);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_spr_batched.hpp
+++ b/clients/include/blas2/testing_spr_batched.hpp
@@ -207,7 +207,7 @@ void testing_spr_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_spr<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b]);
+            ref_spr<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_spr_strided_batched.hpp
+++ b/clients/include/blas2/testing_spr_strided_batched.hpp
@@ -218,7 +218,7 @@ void testing_spr_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_spr<T>(
+            ref_spr<T>(
                 uplo, N, h_alpha, hx.data() + b * stridex, incx, hA_cpu.data() + b * strideA);
         }
 

--- a/clients/include/blas2/testing_symv.hpp
+++ b/clients/include/blas2/testing_symv.hpp
@@ -227,8 +227,7 @@ void testing_symv(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_symv<T>(
-            uplo, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
+        ref_symv<T>(uplo, N, h_alpha, hA.data(), lda, hx.data(), incx, h_beta, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_symv_batched.hpp
+++ b/clients/include/blas2/testing_symv_batched.hpp
@@ -349,7 +349,7 @@ void testing_symv_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_symv<T>(uplo, N, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
+            ref_symv<T>(uplo, N, h_alpha, hA[b], lda, hx[b], incx, h_beta, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_symv_strided_batched.hpp
+++ b/clients/include/blas2/testing_symv_strided_batched.hpp
@@ -430,16 +430,16 @@ void testing_symv_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_symv<T>(uplo,
-                          N,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hx.data() + b * stride_x,
-                          incx,
-                          h_beta,
-                          hy_cpu.data() + b * stride_y,
-                          incy);
+            ref_symv<T>(uplo,
+                        N,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hx.data() + b * stride_x,
+                        incx,
+                        h_beta,
+                        hy_cpu.data() + b * stride_y,
+                        incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_syr.hpp
+++ b/clients/include/blas2/testing_syr.hpp
@@ -175,7 +175,7 @@ void testing_syr(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_syr<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data(), lda);
+        ref_syr<T>(uplo, N, h_alpha, hx.data(), incx, hA_cpu.data(), lda);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_syr2.hpp
+++ b/clients/include/blas2/testing_syr2.hpp
@@ -193,7 +193,7 @@ void testing_syr2(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_syr2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data(), lda);
+        ref_syr2<T>(uplo, N, h_alpha, hx.data(), incx, hy.data(), incy, hA_cpu.data(), lda);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_syr2_batched.hpp
+++ b/clients/include/blas2/testing_syr2_batched.hpp
@@ -283,7 +283,7 @@ void testing_syr2_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_syr2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b], lda);
+            ref_syr2<T>(uplo, N, h_alpha, hx[b], incx, hy[b], incy, hA_cpu[b], lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_syr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_syr2_strided_batched.hpp
@@ -374,15 +374,15 @@ void testing_syr2_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_syr2<T>(uplo,
-                          N,
-                          h_alpha,
-                          hx.data() + b * stridex,
-                          incx,
-                          hy.data() + b * stridey,
-                          incy,
-                          hA_cpu.data() + b * strideA,
-                          lda);
+            ref_syr2<T>(uplo,
+                        N,
+                        h_alpha,
+                        hx.data() + b * stridex,
+                        incx,
+                        hy.data() + b * stridey,
+                        incy,
+                        hA_cpu.data() + b * strideA,
+                        lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_syr_batched.hpp
+++ b/clients/include/blas2/testing_syr_batched.hpp
@@ -232,7 +232,7 @@ void testing_syr_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_syr<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b], lda);
+            ref_syr<T>(uplo, N, h_alpha, hx[b], incx, hA_cpu[b], lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_syr_strided_batched.hpp
+++ b/clients/include/blas2/testing_syr_strided_batched.hpp
@@ -219,7 +219,7 @@ void testing_syr_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_syr<T>(
+            ref_syr<T>(
                 uplo, N, h_alpha, hx.data() + b * stridex, incx, hA_cpu.data() + b * strideA, lda);
         }
 

--- a/clients/include/blas2/testing_tbmv.hpp
+++ b/clients/include/blas2/testing_tbmv.hpp
@@ -174,7 +174,7 @@ void testing_tbmv(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_tbmv<T>(uplo, transA, diag, M, K, hA.data(), lda, hx_cpu.data(), incx);
+        ref_tbmv<T>(uplo, transA, diag, M, K, hA.data(), lda, hx_cpu.data(), incx);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_tbmv_batched.hpp
+++ b/clients/include/blas2/testing_tbmv_batched.hpp
@@ -238,7 +238,7 @@ void testing_tbmv_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_tbmv<T>(uplo, transA, diag, M, K, hA[b], lda, hx_cpu[b], incx);
+            ref_tbmv<T>(uplo, transA, diag, M, K, hA[b], lda, hx_cpu[b], incx);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_tbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_tbmv_strided_batched.hpp
@@ -279,15 +279,15 @@ void testing_tbmv_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_tbmv<T>(uplo,
-                          transA,
-                          diag,
-                          M,
-                          K,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hx_cpu.data() + b * stride_x,
-                          incx);
+            ref_tbmv<T>(uplo,
+                        transA,
+                        diag,
+                        M,
+                        K,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hx_cpu.data() + b * stride_x,
+                        incx);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_tbsv.hpp
+++ b/clients/include/blas2/testing_tbsv.hpp
@@ -169,7 +169,7 @@ void testing_tbsv(const Arguments& arg)
     regular_to_banded(uplo == HIPBLAS_FILL_MODE_UPPER, (T*)hA, N, (T*)hAB, lda, N, K);
     CHECK_HIP_ERROR(hipMemcpy(dAB, hAB.data(), sizeof(T) * size_AB, hipMemcpyHostToDevice));
 
-    cblas_tbmv<T>(uplo, transA, diag, N, K, hAB, lda, hb, incx);
+    ref_tbmv<T>(uplo, transA, diag, N, K, hAB, lda, hb, incx);
     hx_or_b_1 = hb;
 
     // copy data from CPU to device

--- a/clients/include/blas2/testing_tbsv_batched.hpp
+++ b/clients/include/blas2/testing_tbsv_batched.hpp
@@ -225,7 +225,7 @@ void testing_tbsv_batched(const Arguments& arg)
         regular_to_banded(uplo == HIPBLAS_FILL_MODE_UPPER, (T*)hA[b], N, (T*)hAB[b], lda, N, K);
 
         // Calculate hb = hA*hx;
-        cblas_tbmv<T>(uplo, transA, diag, N, K, hAB[b], lda, hb[b], incx);
+        ref_tbmv<T>(uplo, transA, diag, N, K, hAB[b], lda, hb[b], incx);
     }
 
     hx_or_b.copy_from(hb);

--- a/clients/include/blas2/testing_tbsv_strided_batched.hpp
+++ b/clients/include/blas2/testing_tbsv_strided_batched.hpp
@@ -278,7 +278,7 @@ void testing_tbsv_strided_batched(const Arguments& arg)
         regular_to_banded(uplo == HIPBLAS_FILL_MODE_UPPER, hAbat, N, hABbat, lda, N, K);
 
         // Calculate hb = hA*hx;
-        cblas_tbmv<T>(uplo, transA, diag, N, K, hABbat, lda, hbbat, incx);
+        ref_tbmv<T>(uplo, transA, diag, N, K, hABbat, lda, hbbat, incx);
     }
 
     hx_or_b_1 = hb;

--- a/clients/include/blas2/testing_tpmv.hpp
+++ b/clients/include/blas2/testing_tpmv.hpp
@@ -152,7 +152,7 @@ void testing_tpmv(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_tpmv<T>(uplo, transA, diag, N, hA.data(), hx.data(), incx);
+        ref_tpmv<T>(uplo, transA, diag, N, hA.data(), hx.data(), incx);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_tpmv_batched.hpp
+++ b/clients/include/blas2/testing_tpmv_batched.hpp
@@ -205,7 +205,7 @@ void testing_tpmv_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_tpmv<T>(uplo, transA, diag, N, hA[b], hx[b], incx);
+            ref_tpmv<T>(uplo, transA, diag, N, hA[b], hx[b], incx);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_tpmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_tpmv_strided_batched.hpp
@@ -208,7 +208,7 @@ void testing_tpmv_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_tpmv<T>(
+            ref_tpmv<T>(
                 uplo, transA, diag, N, hA.data() + b * stride_A, hx.data() + b * stride_x, incx);
         }
 

--- a/clients/include/blas2/testing_tpsv.hpp
+++ b/clients/include/blas2/testing_tpsv.hpp
@@ -144,19 +144,19 @@ void testing_tpsv(const Arguments& arg)
     hb = hx;
 
     //  calculate AAT = hA * hA ^ T
-    cblas_gemm<T>(HIPBLAS_OP_N,
-                  HIPBLAS_OP_T,
-                  N,
-                  N,
-                  N,
-                  (T)1.0,
-                  hA.data(),
-                  N,
-                  hA.data(),
-                  N,
-                  (T)0.0,
-                  AAT.data(),
-                  N);
+    ref_gemm<T>(HIPBLAS_OP_N,
+                HIPBLAS_OP_T,
+                N,
+                N,
+                N,
+                (T)1.0,
+                hA.data(),
+                N,
+                hA.data(),
+                N,
+                (T)0.0,
+                AAT.data(),
+                N);
 
     //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
     for(int i = 0; i < N; i++)
@@ -170,7 +170,7 @@ void testing_tpsv(const Arguments& arg)
         hA[i + i * N] = t;
     }
     //  calculate Cholesky factorization of SPD matrix hA
-    cblas_potrf<T>(arg.uplo, N, hA.data(), N);
+    ref_potrf<T>(arg.uplo, N, hA.data(), N);
 
     //  make hA unit diagonal if diag == rocblas_diagonal_unit
     if(arg.diag == 'U' || arg.diag == 'u')
@@ -192,7 +192,7 @@ void testing_tpsv(const Arguments& arg)
     }
 
     // Calculate hb = hA*hx;
-    cblas_trmv<T>(uplo, transA, diag, N, hA.data(), N, hb.data(), incx);
+    ref_trmv<T>(uplo, transA, diag, N, hA.data(), N, hb.data(), incx);
     cpu_x_or_b = hb; // cpuXorB <- B
     hx_or_b_1  = hb;
     hx_or_b_2  = hb;

--- a/clients/include/blas2/testing_tpsv_batched.hpp
+++ b/clients/include/blas2/testing_tpsv_batched.hpp
@@ -188,19 +188,19 @@ void testing_tpsv_batched(const Arguments& arg)
     for(int b = 0; b < batch_count; b++)
     {
         //  calculate AAT = hA * hA ^ T
-        cblas_gemm<T>(HIPBLAS_OP_N,
-                      HIPBLAS_OP_T,
-                      N,
-                      N,
-                      N,
-                      (T)1.0,
-                      (T*)hA[b],
-                      N,
-                      (T*)hA[b],
-                      N,
-                      (T)0.0,
-                      (T*)AAT[b],
-                      N);
+        ref_gemm<T>(HIPBLAS_OP_N,
+                    HIPBLAS_OP_T,
+                    N,
+                    N,
+                    N,
+                    (T)1.0,
+                    (T*)hA[b],
+                    N,
+                    (T*)hA[b],
+                    N,
+                    (T)0.0,
+                    (T*)AAT[b],
+                    N);
 
         //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
         for(int i = 0; i < N; i++)
@@ -215,7 +215,7 @@ void testing_tpsv_batched(const Arguments& arg)
         }
 
         //  calculate Cholesky factorization of SPD matrix hA
-        cblas_potrf<T>(arg.uplo, N, hA[b], N);
+        ref_potrf<T>(arg.uplo, N, hA[b], N);
 
         //  make hA unit diagonal if diag == rocblas_diagonal_unit
         if(arg.diag == 'U' || arg.diag == 'u')
@@ -237,7 +237,7 @@ void testing_tpsv_batched(const Arguments& arg)
         }
 
         // Calculate hb = hA*hx;
-        cblas_trmv<T>(uplo, transA, diag, N, hA[b], N, hb[b], incx);
+        ref_trmv<T>(uplo, transA, diag, N, hA[b], N, hb[b], incx);
 
         regular_to_packed(uplo == HIPBLAS_FILL_MODE_UPPER, (T*)hA[b], (T*)hAP[b], N);
     }

--- a/clients/include/blas2/testing_tpsv_strided_batched.hpp
+++ b/clients/include/blas2/testing_tpsv_strided_batched.hpp
@@ -199,7 +199,7 @@ void testing_tpsv_strided_batched(const Arguments& arg)
         T* AATb = AAT.data() + b * strideA;
         T* hbb  = hb.data() + b * stridex;
         //  calculate AAT = hA * hA ^ T
-        cblas_gemm<T>(HIPBLAS_OP_N, HIPBLAS_OP_T, N, N, N, (T)1.0, hAb, N, hAb, N, (T)0.0, AATb, N);
+        ref_gemm<T>(HIPBLAS_OP_N, HIPBLAS_OP_T, N, N, N, (T)1.0, hAb, N, hAb, N, (T)0.0, AATb, N);
 
         //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
         for(int i = 0; i < N; i++)
@@ -213,7 +213,7 @@ void testing_tpsv_strided_batched(const Arguments& arg)
             hAb[i + i * N] = t;
         }
         //  calculate Cholesky factorization of SPD matrix hA
-        cblas_potrf<T>(arg.uplo, N, hAb, N);
+        ref_potrf<T>(arg.uplo, N, hAb, N);
 
         //  make hA unit diagonal if diag == rocblas_diagonal_unit
         if(arg.diag == 'U' || arg.diag == 'u')
@@ -235,7 +235,7 @@ void testing_tpsv_strided_batched(const Arguments& arg)
         }
 
         // Calculate hb = hA*hx;
-        cblas_trmv<T>(uplo, transA, diag, N, hAb, N, hbb, incx);
+        ref_trmv<T>(uplo, transA, diag, N, hAb, N, hbb, incx);
 
         regular_to_packed(uplo == HIPBLAS_FILL_MODE_UPPER, (T*)hAb, (T*)hAPb, N);
     }

--- a/clients/include/blas2/testing_trmv.hpp
+++ b/clients/include/blas2/testing_trmv.hpp
@@ -169,7 +169,7 @@ void testing_trmv(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_trmv<T>(uplo, transA, diag, N, hA.data(), lda, hx.data(), incx);
+        ref_trmv<T>(uplo, transA, diag, N, hA.data(), lda, hx.data(), incx);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas2/testing_trmv_batched.hpp
+++ b/clients/include/blas2/testing_trmv_batched.hpp
@@ -209,7 +209,7 @@ void testing_trmv_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trmv<T>(uplo, transA, diag, N, hA[b], lda, hx[b], incx);
+            ref_trmv<T>(uplo, transA, diag, N, hA[b], lda, hx[b], incx);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_trmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_trmv_strided_batched.hpp
@@ -256,14 +256,14 @@ void testing_trmv_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trmv<T>(uplo,
-                          transA,
-                          diag,
-                          N,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hx.data() + b * stride_x,
-                          incx);
+            ref_trmv<T>(uplo,
+                        transA,
+                        diag,
+                        N,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hx.data() + b * stride_x,
+                        incx);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas2/testing_trsv.hpp
+++ b/clients/include/blas2/testing_trsv.hpp
@@ -153,19 +153,19 @@ void testing_trsv(const Arguments& arg)
     hb = hx;
 
     //  calculate AAT = hA * hA ^ T
-    cblas_gemm<T>(HIPBLAS_OP_N,
-                  HIPBLAS_OP_T,
-                  N,
-                  N,
-                  N,
-                  (T)1.0,
-                  hA.data(),
-                  lda,
-                  hA.data(),
-                  lda,
-                  (T)0.0,
-                  AAT.data(),
-                  lda);
+    ref_gemm<T>(HIPBLAS_OP_N,
+                HIPBLAS_OP_T,
+                N,
+                N,
+                N,
+                (T)1.0,
+                hA.data(),
+                lda,
+                hA.data(),
+                lda,
+                (T)0.0,
+                AAT.data(),
+                lda);
 
     //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
     for(int i = 0; i < N; i++)
@@ -179,7 +179,7 @@ void testing_trsv(const Arguments& arg)
         hA[i + i * lda] = t;
     }
     //  calculate Cholesky factorization of SPD matrix hA
-    cblas_potrf<T>(arg.uplo, N, hA.data(), lda);
+    ref_potrf<T>(arg.uplo, N, hA.data(), lda);
 
     //  make hA unit diagonal if diag == rocblas_diagonal_unit
     if(arg.diag == 'U' || arg.diag == 'u')
@@ -201,7 +201,7 @@ void testing_trsv(const Arguments& arg)
     }
 
     // Calculate hb = hA*hx;
-    cblas_trmv<T>(uplo, transA, diag, N, hA.data(), lda, hb.data(), incx);
+    ref_trmv<T>(uplo, transA, diag, N, hA.data(), lda, hb.data(), incx);
     hx_or_b_1 = hb;
 
     // copy data from CPU to device

--- a/clients/include/blas2/testing_trsv_batched.hpp
+++ b/clients/include/blas2/testing_trsv_batched.hpp
@@ -189,19 +189,19 @@ void testing_trsv_batched(const Arguments& arg)
     for(int b = 0; b < batch_count; b++)
     {
         //  calculate AAT = hA * hA ^ T
-        cblas_gemm<T>(HIPBLAS_OP_N,
-                      HIPBLAS_OP_T,
-                      N,
-                      N,
-                      N,
-                      (T)1.0,
-                      (T*)hA[b],
-                      lda,
-                      (T*)hA[b],
-                      lda,
-                      (T)0.0,
-                      (T*)AAT[b],
-                      lda);
+        ref_gemm<T>(HIPBLAS_OP_N,
+                    HIPBLAS_OP_T,
+                    N,
+                    N,
+                    N,
+                    (T)1.0,
+                    (T*)hA[b],
+                    lda,
+                    (T*)hA[b],
+                    lda,
+                    (T)0.0,
+                    (T*)AAT[b],
+                    lda);
 
         //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
         for(int i = 0; i < N; i++)
@@ -216,7 +216,7 @@ void testing_trsv_batched(const Arguments& arg)
         }
 
         //  calculate Cholesky factorization of SPD matrix hA
-        cblas_potrf<T>(arg.uplo, N, hA[b], lda);
+        ref_potrf<T>(arg.uplo, N, hA[b], lda);
 
         //  make hA unit diagonal if diag == rocblas_diagonal_unit
         if(arg.diag == 'U' || arg.diag == 'u')
@@ -241,7 +241,7 @@ void testing_trsv_batched(const Arguments& arg)
     for(int b = 0; b < batch_count; b++)
     {
         // Calculate hb = hA*hx;
-        cblas_trmv<T>(uplo, transA, diag, N, hA[b], lda, hb[b], incx);
+        ref_trmv<T>(uplo, transA, diag, N, hA[b], lda, hb[b], incx);
     }
 
     hx_or_b_1.copy_from(hb);

--- a/clients/include/blas2/testing_trsv_strided_batched.hpp
+++ b/clients/include/blas2/testing_trsv_strided_batched.hpp
@@ -244,7 +244,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
         T* AATb = AAT.data() + b * strideA;
         T* hbb  = hb.data() + b * stridex;
         //  calculate AAT = hA * hA ^ T
-        cblas_gemm<T>(
+        ref_gemm<T>(
             HIPBLAS_OP_N, HIPBLAS_OP_T, N, N, N, (T)1.0, hAb, lda, hAb, lda, (T)0.0, AATb, lda);
 
         //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
@@ -259,7 +259,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
             hAb[i + i * lda] = t;
         }
         //  calculate Cholesky factorization of SPD matrix hA
-        cblas_potrf<T>(arg.uplo, N, hAb, lda);
+        ref_potrf<T>(arg.uplo, N, hAb, lda);
 
         //  make hA unit diagonal if diag == rocblas_diagonal_unit
         if(arg.diag == 'U' || arg.diag == 'u')
@@ -281,7 +281,7 @@ void testing_trsv_strided_batched(const Arguments& arg)
         }
 
         // Calculate hb = hA*hx;
-        cblas_trmv<T>(uplo, transA, diag, N, hAb, lda, hbb, incx);
+        ref_trmv<T>(uplo, transA, diag, N, hAb, lda, hbb, incx);
     }
 
     hx_or_b_1 = hb;

--- a/clients/include/blas3/testing_geam.hpp
+++ b/clients/include/blas3/testing_geam.hpp
@@ -304,7 +304,7 @@ void testing_geam(const Arguments& arg)
         /* =====================================================================
                 CPU BLAS
         =================================================================== */
-        cblas_geam(
+        ref_geam(
             transA, transB, M, N, &h_alpha, (T*)hA, lda, &h_beta, (T*)hB, ldb, (T*)hC_copy, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_geam_batched.hpp
+++ b/clients/include/blas3/testing_geam_batched.hpp
@@ -480,18 +480,18 @@ void testing_geam_batched(const Arguments& arg)
         // reference calculation
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_geam(transA,
-                       transB,
-                       M,
-                       N,
-                       &h_alpha,
-                       (T*)hA[b],
-                       lda,
-                       &h_beta,
-                       (T*)hB[b],
-                       ldb,
-                       (T*)hC_copy[b],
-                       ldc);
+            ref_geam(transA,
+                     transB,
+                     M,
+                     N,
+                     &h_alpha,
+                     (T*)hA[b],
+                     lda,
+                     &h_beta,
+                     (T*)hB[b],
+                     ldb,
+                     (T*)hC_copy[b],
+                     ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_geam_strided_batched.hpp
+++ b/clients/include/blas3/testing_geam_strided_batched.hpp
@@ -545,18 +545,18 @@ void testing_geam_strided_batched(const Arguments& arg)
         // reference calculation
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_geam(transA,
-                       transB,
-                       M,
-                       N,
-                       &h_alpha,
-                       (T*)hA + b * stride_A,
-                       lda,
-                       &h_beta,
-                       (T*)hB + b * stride_B,
-                       ldb,
-                       (T*)hC_copy + b * stride_C,
-                       ldc);
+            ref_geam(transA,
+                     transB,
+                     M,
+                     N,
+                     &h_alpha,
+                     (T*)hA + b * stride_A,
+                     lda,
+                     &h_beta,
+                     (T*)hB + b * stride_B,
+                     ldb,
+                     (T*)hC_copy + b * stride_C,
+                     ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_gemm.hpp
+++ b/clients/include/blas3/testing_gemm.hpp
@@ -375,19 +375,19 @@ void testing_gemm(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_gemm<T>(transA,
-                      transB,
-                      M,
-                      N,
-                      K,
-                      h_alpha,
-                      hA.data(),
-                      lda,
-                      hB.data(),
-                      ldb,
-                      h_beta,
-                      hC_copy.data(),
-                      ldc);
+        ref_gemm<T>(transA,
+                    transB,
+                    M,
+                    N,
+                    K,
+                    h_alpha,
+                    hA.data(),
+                    lda,
+                    hB.data(),
+                    ldb,
+                    h_beta,
+                    hC_copy.data(),
+                    ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas3/testing_gemm_batched.hpp
+++ b/clients/include/blas3/testing_gemm_batched.hpp
@@ -469,19 +469,19 @@ void testing_gemm_batched(const Arguments& arg)
         // calculate "golden" result on CPU
         for(int i = 0; i < batch_count; i++)
         {
-            cblas_gemm<T>(transA,
-                          transB,
-                          M,
-                          N,
-                          K,
-                          h_alpha,
-                          (T*)hA[i],
-                          lda,
-                          (T*)hB[i],
-                          ldb,
-                          h_beta,
-                          (T*)hC_copy[i],
-                          ldc);
+            ref_gemm<T>(transA,
+                        transB,
+                        M,
+                        N,
+                        K,
+                        h_alpha,
+                        (T*)hA[i],
+                        lda,
+                        (T*)hB[i],
+                        ldb,
+                        h_beta,
+                        (T*)hC_copy[i],
+                        ldc);
         }
 
         // test hipBLAS batched gemm with alpha and beta pointers on device

--- a/clients/include/blas3/testing_gemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_gemm_strided_batched.hpp
@@ -546,19 +546,19 @@ void testing_gemm_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int i = 0; i < batch_count; i++)
         {
-            cblas_gemm<T>(transA,
-                          transB,
-                          M,
-                          N,
-                          K,
-                          h_alpha,
-                          hA.data() + stride_A * i,
-                          lda,
-                          hB.data() + stride_B * i,
-                          ldb,
-                          h_beta,
-                          hC_copy.data() + stride_C * i,
-                          ldc);
+            ref_gemm<T>(transA,
+                        transB,
+                        M,
+                        N,
+                        K,
+                        h_alpha,
+                        hA.data() + stride_A * i,
+                        lda,
+                        hB.data() + stride_B * i,
+                        ldb,
+                        h_beta,
+                        hC_copy.data() + stride_C * i,
+                        ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_hemm.hpp
+++ b/clients/include/blas3/testing_hemm.hpp
@@ -249,7 +249,7 @@ void testing_hemm(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_hemm<T>(
+        ref_hemm<T>(
             side, uplo, M, N, h_alpha, hA.data(), lda, hB.data(), ldb, h_beta, hC_gold.data(), ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_hemm_batched.hpp
+++ b/clients/include/blas3/testing_hemm_batched.hpp
@@ -437,8 +437,7 @@ void testing_hemm_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hemm<T>(
-                side, uplo, M, N, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
+            ref_hemm<T>(side, uplo, M, N, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_hemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_hemm_strided_batched.hpp
@@ -489,18 +489,18 @@ void testing_hemm_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_hemm<T>(side,
-                          uplo,
-                          M,
-                          N,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hB.data() + b * stride_B,
-                          ldb,
-                          h_beta,
-                          hC_gold.data() + b * stride_C,
-                          ldc);
+            ref_hemm<T>(side,
+                        uplo,
+                        M,
+                        N,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hB.data() + b * stride_B,
+                        ldb,
+                        h_beta,
+                        hC_gold.data() + b * stride_C,
+                        ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_her2k.hpp
+++ b/clients/include/blas3/testing_her2k.hpp
@@ -279,7 +279,7 @@ void testing_her2k(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_her2k<T>(uplo, transA, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
+        ref_her2k<T>(uplo, transA, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas3/testing_her2k_batched.hpp
+++ b/clients/include/blas3/testing_her2k_batched.hpp
@@ -440,7 +440,7 @@ void testing_her2k_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her2k<T>(
+            ref_her2k<T>(
                 uplo, transA, N, K, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
         }
 

--- a/clients/include/blas3/testing_her2k_strided_batched.hpp
+++ b/clients/include/blas3/testing_her2k_strided_batched.hpp
@@ -498,18 +498,18 @@ void testing_her2k_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_her2k<T>(uplo,
-                           transA,
-                           N,
-                           K,
-                           h_alpha,
-                           hA.data() + b * stride_A,
-                           lda,
-                           hB.data() + b * stride_B,
-                           ldb,
-                           h_beta,
-                           hC_gold.data() + b * stride_C,
-                           ldc);
+            ref_her2k<T>(uplo,
+                         transA,
+                         N,
+                         K,
+                         h_alpha,
+                         hA.data() + b * stride_A,
+                         lda,
+                         hB.data() + b * stride_B,
+                         ldb,
+                         h_beta,
+                         hC_gold.data() + b * stride_C,
+                         ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_herk.hpp
+++ b/clients/include/blas3/testing_herk.hpp
@@ -236,7 +236,7 @@ void testing_herk(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_herk<T>(uplo, transA, N, K, h_alpha, hA, lda, h_beta, hC_gold, ldc);
+        ref_herk<T>(uplo, transA, N, K, h_alpha, hA, lda, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas3/testing_herk_batched.hpp
+++ b/clients/include/blas3/testing_herk_batched.hpp
@@ -343,7 +343,7 @@ void testing_herk_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_herk<T>(uplo, transA, N, K, h_alpha, hA[b], lda, h_beta, hC_gold[b], ldc);
+            ref_herk<T>(uplo, transA, N, K, h_alpha, hA[b], lda, h_beta, hC_gold[b], ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_herk_strided_batched.hpp
+++ b/clients/include/blas3/testing_herk_strided_batched.hpp
@@ -420,16 +420,16 @@ void testing_herk_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_herk<T>(uplo,
-                          transA,
-                          N,
-                          K,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          h_beta,
-                          hC_gold.data() + b * stride_C,
-                          ldc);
+            ref_herk<T>(uplo,
+                        transA,
+                        N,
+                        K,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        h_beta,
+                        hC_gold.data() + b * stride_C,
+                        ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_herkx.hpp
+++ b/clients/include/blas3/testing_herkx.hpp
@@ -279,7 +279,7 @@ void testing_herkx(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_herkx<T>(uplo, transA, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
+        ref_herkx<T>(uplo, transA, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas3/testing_herkx_batched.hpp
+++ b/clients/include/blas3/testing_herkx_batched.hpp
@@ -440,7 +440,7 @@ void testing_herkx_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_herkx<T>(
+            ref_herkx<T>(
                 uplo, transA, N, K, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
         }
 

--- a/clients/include/blas3/testing_herkx_strided_batched.hpp
+++ b/clients/include/blas3/testing_herkx_strided_batched.hpp
@@ -496,18 +496,18 @@ void testing_herkx_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_herkx<T>(uplo,
-                           transA,
-                           N,
-                           K,
-                           h_alpha,
-                           hA.data() + b * stride_A,
-                           lda,
-                           hB.data() + b * stride_B,
-                           ldb,
-                           h_beta,
-                           hC_gold.data() + b * stride_C,
-                           ldc);
+            ref_herkx<T>(uplo,
+                         transA,
+                         N,
+                         K,
+                         h_alpha,
+                         hA.data() + b * stride_A,
+                         lda,
+                         hB.data() + b * stride_B,
+                         ldb,
+                         h_beta,
+                         hC_gold.data() + b * stride_C,
+                         ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_symm.hpp
+++ b/clients/include/blas3/testing_symm.hpp
@@ -251,7 +251,7 @@ void testing_symm(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_symm<T>(side, uplo, M, N, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
+        ref_symm<T>(side, uplo, M, N, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas3/testing_symm_batched.hpp
+++ b/clients/include/blas3/testing_symm_batched.hpp
@@ -434,8 +434,7 @@ void testing_symm_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_symm<T>(
-                side, uplo, M, N, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
+            ref_symm<T>(side, uplo, M, N, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_symm_strided_batched.hpp
+++ b/clients/include/blas3/testing_symm_strided_batched.hpp
@@ -491,18 +491,18 @@ void testing_symm_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_symm<T>(side,
-                          uplo,
-                          M,
-                          N,
-                          h_alpha,
-                          hA + b * stride_A,
-                          lda,
-                          hB + b * stride_B,
-                          ldb,
-                          h_beta,
-                          hC_gold + b * stride_C,
-                          ldc);
+            ref_symm<T>(side,
+                        uplo,
+                        M,
+                        N,
+                        h_alpha,
+                        hA + b * stride_A,
+                        lda,
+                        hB + b * stride_B,
+                        ldb,
+                        h_beta,
+                        hC_gold + b * stride_C,
+                        ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_syr2k.hpp
+++ b/clients/include/blas3/testing_syr2k.hpp
@@ -269,7 +269,7 @@ void testing_syr2k(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_syr2k<T>(uplo, transA, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
+        ref_syr2k<T>(uplo, transA, N, K, h_alpha, hA, lda, hB, ldb, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas3/testing_syr2k_batched.hpp
+++ b/clients/include/blas3/testing_syr2k_batched.hpp
@@ -420,7 +420,7 @@ void testing_syr2k_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_syr2k<T>(
+            ref_syr2k<T>(
                 uplo, transA, N, K, h_alpha, hA[b], lda, hB[b], ldb, h_beta, hC_gold[b], ldc);
         }
 

--- a/clients/include/blas3/testing_syr2k_strided_batched.hpp
+++ b/clients/include/blas3/testing_syr2k_strided_batched.hpp
@@ -477,18 +477,18 @@ void testing_syr2k_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_syr2k<T>(uplo,
-                           transA,
-                           N,
-                           K,
-                           h_alpha,
-                           hA.data() + b * stride_A,
-                           lda,
-                           hB.data() + b * stride_B,
-                           ldb,
-                           h_beta,
-                           hC_gold.data() + b * stride_C,
-                           ldc);
+            ref_syr2k<T>(uplo,
+                         transA,
+                         N,
+                         K,
+                         h_alpha,
+                         hA.data() + b * stride_A,
+                         lda,
+                         hB.data() + b * stride_B,
+                         ldb,
+                         h_beta,
+                         hC_gold.data() + b * stride_C,
+                         ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_syrk.hpp
+++ b/clients/include/blas3/testing_syrk.hpp
@@ -229,7 +229,7 @@ void testing_syrk(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_syrk<T>(uplo, transA, N, K, h_alpha, hA, lda, h_beta, hC_gold, ldc);
+        ref_syrk<T>(uplo, transA, N, K, h_alpha, hA, lda, h_beta, hC_gold, ldc);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas3/testing_syrk_batched.hpp
+++ b/clients/include/blas3/testing_syrk_batched.hpp
@@ -326,7 +326,7 @@ void testing_syrk_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_syrk<T>(uplo, transA, N, K, h_alpha, hA[b], lda, h_beta, hC_gold[b], ldc);
+            ref_syrk<T>(uplo, transA, N, K, h_alpha, hA[b], lda, h_beta, hC_gold[b], ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_syrk_strided_batched.hpp
+++ b/clients/include/blas3/testing_syrk_strided_batched.hpp
@@ -404,16 +404,16 @@ void testing_syrk_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_syrk<T>(uplo,
-                          transA,
-                          N,
-                          K,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          h_beta,
-                          hC_gold.data() + b * stride_C,
-                          ldc);
+            ref_syrk<T>(uplo,
+                        transA,
+                        N,
+                        K,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        h_beta,
+                        hC_gold.data() + b * stride_C,
+                        ldc);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_trmm.hpp
+++ b/clients/include/blas3/testing_trmm.hpp
@@ -402,7 +402,7 @@ void testing_trmm(const Arguments& arg)
            CPU BLAS
         =================================================================== */
         // use hB matrix for cblas, copy into C matrix for !inplace version to compare with hipblas
-        cblas_trmm<T>(side, uplo, transA, diag, M, N, h_alpha, hA, lda, hB, ldb);
+        ref_trmm<T>(side, uplo, transA, diag, M, N, h_alpha, hA, lda, hB, ldb);
         copy_matrix_with_different_leading_dimensions(hB, hOut_gold, M, N, ldb, ldOut);
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas3/testing_trmm_batched.hpp
+++ b/clients/include/blas3/testing_trmm_batched.hpp
@@ -488,7 +488,7 @@ void testing_trmm_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trmm<T>(side, uplo, transA, diag, M, N, h_alpha, hA[b], lda, hB[b], ldb);
+            ref_trmm<T>(side, uplo, transA, diag, M, N, h_alpha, hA[b], lda, hB[b], ldb);
         }
 
         copy_matrix_with_different_leading_dimensions_batched(hB, hOut_gold, M, N, ldb, ldOut);

--- a/clients/include/blas3/testing_trmm_strided_batched.hpp
+++ b/clients/include/blas3/testing_trmm_strided_batched.hpp
@@ -535,17 +535,17 @@ void testing_trmm_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trmm<T>(side,
-                          uplo,
-                          transA,
-                          diag,
-                          M,
-                          N,
-                          h_alpha,
-                          hA.data() + b * stride_A,
-                          lda,
-                          hB.data() + b * stride_B,
-                          ldb);
+            ref_trmm<T>(side,
+                        uplo,
+                        transA,
+                        diag,
+                        M,
+                        N,
+                        h_alpha,
+                        hA.data() + b * stride_A,
+                        lda,
+                        hB.data() + b * stride_B,
+                        ldb);
         }
 
         copy_matrix_with_different_leading_dimensions(

--- a/clients/include/blas3/testing_trsm.hpp
+++ b/clients/include/blas3/testing_trsm.hpp
@@ -205,7 +205,7 @@ void testing_trsm(const Arguments& arg)
     }
     // proprocess the matrix to avoid ill-conditioned matrix
     std::vector<int> ipiv(K);
-    cblas_getrf(K, K, hA.data(), lda, ipiv.data());
+    ref_getrf(K, K, hA.data(), lda, ipiv.data());
     for(int i = 0; i < K; i++)
     {
         for(int j = i; j < K; j++)
@@ -230,8 +230,7 @@ void testing_trsm(const Arguments& arg)
     hB_gold = hB_host; // original solution hX
 
     // Calculate hB = hA*hX;
-    cblas_trmm<T>(
-        side, uplo, transA, diag, M, N, T(1.0) / h_alpha, (const T*)hA, lda, hB_host, ldb);
+    ref_trmm<T>(side, uplo, transA, diag, M, N, T(1.0) / h_alpha, (const T*)hA, lda, hB_host, ldb);
 
     hB_device = hB_host;
 
@@ -262,7 +261,7 @@ void testing_trsm(const Arguments& arg)
            CPU BLAS
         =================================================================== */
 
-        // cblas_trsm<T>(
+        // ref_trsm<T>(
         //     side, uplo, transA, diag, M, N, h_alpha, (const T*)hA, lda, hB_gold, ldb);
 
         // if enable norm check, norm check is invasive

--- a/clients/include/blas3/testing_trsm_batched.hpp
+++ b/clients/include/blas3/testing_trsm_batched.hpp
@@ -328,7 +328,7 @@ void testing_trsm_batched(const Arguments& arg)
 
         // proprocess the matrix to avoid ill-conditioned matrix
         std::vector<int> ipiv(K);
-        cblas_getrf(K, K, hA[b], lda, ipiv.data());
+        ref_getrf(K, K, hA[b], lda, ipiv.data());
         for(int i = 0; i < K; i++)
         {
             for(int j = i; j < K; j++)
@@ -353,17 +353,17 @@ void testing_trsm_batched(const Arguments& arg)
         // hB_gold[b] = hB_host[b]; // original solution hX
 
         // Calculate hB = hA*hX;
-        cblas_trmm<T>(side,
-                      uplo,
-                      transA,
-                      diag,
-                      M,
-                      N,
-                      T(1.0) / h_alpha,
-                      (const T*)hA[b],
-                      lda,
-                      hB_host[b],
-                      ldb);
+        ref_trmm<T>(side,
+                    uplo,
+                    transA,
+                    diag,
+                    M,
+                    N,
+                    T(1.0) / h_alpha,
+                    (const T*)hA[b],
+                    lda,
+                    hB_host[b],
+                    ldb);
     }
     hB_gold.copy_from(hB_host);
     hB_device.copy_from(hB_host);
@@ -417,7 +417,7 @@ void testing_trsm_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trsm<T>(
+            ref_trsm<T>(
                 side, uplo, transA, diag, M, N, h_alpha, (const T*)hA[b], lda, hB_gold[b], ldb);
         }
 

--- a/clients/include/blas3/testing_trsm_strided_batched.hpp
+++ b/clients/include/blas3/testing_trsm_strided_batched.hpp
@@ -374,7 +374,7 @@ void testing_trsm_strided_batched(const Arguments& arg)
 
         // proprocess the matrix to avoid ill-conditioned matrix
         std::vector<int> ipiv(K);
-        cblas_getrf(K, K, hAb, lda, ipiv.data());
+        ref_getrf(K, K, hAb, lda, ipiv.data());
         for(int i = 0; i < K; i++)
         {
             for(int j = i; j < K; j++)
@@ -398,8 +398,7 @@ void testing_trsm_strided_batched(const Arguments& arg)
         }
 
         // Calculate hB = hA*hX;
-        cblas_trmm<T>(
-            side, uplo, transA, diag, M, N, T(1.0) / h_alpha, (const T*)hAb, lda, hBb, ldb);
+        ref_trmm<T>(side, uplo, transA, diag, M, N, T(1.0) / h_alpha, (const T*)hAb, lda, hBb, ldb);
     }
     hB_gold   = hB_host; // original solutions hX
     hB_device = hB_host;
@@ -459,17 +458,17 @@ void testing_trsm_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trsm<T>(side,
-                          uplo,
-                          transA,
-                          diag,
-                          M,
-                          N,
-                          h_alpha,
-                          (const T*)hA.data() + b * strideA,
-                          lda,
-                          hB_gold.data() + b * strideB,
-                          ldb);
+            ref_trsm<T>(side,
+                        uplo,
+                        transA,
+                        diag,
+                        M,
+                        N,
+                        h_alpha,
+                        (const T*)hA.data() + b * strideA,
+                        lda,
+                        hB_gold.data() + b * strideB,
+                        ldb);
         }
 
         // if enable norm check, norm check is invasive

--- a/clients/include/blas3/testing_trtri.hpp
+++ b/clients/include/blas3/testing_trtri.hpp
@@ -156,7 +156,7 @@ void testing_trtri(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_trtri<T>(arg.uplo, arg.diag, N, hB, lda);
+        ref_trtri<T>(arg.uplo, arg.diag, N, hB, lda);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas3/testing_trtri_batched.hpp
+++ b/clients/include/blas3/testing_trtri_batched.hpp
@@ -207,7 +207,7 @@ void testing_trtri_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trtri<T>(arg.uplo, arg.diag, N, hB[b], lda);
+            ref_trtri<T>(arg.uplo, arg.diag, N, hB[b], lda);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas3/testing_trtri_strided_batched.hpp
+++ b/clients/include/blas3/testing_trtri_strided_batched.hpp
@@ -214,7 +214,7 @@ void testing_trtri_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trtri<T>(arg.uplo, arg.diag, N, hB.data() + b * strideA, lda);
+            ref_trtri<T>(arg.uplo, arg.diag, N, hB.data() + b * strideA, lda);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas_ex/testing_axpy_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_axpy_batched_ex.hpp
@@ -294,7 +294,7 @@ void testing_axpy_batched_ex(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_axpy(N, h_alpha, hx[b], incx, hy_cpu[b], incy);
+            ref_axpy(N, h_alpha, hx[b], incx, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas_ex/testing_axpy_ex.hpp
+++ b/clients/include/blas_ex/testing_axpy_ex.hpp
@@ -225,7 +225,7 @@ void testing_axpy_ex(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_axpy(N, h_alpha, hx.data(), incx, hy_cpu.data(), incy);
+        ref_axpy(N, h_alpha, hx.data(), incx, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas_ex/testing_axpy_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_axpy_strided_batched_ex.hpp
@@ -331,7 +331,7 @@ void testing_axpy_strided_batched_ex(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_axpy(N, h_alpha, hx + b * stridex, incx, hy_cpu + b * stridey, incy);
+            ref_axpy(N, h_alpha, hx + b * stridex, incx, hy_cpu + b * stridey, incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas_ex/testing_dot_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_dot_batched_ex.hpp
@@ -265,8 +265,7 @@ void testing_dot_batched_ex(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            (CONJ ? cblas_dotc<Tx>
-                  : cblas_dot<Tx>)(N, hx[b], incx, hy[b], incy, &(h_cpu_result[b]));
+            (CONJ ? ref_dotc<Tx> : ref_dot<Tx>)(N, hx[b], incx, hy[b], incy, &(h_cpu_result[b]));
         }
 
         if(arg.unit_check)

--- a/clients/include/blas_ex/testing_dot_ex.hpp
+++ b/clients/include/blas_ex/testing_dot_ex.hpp
@@ -235,7 +235,7 @@ void testing_dot_ex(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        (CONJ ? cblas_dotc<Tx> : cblas_dot<Tx>)(N, hx.data(), incx, hy.data(), incy, &cpu_result);
+        (CONJ ? ref_dotc<Tx> : ref_dot<Tx>)(N, hx.data(), incx, hy.data(), incy, &cpu_result);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas_ex/testing_dot_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_dot_strided_batched_ex.hpp
@@ -294,12 +294,12 @@ void testing_dot_strided_batched_ex(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            (CONJ ? cblas_dotc<Tx> : cblas_dot<Tx>)(N,
-                                                    hx.data() + b * stridex,
-                                                    incx,
-                                                    hy.data() + b * stridey,
-                                                    incy,
-                                                    &h_cpu_result[b]);
+            (CONJ ? ref_dotc<Tx> : ref_dot<Tx>)(N,
+                                                hx.data() + b * stridex,
+                                                incx,
+                                                hy.data() + b * stridey,
+                                                incy,
+                                                &h_cpu_result[b]);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -522,19 +522,19 @@ void testing_gemm_batched_ex(const Arguments& arg)
         // CPU BLAS
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_gemm<Ti, To, Tex>(transA,
-                                    transB,
-                                    M,
-                                    N,
-                                    K,
-                                    h_alpha_Tex,
-                                    hA[b],
-                                    lda,
-                                    hB[b],
-                                    ldb,
-                                    h_beta_Tex,
-                                    hC_gold[b],
-                                    ldc);
+            ref_gemm<Ti, To, Tex>(transA,
+                                  transB,
+                                  M,
+                                  N,
+                                  K,
+                                  h_alpha_Tex,
+                                  hA[b],
+                                  lda,
+                                  hB[b],
+                                  ldb,
+                                  h_beta_Tex,
+                                  hC_gold[b],
+                                  ldc);
         }
 
         if(unit_check)

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -494,19 +494,19 @@ void testing_gemm_ex(const Arguments& arg)
         CHECK_HIP_ERROR(hipMemcpy(hC_device, dC, sizeof(To) * size_C, hipMemcpyDeviceToHost));
 
         // reference BLAS
-        cblas_gemm<Ti, To, Tex>(transA,
-                                transB,
-                                M,
-                                N,
-                                K,
-                                h_alpha_Tex,
-                                hA.data(),
-                                lda,
-                                hB.data(),
-                                ldb,
-                                h_beta_Tex,
-                                hC_gold.data(),
-                                ldc);
+        ref_gemm<Ti, To, Tex>(transA,
+                              transB,
+                              M,
+                              N,
+                              K,
+                              h_alpha_Tex,
+                              hA.data(),
+                              lda,
+                              hB.data(),
+                              ldb,
+                              h_beta_Tex,
+                              hC_gold.data(),
+                              ldc);
 
         if(unit_check)
         {

--- a/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -544,19 +544,19 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
         // CPU BLAS
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_gemm<Ti, To, Tex>(transA,
-                                    transB,
-                                    M,
-                                    N,
-                                    K,
-                                    h_alpha_Tex,
-                                    hA.data() + b * stride_A,
-                                    lda,
-                                    hB.data() + b * stride_B,
-                                    ldb,
-                                    h_beta_Tex,
-                                    hC_gold.data() + b * stride_C,
-                                    ldc);
+            ref_gemm<Ti, To, Tex>(transA,
+                                  transB,
+                                  M,
+                                  N,
+                                  K,
+                                  h_alpha_Tex,
+                                  hA.data() + b * stride_A,
+                                  lda,
+                                  hB.data() + b * stride_B,
+                                  ldb,
+                                  h_beta_Tex,
+                                  hC_gold.data() + b * stride_C,
+                                  ldc);
         }
 
         if(unit_check)

--- a/clients/include/blas_ex/testing_nrm2_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_nrm2_batched_ex.hpp
@@ -183,7 +183,7 @@ void testing_nrm2_batched_ex(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_nrm2<Tx, Tr>(N, hx[b], incx, &(h_cpu_result[b]));
+            ref_nrm2<Tx, Tr>(N, hx[b], incx, &(h_cpu_result[b]));
         }
 
         double abs_result = h_cpu_result[0] > 0 ? h_cpu_result[0] : -h_cpu_result[0];

--- a/clients/include/blas_ex/testing_nrm2_ex.hpp
+++ b/clients/include/blas_ex/testing_nrm2_ex.hpp
@@ -146,7 +146,7 @@ void testing_nrm2_ex(const Arguments& arg)
                     CPU BLAS
         =================================================================== */
 
-        cblas_nrm2<Tx, Tr>(N, hx.data(), incx, &cpu_result);
+        ref_nrm2<Tx, Tr>(N, hx.data(), incx, &cpu_result);
 
         // tolerance taken from rocBLAS, could use some improvement
         double abs_result = cpu_result > 0 ? cpu_result : -cpu_result;

--- a/clients/include/blas_ex/testing_nrm2_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_nrm2_strided_batched_ex.hpp
@@ -216,7 +216,7 @@ void testing_nrm2_strided_batched_ex(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_nrm2<Tx, Tr>(N, hx.data() + b * stridex, incx, &(h_cpu_result[b]));
+            ref_nrm2<Tx, Tr>(N, hx.data() + b * stridex, incx, &(h_cpu_result[b]));
         }
 
         double abs_result = h_cpu_result[0] > 0 ? h_cpu_result[0] : -h_cpu_result[0];

--- a/clients/include/blas_ex/testing_rot_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_rot_batched_ex.hpp
@@ -259,7 +259,7 @@ void testing_rot_batched_ex(const Arguments& arg)
         // CBLAS
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_rot<Tx, Tcs, Tcs>(N, hx_cpu[b], incx, hy_cpu[b], incy, *hc, *hs);
+            ref_rot<Tx, Tcs, Tcs>(N, hx_cpu[b], incx, hy_cpu[b], incy, *hc, *hs);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas_ex/testing_rot_ex.hpp
+++ b/clients/include/blas_ex/testing_rot_ex.hpp
@@ -188,7 +188,7 @@ void testing_rot_ex(const Arguments& arg)
 
         // CBLAS
         // TODO: execution type in cblas_rot
-        cblas_rot<Tx, Tcs, Tcs>(N, hx_cpu.data(), incx, hy_cpu.data(), incy, *hc, *hs);
+        ref_rot<Tx, Tcs, Tcs>(N, hx_cpu.data(), incx, hy_cpu.data(), incy, *hc, *hs);
 
         if(arg.unit_check)
         {

--- a/clients/include/blas_ex/testing_rot_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_rot_strided_batched_ex.hpp
@@ -289,7 +289,7 @@ void testing_rot_strided_batched_ex(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_rot<Tx, Tcs, Tcs>(
+            ref_rot<Tx, Tcs, Tcs>(
                 N, hx_cpu.data() + b * stridex, incx, hy_cpu.data() + b * stridey, incy, *hc, *hs);
         }
 

--- a/clients/include/blas_ex/testing_scal_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_scal_batched_ex.hpp
@@ -175,7 +175,7 @@ void testing_scal_batched_ex(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_scal<Tx, Ta>(N, h_alpha, hx_cpu[b], incx);
+            ref_scal<Tx, Ta>(N, h_alpha, hx_cpu[b], incx);
         }
 
         for(size_t b = 0; b < batch_count; b++)

--- a/clients/include/blas_ex/testing_scal_ex.hpp
+++ b/clients/include/blas_ex/testing_scal_ex.hpp
@@ -154,7 +154,7 @@ void testing_scal_ex(const Arguments& arg)
         /* =====================================================================
                     CPU BLAS
         =================================================================== */
-        cblas_scal<Tx, Ta>(N, h_alpha, hx_cpu, incx);
+        ref_scal<Tx, Ta>(N, h_alpha, hx_cpu, incx);
 
         for(size_t i = 0; i < sizeX; i++)
         {

--- a/clients/include/blas_ex/testing_scal_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_scal_strided_batched_ex.hpp
@@ -206,7 +206,7 @@ void testing_scal_strided_batched_ex(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_scal<Tx, Ta>(N, h_alpha, hx_cpu + b * stridex, incx);
+            ref_scal<Tx, Ta>(N, h_alpha, hx_cpu + b * stridex, incx);
         }
 
         for(size_t b = 0; b < batch_count; b++)

--- a/clients/include/blas_ex/testing_trsm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_batched_ex.hpp
@@ -408,7 +408,7 @@ void testing_trsm_batched_ex(const Arguments& arg)
 
         // proprocess the matrix to avoid ill-conditioned matrix
         host_vector<int> ipiv(K);
-        cblas_getrf(K, K, hA[b], lda, ipiv);
+        ref_getrf(K, K, hA[b], lda, ipiv);
         for(int i = 0; i < K; i++)
         {
             for(int j = i; j < K; j++)
@@ -432,17 +432,17 @@ void testing_trsm_batched_ex(const Arguments& arg)
         }
 
         // Calculate hB = hA*hX;
-        cblas_trmm<T>(side,
-                      uplo,
-                      transA,
-                      diag,
-                      M,
-                      N,
-                      T(1.0) / h_alpha,
-                      (const T*)hA[b],
-                      lda,
-                      hB_host[b],
-                      ldb);
+        ref_trmm<T>(side,
+                    uplo,
+                    transA,
+                    diag,
+                    M,
+                    N,
+                    T(1.0) / h_alpha,
+                    (const T*)hA[b],
+                    lda,
+                    hB_host[b],
+                    ldb);
     }
 
     hB_device.copy_from(hB_host);
@@ -541,7 +541,7 @@ void testing_trsm_batched_ex(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trsm<T>(
+            ref_trsm<T>(
                 side, uplo, transA, diag, M, N, h_alpha, (const T*)hA[b], lda, hB_cpu[b], ldb);
         }
 

--- a/clients/include/blas_ex/testing_trsm_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_ex.hpp
@@ -358,7 +358,7 @@ void testing_trsm_ex(const Arguments& arg)
     }
     // proprocess the matrix to avoid ill-conditioned matrix
     host_vector<int> ipiv(K);
-    cblas_getrf(K, K, hA.data(), lda, ipiv.data());
+    ref_getrf(K, K, hA.data(), lda, ipiv.data());
     for(int i = 0; i < K; i++)
     {
         for(int j = i; j < K; j++)
@@ -382,17 +382,17 @@ void testing_trsm_ex(const Arguments& arg)
     }
 
     // Calculate hB = hA*hX;
-    cblas_trmm<T>(side,
-                  uplo,
-                  transA,
-                  diag,
-                  M,
-                  N,
-                  T(1.0) / h_alpha,
-                  (const T*)hA.data(),
-                  lda,
-                  hB_host.data(),
-                  ldb);
+    ref_trmm<T>(side,
+                uplo,
+                transA,
+                diag,
+                M,
+                N,
+                T(1.0) / h_alpha,
+                (const T*)hA.data(),
+                lda,
+                hB_host.data(),
+                ldb);
 
     hB_cpu = hB_device = hB_host;
 
@@ -484,7 +484,7 @@ void testing_trsm_ex(const Arguments& arg)
         /* =====================================================================
            CPU BLAS
         =================================================================== */
-        cblas_trsm<T>(
+        ref_trsm<T>(
             side, uplo, transA, diag, M, N, h_alpha, (const T*)hA.data(), lda, hB_cpu.data(), ldb);
 
         // if enable norm check, norm check is invasive

--- a/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
@@ -467,7 +467,7 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
 
         // proprocess the matrix to avoid ill-conditioned matrix
         host_vector<int> ipiv(K);
-        cblas_getrf(K, K, hAb, lda, ipiv.data());
+        ref_getrf(K, K, hAb, lda, ipiv.data());
         for(int i = 0; i < K; i++)
         {
             for(int j = i; j < K; j++)
@@ -491,8 +491,7 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
         }
 
         // Calculate hB = hA*hX;
-        cblas_trmm<T>(
-            side, uplo, transA, diag, M, N, T(1.0) / h_alpha, (const T*)hAb, lda, hBb, ldb);
+        ref_trmm<T>(side, uplo, transA, diag, M, N, T(1.0) / h_alpha, (const T*)hAb, lda, hBb, ldb);
     }
 
     hB_device = hB_cpu = hB_host;
@@ -599,17 +598,17 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_trsm<T>(side,
-                          uplo,
-                          transA,
-                          diag,
-                          M,
-                          N,
-                          h_alpha,
-                          (const T*)hA.data() + b * strideA,
-                          lda,
-                          hB_cpu.data() + b * strideB,
-                          ldb);
+            ref_trsm<T>(side,
+                        uplo,
+                        transA,
+                        diag,
+                        M,
+                        N,
+                        h_alpha,
+                        (const T*)hA.data() + b * strideA,
+                        lda,
+                        hB_cpu.data() + b * strideB,
+                        ldb);
         }
 
         // if enable norm check, norm check is invasive

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,432 +39,431 @@
  */
 
 template <typename Ta, typename Tx = Ta>
-void cblas_axpy(int n, const Ta alpha, const Tx* x, int incx, Tx* y, int incy);
+void ref_axpy(int n, const Ta alpha, const Tx* x, int incx, Tx* y, int incy);
 template <typename T, typename U = T>
-void cblas_scal(int n, const U alpha, T* x, int incx);
+void ref_scal(int n, const U alpha, T* x, int incx);
 template <typename T>
-void cblas_copy(int n, T* x, int incx, T* y, int incy);
+void ref_copy(int n, T* x, int incx, T* y, int incy);
 template <typename T>
-void cblas_swap(int n, T* x, int incx, T* y, int incy);
+void ref_swap(int n, T* x, int incx, T* y, int incy);
 
 template <typename T>
-void cblas_dot(int n, const T* x, int incx, const T* y, int incy, T* result);
+void ref_dot(int n, const T* x, int incx, const T* y, int incy, T* result);
 
 template <typename T>
-void cblas_dotc(int n, const T* x, int incx, const T* y, int incy, T* result);
+void ref_dotc(int n, const T* x, int incx, const T* y, int incy, T* result);
 
 template <typename T1, typename T2>
-void cblas_nrm2(int n, const T1* x, int incx, T2* result);
+void ref_nrm2(int n, const T1* x, int incx, T2* result);
 
 template <typename T1, typename T2 = T1, typename T3 = T1>
-void cblas_rot(int n, T1* x, int incx, T1* y, int incy, T2 c, T3 s);
+void ref_rot(int n, T1* x, int incx, T1* y, int incy, T2 c, T3 s);
 
 template <typename T1, typename T2 = T1>
-void cblas_rotg(T1* a, T1* b, T2* c, T1* s);
+void ref_rotg(T1* a, T1* b, T2* c, T1* s);
 
 template <typename T1>
-void cblas_rotm(int n, T1* x, int incx, T1* y, int incy, T1* param);
+void ref_rotm(int n, T1* x, int incx, T1* y, int incy, T1* param);
 
 template <typename T1>
-void cblas_rotmg(T1* d1, T1* d2, T1* x1, T1* y1, T1* param);
+void ref_rotmg(T1* d1, T1* d2, T1* x1, T1* y1, T1* param);
 
 template <typename T1, typename T2>
-void cblas_asum(int n, const T1* x, int incx, T2* result);
+void ref_asum(int n, const T1* x, int incx, T2* result);
 
 template <typename T>
-void cblas_iamax(int n, const T* x, int incx, int* result);
+void ref_iamax(int n, const T* x, int incx, int* result);
 
 template <typename T>
-void cblas_iamin(int n, const T* x, int incx, int* result);
+void ref_iamin(int n, const T* x, int incx, int* result);
 
 template <typename T>
-void cblas_gbmv(hipblasOperation_t transA,
-                int                m,
-                int                n,
-                int                kl,
-                int                ku,
-                T                  alpha,
-                T*                 A,
-                int                lda,
-                T*                 x,
-                int                incx,
-                T                  beta,
-                T*                 y,
-                int                incy);
+void ref_gbmv(hipblasOperation_t transA,
+              int                m,
+              int                n,
+              int                kl,
+              int                ku,
+              T                  alpha,
+              T*                 A,
+              int                lda,
+              T*                 x,
+              int                incx,
+              T                  beta,
+              T*                 y,
+              int                incy);
 
 template <typename T>
-void cblas_gemv(hipblasOperation_t transA,
-                int                m,
-                int                n,
-                T                  alpha,
-                T*                 A,
-                int                lda,
-                T*                 x,
-                int                incx,
-                T                  beta,
-                T*                 y,
-                int                incy);
+void ref_gemv(hipblasOperation_t transA,
+              int                m,
+              int                n,
+              T                  alpha,
+              T*                 A,
+              int                lda,
+              T*                 x,
+              int                incx,
+              T                  beta,
+              T*                 y,
+              int                incy);
 
 template <typename T>
-void cblas_symv(
+void ref_symv(
     hipblasFillMode_t uplo, int n, T alpha, T* A, int lda, T* x, int incx, T beta, T* y, int incy);
 
 // ger (ger, geru, gerc)
 template <typename T, bool CONJ>
-void cblas_ger(int m, int n, T alpha, T* x, int incx, T* y, int incy, T* A, int lda);
+void ref_ger(int m, int n, T alpha, T* x, int incx, T* y, int incy, T* A, int lda);
 
 // hbmv
 template <typename T>
-void cblas_hbmv(hipblasFillMode_t uplo,
-                int               n,
-                int               k,
-                T                 alpha,
-                T*                A,
-                int               lda,
-                T*                x,
-                int               incx,
-                T                 beta,
-                T*                y,
-                int               incy);
+void ref_hbmv(hipblasFillMode_t uplo,
+              int               n,
+              int               k,
+              T                 alpha,
+              T*                A,
+              int               lda,
+              T*                x,
+              int               incx,
+              T                 beta,
+              T*                y,
+              int               incy);
 
 // hemv
 template <typename T, typename U>
-void cblas_hemv(
+void ref_hemv(
     hipblasFillMode_t uplo, int n, U alpha, T* A, int lda, T* x, int incx, T beta, T* y, int incy);
 
 // spr
 template <typename T>
-void cblas_spr(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* AP);
+void ref_spr(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* AP);
 
 // spr2
 template <typename T>
-void cblas_spr2(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* y, int incy, T* AP);
+void ref_spr2(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* y, int incy, T* AP);
 
 // syr
 template <typename T>
-void cblas_syr(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* A, int lda);
+void ref_syr(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* A, int lda);
 
 // syr2
 template <typename T>
-void cblas_syr2(
+void ref_syr2(
     hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* y, int incy, T* A, int lda);
 
 // her
 template <typename T, typename U>
-void cblas_her(hipblasFillMode_t uplo, int n, U alpha, T* x, int incx, T* A, int lda);
+void ref_her(hipblasFillMode_t uplo, int n, U alpha, T* x, int incx, T* A, int lda);
 
 // her2
 template <typename T>
-void cblas_her2(
+void ref_her2(
     hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* y, int incy, T* A, int lda);
 
 // hpmv
 template <typename T>
-void cblas_hpmv(
+void ref_hpmv(
     hipblasFillMode_t uplo, int n, T alpha, T* AP, T* x, int incx, T beta, T* y, int incy);
 
 // hpr
 template <typename T, typename U>
-void cblas_hpr(hipblasFillMode_t uplo, int n, U alpha, T* x, int incx, T* AP);
+void ref_hpr(hipblasFillMode_t uplo, int n, U alpha, T* x, int incx, T* AP);
 
 // hpr2
 template <typename T>
-void cblas_hpr2(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* y, int incy, T* AP);
+void ref_hpr2(hipblasFillMode_t uplo, int n, T alpha, T* x, int incx, T* y, int incy, T* AP);
 
 // sbmv
 template <typename T>
-void cblas_sbmv(hipblasFillMode_t uplo,
-                int               n,
-                int               k,
-                T                 alpha,
-                T*                A,
-                int               lda,
-                T*                x,
-                int               incx,
-                T                 beta,
-                T*                y,
-                int               incy);
+void ref_sbmv(hipblasFillMode_t uplo,
+              int               n,
+              int               k,
+              T                 alpha,
+              T*                A,
+              int               lda,
+              T*                x,
+              int               incx,
+              T                 beta,
+              T*                y,
+              int               incy);
 
 // spmv
 template <typename T>
-void cblas_spmv(
+void ref_spmv(
     hipblasFillMode_t uplo, int n, T alpha, T* AP, T* x, int incx, T beta, T* y, int incy);
 
 // symv
 template <typename T>
-void cblas_symv(
+void ref_symv(
     hipblasFillMode_t uplo, int n, T alpha, T* A, int lda, T* x, int incx, T beta, T* y, int incy);
 
 // potrf
 template <typename T>
-int cblas_potrf(char uplo, int m, T* A, int lda);
+int ref_potrf(char uplo, int m, T* A, int lda);
 
 // tbmv
 template <typename T>
-void cblas_tbmv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                int                k,
-                const T*           A,
-                int                lda,
-                T*                 x,
-                int                incx);
+void ref_tbmv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              int                k,
+              const T*           A,
+              int                lda,
+              T*                 x,
+              int                incx);
 
 // tbsv
 template <typename T>
-void cblas_tbsv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                int                k,
-                const T*           A,
-                int                lda,
-                T*                 x,
-                int                incx);
+void ref_tbsv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              int                k,
+              const T*           A,
+              int                lda,
+              T*                 x,
+              int                incx);
 
 // tpmv
 template <typename T>
-void cblas_tpmv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                const T*           A,
-                T*                 x,
-                int                incx);
+void ref_tpmv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              const T*           A,
+              T*                 x,
+              int                incx);
 
 // tpsv
 template <typename T>
-void cblas_tpsv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                n,
-                const T*           AP,
-                T*                 x,
-                int                incx);
+void ref_tpsv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                n,
+              const T*           AP,
+              T*                 x,
+              int                incx);
 
 // trmv
 template <typename T>
-void cblas_trmv(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                const T*           A,
-                int                lda,
-                T*                 x,
-                int                incx);
+void ref_trmv(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              const T*           A,
+              int                lda,
+              T*                 x,
+              int                incx);
 
 // trsv
 template <typename T>
-void cblas_trsv(hipblasHandle_t    handle,
-                hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                const T*           A,
-                int                lda,
-                T*                 x,
-                int                incx);
+void ref_trsv(hipblasHandle_t    handle,
+              hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              const T*           A,
+              int                lda,
+              T*                 x,
+              int                incx);
 
 // hemv
 template <typename T>
-void cblas_hemv(
+void ref_hemv(
     hipblasFillMode_t uplo, int n, T alpha, T* A, int lda, T* x, int incx, T beta, T* y, int incy);
 
 // herk
 template <typename T, typename U>
-void cblas_herk(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                int                n,
-                int                k,
-                U                  alpha,
-                T*                 A,
-                int                lda,
-                U                  beta,
-                T*                 C,
-                int                ldc);
+void ref_herk(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              int                n,
+              int                k,
+              U                  alpha,
+              T*                 A,
+              int                lda,
+              U                  beta,
+              T*                 C,
+              int                ldc);
 
 // herkx
 template <typename T, typename U>
-void cblas_herkx(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 T                  alpha,
-                 T*                 A,
-                 int                lda,
-                 T*                 B,
-                 int                ldb,
-                 U                  beta,
-                 T*                 C,
-                 int                ldc);
+void ref_herkx(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               T                  alpha,
+               T*                 A,
+               int                lda,
+               T*                 B,
+               int                ldb,
+               U                  beta,
+               T*                 C,
+               int                ldc);
 
 // her2k
 template <typename T, typename U>
-void cblas_her2k(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 T                  alpha,
-                 T*                 A,
-                 int                lda,
-                 T*                 B,
-                 int                ldb,
-                 U                  beta,
-                 T*                 C,
-                 int                ldc);
+void ref_her2k(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               T                  alpha,
+               T*                 A,
+               int                lda,
+               T*                 B,
+               int                ldb,
+               U                  beta,
+               T*                 C,
+               int                ldc);
 
 // geam
 template <typename T>
-void cblas_geam(hipblasOperation_t transa,
-                hipblasOperation_t transb,
-                int                m,
-                int                n,
-                T*                 alpha,
-                T*                 A,
-                int                lda,
-                T*                 beta,
-                T*                 B,
-                int                ldb,
-                T*                 C,
-                int                ldc);
+void ref_geam(hipblasOperation_t transa,
+              hipblasOperation_t transb,
+              int                m,
+              int                n,
+              T*                 alpha,
+              T*                 A,
+              int                lda,
+              T*                 beta,
+              T*                 B,
+              int                ldb,
+              T*                 C,
+              int                ldc);
 
 // gemm
 template <typename Ti, typename To = Ti, typename Tc = To>
-void cblas_gemm(hipblasOperation_t transA,
-                hipblasOperation_t transB,
-                int                m,
-                int                n,
-                int                k,
-                Tc                 alpha,
-                Ti*                A,
-                int                lda,
-                Ti*                B,
-                int                ldb,
-                Tc                 beta,
-                To*                C,
-                int                ldc);
+void ref_gemm(hipblasOperation_t transA,
+              hipblasOperation_t transB,
+              int                m,
+              int                n,
+              int                k,
+              Tc                 alpha,
+              Ti*                A,
+              int                lda,
+              Ti*                B,
+              int                ldb,
+              Tc                 beta,
+              To*                C,
+              int                ldc);
 
 // hemm
 template <typename T>
-void cblas_hemm(hipblasSideMode_t side,
-                hipblasFillMode_t uplo,
-                int               m,
-                int               n,
-                T                 alpha,
-                T*                A,
-                int               lda,
-                T*                B,
-                int               ldb,
-                T                 beta,
-                T*                C,
-                int               ldc);
+void ref_hemm(hipblasSideMode_t side,
+              hipblasFillMode_t uplo,
+              int               m,
+              int               n,
+              T                 alpha,
+              T*                A,
+              int               lda,
+              T*                B,
+              int               ldb,
+              T                 beta,
+              T*                C,
+              int               ldc);
 
 // symm
 template <typename T>
-void cblas_symm(hipblasSideMode_t side,
-                hipblasFillMode_t uplo,
-                int               m,
-                int               n,
-                T                 alpha,
-                T*                A,
-                int               lda,
-                T*                B,
-                int               ldb,
-                T                 beta,
-                T*                C,
-                int               ldc);
+void ref_symm(hipblasSideMode_t side,
+              hipblasFillMode_t uplo,
+              int               m,
+              int               n,
+              T                 alpha,
+              T*                A,
+              int               lda,
+              T*                B,
+              int               ldb,
+              T                 beta,
+              T*                C,
+              int               ldc);
 
 // syrk
 template <typename T>
-void cblas_syrk(hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                int                n,
-                int                k,
-                T                  alpha,
-                T*                 A,
-                int                lda,
-                T                  beta,
-                T*                 C,
-                int                ldc);
+void ref_syrk(hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              int                n,
+              int                k,
+              T                  alpha,
+              T*                 A,
+              int                lda,
+              T                  beta,
+              T*                 C,
+              int                ldc);
 
 // syr2k
 template <typename T>
-void cblas_syr2k(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 T                  alpha,
-                 T*                 A,
-                 int                lda,
-                 T*                 B,
-                 int                ldb,
-                 T                  beta,
-                 T*                 C,
-                 int                ldc);
+void ref_syr2k(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               T                  alpha,
+               T*                 A,
+               int                lda,
+               T*                 B,
+               int                ldb,
+               T                  beta,
+               T*                 C,
+               int                ldc);
 
 // syrkx
 template <typename T>
-void cblas_syrkx(hipblasFillMode_t  uplo,
-                 hipblasOperation_t transA,
-                 int                n,
-                 int                k,
-                 T                  alpha,
-                 T*                 A,
-                 int                lda,
-                 T*                 B,
-                 int                ldb,
-                 T                  beta,
-                 T*                 C,
-                 int                ldc);
+void ref_syrkx(hipblasFillMode_t  uplo,
+               hipblasOperation_t transA,
+               int                n,
+               int                k,
+               T                  alpha,
+               T*                 A,
+               int                lda,
+               T*                 B,
+               int                ldb,
+               T                  beta,
+               T*                 C,
+               int                ldc);
 
 // trsm
 template <typename T>
-void cblas_trsm(hipblasSideMode_t  side,
-                hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                int                n,
-                T                  alpha,
-                const T*           A,
-                int                lda,
-                T*                 B,
-                int                ldb);
+void ref_trsm(hipblasSideMode_t  side,
+              hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              int                n,
+              T                  alpha,
+              const T*           A,
+              int                lda,
+              T*                 B,
+              int                ldb);
 
 // trtri
 template <typename T>
-int cblas_trtri(char uplo, char diag, int n, T* A, int lda);
+int ref_trtri(char uplo, char diag, int n, T* A, int lda);
 
 // trmm
 template <typename T>
-void cblas_trmm(hipblasSideMode_t  side,
-                hipblasFillMode_t  uplo,
-                hipblasOperation_t transA,
-                hipblasDiagType_t  diag,
-                int                m,
-                int                n,
-                T                  alpha,
-                const T*           A,
-                int                lda,
-                T*                 B,
-                int                ldb);
+void ref_trmm(hipblasSideMode_t  side,
+              hipblasFillMode_t  uplo,
+              hipblasOperation_t transA,
+              hipblasDiagType_t  diag,
+              int                m,
+              int                n,
+              T                  alpha,
+              const T*           A,
+              int                lda,
+              T*                 B,
+              int                ldb);
 
 template <typename T>
-int cblas_getrf(int m, int n, T* A, int lda, int* ipiv);
+int ref_getrf(int m, int n, T* A, int lda, int* ipiv);
 
 template <typename T>
-int cblas_getrs(char trans, int n, int nrhs, T* A, int lda, int* ipiv, T* B, int ldb);
+int ref_getrs(char trans, int n, int nrhs, T* A, int lda, int* ipiv, T* B, int ldb);
 
 template <typename T>
-int cblas_getri(int n, T* A, int lda, int* ipiv, T* work, int lwork);
+int ref_getri(int n, T* A, int lda, int* ipiv, T* work, int lwork);
 
 template <typename T>
-int cblas_geqrf(int m, int n, T* A, int lda, T* tau, T* work, int lwork);
+int ref_geqrf(int m, int n, T* A, int lda, T* tau, T* work, int lwork);
 
 template <typename T>
-int cblas_gels(
-    char trans, int m, int n, int nrhs, T* A, int lda, T* B, int ldb, T* work, int lwork);
+int ref_gels(char trans, int m, int n, int nrhs, T* A, int lda, T* B, int ldb, T* work, int lwork);
 /* ============================================================================================ */
 
 #endif /* _CBLAS_INTERFACE_ */

--- a/clients/include/solver/testing_gels.hpp
+++ b/clients/include/solver/testing_gels.hpp
@@ -229,7 +229,7 @@ void testing_gels(const Arguments& arg)
         int            sizeW = std::max(1, std::min(M, N) + std::max(std::min(M, N), nrhs));
         host_vector<T> hW(sizeW);
 
-        info = cblas_gels(transc, M, N, nrhs, hA.data(), lda, hB.data(), ldb, hW.data(), sizeW);
+        info = ref_gels(transc, M, N, nrhs, hA.data(), lda, hB.data(), ldb, hW.data(), sizeW);
 
         hipblas_error
             = norm_check_general<T>('F', std::max(M, N), nrhs, ldb, hB.data(), hB_res.data());

--- a/clients/include/solver/testing_gels_batched.hpp
+++ b/clients/include/solver/testing_gels_batched.hpp
@@ -316,7 +316,7 @@ void testing_gels_batched(const Arguments& arg)
 
         for(int b = 0; b < batchCount; b++)
         {
-            info[b] = cblas_gels(transc, M, N, nrhs, hA[b], lda, hB[b], ldb, hW.data(), sizeW);
+            info[b] = ref_gels(transc, M, N, nrhs, hA[b], lda, hB[b], ldb, hW.data(), sizeW);
         }
 
         hipblas_error

--- a/clients/include/solver/testing_gels_strided_batched.hpp
+++ b/clients/include/solver/testing_gels_strided_batched.hpp
@@ -434,16 +434,16 @@ void testing_gels_strided_batched(const Arguments& arg)
 
         for(int b = 0; b < batchCount; b++)
         {
-            info[b] = cblas_gels(transc,
-                                 M,
-                                 N,
-                                 nrhs,
-                                 hA.data() + b * strideA,
-                                 lda,
-                                 hB.data() + b * strideB,
-                                 ldb,
-                                 hW.data(),
-                                 sizeW);
+            info[b] = ref_gels(transc,
+                               M,
+                               N,
+                               nrhs,
+                               hA.data() + b * strideA,
+                               lda,
+                               hB.data() + b * strideB,
+                               ldb,
+                               hW.data(),
+                               sizeW);
         }
 
         hipblas_error = norm_check_general<T>(

--- a/clients/include/solver/testing_geqrf.hpp
+++ b/clients/include/solver/testing_geqrf.hpp
@@ -181,12 +181,12 @@ void testing_geqrf(const Arguments& arg)
 
         // Workspace query
         host_vector<T> work(1);
-        cblas_geqrf(M, N, hA.data(), lda, hIpiv.data(), work.data(), -1);
+        ref_geqrf(M, N, hA.data(), lda, hIpiv.data(), work.data(), -1);
         int lwork = type2int(work[0]);
 
         // Perform factorization
         work = host_vector<T>(lwork);
-        cblas_geqrf(M, N, hA.data(), lda, hIpiv.data(), work.data(), lwork);
+        ref_geqrf(M, N, hA.data(), lda, hIpiv.data(), work.data(), lwork);
 
         double e1     = norm_check_general<T>('F', M, N, lda, hA, hA1);
         double e2     = norm_check_general<T>('F', K, 1, K, hIpiv, hIpiv1);

--- a/clients/include/solver/testing_geqrf_batched.hpp
+++ b/clients/include/solver/testing_geqrf_batched.hpp
@@ -212,14 +212,14 @@ void testing_geqrf_batched(const Arguments& arg)
 
         // Workspace query
         host_vector<T> work(1);
-        cblas_geqrf(M, N, hA[0], lda, hIpiv[0], work.data(), -1);
+        ref_geqrf(M, N, hA[0], lda, hIpiv[0], work.data(), -1);
         int lwork = type2int(work[0]);
 
         // Perform factorization
         work = host_vector<T>(lwork);
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_geqrf(M, N, hA[b], lda, hIpiv[b], work.data(), N);
+            ref_geqrf(M, N, hA[b], lda, hIpiv[b], work.data(), N);
         }
 
         double e1 = norm_check_general<T>('F', M, N, lda, hA, hA1, batch_count);

--- a/clients/include/solver/testing_geqrf_strided_batched.hpp
+++ b/clients/include/solver/testing_geqrf_strided_batched.hpp
@@ -243,14 +243,14 @@ void testing_geqrf_strided_batched(const Arguments& arg)
 
         // Workspace query
         host_vector<T> work(1);
-        cblas_geqrf(M, N, hA.data(), lda, hIpiv.data(), work.data(), -1);
+        ref_geqrf(M, N, hA.data(), lda, hIpiv.data(), work.data(), -1);
         int lwork = type2int(work[0]);
 
         // Perform factorization
         work = host_vector<T>(lwork);
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_geqrf(
+            ref_geqrf(
                 M, N, hA.data() + b * strideA, lda, hIpiv.data() + b * strideP, work.data(), N);
         }
 

--- a/clients/include/solver/testing_getrf.hpp
+++ b/clients/include/solver/testing_getrf.hpp
@@ -144,7 +144,7 @@ void testing_getrf(const Arguments& arg)
         /* =====================================================================
            CPU LAPACK
         =================================================================== */
-        hInfo[0] = cblas_getrf(M, N, hA.data(), lda, hIpiv.data());
+        hInfo[0] = ref_getrf(M, N, hA.data(), lda, hIpiv.data());
 
         hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1);
         if(arg.unit_check)

--- a/clients/include/solver/testing_getrf_batched.hpp
+++ b/clients/include/solver/testing_getrf_batched.hpp
@@ -168,7 +168,7 @@ void testing_getrf_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            hInfo[b] = cblas_getrf(M, N, hA[b], lda, hIpiv.data() + b * strideP);
+            hInfo[b] = ref_getrf(M, N, hA[b], lda, hIpiv.data() + b * strideP);
         }
 
         hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1, batch_count);

--- a/clients/include/solver/testing_getrf_npvt.hpp
+++ b/clients/include/solver/testing_getrf_npvt.hpp
@@ -135,7 +135,7 @@ void testing_getrf_npvt(const Arguments& arg)
         /* =====================================================================
            CPU LAPACK
         =================================================================== */
-        hInfo[0] = cblas_getrf(M, N, hA.data(), lda, hIpiv.data());
+        hInfo[0] = ref_getrf(M, N, hA.data(), lda, hIpiv.data());
 
         hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1);
         if(arg.unit_check)

--- a/clients/include/solver/testing_getrf_npvt_batched.hpp
+++ b/clients/include/solver/testing_getrf_npvt_batched.hpp
@@ -158,7 +158,7 @@ void testing_getrf_npvt_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            hInfo[b] = cblas_getrf(M, N, hA[b], lda, hIpiv.data() + b * strideP);
+            hInfo[b] = ref_getrf(M, N, hA[b], lda, hIpiv.data() + b * strideP);
         }
 
         hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1, batch_count);

--- a/clients/include/solver/testing_getrf_npvt_strided_batched.hpp
+++ b/clients/include/solver/testing_getrf_npvt_strided_batched.hpp
@@ -165,7 +165,7 @@ void testing_getrf_npvt_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            hInfo[b] = cblas_getrf(M, N, hA.data() + b * strideA, lda, hIpiv.data() + b * strideP);
+            hInfo[b] = ref_getrf(M, N, hA.data() + b * strideA, lda, hIpiv.data() + b * strideP);
         }
 
         hipblas_error = norm_check_general<T>('F', M, N, lda, strideA, hA, hA1, batch_count);

--- a/clients/include/solver/testing_getrf_strided_batched.hpp
+++ b/clients/include/solver/testing_getrf_strided_batched.hpp
@@ -178,7 +178,7 @@ void testing_getrf_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            hInfo[b] = cblas_getrf(M, N, hA.data() + b * strideA, lda, hIpiv.data() + b * strideP);
+            hInfo[b] = ref_getrf(M, N, hA.data() + b * strideA, lda, hIpiv.data() + b * strideP);
         }
 
         hipblas_error = norm_check_general<T>('F', M, N, lda, strideA, hA, hA1, batch_count);

--- a/clients/include/solver/testing_getri_batched.hpp
+++ b/clients/include/solver/testing_getri_batched.hpp
@@ -194,7 +194,7 @@ void testing_getri_batched(const Arguments& arg)
 
         // perform LU factorization on A
         int* hIpivb = hIpiv.data() + b * strideP;
-        hInfo[b]    = cblas_getrf(M, N, hA[b], lda, hIpivb);
+        hInfo[b]    = ref_getrf(M, N, hA[b], lda, hIpivb);
     }
 
     CHECK_HIP_ERROR(dA.transfer_from(hA));
@@ -231,12 +231,12 @@ void testing_getri_batched(const Arguments& arg)
         {
             // Workspace query
             host_vector<T> work(1);
-            cblas_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), -1);
+            ref_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), -1);
             int lwork = type2int(work[0]);
 
             // Perform inversion
             work     = host_vector<T>(lwork);
-            hInfo[b] = cblas_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), lwork);
+            hInfo[b] = ref_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), lwork);
 
             hipblas_error = norm_check_general<T>('F', M, N, lda, hA[b], hA1[b]);
             if(arg.unit_check)

--- a/clients/include/solver/testing_getri_npvt_batched.hpp
+++ b/clients/include/solver/testing_getri_npvt_batched.hpp
@@ -187,7 +187,7 @@ void testing_getri_npvt_batched(const Arguments& arg)
 
         // perform LU factorization on A
         int* hIpivb = hIpiv.data() + b * strideP;
-        hInfo[b]    = cblas_getrf(M, N, hA[b], lda, hIpivb);
+        hInfo[b]    = ref_getrf(M, N, hA[b], lda, hIpivb);
     }
 
     CHECK_HIP_ERROR(dA.transfer_from(hA));
@@ -221,12 +221,12 @@ void testing_getri_npvt_batched(const Arguments& arg)
         {
             // Workspace query
             host_vector<T> work(1);
-            cblas_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), -1);
+            ref_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), -1);
             int lwork = type2int(work[0]);
 
             // Perform inversion
             work     = host_vector<T>(lwork);
-            hInfo[b] = cblas_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), lwork);
+            hInfo[b] = ref_getri(N, hA[b], lda, hIpiv.data() + b * strideP, work.data(), lwork);
         }
 
         hipblas_error = norm_check_general<T>('F', M, N, lda, hA, hA1, batch_count);

--- a/clients/include/solver/testing_getrs.hpp
+++ b/clients/include/solver/testing_getrs.hpp
@@ -71,10 +71,10 @@ void setup_getrs_testing(host_vector<T>&     hA,
 
     // Calculate hB = hA*hX;
     hipblasOperation_t opN = HIPBLAS_OP_N;
-    cblas_gemm<T>(opN, opN, N, 1, N, (T)1, hA.data(), lda, hX.data(), ldb, (T)0, hB.data(), ldb);
+    ref_gemm<T>(opN, opN, N, 1, N, (T)1, hA.data(), lda, hX.data(), ldb, (T)0, hB.data(), ldb);
 
     // LU factorize hA on the CPU
-    int info = cblas_getrf<T>(N, N, hA.data(), lda, hIpiv.data());
+    int info = ref_getrf<T>(N, N, hA.data(), lda, hIpiv.data());
     if(info != 0)
     {
         std::cerr << "LU decomposition failed" << std::endl;
@@ -226,7 +226,7 @@ void testing_getrs(const Arguments& arg)
         /* =====================================================================
            CPU LAPACK
         =================================================================== */
-        cblas_getrs('N', N, 1, hA.data(), lda, hIpiv.data(), hB.data(), ldb);
+        ref_getrs('N', N, 1, hA.data(), lda, hIpiv.data(), hB.data(), ldb);
 
         hipblas_error = norm_check_general<T>('F', N, 1, ldb, hB.data(), hB1.data());
 

--- a/clients/include/solver/testing_getrs_batched.hpp
+++ b/clients/include/solver/testing_getrs_batched.hpp
@@ -73,10 +73,10 @@ void setup_getrs_batched_testing(host_batch_vector<T>&   hA,
         }
 
         // Calculate hB = hA*hX;
-        cblas_gemm<T>(op, op, N, 1, N, (T)1, hA[b], lda, hX[b], ldb, (T)0, hB[b], ldb);
+        ref_gemm<T>(op, op, N, 1, N, (T)1, hA[b], lda, hX[b], ldb, (T)0, hB[b], ldb);
 
         // LU factorize hA on the CPU
-        int info = cblas_getrf<T>(N, N, hA[b], lda, hIpiv.data() + b * strideP);
+        int info = ref_getrf<T>(N, N, hA[b], lda, hIpiv.data() + b * strideP);
         if(info != 0)
         {
             std::cerr << "LU decomposition failed" << std::endl;
@@ -282,7 +282,7 @@ void testing_getrs_batched(const Arguments& arg)
 
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_getrs('N', N, 1, hA[b], lda, hIpiv.data() + b * strideP, hB[b], ldb);
+            ref_getrs('N', N, 1, hA[b], lda, hIpiv.data() + b * strideP, hB[b], ldb);
         }
 
         hipblas_error = norm_check_general<T>('F', N, 1, ldb, hB, hB1, batch_count);

--- a/clients/include/solver/testing_getrs_strided_batched.hpp
+++ b/clients/include/solver/testing_getrs_strided_batched.hpp
@@ -82,10 +82,10 @@ void setup_getrs_strided_batched_testing(host_vector<T>&     hA,
         }
 
         // Calculate hB = hA*hX;
-        cblas_gemm<T>(op, op, N, 1, N, (T)1, hAb, lda, hXb, ldb, (T)0, hBb, ldb);
+        ref_gemm<T>(op, op, N, 1, N, (T)1, hAb, lda, hXb, ldb, (T)0, hBb, ldb);
 
         // LU factorize hA on the CPU
-        int info = cblas_getrf<T>(N, N, hAb, lda, hIpivb);
+        int info = ref_getrf<T>(N, N, hAb, lda, hIpivb);
         if(info != 0)
         {
             std::cerr << "LU decomposition failed" << std::endl;
@@ -410,14 +410,14 @@ void testing_getrs_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int b = 0; b < batch_count; b++)
         {
-            cblas_getrs('N',
-                        N,
-                        1,
-                        hA.data() + b * strideA,
-                        lda,
-                        hIpiv.data() + b * strideP,
-                        hB.data() + b * strideB,
-                        ldb);
+            ref_getrs('N',
+                      N,
+                      1,
+                      hA.data() + b * strideA,
+                      lda,
+                      hIpiv.data() + b * strideP,
+                      hB.data() + b * strideB,
+                      ldb);
         }
 
         hipblas_error = norm_check_general<T>('F', N, 1, ldb, strideB, hB, hB1, batch_count);

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -843,7 +843,7 @@ template <typename T>
 void prepare_triangular_solve(T* hA, int lda, T* AAT, int N, char char_uplo)
 {
     //  calculate AAT = hA * hA ^ T
-    cblas_gemm<T>(HIPBLAS_OP_N, HIPBLAS_OP_C, N, N, N, T(1.0), hA, lda, hA, lda, T(0.0), AAT, lda);
+    ref_gemm<T>(HIPBLAS_OP_N, HIPBLAS_OP_C, N, N, N, T(1.0), hA, lda, hA, lda, T(0.0), AAT, lda);
 
     //  copy AAT into hA, make hA strictly diagonal dominant, and therefore SPD
     for(int i = 0; i < N; i++)
@@ -857,7 +857,7 @@ void prepare_triangular_solve(T* hA, int lda, T* AAT, int N, char char_uplo)
         hA[i + i * lda] = t;
     }
     //  calculate Cholesky factorization of SPD matrix hA
-    cblas_potrf<T>(char_uplo, N, hA, lda);
+    ref_potrf<T>(char_uplo, N, hA, lda);
 }
 
 /* ============================================================================================ */


### PR DESCRIPTION
* adding additional ILP64 reference library soon which has yet another cblas_ prefixed helpers much like our own
* _ref for reference functions may be CPU or GPU from cblas or other libraries