### PR TITLE
Enable all L1 64-bit tests

### DIFF
--- a/clients/gtest/blas1/axpy_gtest.yaml
+++ b/clients/gtest/blas1/axpy_gtest.yaml
@@ -61,27 +61,31 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  # - name: axpy_64
-  #   category: stress
-  #   function:
-  #     - axpy: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, incy:  1 }
-  #     - { N: 2, incx:  2147483649, incy:  1 }
-  #     - { N: 2, incx:  1, incy:  2147483649 }
-  #   api: [ C_64 ]
+  - name: axpy_64
+    category: stress
+    function:
+      - axpy: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1, incy:  1 }
+      - { N: 2, incx:  2147483649, incy:  1 }
+      - { N: 2, incx:  1, incy:  2147483649 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
-  # - name: axpy_64
-  #   category: stress
-  #   function:
-  #     - axpy_batched: *single_precision
-  #     - axpy_strided_batched: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
-  #     - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
-  #     - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
-  #     - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: *666666 }
-  #   api: [ C_64 ]
+  - name: axpy_64
+    category: stress
+    function:
+      - axpy_batched: *single_precision
+      - axpy_strided_batched: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
+      - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
+      - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
+      - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
   - name: axpy_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/copy_gtest.yaml
+++ b/clients/gtest/blas1/copy_gtest.yaml
@@ -50,22 +50,27 @@ Tests:
     function:
       - copy: *single_precision
     arguments:
-      # - { N: 2147483649, incx: 1, incy: 1 }
-      # - { N: 2, incx: -214748369, incy: 1 }
-      - { N: 2, incx: 1, incy: -1 }
+      - { N: 2147483649, incx: 1, incy: 1 }
+      - { N: 2, incx: -214748369, incy: 1 }
+      - { N: 2, incx: 1, incy: 2147483649 }
     api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
-  # - name: copy_64
-  #   category: stress
-  #   function:
-  #     - copy_batched: *single_precision
-  #     - copy_strided_batched: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx: 1, incy: 1,  batch_count: 1 }
-  #     - { N: 2, incx: -214748369, incy: 1, batch_count: 1 }
-  #     - { N: 2, incx: 1, incy: -1, stride_x: 2, stride_y: 2, batch_count: 666666 }
-  #   api: [ C_64 ]
-  #   backend_flags: AMD
+  - name: copy_64
+    category: stress
+    function:
+      - copy_batched: *single_precision
+      - copy_strided_batched: *single_precision
+    arguments:
+      - { N: 2147483649, incx: 1, incy: 1,  batch_count: 1 }
+      - { N: 2, incx: -214748369, incy: 1, batch_count: 1 }
+      - { N: 2, incx: 1, incy: 2147483649, batch_count: 1 }
+      - { N: 2, incx: 1, incy: -1, stride_x: 2, stride_y: 2, batch_count: 666666 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
+    backend_flags: AMD
 
   # Bad-arg tests
   - name: copy_bad_arg

--- a/clients/gtest/blas1/dot_gtest.yaml
+++ b/clients/gtest/blas1/dot_gtest.yaml
@@ -62,7 +62,6 @@ Tests:
     category: stress
     function:
       - dot: *single_precision
-      - dotc: *single_precision_complex
     arguments:
       - { N: 2147483649, incx:  1, incy:  1 }
       - { N: 2, incx:  2147483649, incy:  1 }
@@ -70,14 +69,13 @@ Tests:
     api: [ C_64 ]
     os_flags: [ LINUX ]
     gpu_arch: '90a'
+    initialization: hpl
 
   - name: dot_64
     category: stress
     function:
       - dot_batched: *single_precision
       - dot_strided_batched: *single_precision
-      - dotc_batched: *single_precision_complex
-      - dotc_strided_batched: *single_precision_complex
     arguments:
       - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
       - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
@@ -86,6 +84,7 @@ Tests:
     api: [ C_64 ]
     os_flags: [ LINUX ]
     gpu_arch: '90a'
+    initialization: hpl
 
   - name: dot_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/dot_gtest.yaml
+++ b/clients/gtest/blas1/dot_gtest.yaml
@@ -58,30 +58,34 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  # - name: dot_64
-  #   category: stress
-  #   function:
-  #     - dot: *single_precision
-  #     - dotc: *single_precision_complex
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, incy:  1 }
-  #     - { N: 2, incx:  2147483649, incy:  1 }
-  #     - { N: 2, incx:  1, incy:  2147483649 }
-  #   api: [ C_64 ]
+  - name: dot_64
+    category: stress
+    function:
+      - dot: *single_precision
+      - dotc: *single_precision_complex
+    arguments:
+      - { N: 2147483649, incx:  1, incy:  1 }
+      - { N: 2, incx:  2147483649, incy:  1 }
+      - { N: 2, incx:  1, incy:  2147483649 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
-  # - name: dot_64
-  #   category: stress
-  #   function:
-  #     - dot_batched: *single_precision
-  #     - dot_strided_batched: *single_precision
-  #     - dotc_batched: *single_precision_complex
-  #     - dotc_strided_batched: *single_precision_complex
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
-  #     - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
-  #     - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
-  #     - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: *666666 }
-  #   api: [ C_64 ]
+  - name: dot_64
+    category: stress
+    function:
+      - dot_batched: *single_precision
+      - dot_strided_batched: *single_precision
+      - dotc_batched: *single_precision_complex
+      - dotc_strided_batched: *single_precision_complex
+    arguments:
+      - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
+      - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
+      - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
+      - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
   - name: dot_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/iamaxmin_gtest.yaml
+++ b/clients/gtest/blas1/iamaxmin_gtest.yaml
@@ -44,29 +44,33 @@ Tests:
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 
-    # ILP-64 tests
-    # - name: iamaxmin_64
-    #   category: stress
-    #   function:
-    #     - iamax: *single_precision
-    #     - iamin: *single_precision
-    #   arguments:
-    #     - { N: 2147483649, incx:  1 }
-    #     - { N: 2, incx:  2147483649 }
-    #   api: [ C_64 ]
+  # ILP-64 tests
+  - name: iamaxmin_64
+    category: stress
+    function:
+      - iamax: *single_precision
+      - iamin: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1 }
+      - { N: 2, incx:  2147483649 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
-    # - name: iamaxmin_64
-    #   category: stress
-    #   function:
-    #     - iamax_batched: *single_precision
-    #     - iamin_batched: *single_precision
-    #     - iamax_strided_batched: *single_precision
-    #     - iamin_strided_batched: *single_precision
-    #   arguments:
-    #     - { N: 2147483649, incx:  1, batch_count: 1 }
-    #     - { N: 2, incx:  2147483649, batch_count: 1 }
-    #     - { N: 2, incx:  1, stride_x: 2, batch_count: *666666 }
-    #   api: [ C_64 ]
+  - name: iamaxmin_64
+    category: stress
+    function:
+      - iamax_batched: *single_precision
+      - iamin_batched: *single_precision
+      - iamax_strided_batched: *single_precision
+      - iamin_strided_batched: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1, batch_count: 1 }
+      - { N: 2, incx:  2147483649, batch_count: 1 }
+      - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
   - name: iamaxmin_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/nrm2_gtest.yaml
+++ b/clients/gtest/blas1/nrm2_gtest.yaml
@@ -42,26 +42,30 @@ Tests:
     backend_flags: AMD
 
     # ILP-64 tests
-  # - name: nrm2_64
-  #   category: stress
-  #   function:
-  #     - nrm2: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx:  1 }
-  #     - { N: 2, incx:  2147483649 }
-  #   api: [ C_64 ]
+  - name: nrm2_64
+    category: stress
+    function:
+      - nrm2: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1 }
+      - { N: 2, incx:  2147483649 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
-  # - name: nrm2_64
-  #   category: stress
-  #   function:
-  #     - nrm2_batched: *single_precision
-  #     - nrm2_strided_batched: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, batch_count: 1 }
-  #     - { N: 2, incx:  2147483649, batch_count: 1 }
-  #     - { N: 2, incx:  1, stride_x: 2, batch_count: *666666 }
-  #   api: [ C_64 ]
-  #   backend_flags: AMD
+  - name: nrm2_64
+    category: stress
+    function:
+      - nrm2_batched: *single_precision
+      - nrm2_strided_batched: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1, batch_count: 1 }
+      - { N: 2, incx:  2147483649, batch_count: 1 }
+      - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
+    backend_flags: AMD
 
   - name: nrm2_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/nrm2_gtest.yaml
+++ b/clients/gtest/blas1/nrm2_gtest.yaml
@@ -49,6 +49,7 @@ Tests:
     arguments:
       - { N: 2147483649, incx:  1 }
       - { N: 2, incx:  2147483649 }
+    initialization: hpl
     api: [ C_64 ]
     os_flags: [ LINUX ]
     gpu_arch: '90a'
@@ -62,6 +63,7 @@ Tests:
       - { N: 2147483649, incx:  1, batch_count: 1 }
       - { N: 2, incx:  2147483649, batch_count: 1 }
       - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
+    initialization: hpl
     api: [ C_64 ]
     os_flags: [ LINUX ]
     gpu_arch: '90a'

--- a/clients/gtest/blas1/rot_gtest.yaml
+++ b/clients/gtest/blas1/rot_gtest.yaml
@@ -102,16 +102,18 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  # - name: rotg_64
-  #   category: stress
-  #   function:
-  #     - rotg_batched: *single_precision
-  #     - rotg_strided_batched: *single_precision
-  #     - rotmg_batched: *single_precision
-  #     - rotmg_strided_batched: *single_precision
-  #   batch_count: 666666
-  #   api: [ C_64 ]
-  #   backend_flags: AMD
+  - name: rotg_64
+    category: stress
+    function:
+      - rotg_batched: *single_precision
+      - rotg_strided_batched: *single_precision
+      - rotmg_batched: *single_precision
+      - rotmg_strided_batched: *single_precision
+    batch_count: 666666
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
+    backend_flags: AMD
 
   # bad arg tests
   - name: rot_bad_arg

--- a/clients/gtest/blas1/scal_gtest.yaml
+++ b/clients/gtest/blas1/scal_gtest.yaml
@@ -51,27 +51,29 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  # - name: scal_64
-  #   category: stress
-  #   function:
-  #     - scal: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, incy:  1 }
-  #     - { N: 2, incx:  2147483649, incy:  1 }
-  #     - { N: 2, incx:  1, incy:  2147483649 }
-  #   api: [ C_64 ]
+  - name: scal_64
+    category: stress
+    function:
+      - scal: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1, incy:  1 }
+      - { N: 2, incx:  2147483649, incy:  1 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
-  # - name: scal_64
-  #   category: stress
-  #   function:
-  #     - scal_batched: *single_precision
-  #     - scal_strided_batched: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
-  #     - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
-  #     - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
-  #     - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: *666666 }
-  #   api: [ C_64 ]
+  - name: scal_64
+    category: stress
+    function:
+      - scal_batched: *single_precision
+      - scal_strided_batched: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1, batch_count: 1 }
+      - { N: 2, incx:  2147483649, batch_count: 1 }
+      - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
   - name: scal_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/swap_gtest.yaml
+++ b/clients/gtest/blas1/swap_gtest.yaml
@@ -44,27 +44,31 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  # - name: swap_64
-  #   category: stress
-  #   function:
-  #     - swap: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, incy:  1 }
-  #     - { N: 2, incx:  2147483649, incy:  1 }
-  #     - { N: 2, incx:  1, incy:  2147483649 }
-  #   api: [ C_64 ]
+  - name: swap_64
+    category: stress
+    function:
+      - swap: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1, incy:  1 }
+      - { N: 2, incx:  2147483649, incy:  1 }
+      - { N: 2, incx:  1, incy:  2147483649 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
-  # - name: swap_64
-  #   category: stress
-  #   function:
-  #     - swap_batched: *single_precision
-  #     - swap_strided_batched: *single_precision
-  #   arguments:
-  #     - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
-  #     - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
-  #     - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
-  #     - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: *666666 }
-  #   api: [ C_64 ]
+  - name: swap_64
+    category: stress
+    function:
+      - swap_batched: *single_precision
+      - swap_strided_batched: *single_precision
+    arguments:
+      - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
+      - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
+      - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
+      - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
+    api: [ C_64 ]
+    os_flags: [ LINUX ]
+    gpu_arch: '90a'
 
   - name: swap_bad_arg
     category: pre_checkin

--- a/clients/include/blas1/testing_axpy_batched.hpp
+++ b/clients/include/blas1/testing_axpy_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -191,8 +191,7 @@ void testing_axpy_batched(const Arguments& arg)
         =================================================================== */
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2 = b;
-            ref_axpy<T>((int)N, alpha, hx_cpu[b2], (int)incx, hy_cpu[b2], (int)incy);
+            ref_axpy<T>(N, alpha, hx_cpu[b], incx, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas1/testing_copy.hpp
+++ b/clients/include/blas1/testing_copy.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -133,7 +133,7 @@ void testing_copy(const Arguments& arg)
                     CPU BLAS
         =================================================================== */
         // TODO: remove casts
-        ref_copy<T>((int)N, hx_cpu.data(), (int)incx, hy_cpu.data(), (int)incy);
+        ref_copy<T>(N, hx_cpu.data(), incx, hy_cpu.data(), incy);
 
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/blas1/testing_copy_batched.hpp
+++ b/clients/include/blas1/testing_copy_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -131,8 +131,7 @@ void testing_copy_batched(const Arguments& arg)
         =================================================================== */
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2 = b;
-            ref_copy<T>((int)N, hx_cpu[b2], (int)incx, hy_cpu[b2], (int)incy);
+            ref_copy<T>(N, hx_cpu[b], incx, hy_cpu[b], incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas1/testing_copy_strided_batched.hpp
+++ b/clients/include/blas1/testing_copy_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -147,11 +147,7 @@ void testing_copy_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int64_t b = 0; b < batch_count; b++)
         {
-            ref_copy<T>((int)N,
-                        hx_cpu.data() + b * stridex,
-                        (int)incx,
-                        hy_cpu.data() + b * stridey,
-                        (int)incy);
+            ref_copy<T>(N, hx_cpu.data() + b * stridex, incx, hy_cpu.data() + b * stridey, incy);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/blas1/testing_dot.hpp
+++ b/clients/include/blas1/testing_dot.hpp
@@ -175,10 +175,21 @@ void testing_dot(const Arguments& arg)
         =================================================================== */
         (CONJ ? ref_dotc<T> : ref_dot<T>)(N, hx.data(), incx, hy.data(), incy, &cpu_result);
 
+        bool   near_check = arg.initialization == hipblas_initialization::hpl;
+        double abs_error  = hipblas_type_epsilon<T> * N;
+
         if(arg.unit_check)
         {
-            unit_check_general<T>(1, 1, 1, &cpu_result, &h_hipblas_result_1);
-            unit_check_general<T>(1, 1, 1, &cpu_result, &h_hipblas_result_2);
+            if(near_check)
+            {
+                near_check_general<T>(1, 1, 1, &cpu_result, &h_hipblas_result_1, abs_error);
+                near_check_general<T>(1, 1, 1, &cpu_result, &h_hipblas_result_2, abs_error);
+            }
+            else
+            {
+                unit_check_general<T>(1, 1, 1, &cpu_result, &h_hipblas_result_1);
+                unit_check_general<T>(1, 1, 1, &cpu_result, &h_hipblas_result_2);
+            }
         }
         if(arg.norm_check)
         {

--- a/clients/include/blas1/testing_dot.hpp
+++ b/clients/include/blas1/testing_dot.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -127,10 +127,10 @@ void testing_dot(const Arguments& arg)
         return;
     }
 
-    int    abs_incx = incx >= 0 ? incx : -incx;
-    int    abs_incy = incy >= 0 ? incy : -incy;
-    size_t sizeX    = size_t(N) * abs_incx;
-    size_t sizeY    = size_t(N) * abs_incy;
+    int64_t abs_incx = incx >= 0 ? incx : -incx;
+    int64_t abs_incy = incy >= 0 ? incy : -incy;
+    size_t  sizeX    = size_t(N) * abs_incx;
+    size_t  sizeY    = size_t(N) * abs_incy;
     if(!sizeX)
         sizeX = 1;
     if(!sizeY)

--- a/clients/include/blas1/testing_dot_batched.hpp
+++ b/clients/include/blas1/testing_dot_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -134,10 +134,10 @@ void testing_dot_batched(const Arguments& arg)
         return;
     }
 
-    int    abs_incx = incx >= 0 ? incx : -incx;
-    int    abs_incy = incy >= 0 ? incy : -incy;
-    size_t sizeX    = size_t(N) * abs_incx;
-    size_t sizeY    = size_t(N) * abs_incy;
+    int64_t abs_incx = incx >= 0 ? incx : -incx;
+    int64_t abs_incy = incy >= 0 ? incy : -incy;
+    size_t  sizeX    = size_t(N) * abs_incx;
+    size_t  sizeY    = size_t(N) * abs_incy;
 
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
@@ -195,8 +195,7 @@ void testing_dot_batched(const Arguments& arg)
         =================================================================== */
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2 = b;
-            (CONJ ? ref_dotc<T> : ref_dot<T>)(N, hx[b2], incx, hy[b2], incy, &(h_cpu_result[b2]));
+            (CONJ ? ref_dotc<T> : ref_dot<T>)(N, hx[b], incx, hy[b], incy, &(h_cpu_result[b]));
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_dot_batched.hpp
+++ b/clients/include/blas1/testing_dot_batched.hpp
@@ -134,11 +134,6 @@ void testing_dot_batched(const Arguments& arg)
         return;
     }
 
-    int64_t abs_incx = incx >= 0 ? incx : -incx;
-    int64_t abs_incy = incy >= 0 ? incy : -incy;
-    size_t  sizeX    = size_t(N) * abs_incx;
-    size_t  sizeY    = size_t(N) * abs_incy;
-
     double gpu_time_used, hipblas_error_host, hipblas_error_device;
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
@@ -198,10 +193,23 @@ void testing_dot_batched(const Arguments& arg)
             (CONJ ? ref_dotc<T> : ref_dot<T>)(N, hx[b], incx, hy[b], incy, &(h_cpu_result[b]));
         }
 
+        bool   near_check = arg.initialization == hipblas_initialization::hpl;
+        double abs_error  = hipblas_type_epsilon<T> * N;
+
         if(arg.unit_check)
         {
-            unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_hipblas_result1);
-            unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_hipblas_result2);
+            if(near_check)
+            {
+                near_check_general<T>(
+                    batch_count, 1, 1, h_cpu_result.data(), h_hipblas_result1.data(), abs_error);
+                near_check_general<T>(
+                    batch_count, 1, 1, h_cpu_result.data(), h_hipblas_result2.data(), abs_error);
+            }
+            else
+            {
+                unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_hipblas_result1);
+                unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_hipblas_result2);
+            }
         }
         if(arg.norm_check)
         {

--- a/clients/include/blas1/testing_dot_strided_batched.hpp
+++ b/clients/include/blas1/testing_dot_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -210,13 +210,12 @@ void testing_dot_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2 = b;
             (CONJ ? ref_dotc<T> : ref_dot<T>)(N,
                                               hx.data() + b * stridex,
                                               incx,
                                               hy.data() + b * stridey,
                                               incy,
-                                              &h_cpu_result[b2]);
+                                              &h_cpu_result[b]);
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_dot_strided_batched.hpp
+++ b/clients/include/blas1/testing_dot_strided_batched.hpp
@@ -218,10 +218,23 @@ void testing_dot_strided_batched(const Arguments& arg)
                                               &h_cpu_result[b]);
         }
 
+        bool   near_check = arg.initialization == hipblas_initialization::hpl;
+        double abs_error  = hipblas_type_epsilon<T> * N;
+
         if(arg.unit_check)
         {
-            unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_hipblas_result1);
-            unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_hipblas_result2);
+            if(near_check)
+            {
+                near_check_general<T>(
+                    batch_count, 1, 1, h_cpu_result.data(), h_hipblas_result1.data(), abs_error);
+                near_check_general<T>(
+                    batch_count, 1, 1, h_cpu_result.data(), h_hipblas_result2.data(), abs_error);
+            }
+            else
+            {
+                unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_hipblas_result1);
+                unit_check_general<T>(1, batch_count, 1, h_cpu_result, h_hipblas_result2);
+            }
         }
         if(arg.norm_check)
         {

--- a/clients/include/blas1/testing_iamax_iamin_batched.hpp
+++ b/clients/include/blas1/testing_iamax_iamin_batched.hpp
@@ -169,20 +169,19 @@ void testing_iamax_iamin_batched(const Arguments& arg, FUNC func)
 
         if(arg.unit_check)
         {
-            unit_check_general<R>(1, 1, (int)batch_count, cpu_result, hipblas_result_host);
-            unit_check_general<R>(1, 1, (int)batch_count, cpu_result, hipblas_result_device);
+            unit_check_general<R>(1, 1, batch_count, cpu_result, hipblas_result_host);
+            unit_check_general<R>(1, 1, batch_count, cpu_result, hipblas_result_device);
         }
         if(arg.norm_check)
         {
             for(int64_t b = 0; b < batch_count; b++)
             {
-                int b2 = b;
                 hipblas_error_host
                     = std::max(int64_t(hipblas_error_host),
-                               int64_t(hipblas_abs(hipblas_result_host[b2] - cpu_result[b2])));
+                               int64_t(hipblas_abs(hipblas_result_host[b] - cpu_result[b])));
                 hipblas_error_device
                     = std::max(int64_t(hipblas_error_device),
-                               int64_t(hipblas_abs(hipblas_result_device[b2] - cpu_result[b2])));
+                               int64_t(hipblas_abs(hipblas_result_device[b] - cpu_result[b])));
             }
         }
     } // end of if unit/norm check

--- a/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
+++ b/clients/include/blas1/testing_iamax_iamin_strided_batched.hpp
@@ -191,13 +191,12 @@ void testing_iamax_iamin_strided_batched(const Arguments& arg, FUNC func)
         {
             for(int64_t b = 0; b < batch_count; b++)
             {
-                int b2 = b;
                 hipblas_error_host
                     = std::max(int64_t(hipblas_error_host),
-                               int64_t(hipblas_abs(hipblas_result_host[b2] - cpu_result[b2])));
+                               int64_t(hipblas_abs(hipblas_result_host[b] - cpu_result[b])));
                 hipblas_error_device
                     = std::max(int64_t(hipblas_error_device),
-                               int64_t(hipblas_abs(hipblas_result_device[b2] - cpu_result[b2])));
+                               int64_t(hipblas_abs(hipblas_result_device[b] - cpu_result[b])));
             }
         }
     } // end of if unit/norm check

--- a/clients/include/blas1/testing_nrm2_batched.hpp
+++ b/clients/include/blas1/testing_nrm2_batched.hpp
@@ -154,8 +154,7 @@ void testing_nrm2_batched(const Arguments& arg)
         =================================================================== */
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2 = b;
-            ref_nrm2<T, Tr>(N, hx[b2], incx, &(h_cpu_result[b2]));
+            ref_nrm2<T, Tr>(N, hx[b], incx, &(h_cpu_result[b]));
         }
 
         if(arg.unit_check)

--- a/clients/include/blas1/testing_nrm2_strided_batched.hpp
+++ b/clients/include/blas1/testing_nrm2_strided_batched.hpp
@@ -162,8 +162,7 @@ void testing_nrm2_strided_batched(const Arguments& arg)
         =================================================================== */
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2 = b;
-            ref_nrm2<T, Tr>(N, hx.data() + b2 * stridex, incx, &(h_cpu_result[b2]));
+            ref_nrm2<T, Tr>(N, hx.data() + b * stridex, incx, &(h_cpu_result[b]));
         }
 
         if(arg.unit_check)
@@ -175,12 +174,11 @@ void testing_nrm2_strided_batched(const Arguments& arg)
         {
             for(int64_t b = 0; b < batch_count; b++)
             {
-                int b2             = b;
-                hipblas_error_host = std::max(
-                    vector_norm_1(1, 1, &(h_cpu_result[b2]), &(h_hipblas_result_host[b2])),
-                    hipblas_error_host);
+                hipblas_error_host
+                    = std::max(vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_host[b])),
+                               hipblas_error_host);
                 hipblas_error_device = std::max(
-                    vector_norm_1(1, 1, &(h_cpu_result[b2]), &(h_hipblas_result_device[b2])),
+                    vector_norm_1(1, 1, &(h_cpu_result[b]), &(h_hipblas_result_device[b])),
                     hipblas_error_device);
             }
         }

--- a/clients/include/blas1/testing_rot_batched.hpp
+++ b/clients/include/blas1/testing_rot_batched.hpp
@@ -139,8 +139,7 @@ void testing_rot_batched(const Arguments& arg)
     // cy[0] = hy[0];
     for(int64_t b = 0; b < batch_count; b++)
     {
-        int b2 = b;
-        ref_rot<T, U, V>(N, cx[b2], incx, cy[b2], incy, *hc, *hs);
+        ref_rot<T, U, V>(N, cx[b], incx, cy[b], incy, *hc, *hs);
     }
 
     if(arg.unit_check || arg.norm_check)
@@ -168,7 +167,7 @@ void testing_rot_batched(const Arguments& arg)
 
             if(arg.unit_check)
             {
-                for(int b = 0; b < batch_count; b++)
+                for(int64_t b = 0; b < batch_count; b++)
                 {
                     near_check_general(1, N, abs_incx, cx[b], rx[b], rel_error);
                     near_check_general(1, N, abs_incy, cy[b], ry[b], rel_error);
@@ -210,9 +209,8 @@ void testing_rot_batched(const Arguments& arg)
             {
                 for(int64_t b = 0; b < batch_count; b++)
                 {
-                    int b2 = b;
-                    near_check_general(1, N, abs_incx, cx[b2], rx[b2], rel_error);
-                    near_check_general(1, N, abs_incy, cy[b2], ry[b2], rel_error);
+                    near_check_general(1, N, abs_incx, cx[b], rx[b], rel_error);
+                    near_check_general(1, N, abs_incy, cy[b], ry[b], rel_error);
                 }
             }
             if(arg.norm_check)

--- a/clients/include/blas1/testing_rotg_batched.hpp
+++ b/clients/include/blas1/testing_rotg_batched.hpp
@@ -162,13 +162,12 @@ void testing_rotg_batched(const Arguments& arg)
         // CBLAS
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2 = b;
-            ref_rotg<T, U>(ca[b2], cb[b2], cc[b2], cs[b2]);
+            ref_rotg<T, U>(ca[b], cb[b], cc[b], cs[b]);
         }
 
         if(arg.unit_check)
         {
-            for(int b = 0; b < batch_count; b++)
+            for(int64_t b = 0; b < batch_count; b++)
             {
                 near_check_general<T>(1, 1, 1, ca[b], ha[b], rel_error);
                 near_check_general<T>(1, 1, 1, cb[b], hb[b], rel_error);

--- a/clients/include/blas1/testing_rotm_batched.hpp
+++ b/clients/include/blas1/testing_rotm_batched.hpp
@@ -124,8 +124,7 @@ void testing_rotm_batched(const Arguments& arg)
 
     for(int64_t b = 0; b < batch_count; b++)
     {
-        int b2 = b;
-        ref_rotmg<T>(&hdata[b2][0], &hdata[b2][1], &hdata[b2][2], &hdata[b2][3], hparam[b2]);
+        ref_rotmg<T>(&hdata[b][0], &hdata[b][1], &hdata[b][2], &hdata[b][3], hparam[b]);
     }
 
     constexpr int FLAG_COUNT        = 4;
@@ -137,8 +136,7 @@ void testing_rotm_batched(const Arguments& arg)
         {
             for(int64_t b = 0; b < batch_count; b++)
             {
-                int b2        = b;
-                hparam[b2][0] = FLAGS[i];
+                hparam[b][0] = FLAGS[i];
             }
 
             // Test device
@@ -168,18 +166,16 @@ void testing_rotm_batched(const Arguments& arg)
 
             for(int64_t b = 0; b < batch_count; b++)
             {
-                int b2 = b;
                 // CPU BLAS reference data
-                ref_rotm<T>(N, cx[b2], incx, cy[b2], incy, hparam[b2]);
+                ref_rotm<T>(N, cx[b], incx, cy[b], incy, hparam[b]);
             }
 
             if(arg.unit_check)
             {
                 for(int64_t b = 0; b < batch_count; b++)
                 {
-                    int b2 = b;
-                    near_check_general<T>(1, N, abs_incx, cx[b2], rx[b2], rel_error);
-                    near_check_general<T>(1, N, abs_incy, cy[b2], ry[b2], rel_error);
+                    near_check_general<T>(1, N, abs_incx, cx[b], rx[b], rel_error);
+                    near_check_general<T>(1, N, abs_incy, cy[b], ry[b], rel_error);
                 }
             }
             if(arg.norm_check)
@@ -196,8 +192,7 @@ void testing_rotm_batched(const Arguments& arg)
     {
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2        = b;
-            hparam[b2][0] = 0;
+            hparam[b][0] = 0;
         }
 
         hipStream_t stream;

--- a/clients/include/blas1/testing_rotm_strided_batched.hpp
+++ b/clients/include/blas1/testing_rotm_strided_batched.hpp
@@ -194,7 +194,7 @@ void testing_rotm_strided_batched(const Arguments& arg)
     {
         if(arg.unit_check || arg.norm_check)
         {
-            for(int b = 0; b < batch_count; b++)
+            for(int64_t b = 0; b < batch_count; b++)
                 (hparam + b * stride_param)[0] = FLAGS[i];
 
             // Test device

--- a/clients/include/blas1/testing_rotmg_batched.hpp
+++ b/clients/include/blas1/testing_rotmg_batched.hpp
@@ -172,26 +172,24 @@ void testing_rotmg_batched(const Arguments& arg)
         // CBLAS
         for(int64_t b = 0; b < batch_count; b++)
         {
-            int b2 = b;
-            ref_rotmg<T>(cd1[b2], cd2[b2], cx1[b2], cy1[b2], cparams[b2]);
+            ref_rotmg<T>(cd1[b], cd2[b], cx1[b], cy1[b], cparams[b]);
         }
 
         if(arg.unit_check)
         {
-            for(int b = 0; b < batch_count; b++)
+            for(int64_t b = 0; b < batch_count; b++)
             {
-                int b2 = b;
-                near_check_general<T>(1, 1, 1, cd1[b2], hd1[b2], rel_error);
-                near_check_general<T>(1, 1, 1, cd2[b2], hd2[b2], rel_error);
-                near_check_general<T>(1, 1, 1, cx1[b2], hx1[b2], rel_error);
-                near_check_general<T>(1, 1, 1, cy1[b2], hy1[b2], rel_error);
-                near_check_general<T>(1, 5, 1, cparams[b2], hparams[b2], rel_error);
+                near_check_general<T>(1, 1, 1, cd1[b], hd1[b], rel_error);
+                near_check_general<T>(1, 1, 1, cd2[b], hd2[b], rel_error);
+                near_check_general<T>(1, 1, 1, cx1[b], hx1[b], rel_error);
+                near_check_general<T>(1, 1, 1, cy1[b], hy1[b], rel_error);
+                near_check_general<T>(1, 5, 1, cparams[b], hparams[b], rel_error);
 
-                near_check_general<T>(1, 1, 1, cd1[b2], hd1_d[b2], rel_error);
-                near_check_general<T>(1, 1, 1, cd2[b2], hd2_d[b2], rel_error);
-                near_check_general<T>(1, 1, 1, cx1[b2], hx1_d[b2], rel_error);
-                near_check_general<T>(1, 1, 1, cy1[b2], hy1_d[b2], rel_error);
-                near_check_general<T>(1, 5, 1, cparams[b2], hparams_d[b2], rel_error);
+                near_check_general<T>(1, 1, 1, cd1[b], hd1_d[b], rel_error);
+                near_check_general<T>(1, 1, 1, cd2[b], hd2_d[b], rel_error);
+                near_check_general<T>(1, 1, 1, cx1[b], hx1_d[b], rel_error);
+                near_check_general<T>(1, 1, 1, cy1[b], hy1_d[b], rel_error);
+                near_check_general<T>(1, 5, 1, cparams[b], hparams_d[b], rel_error);
             }
         }
 

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -83,9 +83,9 @@ void unit_check_error(T error, T tolerance)
 template <typename T, typename Tex = T>
 void unit_check_nrm2(T cpu_result, T gpu_result, int64_t vector_length)
 {
-    T allowable_error = vector_length * hipblas_type_epsilon<T> * cpu_result;
+    T allowable_error = vector_length * hipblas_type_epsilon<Tex> * cpu_result;
     if(allowable_error == 0)
-        allowable_error = vector_length * hipblas_type_epsilon<T>;
+        allowable_error = vector_length * hipblas_type_epsilon<Tex>;
 #ifdef GOOGLE_TEST
     ASSERT_NEAR(cpu_result, gpu_result, allowable_error);
 #endif
@@ -99,9 +99,9 @@ void unit_check_nrm2(int64_t        batch_count,
 {
     for(int64_t b = 0; b < batch_count; b++)
     {
-        T allowable_error = vector_length * hipblas_type_epsilon<T> * cpu_result[b];
+        T allowable_error = vector_length * hipblas_type_epsilon<Tex> * cpu_result[b];
         if(allowable_error == 0)
-            allowable_error = vector_length * hipblas_type_epsilon<T>;
+            allowable_error = vector_length * hipblas_type_epsilon<Tex>;
 #ifdef GOOGLE_TEST
         ASSERT_NEAR(cpu_result[b], gpu_result[b], allowable_error);
 #endif

--- a/clients/include/unit.h
+++ b/clients/include/unit.h
@@ -81,27 +81,27 @@ void unit_check_error(T error, T tolerance)
 }
 
 template <typename T, typename Tex = T>
-void unit_check_nrm2(T cpu_result, T gpu_result, int vector_length)
+void unit_check_nrm2(T cpu_result, T gpu_result, int64_t vector_length)
 {
-    T allowable_error = vector_length * std::numeric_limits<Tex>::epsilon() * cpu_result;
+    T allowable_error = vector_length * hipblas_type_epsilon<T> * cpu_result;
     if(allowable_error == 0)
-        allowable_error = vector_length * std::numeric_limits<Tex>::epsilon();
+        allowable_error = vector_length * hipblas_type_epsilon<T>;
 #ifdef GOOGLE_TEST
     ASSERT_NEAR(cpu_result, gpu_result, allowable_error);
 #endif
 }
 
 template <typename T, typename Tex = T>
-void unit_check_nrm2(int            batch_count,
+void unit_check_nrm2(int64_t        batch_count,
                      host_vector<T> cpu_result,
                      host_vector<T> gpu_result,
-                     int            vector_length)
+                     int64_t        vector_length)
 {
-    for(int b = 0; b < batch_count; b++)
+    for(int64_t b = 0; b < batch_count; b++)
     {
-        T allowable_error = vector_length * std::numeric_limits<Tex>::epsilon() * cpu_result[b];
+        T allowable_error = vector_length * hipblas_type_epsilon<T> * cpu_result[b];
         if(allowable_error == 0)
-            allowable_error = vector_length * std::numeric_limits<Tex>::epsilon();
+            allowable_error = vector_length * hipblas_type_epsilon<T>;
 #ifdef GOOGLE_TEST
         ASSERT_NEAR(cpu_result[b], gpu_result[b], allowable_error);
 #endif


### PR DESCRIPTION
Enabling all _64 tests. Only run on gfx90a, not tested with cublas backend right now.