### PR TITLE
cmake: add rocblas/rocsolver as package deps if building static lib

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -64,6 +64,8 @@ add_library( hipblas
 )
 add_library( roc::hipblas ALIAS hipblas )
 
+set(static_depends)
+
 # Build hipblas from source on AMD platform
 if(HIP_PLATFORM STREQUAL amd)
   if( NOT TARGET rocblas )
@@ -76,6 +78,7 @@ if(HIP_PLATFORM STREQUAL amd)
     else()
       find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocblas )
     endif( )
+    list(APPEND static_depends PACKAGE rocblas)
   endif( )
 
   target_link_libraries( hipblas PRIVATE roc::rocblas hip::host )
@@ -98,6 +101,7 @@ if(HIP_PLATFORM STREQUAL amd)
         find_package( rocsolver REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocsolver /usr/local/rocsolver )
       endif()
     endif( )
+    list(APPEND static_depends PACKAGE rocsolver)
     target_link_libraries( hipblas PRIVATE roc::rocsolver )
   endif( )
 
@@ -180,6 +184,7 @@ if(HIP_PLATFORM STREQUAL amd)
     rocm_export_targets(
         TARGETS roc::hipblas
 	DEPENDS PACKAGE hip
+	STATIC_DEPENDS ${static_depends}
 	NAMESPACE roc::
     )
 else( )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -78,9 +78,9 @@ if(HIP_PLATFORM STREQUAL amd)
     else()
       find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocblas )
     endif( )
-    list(APPEND static_depends PACKAGE rocblas)
   endif( )
 
+  list(APPEND static_depends PACKAGE rocblas)
   target_link_libraries( hipblas PRIVATE roc::rocblas hip::host )
 
   # Add rocSOLVER as a dependency if BUILD_WITH_SOLVER is on


### PR DESCRIPTION
When a static library is built, no linking is done.  (Basically static libraries are just archives of object files.)

So if `libfoo.a` depends on `libbar.a`, CMake just has to remember that when you link `libfoo.a`, it also needs to pull in `libbar.a`.  The problem is that CMake only knows about `libbar.a` if a `find_package(bar)` is done.  This PR fixes our generated `foo-config.cmake` file to find this dependency, when we're building a static library.