### PR TITLE
Add LLVM_DEFAULT_TARGET_TRIPLE to find new location of -lomp

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -118,11 +118,23 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   # if there is no omp.h to find the client compilation will fail and this should be obvious, used to be REQUIRED
   find_package(OpenMP)
 
+  execute_process (
+    COMMAND bash -c "${HIP_CLANG_ROOT}/bin/clang --version | grep -oP '(?<=Target: ).+' | tr -d '\n'"
+    OUTPUT_VARIABLE LLVM_DEFAULT_TARGET_TRIPLE)
+
   if (TARGET OpenMP::OpenMP_CXX)
     set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
     if(HIP_PLATFORM STREQUAL amd)
+      if (NOT WIN32)
+        if(LLVM_DEFAULT_TARGET_TRIPLE)
+          list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib/${LLVM_DEFAULT_TARGET_TRIPLE}\"")
+        endif()
+      endif()
       list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
       if (NOT WIN32)
+        if(LLVM_DEFAULT_TARGET_TRIPLE)
+          list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib/${LLVM_DEFAULT_TARGET_TRIPLE}")
+        endif()
         list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib -lomp")
       else()
         list( APPEND COMMON_LINK_LIBS "libomp")

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -118,14 +118,13 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   # if there is no omp.h to find the client compilation will fail and this should be obvious, used to be REQUIRED
   find_package(OpenMP)
 
-  execute_process (
-    COMMAND bash -c "${HIP_CLANG_ROOT}/bin/clang --version | grep -oP '(?<=Target: ).+' | tr -d '\n'"
-    OUTPUT_VARIABLE LLVM_DEFAULT_TARGET_TRIPLE)
-
   if (TARGET OpenMP::OpenMP_CXX)
     set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
     if(HIP_PLATFORM STREQUAL amd)
       if (NOT WIN32)
+        execute_process (
+          COMMAND bash -c "${HIP_CLANG_ROOT}/bin/clang --version | grep -oP '(?<=Target: ).+' | tr -d '\n'"
+          OUTPUT_VARIABLE LLVM_DEFAULT_TARGET_TRIPLE)
         if(LLVM_DEFAULT_TARGET_TRIPLE)
           list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib/${LLVM_DEFAULT_TARGET_TRIPLE}\"")
         endif()

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -122,9 +122,11 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
     if(HIP_PLATFORM STREQUAL amd)
       if (NOT WIN32)
-        execute_process (
-          COMMAND bash -c "${HIP_CLANG_ROOT}/bin/amdclang --version | grep -oP '(?<=Target: ).+' | tr -d '\n'"
-          OUTPUT_VARIABLE LLVM_DEFAULT_TARGET_TRIPLE)
+        execute_process(
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          COMMAND bash -c "${HIP_CLANG_ROOT}/bin/amdclang --version | grep -oP '(?<=Target: ).+'"
+          OUTPUT_VARIABLE LLVM_DEFAULT_TARGET_TRIPLE
+        )
         if(LLVM_DEFAULT_TARGET_TRIPLE)
           list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib/${LLVM_DEFAULT_TARGET_TRIPLE}\"")
         endif()

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -123,7 +123,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     if(HIP_PLATFORM STREQUAL amd)
       if (NOT WIN32)
         execute_process (
-          COMMAND bash -c "${HIP_CLANG_ROOT}/bin/clang --version | grep -oP '(?<=Target: ).+' | tr -d '\n'"
+          COMMAND bash -c "${HIP_CLANG_ROOT}/bin/amdclang --version | grep -oP '(?<=Target: ).+' | tr -d '\n'"
           OUTPUT_VARIABLE LLVM_DEFAULT_TARGET_TRIPLE)
         if(LLVM_DEFAULT_TARGET_TRIPLE)
           list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib/${LLVM_DEFAULT_TARGET_TRIPLE}\"")


### PR DESCRIPTION
Summary of proposed changes:
An upstream llvm change enables ```LLVM_ENABLE_PER_TARGET_RUNTIME_DIR``` by default for the openmp
build. This installs the openmp libraries into ```/opt/rocm-ver/llvm/lib/x86_64-unknown-linux-gnu``` instead of
```/opt/rocm-ver/llvm/lib```. Currenty, hipBLAS only looks in /lib. Prepend lib/x86_64-unknown-linux-gnu to ```-L``` and ```--rpath``` to avoid a linker error when the upstream change lands in ```amd-staging```.
