### PR TITLE
Removing L1 stress 64-bit tests until we get better memory test infrastructure

### DIFF
--- a/clients/gtest/blas1/asum_gtest.yaml
+++ b/clients/gtest/blas1/asum_gtest.yaml
@@ -42,33 +42,33 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  - name: asum_64
-    category: stress
-    function:
-      - asum: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1 }
-      - { N: 2, incx:  2147483649 }
-    initialization: hpl
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
-    backend_flags: AMD # temporary until cuda pipeline is fixed
+  # - name: asum_64
+  #   category: stress
+  #   function:
+  #     - asum: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1 }
+  #     - { N: 2, incx:  2147483649 }
+  #   initialization: hpl
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
+  #   backend_flags: AMD # temporary until cuda pipeline is fixed
 
-  - name: asum_64
-    category: stress
-    function:
-      - asum_batched: *single_precision
-      - asum_strided_batched: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, batch_count: 1 }
-      - { N: 2, incx:  2147483649, batch_count: 1 }
-      - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
-    initialization: hpl
-    api: [ C_64 ]
-    backend_flags: AMD
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: asum_64
+  #   category: stress
+  #   function:
+  #     - asum_batched: *single_precision
+  #     - asum_strided_batched: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, batch_count: 1 }
+  #     - { N: 2, incx:  2147483649, batch_count: 1 }
+  #     - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
+  #   initialization: hpl
+  #   api: [ C_64 ]
+  #   backend_flags: AMD
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
   - name: asum_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/axpy_gtest.yaml
+++ b/clients/gtest/blas1/axpy_gtest.yaml
@@ -61,31 +61,31 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  - name: axpy_64
-    category: stress
-    function:
-      - axpy: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, incy:  1 }
-      - { N: 2, incx:  2147483649, incy:  1 }
-      - { N: 2, incx:  1, incy:  2147483649 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: axpy_64
+  #   category: stress
+  #   function:
+  #     - axpy: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, incy:  1 }
+  #     - { N: 2, incx:  2147483649, incy:  1 }
+  #     - { N: 2, incx:  1, incy:  2147483649 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
-  - name: axpy_64
-    category: stress
-    function:
-      - axpy_batched: *single_precision
-      - axpy_strided_batched: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
-      - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
-      - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
-      - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: axpy_64
+  #   category: stress
+  #   function:
+  #     - axpy_batched: *single_precision
+  #     - axpy_strided_batched: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
+  #     - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
+  #     - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
+  #     - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
   - name: axpy_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/copy_gtest.yaml
+++ b/clients/gtest/blas1/copy_gtest.yaml
@@ -45,32 +45,32 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  - name: copy_64
-    category: stress
-    function:
-      - copy: *single_precision
-    arguments:
-      - { N: 2147483649, incx: 1, incy: 1 }
-      - { N: 2, incx: -214748369, incy: 1 }
-      - { N: 2, incx: 1, incy: 2147483649 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: copy_64
+  #   category: stress
+  #   function:
+  #     - copy: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx: 1, incy: 1 }
+  #     - { N: 2, incx: -214748369, incy: 1 }
+  #     - { N: 2, incx: 1, incy: 2147483649 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
-  - name: copy_64
-    category: stress
-    function:
-      - copy_batched: *single_precision
-      - copy_strided_batched: *single_precision
-    arguments:
-      - { N: 2147483649, incx: 1, incy: 1,  batch_count: 1 }
-      - { N: 2, incx: -214748369, incy: 1, batch_count: 1 }
-      - { N: 2, incx: 1, incy: 2147483649, batch_count: 1 }
-      - { N: 2, incx: 1, incy: -1, stride_x: 2, stride_y: 2, batch_count: 666666 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
-    backend_flags: AMD
+  # - name: copy_64
+  #   category: stress
+  #   function:
+  #     - copy_batched: *single_precision
+  #     - copy_strided_batched: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx: 1, incy: 1,  batch_count: 1 }
+  #     - { N: 2, incx: -214748369, incy: 1, batch_count: 1 }
+  #     - { N: 2, incx: 1, incy: 2147483649, batch_count: 1 }
+  #     - { N: 2, incx: 1, incy: -1, stride_x: 2, stride_y: 2, batch_count: 666666 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
+  #   backend_flags: AMD
 
   # Bad-arg tests
   - name: copy_bad_arg

--- a/clients/gtest/blas1/dot_gtest.yaml
+++ b/clients/gtest/blas1/dot_gtest.yaml
@@ -58,33 +58,33 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  - name: dot_64
-    category: stress
-    function:
-      - dot: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, incy:  1 }
-      - { N: 2, incx:  2147483649, incy:  1 }
-      - { N: 2, incx:  1, incy:  2147483649 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
-    initialization: hpl
+  # - name: dot_64
+  #   category: stress
+  #   function:
+  #     - dot: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, incy:  1 }
+  #     - { N: 2, incx:  2147483649, incy:  1 }
+  #     - { N: 2, incx:  1, incy:  2147483649 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
+  #   initialization: hpl
 
-  - name: dot_64
-    category: stress
-    function:
-      - dot_batched: *single_precision
-      - dot_strided_batched: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
-      - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
-      - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
-      - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
-    initialization: hpl
+  # - name: dot_64
+  #   category: stress
+  #   function:
+  #     - dot_batched: *single_precision
+  #     - dot_strided_batched: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
+  #     - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
+  #     - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
+  #     - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
+  #   initialization: hpl
 
   - name: dot_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/iamaxmin_gtest.yaml
+++ b/clients/gtest/blas1/iamaxmin_gtest.yaml
@@ -45,32 +45,32 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  - name: iamaxmin_64
-    category: stress
-    function:
-      - iamax: *single_precision
-      - iamin: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1 }
-      - { N: 2, incx:  2147483649 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: iamaxmin_64
+  #   category: stress
+  #   function:
+  #     - iamax: *single_precision
+  #     - iamin: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1 }
+  #     - { N: 2, incx:  2147483649 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
-  - name: iamaxmin_64
-    category: stress
-    function:
-      - iamax_batched: *single_precision
-      - iamin_batched: *single_precision
-      - iamax_strided_batched: *single_precision
-      - iamin_strided_batched: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, batch_count: 1 }
-      - { N: 2, incx:  2147483649, batch_count: 1 }
-      - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: iamaxmin_64
+  #   category: stress
+  #   function:
+  #     - iamax_batched: *single_precision
+  #     - iamin_batched: *single_precision
+  #     - iamax_strided_batched: *single_precision
+  #     - iamin_strided_batched: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, batch_count: 1 }
+  #     - { N: 2, incx:  2147483649, batch_count: 1 }
+  #     - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
   - name: iamaxmin_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/nrm2_gtest.yaml
+++ b/clients/gtest/blas1/nrm2_gtest.yaml
@@ -42,32 +42,32 @@ Tests:
     backend_flags: AMD
 
     # ILP-64 tests
-  - name: nrm2_64
-    category: stress
-    function:
-      - nrm2: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1 }
-      - { N: 2, incx:  2147483649 }
-    initialization: hpl
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: nrm2_64
+  #   category: stress
+  #   function:
+  #     - nrm2: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1 }
+  #     - { N: 2, incx:  2147483649 }
+  #   initialization: hpl
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
-  - name: nrm2_64
-    category: stress
-    function:
-      - nrm2_batched: *single_precision
-      - nrm2_strided_batched: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, batch_count: 1 }
-      - { N: 2, incx:  2147483649, batch_count: 1 }
-      - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
-    initialization: hpl
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
-    backend_flags: AMD
+  # - name: nrm2_64
+  #   category: stress
+  #   function:
+  #     - nrm2_batched: *single_precision
+  #     - nrm2_strided_batched: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, batch_count: 1 }
+  #     - { N: 2, incx:  2147483649, batch_count: 1 }
+  #     - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
+  #   initialization: hpl
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
+  #   backend_flags: AMD
 
   - name: nrm2_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/rot_gtest.yaml
+++ b/clients/gtest/blas1/rot_gtest.yaml
@@ -102,18 +102,18 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  - name: rotg_64
-    category: stress
-    function:
-      - rotg_batched: *single_precision
-      - rotg_strided_batched: *single_precision
-      - rotmg_batched: *single_precision
-      - rotmg_strided_batched: *single_precision
-    batch_count: 666666
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
-    backend_flags: AMD
+  # - name: rotg_64
+  #   category: stress
+  #   function:
+  #     - rotg_batched: *single_precision
+  #     - rotg_strided_batched: *single_precision
+  #     - rotmg_batched: *single_precision
+  #     - rotmg_strided_batched: *single_precision
+  #   batch_count: 666666
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
+  #   backend_flags: AMD
 
   # bad arg tests
   - name: rot_bad_arg

--- a/clients/gtest/blas1/scal_gtest.yaml
+++ b/clients/gtest/blas1/scal_gtest.yaml
@@ -51,29 +51,29 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  - name: scal_64
-    category: stress
-    function:
-      - scal: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, incy:  1 }
-      - { N: 2, incx:  2147483649, incy:  1 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: scal_64
+  #   category: stress
+  #   function:
+  #     - scal: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, incy:  1 }
+  #     - { N: 2, incx:  2147483649, incy:  1 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
-  - name: scal_64
-    category: stress
-    function:
-      - scal_batched: *single_precision
-      - scal_strided_batched: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, batch_count: 1 }
-      - { N: 2, incx:  2147483649, batch_count: 1 }
-      - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: scal_64
+  #   category: stress
+  #   function:
+  #     - scal_batched: *single_precision
+  #     - scal_strided_batched: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, batch_count: 1 }
+  #     - { N: 2, incx:  2147483649, batch_count: 1 }
+  #     - { N: 2, incx:  1, stride_x: 2, batch_count: 666666 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
   - name: scal_bad_arg
     category: pre_checkin

--- a/clients/gtest/blas1/swap_gtest.yaml
+++ b/clients/gtest/blas1/swap_gtest.yaml
@@ -44,31 +44,31 @@ Tests:
     backend_flags: AMD
 
   # ILP-64 tests
-  - name: swap_64
-    category: stress
-    function:
-      - swap: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, incy:  1 }
-      - { N: 2, incx:  2147483649, incy:  1 }
-      - { N: 2, incx:  1, incy:  2147483649 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: swap_64
+  #   category: stress
+  #   function:
+  #     - swap: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, incy:  1 }
+  #     - { N: 2, incx:  2147483649, incy:  1 }
+  #     - { N: 2, incx:  1, incy:  2147483649 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
-  - name: swap_64
-    category: stress
-    function:
-      - swap_batched: *single_precision
-      - swap_strided_batched: *single_precision
-    arguments:
-      - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
-      - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
-      - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
-      - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
-    api: [ C_64 ]
-    os_flags: [ LINUX ]
-    gpu_arch: '90a'
+  # - name: swap_64
+  #   category: stress
+  #   function:
+  #     - swap_batched: *single_precision
+  #     - swap_strided_batched: *single_precision
+  #   arguments:
+  #     - { N: 2147483649, incx:  1, incy:  1, batch_count: 1 }
+  #     - { N: 2, incx:  2147483649, incy:  1, batch_count: 1 }
+  #     - { N: 2, incx:  1, incy:  2147483649, batch_count: 1 }
+  #     - { N: 2, incx:  1, incy:  1, stride_x: 2, stride_y: 2, batch_count: 666666 }
+  #   api: [ C_64 ]
+  #   os_flags: [ LINUX ]
+  #   gpu_arch: '90a'
 
   - name: swap_bad_arg
     category: pre_checkin


### PR DESCRIPTION
Still have tests for non-64 bit version just without large values.