### PR TITLE
Link hip::host as PUBLIC

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -81,7 +81,8 @@ if(HIP_PLATFORM STREQUAL amd)
   endif( )
 
   list(APPEND static_depends PACKAGE rocblas)
-  target_link_libraries( hipblas PRIVATE roc::rocblas hip::host )
+  target_link_libraries( hipblas PRIVATE roc::rocblas )
+  target_link_libraries( hipblas PUBLIC hip::host )
 
   # Add rocSOLVER as a dependency if BUILD_WITH_SOLVER is on
   if( BUILD_WITH_SOLVER )


### PR DESCRIPTION
The hipblas library includes HIP headers in its public headers, so it should link hip::host as PUBLIC. This will ensure that the HIP runtime include paths are passed to any library that links against roc::hipblas.