### PR TITLE
Remove immintrin header

### DIFF
--- a/clients/include/hipblas_arguments.hpp
+++ b/clients/include/hipblas_arguments.hpp
@@ -30,7 +30,6 @@
 #include "hipblas_datatype2string.hpp"
 #include "utility.h"
 #include <cmath>
-#include <immintrin.h>
 #include <random>
 #include <stdio.h>
 #include <stdlib.h>

--- a/clients/include/type_utils.h
+++ b/clients/include/type_utils.h
@@ -30,7 +30,6 @@
 #include "complex.hpp"
 #include <cmath>
 #include <cstdio>
-#include <immintrin.h>
 #include <iostream>
 #include <random>
 #include <type_traits>


### PR DESCRIPTION
This header provides x86 intrinsics, but is not used within the hipblas clients.
