### PR TITLE
Invoke rmake.py when using install.sh to build

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -31,6 +31,9 @@ if( NOT TARGET hipblas )
   find_package( hipblas REQUIRED CONFIG PATHS /opt/rocm/hipblas )
 endif( )
 
+if(EXISTS  "${BUILD_DIR}/deps/deps-install/lib/libgtest.a")
+  set( GTEST_ROOT "${BUILD_DIR}/deps/deps-install")
+endif()
 find_package( GTest REQUIRED )
 
 set(hipblas_test_source
@@ -146,6 +149,7 @@ target_include_directories( hipblas-test
     $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${BLAS_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     ${ROCM_PATH}/include
 )
 target_include_directories( hipblas_v2-test
@@ -154,6 +158,7 @@ target_include_directories( hipblas_v2-test
     $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${BLAS_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     ${ROCM_PATH}/include
 )
 

--- a/install.sh
+++ b/install.sh
@@ -22,80 +22,13 @@
 #
 # ########################################################################
 
+declare -a input_args
+input_args="$@"
+
+#use readlink rather than realpath for CentOS 6.10 support
+HIPBLAS_SRC_PATH=`dirname "$(readlink -m $0)"`
+
 /bin/ln -fs ../../.githooks/pre-commit "$(dirname "$0")/.git/hooks/"
-
-
-# #################################################
-# helper functions
-# #################################################
-function display_help()
-{
-cat <<EOF
-
-  hipBLAS library build & installation helper script.
-
-  Usage:
-    $0 (build hipblas and put library files at ./build/hipblas-install)
-    $0 <options> (modify default behavior according to the following flags)
-
-  Options:
-    --address-sanitizer           Build with address sanitizer enabled. Uses hipcc as compiler.
-
-    -b, --rocblas <version>       Specify rocblas version (e.g. 2.42.0).
-
-    -c, --clients                 Build the library clients benchmark and gtest.
-                                  (Generated binaries will be located at builddir/clients/staging)
-
-    --cuda, --use-cuda            Build library for CUDA backend (deprecated).
-                                  The target HIP platform is determined by `hipconfig --platform`.
-                                  To explicitly specify a platform, set the `HIP_PLATFORM` environment variable.
-
-    --cudapath <cudadir>          Specify path of CUDA install (default /usr/local/cuda).
-
-    --cmake-arg                   Forward the given argument to CMake when configuring the build.
-
-    --compiler </compiler/path>    Specify path to host compiler. (e.g. /opt/rocm/bin/hipcc)
-
-    --custom-target <target>      Specify custom target to link the library against (eg. host, device).
-
-    --codecoverage                Build with code coverage profiling enabled, excluding release mode.
-
-    -d, --dependencies            Build and install external dependencies. Dependencies are to be installed in /usr/local.
-                                  This should be done only once (this does not install rocBLAS, rocSolver, or cuda).
-
-    --installcuda                 Install cuda package.
-
-    --installcudaversion <version> Used with --installcuda, optionally specify cuda version to install.
-
-    -g, --debug                   Build in Debug mode, equivalent to set CMAKE_BUILD_TYPE=Debug. (Default build type is Release)
-
-    -h, --help                    Print this help message.
-
-    --hip-clang                   Build library using the hip-clang compiler.
-
-    -i, -install                  Generate and install library package after build.
-
-    -k,  --relwithdebinfo         Build in release debug mode, equivalent to set CMAKE_BUILD_TYPE=RelWithDebInfo.(Default build type is Release)
-
-    -n, --no-solver               Build hipLBAS library without rocSOLVER dependency
-
-    --no-hip-clang                Build library without using hip-clang compiler.
-
-    -p, --cmakepp                 To add CMAKE_PREFIX_PATH
-
-    -r, --relocatable             Create a package to support relocatable ROCm
-
-    --rocblas-path <blasdir>      Specify path to an existing rocBLAS install directory (e.g. /src/rocBLAS/build/release/rocblas-install).
-
-    --rocsolver-path <solverdir>  Specify path to an existing rocSOLVER install directory (e.g. /src/rocSOLVER/build/release/rocsolver-install).
-
-    -s, --static                  Build hipblas as a static library (hipblas must be built statically when the used companion rocblas is also static).
-
-    -v, --rocm-dev <version>      Specify specific rocm-dev version. (e.g. 4.5.0)
-
-    --rm-legacy-include-dir       Remove legacy include dir Packaging added for file/folder reorg backward compatibility.
-EOF
-}
 
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root
 # true is a system command that completes successfully, function returns success
@@ -420,6 +353,71 @@ fi
 # The following function exits script if an unsupported distro is detected
 supported_distro
 
+function display_help()
+{
+cat <<EOF
+
+  hipBLAS library build & installation helper script.
+
+  Usage:
+    $0 (build hipblas and put library files at ./build/hipblas-install)
+    $0 <options> (modify default behavior according to the following flags)
+
+  Options:
+    --address-sanitizer           Build with address sanitizer enabled. Uses hipcc as compiler.
+
+    -b, --rocblas <version>       Specify rocblas version (e.g. 2.42.0).
+
+    -c, --clients                 Build the library clients benchmark and gtest.
+                                  (Generated binaries will be located at builddir/clients/staging)
+
+    --cuda, --use-cuda            Build library for CUDA backend (deprecated).
+                                  The target HIP platform is determined by `hipconfig --platform`.
+                                  To explicitly specify a platform, set the `HIP_PLATFORM` environment variable.
+
+    --cudapath <cudadir>          Specify path of CUDA install (default /usr/local/cuda).
+
+    --cmake-arg                   Forward the given argument to CMake when configuring the build.
+
+    --compiler </compiler/path>    Specify path to host compiler. (e.g. /opt/rocm/bin/hipcc)
+
+    --custom-target <target>      Specify custom target to link the library against (eg. host, device).
+
+    --codecoverage                Build with code coverage profiling enabled, excluding release mode.
+
+    -d, --dependencies            Build and install external dependencies. Dependencies are to be installed in /usr/local.
+                                  This should be done only once (this does not install rocBLAS, rocSolver, or cuda).
+
+    --installcuda                 Install cuda package.
+
+    --installcudaversion <version> Used with --installcuda, optionally specify cuda version to install.
+
+    -g, --debug                   Build in Debug mode, equivalent to set CMAKE_BUILD_TYPE=Debug. (Default build type is Release)
+
+    -h, --help                    Print this help message.
+
+    --hip-clang                   [DEPRECATED] Build library using the hip-clang compiler. Deprecated, use --compiler.
+
+    -i, -install                  Generate and install library package after build.
+
+    -k,  --relwithdebinfo         Build in release debug mode, equivalent to set CMAKE_BUILD_TYPE=RelWithDebInfo.(Default build type is Release)
+
+    -n, --no-solver               Build hipLBAS library without rocSOLVER dependency
+
+    --no-hip-clang                [DEPRECATED] Build library without using hip-clang compiler. Deprecated, use --compiler.
+
+    -r, --relocatable             Create a package to support relocatable ROCm
+
+    --rocblas-path <blasdir>      Specify path to an existing rocBLAS install directory (e.g. /src/rocBLAS/build/release/rocblas-install).
+
+    --rocsolver-path <solverdir>  Specify path to an existing rocSOLVER install directory (e.g. /src/rocSOLVER/build/release/rocsolver-install).
+
+    -s, --static                  Build hipblas as a static library (hipblas must be built statically when the used companion rocblas is also static).
+
+    -v, --rocm-dev <version>      Specify specific rocm-dev version. (e.g. 4.5.0)
+EOF
+}
+
 # #################################################
 # global variables
 # #################################################
@@ -435,14 +433,13 @@ build_address_sanitizer=false
 install_cuda=false
 cuda_version_install=default
 cuda_path=/usr/local/cuda
-cmake_prefix_path=/opt/rocm
 rocm_path=/opt/rocm
 compiler=g++
 build_static=false
 build_release_debug=false
 build_codecoverage=false
 update_cmake=false
-build_freorg_bkwdcomp=false
+rmake_invoked=false
 declare -a cmake_common_options
 declare -a cmake_client_options
 
@@ -453,7 +450,7 @@ declare -a cmake_client_options
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,codecoverage,clients,no-solver,dependencies,debug,hip-clang,no-hip-clang,compiler:,cmake_install,cuda,use-cuda,cudapath:,installcuda,installcudaversion:,static,cmakepp,relocatable:,rocm-dev:,rocblas:,rocblas-path:,rocsolver-path:,custom-target:,address-sanitizer,rm-legacy-include-dir,cmake-arg: --options rhicndgp:v:b: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,codecoverage,clients,no-solver,dependencies,debug,hip-clang,no-hip-clang,compiler:,cmake_install,cuda,use-cuda,cudapath:,installcuda,installcudaversion:,static,relocatable:,rmake_invoked,rocm-dev:,rocblas:,rocblas-path:,rocsolver-path:,custom-target:,address-sanitizer,cmake-arg: --options rhicndgv:b: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -512,15 +509,15 @@ while true; do
         build_cuda=true
         shift ;;
     --cudapath)
-	cuda_path=${2}
-	export CUDA_BIN_PATH=${cuda_path}
-	shift 2 ;;
+      cuda_path=${2}
+      export CUDA_BIN_PATH=${cuda_path}
+      shift 2 ;;
     --installcuda)
-	install_cuda=true
-	shift ;;
+      install_cuda=true
+      shift ;;
     --installcudaversion)
-	cuda_version_install=${2}
-	shift 2 ;;
+      cuda_version_install=${2}
+      shift 2 ;;
     --static)
         build_static=true
         shift ;;
@@ -531,12 +528,6 @@ while true; do
         build_address_sanitizer=true
         compiler=hipcc
         shift ;;
-    --rm-legacy-include-dir)
-        build_freorg_bkwdcomp=false
-        shift ;;
-    -p|--cmakepp)
-        cmake_prefix_path=${2}
-        shift 2 ;;
     --custom-target)
         custom_target=${2}
         shift 2 ;;
@@ -558,23 +549,15 @@ while true; do
     --cmake-arg)
         cmake_common_options+=("${2}")
         shift 2 ;;
+    --rmake_invoked)
+        rmake_invoked=true
+        shift ;;
     --) shift ; break ;;
     *)  echo "Unexpected command line parameter received; aborting";
         exit 1
         ;;
   esac
 done
-
-if [[ "${build_relocatable}" == true ]]; then
-    if ! [ -z ${ROCM_PATH+x} ]; then
-        rocm_path=${ROCM_PATH}
-    fi
-
-    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
-    if ! [ -z ${ROCM_RPATH+x} ]; then
-        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
-    fi
-fi
 
 build_dir=$(readlink -m ./build)
 printf "\033[32mCreating project build directory in: \033[33m${build_dir}\033[0m\n"
@@ -591,17 +574,11 @@ else
   rm -rf ${build_dir}/debug
 fi
 
-# resolve relative paths
-if [[ -n "${rocblas_path+x}" ]]; then
-  rocblas_path="$(make_absolute_path "${rocblas_path}")"
-fi
-if [[ -n "${rocsolver_path+x}" ]]; then
-  rocsolver_path="$(make_absolute_path "${rocsolver_path}")"
-fi
-
 # Default cmake executable is called cmake
 cmake_executable=cmake
-export FC="gfortran"
+cxx="g++"
+cc="gcc"
+fc="gfortran"
 
 # #################################################
 # dependencies
@@ -633,7 +610,7 @@ if [[ "${install_dependencies}" == true ]]; then
   pushd .
     printf "\033[32mBuilding \033[33mgoogletest & lapack\033[32m from source; installing into build tree and not default \033[33m/usr/local\033[0m\n"
     mkdir -p ${build_dir}/deps && cd ${build_dir}/deps
-    ${cmake_executable} -DCMAKE_INSTALL_PREFIX=deps-install ../../deps
+    CXX=${cxx} CC=${cc} FC=${fc} ${cmake_executable} -DCMAKE_INSTALL_PREFIX=deps-install ../../deps
     make -j$(nproc)
     # as installing into build tree deps/deps-install rather than /usr/local won't elevate if not root
     make install
@@ -644,130 +621,70 @@ if [[ "${install_cuda}" == true ]]; then
   install_cuda_package
 fi
 
-# We append customary rocm path; if user provides custom rocm path in ${path}, our
-# hard-coded path has lesser priority
-# export PATH=${PATH}:/opt/rocm/bin
+# #################################################
+# configure & build
+# #################################################
+
+full_build_dir=""
+if [[ "${build_release}" == true ]]; then
+  full_build_dir=${build_dir}/release
+elif [[ "${build_release_debug}" == true ]]; then
+  full_build_dir=${build_dir}/release-debug
+else
+  full_build_dir=${build_dir}/debug
+fi
+
+# Support deprecated use of --cuda by only calling
+# hipconfig when --cuda is not used.
+if [[ "${build_cuda}" != true ]]; then
+  export HIP_PLATFORM="$(hipconfig --platform)"
+fi
+
+if [[ "${rmake_invoked}" == false ]]; then
+  pushd .
+
+  # ensure a clean build environment
+  rm -rf ${full_build_dir}
+
+  # rmake.py at top level same as install.sh
+  python3 ./rmake.py --install_invoked ${input_args} --build_dir=${build_dir} --src_path=${HIPBLAS_SRC_PATH}
+  check_exit_code "$?"
+
+  popd
+else
+  # only dependency install supported when called from rmake
+  exit 0
+fi
+
+# #################################################
+# install
+# #################################################
+
 pushd .
-  # #################################################
-  # configure & build
-  # #################################################
 
-  # Support deprecated use of --cuda by only calling
-  # hipconfig when --cuda is not used.
-  if [[ "${build_cuda}" != true ]]; then
-    hip_platform="$(hipconfig --platform)"
-    if [[ "${hip_platform}" == "nvidia" ]]; then
-      build_cuda=true
-    else # hip_platform=amd; or default
-      build_cuda=false
-    fi
-  fi
+cd ${full_build_dir}
 
-  if [[ "${build_static}" == true ]]; then
-    if [[ "${build_cuda}" == true ]]; then
-      printf "Static library not supported for CUDA backend.\n"
-      exit 1
-    fi
-    cmake_common_options+=("-DBUILD_SHARED_LIBS=OFF")
-  fi
-
-  # build type
-  if [[ "${build_release}" == true ]]; then
-    mkdir -p ${build_dir}/release/clients && cd ${build_dir}/release
-    cmake_common_options+=("-DCMAKE_BUILD_TYPE=Release")
-  elif [[ "${build_release_debug}" == true ]]; then
-    mkdir -p ${build_dir}/release-debug/clients && cd ${build_dir}/release-debug
-    cmake_common_options+=("-DCMAKE_BUILD_TYPE=RelWithDebInfo")
-  else
-    mkdir -p ${build_dir}/debug/clients && cd ${build_dir}/debug
-    cmake_common_options+=("-DCMAKE_BUILD_TYPE=Debug")
-  fi
-
-  # clients
-  if [[ "${build_clients}" == true ]]; then
-    cmake_client_options+=("-DBUILD_CLIENTS_TESTS=ON" "-DBUILD_CLIENTS_BENCHMARKS=ON" "-DBUILD_CLIENTS_SAMPLES=ON" "-DBUILD_DIR=${build_dir}")
-    if [[ "${build_cuda}" == false ]]; then
-      cmake_client_options+=("-DLINK_BLIS=ON")
-    fi
-  fi
-
-  # solver
-  if [[ "${build_solver}" == false ]]; then
-    cmake_common_options+=("-DBUILD_WITH_SOLVER=OFF")
-  fi
-
-  # sanitizer
-  if [[ "${build_address_sanitizer}" == true ]]; then
-    cmake_common_options+=("-DBUILD_ADDRESS_SANITIZER=ON")
-  fi
-
-  if [[ ${custom_target+foo} ]]; then
-    cmake_common_options+=("-DCUSTOM_TARGET=${custom_target}")
-  fi
-
-  # custom rocblas
-  if [[ ${rocblas_path+foo} ]]; then
-    cmake_common_options+=("-DCUSTOM_ROCBLAS=${rocblas_path}")
-  fi
-
-  # custom rocsolver
-  if [[ ${rocsolver_path+foo} ]]; then
-    cmake_common_options+=("-DCUSTOM_ROCSOLVER=${rocsolver_path}")
-  fi
-
-  # code coverage
-  if [[ "${build_codecoverage}" == true ]]; then
-      if [[ "${build_release}" == true ]]; then
-          echo "Code coverage is disabled in Release mode, to enable code coverage select either Debug mode (-g | --debug) or RelWithDebInfo mode (-k | --relwithdebinfo); aborting";
-          exit 1
-      fi
-      cmake_common_options+=("-DBUILD_CODE_COVERAGE=ON")
-  fi
-
-  if [[ "${build_freorg_bkwdcomp}" == true ]]; then
-    cmake_common_options+=("-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=ON")
-  else
-    cmake_common_options+=("-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF")
-  fi
-
-  # Build library
-  if [[ "${build_relocatable}" == true ]]; then
-    CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
-    -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hip;$(pwd)/../deps/deps-install;${cuda_path};${cmake_prefix_path}" \
-    -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
-    -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--enable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
-    -DROCM_DISABLE_LDCONFIG=ON \
-    -DROCM_PATH="${rocm_path}" ../..
-  else
-    CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..
-  fi
+# installing through package manager, which makes uninstalling easy
+if [[ "${install_package}" == true ]]; then
+  make package
   check_exit_code "$?"
 
-  make -j$(nproc)
-  check_exit_code "$?"
+  case "${ID}" in
+    ubuntu)
+      elevate_if_not_root dpkg -i hipblas[-\_]*.deb
+    ;;
+    centos|rhel)
+      elevate_if_not_root yum -y localinstall hipblas-*.rpm
+    ;;
+    fedora)
+      elevate_if_not_root dnf install hipblas-*.rpm
+    ;;
+    sles|opensuse-leap)
+      elevate_if_not_root zypper -n --no-gpg-checks install hipblas-*.rpm
+    ;;
+  esac
 
-  # #################################################
-  # install
-  # #################################################
-  # installing through package manager, which makes uninstalling easy
-  if [[ "${install_package}" == true ]]; then
-    make package
-    check_exit_code "$?"
+fi
+check_exit_code "$?"
 
-    case "${ID}" in
-      ubuntu)
-        elevate_if_not_root dpkg -i hipblas[-\_]*.deb
-      ;;
-      centos|rhel)
-        elevate_if_not_root yum -y localinstall hipblas-*.rpm
-      ;;
-      fedora)
-        elevate_if_not_root dnf install hipblas-*.rpm
-      ;;
-      sles|opensuse-leap)
-        elevate_if_not_root zypper -n --no-gpg-checks install hipblas-*.rpm
-      ;;
-    esac
-
-  fi
 popd

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,19 @@ if( BUILD_VERBOSE )
   message( STATUS "\t==>CMAKE_CXX_COMPILER relwithdebinfo flags: " ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} )
   message( STATUS "\t==>CMAKE_EXE_LINKER link flags: " ${CMAKE_EXE_LINKER_FLAGS} )
 endif( )
+
+# Get the git hash of the hipBLAS branch
+find_package(Git REQUIRED)
+
+execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+                WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+                OUTPUT_VARIABLE GIT_HASH_HIPBLAS
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+set(hipblas_VERSION_COMMIT_ID "${GIT_HASH_HIPBLAS}")
+
+# log build commits
+message( STATUS "*** Building hipBLAS commit: ${hipblas_VERSION_COMMIT_ID}" )
 
 # configure a header file to pass the CMake version settings to the source, and package the header files in the output archive
 configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/hipblas-version.h.in" "${PROJECT_BINARY_DIR}/include/hipblas/hipblas-version.h" )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -143,7 +143,7 @@ set_target_properties( hipblas PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BI
 if (WIN32)
   add_custom_command( TARGET hipblas POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/staging/$<TARGET_FILE_NAME:hipblas> ${PROJECT_BINARY_DIR}/clients/staging/$<TARGET_FILE_NAME:hipblas> )
   if( ${CMAKE_BUILD_TYPE} MATCHES "Debug")
-    add_custom_command( TARGET hipblas POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/staging/hipblas-d.pdb ${PROJECT_BINARY_DIR}/clients/staging/hipblas-d.pdb )
+    add_custom_command( TARGET hipblas POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/staging/hipblas.pdb ${PROJECT_BINARY_DIR}/clients/staging/hipblas.pdb )
   endif()
 endif()
 

--- a/rmake.py
+++ b/rmake.py
@@ -289,8 +289,9 @@ def config_cmd():
     if args.build_clients:
         cmake_build_dir = cmake_path(build_dir)
         cmake_options.append( f"-DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON -DBUILD_CLIENTS_SAMPLES=ON -DBUILD_DIR={cmake_build_dir} " )
-        # if os.name != "nt":
-        #     cmake_options.append( f"-DLINK_BLIS=ON")
+        if os.name != "nt" and os.environ['HIP_PLATFORM'] == 'amd':
+            cmake_options.append( f"-DLINK_BLIS=ON")
+
 
     if args.build_solver:
         cmake_options.append (f"-DBUILD_WITH_SOLVER=ON")

--- a/rmake.py
+++ b/rmake.py
@@ -39,7 +39,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="""Checks build arguments""")
 
     parser.add_argument(       '--address-sanitizer', dest='address_sanitizer', required=False, default=False,
-                        help='uild with address sanitizer enabled. (optional, default: False)')
+                        help='Build with address sanitizer enabled. (optional, default: False)')
 
     parser.add_argument(      '--build_dir', type=str, required=False, default = "build",
                         help='Configure & build process output directory.(optional, default: ./build)')
@@ -317,9 +317,6 @@ def config_cmd():
     cmake_options.append( f"{src_path}")
     cmd_opts = " ".join(cmake_options)
 
-    print('cmake_options:')
-    print(cmd_opts)
-    # exit(1)
     return cmake_executable, cmd_opts
 
 def make_cmd():
@@ -356,10 +353,6 @@ def main():
     global args
     os_detect()
     args = parse_args()
-
-    print("args:")
-    print(args)
-    # exit(1)
 
     hip_platform = os.getenv('HIP_PLATFORM')
     if hip_platform == 'nvidia' and args.static_libs:

--- a/rmake.py
+++ b/rmake.py
@@ -38,9 +38,6 @@ def parse_args():
     """Parse command-line arguments"""
     parser = argparse.ArgumentParser(description="""Checks build arguments""")
 
-    parser.add_argument('-b', '--rocblas', dest='rocblas_version', type=str, required=False, default="",
-                        help='Specify rocblas version (e.g. 2.42.0). (optional).')
-
     parser.add_argument(       '--address-sanitizer', dest='address_sanitizer', required=False, default=False,
                         help='uild with address sanitizer enabled. (optional, default: False)')
 
@@ -87,7 +84,7 @@ def parse_args():
                         help='Used with --installcuda, optionally specify cuda version to install.')
 
     parser.add_argument(      '--install_invoked', required=False, default=False, action='store_true',
-                help='rmake invoked from install.sh so do not do dependency or package installation (default: False)')
+                        help='rmake invoked from install.sh so do not do dependency or package installation (default: False)')
 
     parser.add_argument('-k', '--relwithdebinfo', required=False, default = False, action='store_true',
                         help='Build in Release with Debug Info (optional, default: False)')
@@ -104,10 +101,8 @@ def parse_args():
     parser.add_argument('--rocsolver-path', dest='rocsolver_path', type=str, required=False, default=None,
                         help='Specify path to an existing rocSOLVER install directory (optional, e.g. /src/rocSOLVER/build/release/rocsolver-install).')
 
-    parser.add_argument('--rocm-dev', '--rocm_dev', type=str, required=False, default = "",
-                        help='Specify specific rocm-dev version to install, used with -d. (e.g. 4.5.0)')
-
-    parser.add_argument(      '--skip_ld_conf_entry', required=False, default = False, help='Linux only: Skip ld.so.conf entry.')
+    parser.add_argument(      '--skip_ld_conf_entry', action='store_true', required=False, default = False,
+                        help='Linux only: Skip ld.so.conf entry.')
 
     parser.add_argument(      '--static', required=False, default = False, dest='static_lib', action='store_true',
                         help='Build hipblas as a static library.(optional, default: False). hipblas must be built statically when the used companion rocblas is also static')
@@ -115,7 +110,7 @@ def parse_args():
     parser.add_argument(      '--src_path', type=str, required=False, default="",
                         help='Source path. (optional, default: Current directory)')
 
-    parser.add_argument(      '--hip-clang', dest='use_hipcc_compiler', required=False, default=True, action='store_true',
+    parser.add_argument(      '--hip-clang', dest='use_hipcc_compiler', required=False, default=False, action='store_true',
                         help='[DEPRECATED] Linux only: Build hipBLAS using hipcc compiler. Deprecated, use --compiler instead.')
 
     parser.add_argument(      '--no-hip-clang', dest='use_hipcc_compiler', required=False, default=True, action='store_false',
@@ -183,7 +178,10 @@ def config_cmd():
     cwd_path = os.getcwd()
     cmake_executable = "cmake"
     cmake_options = []
-    src_path = cmake_path(cwd_path)
+    if len(args.src_path):
+        src_path = args.src_path
+    else:
+        src_path = cmake_path(cwd_path)
     cmake_platform_opts = []
     if os.name == "nt":
         generator = f"-G Ninja"

--- a/rmake.py
+++ b/rmake.py
@@ -59,7 +59,7 @@ def parse_args():
     parser.add_argument(      '--compiler', type=str, required=False, default='g++', dest='compiler',
                         help='Spcify path to host compiler.')
 
-    parser.add_argument('--cuda', '--use-cuda', dest='use_cuda', required=False, default=False,
+    parser.add_argument('--cuda', '--use-cuda', dest='use_cuda', required=False, default=False, action='store_true',
                         help='[DEPRECATED] Build library for CUDA backend. Deprecated, use HIP_PLATFORM environment variable to override default which is determined by `hipconfig --platform`')
 
     parser.add_argument(      '--cudapath', type=str, required=False, default='/usr/local/cuda', dest='cuda_path',
@@ -355,7 +355,7 @@ def main():
     args = parse_args()
 
     hip_platform = os.getenv('HIP_PLATFORM')
-    if hip_platform == 'nvidia' and args.static_libs:
+    if hip_platform == 'nvidia' and args.static_lib:
         fatal("Static library not supported for CUDA backend. Not continuing.")
 
     if args.install_invoked:


### PR DESCRIPTION
- install.sh now invokes rmake.py to build
- fixes debug build on windows (copying hipblas library w/o `-d` suffix)
- builds against local gtest (in build/deps/deps-install) if possible
- removes build options --rm-legacy-include-dir, --cmakepp, and --rocm-dev build options
- print hipblas git hash during build