### PR TITLE
ROCm 6.1 CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for hipBLAS is available at
 [https://rocm.docs.amd.com/projects/hipBLAS/en/latest/](https://rocm.docs.amd.com/projects/hipBLAS/en/latest/).
 
-## (Unreleased) hipBLAS 2.1.0
+## hipBLAS 2.1.0 for ROCm 6.1
 
 ### Additions
 


### PR DESCRIPTION
- remove "Unreleased" from CHANGELOG.md after release/rocm-rel-6.1 branch created