### PR TITLE
Allocated batched test memory in contiguous memory

### DIFF
--- a/clients/include/device_batch_vector.hpp
+++ b/clients/include/device_batch_vector.hpp
@@ -187,7 +187,7 @@ public:
     //!
     //! @brief Const cast of the data on host.
     //!
-    operator const T* const*() const
+    operator const T* const *() const
     {
         return this->m_data;
     }

--- a/clients/include/host_batch_vector.hpp
+++ b/clients/include/host_batch_vector.hpp
@@ -155,7 +155,7 @@ public:
     //!
     //! @brief Constant cast to a double pointer.
     //!
-    operator const T* const*()
+    operator const T* const *()
     {
         return this->m_data;
     }


### PR DESCRIPTION
Use contiguous memory when allocating batched vectors for test code, similar to rocBLAS. Previously we were allocating a bunch of memory for padding for each batch, which isn't scalable to the large-batch 64-bit tests.

This should solve the failures in #768, or I can just remove/reduce the batched testing since it isn't necessarily hipBLAS' job to test batch sizes larger than the block size.