### PR TITLE
Reducing the number and sizes of tests

### DIFF
--- a/clients/gtest/blas1/asum_gtest.yaml
+++ b/clients/gtest/blas1/asum_gtest.yaml
@@ -3,13 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_range
-    - [-1, 1 ]
+    - [-1, 2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: asum_general
@@ -37,7 +37,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas1/axpy_gtest.yaml
+++ b/clients/gtest/blas1/axpy_gtest.yaml
@@ -3,18 +3,17 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_incy_range
     - { incx:  1, incy:  1 }
-    - { incx:  1, incy:  2 }
-    - { incx: -1, incy: -1 }
+    - { incx: -1, incy: -2 }
 
   - &alpha_beta_range
     - { alpha: 2.0, alphai:  2.0, beta:  0.0, betai: 0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: axpy_general
@@ -56,7 +55,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas1/copy_gtest.yaml
+++ b/clients/gtest/blas1/copy_gtest.yaml
@@ -3,15 +3,14 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_incy_range
     - { incx:  1, incy:  1 }
-    - { incx:  1, incy:  2 }
-    - { incx: -1, incy: -1 }
+    - { incx: -1, incy: -2 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   # General tests
@@ -40,7 +39,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas1/dot_gtest.yaml
+++ b/clients/gtest/blas1/dot_gtest.yaml
@@ -3,15 +3,14 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_incy_range
     - { incx:  1, incy:  1 }
-    - { incx:  1, incy:  2 }
-    - { incx: -1, incy: -1 }
+    - { incx: -1, incy: -2 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: dot_general_nv
@@ -53,7 +52,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas1/iamaxmin_gtest.yaml
+++ b/clients/gtest/blas1/iamaxmin_gtest.yaml
@@ -3,13 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_range
-    - [-1, 1 ]
+    - [-1, 2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: iamaxmin_general
@@ -40,7 +40,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas1/nrm2_gtest.yaml
+++ b/clients/gtest/blas1/nrm2_gtest.yaml
@@ -3,13 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_range
-    - [-1, 1 ]
+    - [-1, 2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: nrm2_general
@@ -37,7 +37,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas1/rot_gtest.yaml
+++ b/clients/gtest/blas1/rot_gtest.yaml
@@ -3,15 +3,14 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_incy_range
     - { incx:  1, incy:  1 }
-    - { incx:  1, incy:  2 }
-    - { incx: -1, incy: -1 }
+    - { incx: -1, incy: -2 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   # rot, rotm
@@ -43,7 +42,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 
@@ -97,7 +96,7 @@ Tests:
       - rotg_strided_batched: *rotg_precisions
       - rotmg_strided_batched: *single_double_precisions
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas1/scal_gtest.yaml
+++ b/clients/gtest/blas1/scal_gtest.yaml
@@ -3,16 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_range
-    - [-1, 1 ]
+    - [-1, 2 ]
 
   - &alpha_beta_range
     - { alpha: 2.0, alphai:  2.0, beta:  0.0, betai: 0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: scal_general
@@ -46,7 +46,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas1/swap_gtest.yaml
+++ b/clients/gtest/blas1/swap_gtest.yaml
@@ -3,15 +3,14 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_incy_range
     - { incx:  1, incy:  1 }
-    - { incx:  1, incy:  2 }
-    - { incx: -1, incy: -1 }
+    - { incx: -1, incy: -2 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: swap_general
@@ -39,7 +38,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/gbmv_gtest.yaml
+++ b/clients/gtest/blas2/gbmv_gtest.yaml
@@ -4,21 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M: -1, N: -1, KL: -1, KU: -1, lda: -1 }
-    - { M: 1000, N: 1000, KL: 150, KU: 84, lda: 1000 }
+    - { M: 100, N: 100, KL: 42, KU: 21, lda: 1000 }
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy: -1 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -2, incy:  1 }
 
   - &alpha_beta_range
-    - { alpha:  1.0, beta:  0.0 }
-    - { alpha: -1.0, beta: -1.0 }
-    - { alpha:  2.0, beta:  1.0 }
-    - { alpha:  0.0, beta:  1.0 }
+    - { alpha:  2.0, beta:  2.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: gbmv_general
@@ -52,7 +47,7 @@ Tests:
     matrix_size: *size_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/gemv_gtest.yaml
+++ b/clients/gtest/blas2/gemv_gtest.yaml
@@ -4,21 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M: -1, N: -1, lda: -1 }
-    - { M: 1000, N: 1000, lda: 1000 }
+    - { M: 100, N: 100, lda: 200 }
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy: -1 }
-    - { incx: -1, incy: -1 }
+    - { incx: -2, incy:  1 }
 
   - &alpha_beta_range
-    - { alpha:  1.0, beta:  0.0 }
-    - { alpha: -1.0, beta: -1.0 }
-    - { alpha:  2.0, beta:  1.0 }
-    - { alpha:  0.0, beta:  1.0 }
+    - { alpha:  2.0, beta:  2.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: gemv_general
@@ -58,20 +53,6 @@ Tests:
     stride_scale: [ 1.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
-
-  #Remove this test before merge
-  - name: gemv_64
-    category: pre_checkin
-    arguments:
-      - { transA: N, M: 21474836498, N: 1, lda: 21474836498, incx: 1, incy: 1, batch_count: 1 }
-      - { transA: T, M: 21474836498, N: 1, lda: 21474836498, incx: 1, incy: 1, batch_count: 1 }
-    alpha_beta: *alpha_beta_range
-    pointer_mode_host: false
-    initialization: hpl # large reductions so ints can overflow
-    api: [ C_64 ]
-    function:
-      - gemv: *single_precision
-      - gemv_batched: *single_precision
 
   - name: gemv_general
     category: quick

--- a/clients/gtest/blas2/ger_gtest.yaml
+++ b/clients/gtest/blas2/ger_gtest.yaml
@@ -4,18 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M: -1, N: -1, lda: -1 }
-    - { M: 1000, N: 1000, lda: 1000 }
+    - { M: 100, N: 100, lda: 200 }
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy: -1 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -2, incy:  1 }
 
   - &alpha_range
-    - [ -1.0, 0.0, 1.0, 2.0 ]
+    - [ -1.0, 2.0 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: ger_general
@@ -53,7 +51,7 @@ Tests:
     matrix_size: *size_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/hbmv_gtest.yaml
+++ b/clients/gtest/blas2/hbmv_gtest.yaml
@@ -4,21 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N:   -1, K:  -1, lda:   -1 }
-    - { N: 1000, K: 501, lda: 1000 }
+    - { N: 100, K: 51, lda: 200 }
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy: -1 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -2, incy:  1 }
 
   - &alpha_beta_range
-    - { alpha:  1.0, beta:  0.0 }
-    - { alpha: -1.0, beta: -1.0 }
-    - { alpha:  2.0, beta:  1.0 }
-    - { alpha:  0.0, beta:  1.0 }
+    - { alpha:  2.0, beta:  2.0 }
 
   - &batch_count_range
-    - [ -1, 0, 2 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: hbmv_general
@@ -52,7 +47,7 @@ Tests:
     matrix_size: *size_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/hemv_gtest.yaml
+++ b/clients/gtest/blas2/hemv_gtest.yaml
@@ -4,21 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, lda: -1 }
-    - { N: 1000, lda: 1000 }
+    - { N: 100, lda: 200 }
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy: -1 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -2, incy:  1 }
 
   - &alpha_beta_range
-    - { alpha:  1.0, beta:  0.0 }
-    - { alpha: -1.0, beta: -1.0 }
-    - { alpha:  2.0, beta:  1.0 }
-    - { alpha:  0.0, beta:  1.0 }
+    - { alpha:  2.0, beta:  2.0 }
 
   - &batch_count_range
-    - [ -1, 0, 2 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: hemv_general
@@ -52,7 +47,7 @@ Tests:
     matrix_size: *size_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/her2_gtest.yaml
+++ b/clients/gtest/blas2/her2_gtest.yaml
@@ -4,26 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, lda: -1 }
-    - { N: 11, lda: 11 }
-    - { N: 16, lda: 16 }
-    - { N: 32, lda: 32 }
-    - { N: 65, lda: 65 }
+    - { N: 65, lda: 68 }
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy:  0 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -2, incy:  1 }
 
   - &alpha_range
-    - { alpha: -0.5, alphai:  1.5 }
     - { alpha:  2.0, alphai: -1.0 }
-    - { alpha:  0.0, alphai:  0.0 }
-
-  - &alpha_range_ILP64
-    - { alpha: -0.5, alphai:  0.5 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: her2_general
@@ -57,7 +47,7 @@ Tests:
     matrix_size: *size_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/her_gtest.yaml
+++ b/clients/gtest/blas2/her_gtest.yaml
@@ -4,22 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, lda: -1 }
-    - { N: 11, lda: 11 }
-    - { N: 16, lda: 16 }
-    - { N: 32, lda: 32 }
-    - { N: 65, lda: 65 }
+    - { N: 65, lda: 68 }
 
   - &incx_range
-    - [ -1, 0, 2 ]
+    - [ -1, 2 ]
 
   - &alpha_range
-    - [ -0.5, 2.0, 0.0 ]
-
-  - &alpha_range_ILP64
-    - { alpha: -0.5, alphai:  0.5 }
+    - [ 2.0 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: her_general
@@ -53,7 +47,7 @@ Tests:
     matrix_size: *size_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/hpmv_gtest.yaml
+++ b/clients/gtest/blas2/hpmv_gtest.yaml
@@ -3,21 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 1000 ]
+    - [ -1, 100 ]
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy: -1 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -2, incy:  1 }
 
   - &alpha_beta_range
-    - { alpha:  1.0, alphai:  0.0, beta:  0.0, betai:  0.0 }
-    - { alpha: -1.0, alphai:  1.5, beta: -1.0, betai:  2.0 }
     - { alpha:  2.0, alphai: -1.5, beta:  1.0, betai:  1.5 }
-    - { alpha:  0.0, alphai:  0.0, beta:  1.0, betai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 2 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: hpmv_general
@@ -51,7 +46,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/hpr2_gtest.yaml
+++ b/clients/gtest/blas2/hpr2_gtest.yaml
@@ -3,20 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 11, 16, 32, 65 ]
+    - [ -1, 65 ]
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy:  0 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -2, incy:  1 }
 
   - &alpha_beta_range
-    - { alpha: -0.5, alphai:  1.5 }
     - { alpha:  2.0, alphai: -1.0 }
-    - { alpha:  0.0, alphai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: hpr2_general
@@ -50,7 +46,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/hpr_gtest.yaml
+++ b/clients/gtest/blas2/hpr_gtest.yaml
@@ -3,16 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 11, 16, 32, 65 ]
+    - [ -1, 65 ]
 
   - &incx_range
-    - [ -1, 0, 2 ]
+    - [ -2 ]
 
   - &alpha_range
-    - [ -0.5, 2.0, 0.0 ]
+    - [ 2.0 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: hpr_general
@@ -46,7 +46,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/sbmv_gtest.yaml
+++ b/clients/gtest/blas2/sbmv_gtest.yaml
@@ -4,21 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, K: -1, lda: -1 }
-    - { N: 1000, K: 1000, lda: 1000 }
+    - { N: 100, K: 21, lda: 200 }
 
   - &incx_incy_range
-    - { incx:  2, incy:  1 }
-    - { incx:  0, incy: -1 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -2, incy:  1 }
 
   - &alpha_beta_range
-    - { alpha:  1.0, beta:  0.0 }
-    - { alpha: -1.0, beta: -1.0 }
     - { alpha:  2.0, beta:  1.0 }
-    - { alpha:  0.0, beta:  1.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: sbmv_general
@@ -53,7 +48,7 @@ Tests:
     matrix_size: *size_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/spmv_gtest.yaml
+++ b/clients/gtest/blas2/spmv_gtest.yaml
@@ -3,20 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 11, 16, 32, 65 ]
+    - [ -1, 65 ]
 
   - &incx_incy_range
-    - { incx:  1, incy:  2 }
-    - { incx:  0, incy:  0 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -1, incy:  2 }
 
   - &alpha_beta_range
-    - { alpha: -0.5, beta:  1.5 }
     - { alpha:  2.0, beta: -1.0 }
-    - { alpha:  0.0, beta:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: spmv_general
@@ -51,7 +47,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/spr2_gtest.yaml
+++ b/clients/gtest/blas2/spr2_gtest.yaml
@@ -3,20 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 11, 16, 32, 65 ]
+    - [ -1, 65 ]
 
   - &incx_incy_range
-    - { incx:  1, incy:  2 }
-    - { incx:  0, incy:  0 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -1, incy:  2 }
 
   - &alpha_beta_range
-    - { alpha: -0.5, alphai:  1.5 }
     - { alpha:  2.0, alphai: -1.0 }
-    - { alpha:  0.0, alphai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: spr2_general
@@ -50,7 +46,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/spr_gtest.yaml
+++ b/clients/gtest/blas2/spr_gtest.yaml
@@ -3,16 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 11, 16, 32, 65 ]
+    - [ -1, 65 ]
 
   - &incx_range
-    - [ -2, 1, 0, 2 ]
+    - [ -2 ]
 
   - &alpha_range
-    - [ -0.5, 2.0, 0.0 ]
+    - [ 2.0 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: spr_general
@@ -57,7 +57,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/symv_gtest.yaml
+++ b/clients/gtest/blas2/symv_gtest.yaml
@@ -4,23 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, lda: -1 }
-    - { N: 11, lda: 11 }
-    - { N: 16, lda: 16 }
-    - { N: 32, lda: 32 }
-    - { N: 65, lda: 65 }
+    - { N: 65, lda: 68 }
 
   - &incx_incy_range
-    - { incx:  1, incy:  2 }
-    - { incx:  0, incy: -1 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -1, incy:  2 }
 
   - &alpha_beta_range
-    - { alpha: -0.5, alphai:  1.5, beta:  1.5, betai: -1.0 }
     - { alpha:  2.0, alphai: -1.0, beta: -1.0, betai:  2.0 }
-    - { alpha:  0.0, alphai:  0.0, beta:  0.0, betai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: symv_general
@@ -32,7 +25,6 @@ Tests:
     matrix_size: *size_range
     incx_incy: *incx_incy_range
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
-
 
   - name: symv_batched_general
     category: quick

--- a/clients/gtest/blas2/syr2_gtest.yaml
+++ b/clients/gtest/blas2/syr2_gtest.yaml
@@ -4,23 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, lda: -1 }
-    - { N: 11, lda: 11 }
-    - { N: 16, lda: 16 }
-    - { N: 32, lda: 32 }
-    - { N: 65, lda: 65 }
+    - { N: 65, lda: 68 }
 
   - &incx_incy_range
-    - { incx:  1, incy: 2 }
-    - { incx:  0, incy:  0 }
-    - { incx: -1, incy: -1 }
+    - { incx:  -1, incy: 2 }
 
   - &alpha_beta_range
-    - { alpha: -0.5, alphai:  1.5 }
     - { alpha:  2.0, alphai: -1.0 }
-    - { alpha:  0.0, alphai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: syr2_general

--- a/clients/gtest/blas2/syr_gtest.yaml
+++ b/clients/gtest/blas2/syr_gtest.yaml
@@ -4,19 +4,16 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, lda: -1 }
-    - { N: 11, lda: 11 }
-    - { N: 16, lda: 16 }
-    - { N: 32, lda: 32 }
-    - { N: 65, lda: 65 }
+    - { N: 65, lda: 68 }
 
   - &incx_range
-    - [ -1, 0, 2 ]
+    - [ -2 ]
 
   - &alpha_range
-    - [ -0.5, 2.0, 0.0 ]
+    - [ 2.0 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: syr_general

--- a/clients/gtest/blas2/tbmv_gtest.yaml
+++ b/clients/gtest/blas2/tbmv_gtest.yaml
@@ -4,16 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M: -1, K: -1, lda: -1 }
-    - { M: 11, K:  5, lda: 11 }
-    - { M: 16, K:  8, lda: 16 }
-    - { M: 32, K: 16, lda: 32 }
-    - { M: 65, K: 64, lda: 65 }
+    - { M: 65, K: 59, lda: 68 }
 
   - &incx_range
-    - [ -1, 0, 2 ]
+    - [ -2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: tbmv_general
@@ -51,7 +48,7 @@ Tests:
     matrix_size: *size_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/tbsv_gtest.yaml
+++ b/clients/gtest/blas2/tbsv_gtest.yaml
@@ -4,17 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, K: -1, lda: -1 }
-    - { N: 11, K:  5, lda: 11 }
-    - { N: 16, K:  8, lda: 16 }
-    - { N: 32, K: 16, lda: 32 }
-    - { N: 65, K: 64, lda: 65 }
+    - { M: 65, K: 59, lda: 68 }
 
   - &incx_range
-    - [ -1, 0, 2 ]
-
+    - [ -2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: tbsv_general
@@ -52,7 +48,7 @@ Tests:
     matrix_size: *size_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/tpmv_gtest.yaml
+++ b/clients/gtest/blas2/tpmv_gtest.yaml
@@ -3,13 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 11, 16, 32, 65 ]
+    - [ -1, 65 ]
 
   - &incx_range
-    - [ -1, 0, 2 ]
+    - [ -2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: tpmv_general
@@ -47,7 +47,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/tpsv_gtest.yaml
+++ b/clients/gtest/blas2/tpsv_gtest.yaml
@@ -3,13 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 11, 16, 32, 65 ]
+    - [ -1, 65 ]
 
   - &incx_range
-    - [ -2, 1, 0, 2 ]
+    - [ -2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: tpsv_general
@@ -47,7 +47,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/trmv_gtest.yaml
+++ b/clients/gtest/blas2/trmv_gtest.yaml
@@ -4,16 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, lda: -1 }
-    - { N: 11, lda: 11 }
-    - { N: 16, lda: 16 }
-    - { N: 32, lda: 32 }
-    - { N: 65, lda: 65 }
+    - { N: 65, lda: 68 }
 
   - &incx_range
-    - [ -2, 1, 0, 2 ]
+    - [ -2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: trmv_general
@@ -51,7 +48,7 @@ Tests:
     matrix_size: *size_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas2/trsv_gtest.yaml
+++ b/clients/gtest/blas2/trsv_gtest.yaml
@@ -4,16 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, lda: -1 }
-    - { N: 11, lda: 11 }
-    - { N: 16, lda: 16 }
-    - { N: 32, lda: 32 }
-    - { N: 65, lda: 65 }
+    - { N: 65, lda: 68 }
 
   - &incx_range
-    [ -2, 1, 0, 2 ]
+    [ -2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: trsv_general
@@ -51,7 +48,7 @@ Tests:
     matrix_size: *size_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/dgmm_gtest.yaml
+++ b/clients/gtest/blas3/dgmm_gtest.yaml
@@ -3,15 +3,14 @@ include: hipblas_common.yaml
 
 Definitions:
   - &size_range
-    - { M:   -1, N:   -1, lda:   -1, ldc:   -1 }
-    - { M:  128, N:  128, lda:  150, ldc:  130 }
-    - { M: 1000, N: 1000, lda: 1000, ldc: 1000 }
+    - { M:  -1, N:  -1, lda:  -1, ldc:  -1 }
+    - { M: 100, N: 100, lda: 200, ldc: 300 }
 
   - &incx_range
-    - [ -1, 2 ]
+    - [ -2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: dgmm_general
@@ -42,7 +41,7 @@ Tests:
     matrix_size: *size_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/geam_gtest.yaml
+++ b/clients/gtest/blas3/geam_gtest.yaml
@@ -3,20 +3,14 @@ include: hipblas_common.yaml
 
 Definitions:
   - &size_range
-    - { M:  -1, N:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { M:   5, N:   5, lda:   5, ldb:   5, ldc:   5 }
-    - { M:   3, N:  33, lda:  33, ldb:  34, ldc:  35 }
-    - { M:  10, N:  10, lda: 100, ldb:  10, ldc:  10 }
-    - { M: 600, N: 500, lda: 500, ldb: 600, ldc: 500 }
+    - { M: -1, N: -1, lda:  -1, ldb:  -1, ldc:  -1 }
+    - { M: 60, N: 50, lda: 100, ldb: 200, ldc: 300 }
 
   - &alpha_beta_range
-    - { alpha: 2.0, alphai: -3.0, beta: 0.0, betai:  0.0 }
-    - { alpha: 3.0, alphai:  1.0, beta: 1.0, betai: -1.0 }
-    - { alpha: 0.0, alphai:  0.0, beta: 2.0, betai: -5.0 }
-    - { alpha: 0.0, alphai:  0.0, beta: 0.0, betai:  0.0 }
+    - { alpha: 2.0, alphai: -3.0, beta: 3.0, betai:  -1.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: geam_general
@@ -50,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/gemm_gtest.yaml
+++ b/clients/gtest/blas3/gemm_gtest.yaml
@@ -4,19 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M:  -1, N:  -1, K: 33, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { M:   5, N:   5, K: 33, lda:   5, ldb:   5, ldc:   5 }
-    - { M:   3, N:  33, K: 33, lda:  33, ldb:  34, ldc:  35 }
-    - { M:  10, N:  10, K: 33, lda: 100, ldb:  10, ldc:  10 }
-    - { M: 600, N: 500, K: 33, lda: 500, ldb: 600, ldc: 500 }
+    - { M: 600, N: 500, K: 33, lda: 500, ldb: 600, ldc: 501 }
 
   - &alpha_beta_range
-    - { alpha: 2.0, alphai: -3.0, beta: 0.0, betai:  0.0 }
-    - { alpha: 3.0, alphai:  1.0, beta: 1.0, betai: -1.0 }
-    - { alpha: 0.0, alphai:  0.0, beta: 2.0, betai: -5.0 }
-    - { alpha: 0.0, alphai:  0.0, beta: 0.0, betai:  0.0 }
+    - { alpha: 2.0, alphai: -3.0, beta: 2.0, betai:  -1.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: gemm_general
@@ -50,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/hemm_gtest.yaml
+++ b/clients/gtest/blas3/hemm_gtest.yaml
@@ -4,16 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M:  -1, N:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { M:   5, N:   5, lda:   5, ldb:   5, ldc:   5 }
-    - { M:   3, N:  33, lda:  33, ldb:  34, ldc:  35 }
-    - { M:  10, N:  10, lda: 100, ldb:  10, ldc:  10 }
-    - { M: 600, N: 500, lda: 500, ldb: 600, ldc: 500 }
+    - { M: 600, N: 500, lda: 500, ldb: 600, ldc: 501 }
 
   - &alpha_beta_range
     - { alpha: -5.0, alphai: 2.0, beta: 3.0, betai: -2.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: hemm_general
@@ -47,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/her2k_gtest.yaml
+++ b/clients/gtest/blas3/her2k_gtest.yaml
@@ -4,18 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, K: -1, lda: -1, ldc: -1 }
-    - { N: 11, K:  6, lda: 11, ldc: 11 }
-    - { N: 16, K: 15, lda: 33, ldc: 35 }
-    - { N: 32, K: 12, lda: 32, ldc: 33 }
-    - { N: 65, K:  4, lda: 65, ldc: 65 }
+    - { N: 65, K:  4, lda: 67, ldc: 68 }
 
   - &alpha_beta_range
-    - { alpha: -0.5, alphai: 1.5, beta: 2.0, betai: 1.5 }
     - { alpha:  2.0, alphai: 1.0, beta: 2.0, betai: 1.0 }
-    - { alpha:  0.0, alphai: 0.0, beta: 0.0, betai: 0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: her2k_general
@@ -49,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/herk_gtest.yaml
+++ b/clients/gtest/blas3/herk_gtest.yaml
@@ -4,18 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, K: -1, lda: -1, ldc: -1 }
-    - { N: 11, K:  6, lda: 11, ldc: 11 }
-    - { N: 16, K: 15, lda: 33, ldc: 35 }
-    - { N: 32, K: 12, lda: 32, ldc: 33 }
-    - { N: 65, K:  4, lda: 65, ldc: 65 }
+    - { N: 65, K:  4, lda: 67, ldc: 68 }
 
   - &alpha_beta_range
-    - { alpha: -0.5, alphai: 1.5, beta: 2.0, betai: 1.5 }
     - { alpha:  2.0, alphai: 1.0, beta: 2.0, betai: 1.0 }
-    - { alpha:  0.0, alphai: 0.0, beta: 0.0, betai: 0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: herk_general
@@ -49,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/herkx_gtest.yaml
+++ b/clients/gtest/blas3/herkx_gtest.yaml
@@ -4,18 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N: -1, K: -1, lda: -1, ldc: -1 }
-    - { N: 11, K:  6, lda: 11, ldc: 11 }
-    - { N: 16, K: 15, lda: 33, ldc: 35 }
-    - { N: 32, K: 12, lda: 32, ldc: 33 }
-    - { N: 65, K:  4, lda: 65, ldc: 65 }
+    - { N: 65, K:  4, lda: 67, ldc: 68 }
 
   - &alpha_beta_range
-    - { alpha: -0.5, alphai: 1.5, beta: 2.0, betai: 1.5 }
     - { alpha:  2.0, alphai: 1.0, beta: 2.0, betai: 1.0 }
-    - { alpha:  0.0, alphai: 0.0, beta: 0.0, betai: 0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: herkx_general
@@ -49,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/symm_gtest.yaml
+++ b/clients/gtest/blas3/symm_gtest.yaml
@@ -4,14 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M:  -1, N:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { M:   3, N:  33, lda:  33, ldb:  34, ldc:  35 }
-    - { M: 600, N: 500, lda: 500, ldb: 600, ldc: 500 }
+    - { M: 600, N: 500, lda: 500, ldb: 600, ldc: 501 }
 
   - &alpha_beta_range
     - { alpha: 2.0, alphai: -3.0, beta: 0.0, betai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: symm_general
@@ -45,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/syr2k_gtest.yaml
+++ b/clients/gtest/blas3/syr2k_gtest.yaml
@@ -4,13 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N:  -1, K:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { N: 600, K: 500, lda: 600, ldb: 601, ldc: 602 }
+    - { M: 600, N: 500, lda: 500, ldb: 600, ldc: 501 }
 
   - &alpha_beta_range
     - { alpha: 2.0, alphai: -3.0, beta: 0.0, betai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: syr2k_general
@@ -44,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/syrk_gtest.yaml
+++ b/clients/gtest/blas3/syrk_gtest.yaml
@@ -4,13 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N:  -1, K:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { N: 600, K: 500, lda: 600, ldb: 601, ldc: 602 }
+    - { M: 600, N: 500, lda: 500, ldb: 600, ldc: 501 }
 
   - &alpha_beta_range
     - { alpha: 2.0, alphai: -3.0, beta: 0.0, betai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: syrk_general
@@ -44,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/syrkx_gtest.yaml
+++ b/clients/gtest/blas3/syrkx_gtest.yaml
@@ -4,13 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N:  -1, K:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { N: 600, K: 500, lda: 600, ldb: 601, ldc: 602 }
+    - { M: 600, N: 500, lda: 500, ldb: 600, ldc: 501 }
 
   - &alpha_beta_range
     - { alpha: 2.0, alphai: -3.0, beta: 0.0, betai:  0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: syrkx_general
@@ -44,7 +44,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/trmm_gtest.yaml
+++ b/clients/gtest/blas3/trmm_gtest.yaml
@@ -3,15 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &size_range
-    - { M:  -1, N:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { M:  10, N:  10, lda:  20, ldb: 100, ldc: 150 }
-    - { M: 192, N: 192, lda: 192, ldb: 192, ldc: 192 }
+    - { M: 92, N: 100, lda: 300, ldb: 302, ldc: 305 }
 
   - &alpha_range
     - { alpha: 2.0, alphai: -3.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: trmm_general
@@ -51,7 +49,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/trsm_gtest.yaml
+++ b/clients/gtest/blas3/trsm_gtest.yaml
@@ -3,15 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &size_range
-    - { M:  -1, N:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { M:  10, N:  10, lda:  20, ldb: 100, ldc: 150 }
-    - { M: 192, N: 192, lda: 192, ldb: 192, ldc: 192 }
+    - { M: 92, N: 100, lda: 300, ldb: 302, ldc: 305 }
 
   - &alpha_range
     - { alpha: 2.0, alphai: -3.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: trsm_general
@@ -51,7 +49,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas3/trtri_gtest.yaml
+++ b/clients/gtest/blas3/trtri_gtest.yaml
@@ -4,14 +4,10 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { N:  -1, lda:  -1, ldb:  -1 }
-    - { N:  10, lda:  20, ldb: 100 }
-    - { N:  20, lda: 160, ldb: 192 }
-    - { N:  21, lda:  14, ldb:  21 }
-    - { N:  32, lda:  32, ldb:  33 }
     - { N: 111, lda: 122, ldb: 133 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 0, 5 ]
 
 Tests:
   - name: trtri_general
@@ -43,7 +39,7 @@ Tests:
     diag: [ 'N', 'U' ]
     matrix_size: *size_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 

--- a/clients/gtest/blas_ex/axpy_ex_gtest.yaml
+++ b/clients/gtest/blas_ex/axpy_ex_gtest.yaml
@@ -3,18 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_incy_range
-    - { incx:  1, incy:  1 }
     - { incx:  2, incy:  3 }
-    - { incx: -1, incy: -1 }
 
   - &alpha_beta_range
     - { alpha: 2.0, alphai:  2.0, beta:  0.0, betai: 0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ 0, 5 ]
 
 Tests:
   - name: axpy_ex_general
@@ -57,7 +55,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas_ex/dot_ex_gtest.yaml
+++ b/clients/gtest/blas_ex/dot_ex_gtest.yaml
@@ -3,15 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_incy_range
-    - { incx:  1, incy:  1 }
     - { incx:  1, incy:  2 }
-    - { incx: -1, incy: -1 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ 0, 5 ]
 
 Tests:
   - name: dot_ex_general_all
@@ -52,7 +50,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas_ex/gemm_ex_gtest.yaml
+++ b/clients/gtest/blas_ex/gemm_ex_gtest.yaml
@@ -4,15 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M:  -1, N:  -1, K: 33, lda:  33, ldb:  33, ldc:  -1 }
-    - { M:   5, N:   5, K: 33, lda:  33, ldb:  34, ldc:   5 }
-    - { M:   3, N:  33, K: 33, lda:  34, ldb:  33, ldc:  35 }
     - { M:  10, N:  10, K: 33, lda: 100, ldb:  35, ldc:  10 }
 
   - &alpha_beta_range
     - { alpha: 3.0, alphai:  1.0, beta: 1.0, betai: -1.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
   - &gemm_flags
     - [ 0, 4 ]
@@ -71,7 +69,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_beta_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
 
   - name: gemm_ex_bad_arg

--- a/clients/gtest/blas_ex/nrm2_ex_gtest.yaml
+++ b/clients/gtest/blas_ex/nrm2_ex_gtest.yaml
@@ -3,13 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_range
-    - [-1, 1 ]
+    - [ 2 ]
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ 0, 5 ]
 
 Tests:
   - name: nrm2_ex_general
@@ -37,7 +37,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas_ex/rot_ex_gtest.yaml
+++ b/clients/gtest/blas_ex/rot_ex_gtest.yaml
@@ -3,15 +3,13 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_incy_range
-    - { incx:  1, incy:  1 }
-    - { incx:  1, incy:  2 }
-    - { incx: -1, incy: -1 }
+    - { incx:  2, incy:  3 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ 0, 5 ]
 
 Tests:
   # rot
@@ -40,7 +38,7 @@ Tests:
     N: *N_range
     incx_incy: *incx_incy_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas_ex/scal_ex_gtest.yaml
+++ b/clients/gtest/blas_ex/scal_ex_gtest.yaml
@@ -3,16 +3,16 @@ include: hipblas_common.yaml
 
 Definitions:
   - &N_range
-    - [ -1, 10, 500, 1000, 7111, 10000 ]
+    - [ -1, 0, 1000 ]
 
   - &incx_range
-    - [-1, 1 ]
+    - [ 1 ]
 
   - &alpha_beta_range
     - { alpha: 2.0, alphai:  2.0, beta:  0.0, betai: 0.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 2, 10 ]
+    - [ 0, 5 ]
 
 Tests:
   - name: scal_ex_general
@@ -55,7 +55,7 @@ Tests:
     N: *N_range
     incx: *incx_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C, FORTRAN_64, C_64 ]
     backend_flags: AMD
 

--- a/clients/gtest/blas_ex/trsm_ex_gtest.yaml
+++ b/clients/gtest/blas_ex/trsm_ex_gtest.yaml
@@ -4,14 +4,13 @@ include: hipblas_common.yaml
 Definitions:
   - &size_range
     - { M:  -1, N:  -1, lda:  -1, ldb:  -1, ldc:  -1 }
-    - { M:  10, N:  10, lda:  20, ldb: 100, ldc: 150 }
-    - { M: 192, N: 192, lda: 192, ldb: 192, ldc: 192 }
+    - { M: 192, N: 180, lda: 201, ldb: 205, ldc: 208 }
 
   - &alpha_range
     - { alpha: 2.0, alphai: -3.0 }
 
   - &batch_count_range
-    - [ -1, 0, 1, 5 ]
+    - [ -1, 5 ]
 
 Tests:
   - name: trsm_ex_general
@@ -52,7 +51,7 @@ Tests:
     matrix_size: *size_range
     alpha_beta: *alpha_range
     batch_count: *batch_count_range
-    stride_scale: [ 1.0, 2.5 ]
+    stride_scale: [ 2.5 ]
     api: [ FORTRAN, C ]
     backend_flags: AMD
 


### PR DESCRIPTION
Greatly reduce the number of tests and the size of the tests in hipBLAS. We don't need to test a bunch of sizes here, just one or two to make sure the API is passing in the arguments correctly. I don't think the changes here should really reduce coverage w.r.t. hipblas.

On my local gfx906 (without solver tests):

| executable | develop # tests | develop time | new # tests | new time |
| --- | --- | --- | --- | --- |
| hipblas-test | 702893 | 84m | 39769 | 115s |
| hipblas_v2-test | 351456 | 38m | 19886 | 60s |
