### PR TITLE
docs: fix broken contributing link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ The hipBLAS documentation is structured as follows:
     * :ref:`api_label`
     * :ref:`deprecations`
 
-To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/index.html>`_.
+To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 
 You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.
 


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- Fix broken contributing link in `docs/index.rst`
-
-
