### PR TITLE
Add documentation for 64-bit interface

### DIFF
--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -195,7 +195,7 @@ hipblasIXamax + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzamax
 
-    The amax function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The amax function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasIsamaxBatched
     :outline:
@@ -205,7 +205,7 @@ hipblasIXamax + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzamaxBatched
 
-    The amaxBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The amaxBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasIsamaxStridedBatched
     :outline:
@@ -215,7 +215,7 @@ hipblasIXamax + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzamaxStridedBatched
 
-    The amaxStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The amaxStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 
 hipblasIXamin + Batched, StridedBatched
@@ -228,7 +228,7 @@ hipblasIXamin + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzamin
 
-    The amin function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The amin function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasIsaminBatched
     :outline:
@@ -238,7 +238,7 @@ hipblasIXamin + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzaminBatched
 
-    The aminBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The aminBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasIsaminStridedBatched
     :outline:
@@ -248,7 +248,7 @@ hipblasIXamin + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzaminStridedBatched
 
-    The aminStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The aminStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXasum + Batched, StridedBatched
 ----------------------------------------
@@ -260,7 +260,7 @@ hipblasXasum + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDzasum
 
-    The asum function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The asum function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSasumBatched
     :outline:
@@ -270,7 +270,7 @@ hipblasXasum + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDzasumBatched
 
-    The asumBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The asumBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSasumStridedBatched
     :outline:
@@ -280,7 +280,7 @@ hipblasXasum + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDzasumStridedBatched
 
-    The asumStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The asumStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXaxpy + Batched, StridedBatched
 ----------------------------------------
@@ -294,7 +294,7 @@ hipblasXaxpy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZaxpy
 
-    The axpy function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The axpy function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasHaxpyBatched
     :outline:
@@ -306,7 +306,7 @@ hipblasXaxpy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZaxpyBatched
 
-    The axpyBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The axpyBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasHaxpyStridedBatched
     :outline:
@@ -318,7 +318,7 @@ hipblasXaxpy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZaxpyStridedBatched
 
-    The axpyStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The axpyStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXcopy + Batched, StridedBatched
 ----------------------------------------
@@ -330,7 +330,7 @@ hipblasXcopy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZcopy
 
-    The copy function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The copy function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasScopyBatched
     :outline:
@@ -340,7 +340,7 @@ hipblasXcopy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZcopyBatched
 
-    The copyBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The copyBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasScopyStridedBatched
     :outline:
@@ -350,7 +350,7 @@ hipblasXcopy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZcopyStridedBatched
 
-    The copyStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The copyStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXdot + Batched, StridedBatched
 ---------------------------------------
@@ -370,7 +370,7 @@ hipblasXdot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdotu
 
-    The dot function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The dot function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasHdotBatched
     :outline:
@@ -388,7 +388,7 @@ hipblasXdot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdotuBatched
 
-    The dotBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The dotBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasHdotStridedBatched
     :outline:
@@ -406,7 +406,7 @@ hipblasXdot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdotuStridedBatched
 
-    The dotStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The dotStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXnrm2 + Batched, StridedBatched
 ----------------------------------------
@@ -418,7 +418,7 @@ hipblasXnrm2 + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDznrm2
 
-    The nrm2 function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The nrm2 function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSnrm2Batched
     :outline:
@@ -428,7 +428,7 @@ hipblasXnrm2 + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDznrm2Batched
 
-    The nrm2Batched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The nrm2Batched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSnrm2StridedBatched
     :outline:
@@ -438,7 +438,7 @@ hipblasXnrm2 + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDznrm2StridedBatched
 
-    The nrm2StridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The nrm2StridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXrot + Batched, StridedBatched
 ---------------------------------------
@@ -454,7 +454,7 @@ hipblasXrot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdrot
 
-    The rot function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rot function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotBatched
     :outline:
@@ -468,7 +468,7 @@ hipblasXrot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdrotBatched
 
-    The rotBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotStridedBatched
     :outline:
@@ -482,7 +482,7 @@ hipblasXrot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdrotStridedBatched
 
-    The rotStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXrotg + Batched, StridedBatched
 ----------------------------------------
@@ -494,7 +494,7 @@ hipblasXrotg + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZrotg
 
-    The rotg function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotg function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotgBatched
     :outline:
@@ -504,7 +504,7 @@ hipblasXrotg + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZrotgBatched
 
-    The rotgBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotgBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotgStridedBatched
     :outline:
@@ -514,7 +514,7 @@ hipblasXrotg + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZrotgStridedBatched
 
-    The rotgStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotgStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXrotm + Batched, StridedBatched
 ----------------------------------------
@@ -522,19 +522,19 @@ hipblasXrotm + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDrotm
 
-    The rotm function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotm function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotmBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmBatched
 
-    The rotmBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotmBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotmStridedBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmStridedBatched
 
-    The rotmStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotmStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXrotmg + Batched, StridedBatched
 -----------------------------------------
@@ -542,19 +542,19 @@ hipblasXrotmg + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmg
 
-    The rotmg function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotmg function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotmgBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmgBatched
 
-    The rotmgBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotmgBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotmgStridedBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmgStridedBatched
 
-    The rotmgStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The rotmgStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXscal + Batched, StridedBatched
 ----------------------------------------
@@ -570,7 +570,7 @@ hipblasXscal + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdscal
 
-    The scal function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The scal function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSscalBatched
     :outline:
@@ -584,7 +584,7 @@ hipblasXscal + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdscalBatched
 
-    The scalBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The scalBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSscalStridedBatched
     :outline:
@@ -598,7 +598,7 @@ hipblasXscal + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdscalStridedBatched
 
-    The scalStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The scalStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXswap + Batched, StridedBatched
 ----------------------------------------
@@ -610,7 +610,7 @@ hipblasXswap + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZswap
 
-    The swap function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The swap function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSswapBatched
     :outline:
@@ -620,7 +620,7 @@ hipblasXswap + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZswapBatched
 
-    The swapBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The swapBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSswapStridedBatched
     :outline:
@@ -630,7 +630,7 @@ hipblasXswap + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZswapStridedBatched
 
-    The swapStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+The swapStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 Level 2 BLAS
 ============

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -44,6 +44,14 @@ hipBLAS function uses the following notations to denote precisions:
 - c  = single complex
 - z  = double complex
 
+ILP64 Interface
+===============
+The hipBLAS library Level-1 functions are also provided with ILP64 interfaces. With these interfaces all "int" arguments are replaced by the typename
+int64_t.  These ILP64 function names all end with a suffix ``_64``.   The only output arguments that change are for the
+xMAX and xMIN for which the index is now int64_t. Function level documentation is not repeated for these API as they are identical in behavior to the LP64 versions,
+however functions which support this alternate API include the line:
+``This function supports the 64-bit integer interface (ILP64)``.
+
 HIPBLAS_V2 and Deprecations
 ===========================
 

--- a/docs/functions.rst
+++ b/docs/functions.rst
@@ -44,13 +44,15 @@ hipBLAS function uses the following notations to denote precisions:
 - c  = single complex
 - z  = double complex
 
+.. _ILP64 API:
+
 ILP64 Interface
 ===============
 The hipBLAS library Level-1 functions are also provided with ILP64 interfaces. With these interfaces all "int" arguments are replaced by the typename
 int64_t.  These ILP64 function names all end with a suffix ``_64``.   The only output arguments that change are for the
 xMAX and xMIN for which the index is now int64_t. Function level documentation is not repeated for these API as they are identical in behavior to the LP64 versions,
 however functions which support this alternate API include the line:
-``This function supports the 64-bit integer interface (ILP64)``.
+``This function supports the 64-bit integer interface``.
 
 HIPBLAS_V2 and Deprecations
 ===========================
@@ -193,6 +195,8 @@ hipblasIXamax + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzamax
 
+    The amax function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasIsamaxBatched
     :outline:
 .. doxygenfunction:: hipblasIdamaxBatched
@@ -201,6 +205,8 @@ hipblasIXamax + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzamaxBatched
 
+    The amaxBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasIsamaxStridedBatched
     :outline:
 .. doxygenfunction:: hipblasIdamaxStridedBatched
@@ -208,6 +214,8 @@ hipblasIXamax + Batched, StridedBatched
 .. doxygenfunction:: hipblasIcamaxStridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzamaxStridedBatched
+
+    The amaxStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 
 hipblasIXamin + Batched, StridedBatched
@@ -220,6 +228,8 @@ hipblasIXamin + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzamin
 
+    The amin function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasIsaminBatched
     :outline:
 .. doxygenfunction:: hipblasIdaminBatched
@@ -228,6 +238,8 @@ hipblasIXamin + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzaminBatched
 
+    The aminBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasIsaminStridedBatched
     :outline:
 .. doxygenfunction:: hipblasIdaminStridedBatched
@@ -235,6 +247,8 @@ hipblasIXamin + Batched, StridedBatched
 .. doxygenfunction:: hipblasIcaminStridedBatched
     :outline:
 .. doxygenfunction:: hipblasIzaminStridedBatched
+
+    The aminStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXasum + Batched, StridedBatched
 ----------------------------------------
@@ -246,6 +260,8 @@ hipblasXasum + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDzasum
 
+    The asum function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSasumBatched
     :outline:
 .. doxygenfunction:: hipblasDasumBatched
@@ -254,6 +270,8 @@ hipblasXasum + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDzasumBatched
 
+    The asumBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSasumStridedBatched
     :outline:
 .. doxygenfunction:: hipblasDasumStridedBatched
@@ -261,6 +279,8 @@ hipblasXasum + Batched, StridedBatched
 .. doxygenfunction:: hipblasScasumStridedBatched
     :outline:
 .. doxygenfunction:: hipblasDzasumStridedBatched
+
+    The asumStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXaxpy + Batched, StridedBatched
 ----------------------------------------
@@ -274,6 +294,8 @@ hipblasXaxpy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZaxpy
 
+    The axpy function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasHaxpyBatched
     :outline:
 .. doxygenfunction:: hipblasSaxpyBatched
@@ -283,6 +305,8 @@ hipblasXaxpy + Batched, StridedBatched
 .. doxygenfunction:: hipblasCaxpyBatched
     :outline:
 .. doxygenfunction:: hipblasZaxpyBatched
+
+    The axpyBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasHaxpyStridedBatched
     :outline:
@@ -294,6 +318,8 @@ hipblasXaxpy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZaxpyStridedBatched
 
+    The axpyStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 hipblasXcopy + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasScopy
@@ -304,6 +330,8 @@ hipblasXcopy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZcopy
 
+    The copy function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasScopyBatched
     :outline:
 .. doxygenfunction:: hipblasDcopyBatched
@@ -312,6 +340,8 @@ hipblasXcopy + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZcopyBatched
 
+    The copyBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasScopyStridedBatched
     :outline:
 .. doxygenfunction:: hipblasDcopyStridedBatched
@@ -319,6 +349,8 @@ hipblasXcopy + Batched, StridedBatched
 .. doxygenfunction:: hipblasCcopyStridedBatched
     :outline:
 .. doxygenfunction:: hipblasZcopyStridedBatched
+
+    The copyStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXdot + Batched, StridedBatched
 ---------------------------------------
@@ -338,6 +370,8 @@ hipblasXdot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdotu
 
+    The dot function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasHdotBatched
     :outline:
 .. doxygenfunction:: hipblasBfdotBatched
@@ -353,6 +387,8 @@ hipblasXdot + Batched, StridedBatched
 .. doxygenfunction:: hipblasZdotcBatched
     :outline:
 .. doxygenfunction:: hipblasZdotuBatched
+
+    The dotBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasHdotStridedBatched
     :outline:
@@ -370,6 +406,8 @@ hipblasXdot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdotuStridedBatched
 
+    The dotStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 hipblasXnrm2 + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSnrm2
@@ -380,6 +418,8 @@ hipblasXnrm2 + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDznrm2
 
+    The nrm2 function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSnrm2Batched
     :outline:
 .. doxygenfunction:: hipblasDnrm2Batched
@@ -388,6 +428,8 @@ hipblasXnrm2 + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDznrm2Batched
 
+    The nrm2Batched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSnrm2StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDnrm2StridedBatched
@@ -395,6 +437,8 @@ hipblasXnrm2 + Batched, StridedBatched
 .. doxygenfunction:: hipblasScnrm2StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDznrm2StridedBatched
+
+    The nrm2StridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXrot + Batched, StridedBatched
 ---------------------------------------
@@ -410,6 +454,8 @@ hipblasXrot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdrot
 
+    The rot function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSrotBatched
     :outline:
 .. doxygenfunction:: hipblasDrotBatched
@@ -421,6 +467,8 @@ hipblasXrot + Batched, StridedBatched
 .. doxygenfunction:: hipblasZrotBatched
     :outline:
 .. doxygenfunction:: hipblasZdrotBatched
+
+    The rotBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotStridedBatched
     :outline:
@@ -434,6 +482,8 @@ hipblasXrot + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdrotStridedBatched
 
+    The rotStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 hipblasXrotg + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSrotg
@@ -444,6 +494,8 @@ hipblasXrotg + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZrotg
 
+    The rotg function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSrotgBatched
     :outline:
 .. doxygenfunction:: hipblasDrotgBatched
@@ -451,6 +503,8 @@ hipblasXrotg + Batched, StridedBatched
 .. doxygenfunction:: hipblasCrotgBatched
     :outline:
 .. doxygenfunction:: hipblasZrotgBatched
+
+    The rotgBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSrotgStridedBatched
     :outline:
@@ -460,19 +514,27 @@ hipblasXrotg + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZrotgStridedBatched
 
+    The rotgStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 hipblasXrotm + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSrotm
     :outline:
 .. doxygenfunction:: hipblasDrotm
 
+    The rotm function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSrotmBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmBatched
 
+    The rotmBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSrotmStridedBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmStridedBatched
+
+    The rotmStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXrotmg + Batched, StridedBatched
 -----------------------------------------
@@ -480,13 +542,19 @@ hipblasXrotmg + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmg
 
+    The rotmg function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSrotmgBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmgBatched
 
+    The rotmgBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSrotmgStridedBatched
     :outline:
 .. doxygenfunction:: hipblasDrotmgStridedBatched
+
+    The rotmgStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 hipblasXscal + Batched, StridedBatched
 ----------------------------------------
@@ -502,6 +570,8 @@ hipblasXscal + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdscal
 
+    The scal function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSscalBatched
     :outline:
 .. doxygenfunction:: hipblasDscalBatched
@@ -513,6 +583,8 @@ hipblasXscal + Batched, StridedBatched
 .. doxygenfunction:: hipblasCsscalBatched
     :outline:
 .. doxygenfunction:: hipblasZdscalBatched
+
+    The scalBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSscalStridedBatched
     :outline:
@@ -526,6 +598,8 @@ hipblasXscal + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZdscalStridedBatched
 
+    The scalStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 hipblasXswap + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSswap
@@ -536,6 +610,8 @@ hipblasXswap + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZswap
 
+    The swap function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
+
 .. doxygenfunction:: hipblasSswapBatched
     :outline:
 .. doxygenfunction:: hipblasDswapBatched
@@ -543,6 +619,8 @@ hipblasXswap + Batched, StridedBatched
 .. doxygenfunction:: hipblasCswapBatched
     :outline:
 .. doxygenfunction:: hipblasZswapBatched
+
+    The swapBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 .. doxygenfunction:: hipblasSswapStridedBatched
     :outline:
@@ -552,6 +630,7 @@ hipblasXswap + Batched, StridedBatched
     :outline:
 .. doxygenfunction:: hipblasZswapStridedBatched
 
+    The swapStridedBatched function supports the 64-bit integer interface. Refer to section :ref:`ILP64 API`.
 
 Level 2 BLAS
 ============

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -863,6 +863,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasGetAtomicsMode(hipblasHandle_t       handl
     result
               device pointer or host pointer to store the amax index.
               return is 0.0 if n, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasIsamax(hipblasHandle_t handle, int n, const float* x, int incx, int* result);
@@ -932,6 +935,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzamax_64_v2(
     result
               device or host array of pointers of batchCount size for results.
               return is 0 if n, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasIsamaxBatched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, int* result);
@@ -1041,6 +1047,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzamaxBatched_64_v2(hipblasHandle_t       
     result
               device or host pointer for storing contiguous batchCount results.
               return is 0 if n <= 0, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -1166,6 +1174,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzamaxStridedBatched_64_v2(hipblasHandle_t
     result
               device pointer or host pointer to store the amin index.
               return is 0.0 if n, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
@@ -1236,6 +1247,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzamin_64_v2(
     result
               device or host pointers to array of batchCount size for results.
               return is 0 if n, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasIsaminBatched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, int* result);
@@ -1345,6 +1359,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzaminBatched_64_v2(hipblasHandle_t       
     result
               device or host pointer to array for storing contiguous batchCount results.
               return is 0 if n <= 0, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -1472,6 +1488,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzaminStridedBatched_64_v2(hipblasHandle_t
               device pointer or host pointer to store the asum product.
               return is 0.0 if n <= 0.
 
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
@@ -1541,6 +1559,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasum_64_v2(
     result
               device array or host array of batchCount size for results.
               return is 0.0 if n, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSasumBatched(
@@ -1660,6 +1681,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumBatched_64_v2(hipblasHandle_t       
     result
               device pointer or host pointer to array for storing contiguous batchCount results.
               return is 0.0 if n, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSasumStridedBatched(hipblasHandle_t handle,
@@ -1789,6 +1813,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumStridedBatched_64_v2(hipblasHandle_t
     @param[inout]
     incy      [int]
               specifies the increment for the elements of y.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasHaxpy(hipblasHandle_t    handle,
@@ -1937,6 +1963,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpy_64_v2(hipblasHandle_t         handle
     @param[in]
     batchCount [int]
               number of instances in the batch
+
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasHaxpyBatched(hipblasHandle_t          handle,
                                                    int                      n,
@@ -2103,6 +2132,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpyBatched_64_v2(hipblasHandle_t        
     @param[in]
     batchCount [int]
               number of instances in the batch
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasHaxpyStridedBatched(hipblasHandle_t    handle,
@@ -2290,6 +2321,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpyStridedBatched_64_v2(hipblasHandle_t 
     incy      [int]
               specifies the increment for the elements of y.
 
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
@@ -2387,6 +2420,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopy_64_v2(hipblasHandle_t         handle
     @param[in]
     batchCount [int]
                 number of instances in the batch
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -2533,6 +2568,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyBatched_64_v2(hipblasHandle_t        
     @param[in]
     batchCount [int]
                 number of instances in the batch
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -2693,6 +2730,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyStridedBatched_64_v2(hipblasHandle_t 
     result
               device pointer or host pointer to store the dot product.
               return is 0.0 if n <= 0.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -2931,6 +2970,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotu_64_v2(hipblasHandle_t         handle
     result
               device array or host array of batchCount size to store the dot products of each batch.
               return 0.0 for each element if n <= 0.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -3199,6 +3240,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuBatched_64_v2(hipblasHandle_t        
     result
               device array or host array of batchCount size to store the dot products of each batch.
               return 0.0 for each element if n <= 0.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -3495,6 +3538,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuStridedBatched_64_v2(hipblasHandle_t 
     result
               device pointer or host pointer to store the nrm2 product.
               return is 0.0 if n, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
@@ -3566,6 +3612,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2_64_v2(
     result
               device pointer or host pointer to array of batchCount size for nrm2 results.
               return is 0.0 for each element if n <= 0, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasSnrm2Batched(
@@ -3687,6 +3735,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2Batched_64_v2(hipblasHandle_t       
     result
               device pointer or host pointer to array for storing contiguous batchCount results.
               return is 0.0 for each element if n <= 0, incx<=0.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -3818,6 +3868,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2StridedBatched_64_v2(hipblasHandle_t
     c       device pointer or host pointer storing scalar cosine component of the rotation matrix.
     @param[in]
     s       device pointer or host pointer storing scalar sine component of the rotation matrix.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -4036,6 +4088,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrot_64_v2(hipblasHandle_t   handle,
     @param[in]
     batchCount [int]
                 the number of x and y arrays, i.e. the number of batches.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -4280,6 +4334,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotBatched_64_v2(hipblasHandle_t        
     @param[in]
     batchCount [int]
             the number of x and y arrays, i.e. the number of batches.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -4549,6 +4605,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotStridedBatched_64_v2(hipblasHandle_t 
     @param[inout]
     s       device pointer or host pointer sine element of Givens rotation.
 
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
@@ -4627,6 +4685,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotg_64_v2(hipblasHandle_t   handle,
     @param[in]
     batchCount [int]
                 number of batches (length of arrays a, b, c, and s).
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -4754,6 +4814,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgBatched_64_v2(hipblasHandle_t        
     @param[in]
     batchCount [int]
                 number of batches (length of arrays a, b, c, and s).
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -4930,6 +4992,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgStridedBatched_64_v2(hipblasHandle_t 
             flag = -2 => H = ( 1.0 0.0 0.0 1.0 )
             param may be stored in either host or device memory, location is specified by calling hipblasSetPointerMode.
 
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotm(
@@ -4997,6 +5061,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotm_64(hipblasHandle_t handle,
     @param[in]
     batchCount [int]
                 the number of x and y arrays, i.e. the number of batches.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -5089,6 +5155,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmBatched_64(hipblasHandle_t     handle
     batchCount [int]
                 the number of x and y arrays, i.e. the number of batches.
 
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotmStridedBatched(hipblasHandle_t handle,
@@ -5178,6 +5246,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmStridedBatched_64(hipblasHandle_t han
             flag = -2 => H = ( 1.0 0.0 0.0 1.0 )
             param may be stored in either host or device memory, location is specified by calling hipblasSetPointerMode.
 
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotmg(
@@ -5233,6 +5303,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmg_64(
     @param[in]
     batchCount [int]
                 the number of instances in the batch.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -5325,6 +5397,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmgBatched_64(hipblasHandle_t     handl
     batchCount [int]
                 the number of instances in the batch.
 
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotmgStridedBatched(hipblasHandle_t handle,
@@ -5406,6 +5480,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmgStridedBatched_64(hipblasHandle_t ha
     incx      [int]
               specifies the increment for the elements of x.
 
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t
@@ -5510,6 +5585,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscal_64_v2(
     @param[in]
     batchCount [int]
                 specifies the number of batches in x.
+
+        This function supports the 64-bit integer interface (ILP64).
+
      ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSscalBatched(
@@ -5684,6 +5762,9 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalBatched_64_v2(hipblasHandle_t       
     @param[in]
     batchCount [int]
                 specifies the number of batches in x.
+
+        This function supports the 64-bit integer interface (ILP64).
+
      ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle,
                                                           int             n,
@@ -5875,6 +5956,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalStridedBatched_64_v2(hipblasHandle_t
     incy      [int]
               specifies the increment for the elements of y.
 
+        This function supports the 64-bit integer interface (ILP64).
+
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
@@ -5961,6 +6044,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswap_64_v2(hipblasHandle_t   handle,
     @param[in]
     batchCount [int]
                 number of instances in the batch.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -6104,6 +6189,8 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswapBatched_64_v2(hipblasHandle_t        
      @param[in]
      batchCount [int]
                  number of instances in the batch.
+
+        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -864,8 +864,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasGetAtomicsMode(hipblasHandle_t       handl
               device pointer or host pointer to store the amax index.
               return is 0.0 if n, incx<=0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasIsamax(hipblasHandle_t handle, int n, const float* x, int incx, int* result);
@@ -935,8 +933,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzamax_64_v2(
     result
               device or host array of pointers of batchCount size for results.
               return is 0 if n, incx<=0.
-
-        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasIsamaxBatched(
@@ -1047,8 +1043,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzamaxBatched_64_v2(hipblasHandle_t       
     result
               device or host pointer for storing contiguous batchCount results.
               return is 0 if n <= 0, incx<=0.
-
-        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -1175,8 +1169,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzamaxStridedBatched_64_v2(hipblasHandle_t
               device pointer or host pointer to store the amin index.
               return is 0.0 if n, incx<=0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
@@ -1247,8 +1239,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzamin_64_v2(
     result
               device or host pointers to array of batchCount size for results.
               return is 0 if n, incx<=0.
-
-        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasIsaminBatched(
@@ -1359,8 +1349,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzaminBatched_64_v2(hipblasHandle_t       
     result
               device or host pointer to array for storing contiguous batchCount results.
               return is 0 if n <= 0, incx<=0.
-
-        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -1488,8 +1476,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasIzaminStridedBatched_64_v2(hipblasHandle_t
               device pointer or host pointer to store the asum product.
               return is 0.0 if n <= 0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
     ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
@@ -1559,8 +1545,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasum_64_v2(
     result
               device array or host array of batchCount size for results.
               return is 0.0 if n, incx<=0.
-
-        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -1681,8 +1665,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumBatched_64_v2(hipblasHandle_t       
     result
               device pointer or host pointer to array for storing contiguous batchCount results.
               return is 0.0 if n, incx<=0.
-
-        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 
@@ -1813,8 +1795,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDzasumStridedBatched_64_v2(hipblasHandle_t
     @param[inout]
     incy      [int]
               specifies the increment for the elements of y.
-
-        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasHaxpy(hipblasHandle_t    handle,
@@ -1963,8 +1943,6 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpy_64_v2(hipblasHandle_t         handle
     @param[in]
     batchCount [int]
               number of instances in the batch
-
-        This function supports the 64-bit integer interface (ILP64).
 
     ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasHaxpyBatched(hipblasHandle_t          handle,
@@ -2133,9 +2111,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpyBatched_64_v2(hipblasHandle_t        
     batchCount [int]
               number of instances in the batch
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasHaxpyStridedBatched(hipblasHandle_t    handle,
                                                           int                n,
                                                           const hipblasHalf* alpha,
@@ -2321,9 +2297,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZaxpyStridedBatched_64_v2(hipblasHandle_t 
     incy      [int]
               specifies the increment for the elements of y.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasScopy(hipblasHandle_t handle, int n, const float* x, int incx, float* y, int incy);
@@ -2421,9 +2395,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopy_64_v2(hipblasHandle_t         handle
     batchCount [int]
                 number of instances in the batch
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScopyBatched(hipblasHandle_t    handle,
                                                    int                n,
@@ -2569,9 +2541,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyBatched_64_v2(hipblasHandle_t        
     batchCount [int]
                 number of instances in the batch
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasScopyStridedBatched(hipblasHandle_t handle,
                                                           int             n,
@@ -2731,9 +2701,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZcopyStridedBatched_64_v2(hipblasHandle_t 
               device pointer or host pointer to store the dot product.
               return is 0.0 if n <= 0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasHdot(hipblasHandle_t    handle,
                                            int                n,
@@ -2971,9 +2939,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotu_64_v2(hipblasHandle_t         handle
               device array or host array of batchCount size to store the dot products of each batch.
               return 0.0 for each element if n <= 0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasHdotBatched(hipblasHandle_t          handle,
                                                   int                      n,
@@ -3241,9 +3207,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuBatched_64_v2(hipblasHandle_t        
               device array or host array of batchCount size to store the dot products of each batch.
               return 0.0 for each element if n <= 0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasHdotStridedBatched(hipblasHandle_t    handle,
                                                          int                n,
@@ -3539,9 +3503,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdotuStridedBatched_64_v2(hipblasHandle_t 
               device pointer or host pointer to store the nrm2 product.
               return is 0.0 if n, incx<=0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasSnrm2(hipblasHandle_t handle, int n, const float* x, int incx, float* result);
@@ -3613,9 +3575,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2_64_v2(
               device pointer or host pointer to array of batchCount size for nrm2 results.
               return is 0.0 for each element if n <= 0, incx<=0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasSnrm2Batched(
     hipblasHandle_t handle, int n, const float* const x[], int incx, int batchCount, float* result);
 
@@ -3736,9 +3696,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2Batched_64_v2(hipblasHandle_t       
               device pointer or host pointer to array for storing contiguous batchCount results.
               return is 0.0 for each element if n <= 0, incx<=0.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSnrm2StridedBatched(hipblasHandle_t handle,
                                                           int             n,
@@ -3869,9 +3827,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDznrm2StridedBatched_64_v2(hipblasHandle_t
     @param[in]
     s       device pointer or host pointer storing scalar sine component of the rotation matrix.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrot(hipblasHandle_t handle,
                                            int             n,
@@ -4089,9 +4045,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrot_64_v2(hipblasHandle_t   handle,
     batchCount [int]
                 the number of x and y arrays, i.e. the number of batches.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotBatched(hipblasHandle_t handle,
                                                   int             n,
@@ -4335,9 +4289,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotBatched_64_v2(hipblasHandle_t        
     batchCount [int]
             the number of x and y arrays, i.e. the number of batches.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotStridedBatched(hipblasHandle_t handle,
                                                          int             n,
@@ -4605,9 +4557,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdrotStridedBatched_64_v2(hipblasHandle_t 
     @param[inout]
     s       device pointer or host pointer sine element of Givens rotation.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasSrotg(hipblasHandle_t handle, float* a, float* b, float* c, float* s);
@@ -4686,9 +4636,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotg_64_v2(hipblasHandle_t   handle,
     batchCount [int]
                 number of batches (length of arrays a, b, c, and s).
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotgBatched(hipblasHandle_t handle,
                                                    float* const    a[],
@@ -4815,9 +4763,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgBatched_64_v2(hipblasHandle_t        
     batchCount [int]
                 number of batches (length of arrays a, b, c, and s).
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotgStridedBatched(hipblasHandle_t handle,
                                                           float*          a,
@@ -4992,9 +4938,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZrotgStridedBatched_64_v2(hipblasHandle_t 
             flag = -2 => H = ( 1.0 0.0 0.0 1.0 )
             param may be stored in either host or device memory, location is specified by calling hipblasSetPointerMode.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotm(
     hipblasHandle_t handle, int n, float* x, int incx, float* y, int incy, const float* param);
@@ -5062,9 +5006,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotm_64(hipblasHandle_t handle,
     batchCount [int]
                 the number of x and y arrays, i.e. the number of batches.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotmBatched(hipblasHandle_t    handle,
                                                    int                n,
@@ -5155,9 +5097,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmBatched_64(hipblasHandle_t     handle
     batchCount [int]
                 the number of x and y arrays, i.e. the number of batches.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotmStridedBatched(hipblasHandle_t handle,
                                                           int             n,
@@ -5246,9 +5186,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmStridedBatched_64(hipblasHandle_t han
             flag = -2 => H = ( 1.0 0.0 0.0 1.0 )
             param may be stored in either host or device memory, location is specified by calling hipblasSetPointerMode.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotmg(
     hipblasHandle_t handle, float* d1, float* d2, float* x1, const float* y1, float* param);
@@ -5304,9 +5242,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmg_64(
     batchCount [int]
                 the number of instances in the batch.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotmgBatched(hipblasHandle_t    handle,
                                                     float* const       d1[],
@@ -5397,9 +5333,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmgBatched_64(hipblasHandle_t     handl
     batchCount [int]
                 the number of instances in the batch.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSrotmgStridedBatched(hipblasHandle_t handle,
                                                            float*          d1,
@@ -5480,9 +5414,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasDrotmgStridedBatched_64(hipblasHandle_t ha
     incx      [int]
               specifies the increment for the elements of x.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasSscal(hipblasHandle_t handle, int n, const float* alpha, float* x, int incx);
 
@@ -5586,9 +5518,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscal_64_v2(
     batchCount [int]
                 specifies the number of batches in x.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-     ********************************************************************/
+             ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSscalBatched(
     hipblasHandle_t handle, int n, const float* alpha, float* const x[], int incx, int batchCount);
@@ -5763,9 +5693,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalBatched_64_v2(hipblasHandle_t       
     batchCount [int]
                 specifies the number of batches in x.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-     ********************************************************************/
+             ********************************************************************/
 HIPBLAS_EXPORT hipblasStatus_t hipblasSscalStridedBatched(hipblasHandle_t handle,
                                                           int             n,
                                                           const float*    alpha,
@@ -5956,9 +5884,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZdscalStridedBatched_64_v2(hipblasHandle_t
     incy      [int]
               specifies the increment for the elements of y.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t
     hipblasSswap(hipblasHandle_t handle, int n, float* x, int incx, float* y, int incy);
@@ -6045,9 +5971,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswap_64_v2(hipblasHandle_t   handle,
     batchCount [int]
                 number of instances in the batch.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSswapBatched(hipblasHandle_t handle,
                                                    int             n,
@@ -6190,9 +6114,7 @@ HIPBLAS_EXPORT hipblasStatus_t hipblasZswapBatched_64_v2(hipblasHandle_t        
      batchCount [int]
                  number of instances in the batch.
 
-        This function supports the 64-bit integer interface (ILP64).
-
-    ********************************************************************/
+            ********************************************************************/
 
 HIPBLAS_EXPORT hipblasStatus_t hipblasSswapStridedBatched(hipblasHandle_t handle,
                                                           int             n,


### PR DESCRIPTION
Copied documentation from rocBLAS minus the comment about performance since we hipBLAS doesn't have any bearing on performance.