### PR TITLE
Apply Documentation Standardization for ReadtheDocs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/docs/.sphinx" # Location of package manifests
+    directory: "/docs/sphinx" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,4 @@ _images/
 _static/
 _templates/
 _toc.yml
-docBin/
 _doxygen/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,13 +6,13 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip]
+formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/.sphinx/requirements.txt
+   - requirements: docs/sphinx/requirements.txt
 
 build:
-   os: ubuntu-20.04
+   os: ubuntu-22.04
    tools:
       python: "3.8"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To build our documentation locally, use the following code:
 ```bash
 cd docs
 
-pip3 install -r .sphinx/requirements.txt
+pip3 install -r sphinx/requirements.txt
 
 python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
 ```

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,0 @@
-rocm-docs-core>=0.24.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,14 +4,31 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import re
+
 from rocm_docs import ROCmDocs
 
+with open('../CMakeLists.txt', encoding='utf-8') as f:
+    match = re.search(r'.*\bset\s+\(\s+VERSION_STRING\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    if not match:
+        raise ValueError("VERSION not found!")
+    version_number = match[1]
+left_nav_title = f"hipBLAS {version_number} Documentation"
+
+# for PDF output on Read the Docs
+project = "hipBLAS Documentation"
+author = "Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
+
+external_toc_path = "./sphinx/_toc.yml"
+
+docs_core = ROCmDocs(left_nav_title)
+docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
+docs_core.setup()
 
 external_projects_current_project = "hipblas"
-
-docs_core = ROCmDocs("hipBLAS Documentation")
-docs_core.run_doxygen()
-docs_core.setup()
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docBin
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -784,7 +784,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../library/include
+INPUT                  = ../../library/include  ../../README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -963,7 +963,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ../README.md
+USE_MDFILE_AS_MAINPAGE = ../../README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,5 @@
+************
+License
+************
+
+.. include:: ../LICENSE.md

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -10,3 +10,6 @@ subtrees:
     - file: clients
     - file: deprecation
     - file: contributing
+  - caption: About
+    entries:
+    - file: license

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,0 +1,1 @@
+rocm-docs-core==0.30.3

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -84,9 +84,7 @@ pygments==2.15.0
     #   pydata-sphinx-theme
     #   sphinx
 pyjwt[crypto]==2.6.0
-    # via
-    #   pygithub
-    #   pyjwt
+    # via pygithub
 pynacl==1.5.0
     # via pygithub
 pytz==2023.3.post1


### PR DESCRIPTION
relates to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/330

Apply the following changes to project documentation for ReadtheDocs:
add version number to documentation left navigation bar and page title
add an "About" section with a license page
enable htmlzip, pdf, epub formats when publishing on Read the Docs
set pdf title, author, copyright, and version
rename .sphinx/.doxygen to sphinx/doxygen
remove docBin from URL
update rocm-docs-core dependency
update dependabot config