### PR TITLE
Revamp how libomp.so is found

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -136,14 +136,15 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     endif()
   endif()
 
-  if(HIP_PLATFORM STREQUAL amd)
-    if(LIBOMP_FOUND)
-      set( COMMON_LINK_LIBS ${LIBOMP_FOUND})
-      if (NOT WIN32)
-        list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${LIBOMP_PATH}")
-      endif()
-    # If cmake cannot find the proper libomp.so, use HIP_CLANG_ROOT as fallback.
-    else()
+  if(LIBOMP_FOUND)
+    # LIBOMP_FOUND will contain full path to libomp.so
+    set( COMMON_LINK_LIBS ${LIBOMP_FOUND})
+    if(HIP_PLATFORM STREQUAL amd AND NOT WIN32)
+      list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${LIBOMP_PATH}")
+    endif()
+  # If cmake cannot find the proper libomp.so, use HIP_CLANG_ROOT as fallback.
+  else()
+    if(HIP_PLATFORM STREQUAL amd)
       # Add library search paths.
       list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib/${LLVM_TARGET_TRIPLE}\"")
       list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -124,13 +124,17 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     endif()
   # Support for using gnu as cmake compiler.
   else()
+    # Discover path to amdclang
+    get_filename_component(AMDCLANG_PATH "${HIP_HIPCC_EXECUTABLE}/../amdclang" REALPATH)
+    get_filename_component(AMDCLANG_DIR "${AMDCLANG_PATH}" DIRECTORY)
+    set(AMDCLANG_LIBDIR "${AMDCLANG_DIR}/../lib")
     # libomp.so may be in a target subdirectory directory.
     execute_process(
       OUTPUT_STRIP_TRAILING_WHITESPACE
-      COMMAND bash -c "${HIP_CLANG_ROOT}/bin/amdclang --version | grep -oP '(?<=Target: ).+'"
+      COMMAND bash -c "${AMDCLANG_DIR}/amdclang --version | grep -oP '(?<=Target: ).+'"
       OUTPUT_VARIABLE LLVM_TARGET_TRIPLE
     )
-    find_library(LIBOMP_FOUND omp PATHS ${HIP_CLANG_ROOT}/lib PATH_SUFFIXES ${LLVM_TARGET_TRIPLE} NO_DEFAULT_PATH)
+    find_library(LIBOMP_FOUND omp PATHS ${AMDCLANG_LIBDIR} PATH_SUFFIXES ${LLVM_TARGET_TRIPLE} NO_DEFAULT_PATH)
     if (LIBOMP_FOUND)
       get_filename_component(LIBOMP_PATH "${LIBOMP_FOUND}" PATH)
     endif()
@@ -139,22 +143,20 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   if(LIBOMP_FOUND)
     # LIBOMP_FOUND will contain full path to libomp.so
     set( COMMON_LINK_LIBS ${LIBOMP_FOUND})
-    if(HIP_PLATFORM STREQUAL amd AND NOT WIN32)
+    if(NOT WIN32)
       list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${LIBOMP_PATH}")
     endif()
   # If cmake cannot find the proper libomp.so, use HIP_CLANG_ROOT as fallback.
   else()
-    if(HIP_PLATFORM STREQUAL amd)
-      # Add library search paths.
-      list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib/${LLVM_TARGET_TRIPLE}\"")
-      list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
-      if(NOT WIN32)
-        # Add rpath.
-        list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib/${LLVM_TARGET_TRIPLE}")
-        list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib -lomp")
-      else()
-        list( APPEND COMMON_LINK_LIBS "libomp")
-      endif()
+    # Add library search paths.
+    list( APPEND COMMON_LINK_LIBS "-L\"${AMDCLANG_LIBDIR}/${LLVM_TARGET_TRIPLE}\"")
+    list( APPEND COMMON_LINK_LIBS "-L\"${AMDCLANG_LIBDIR}\"")
+    if(NOT WIN32)
+      # Add rpath.
+      list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${AMDCLANG_LIBDIR}/${LLVM_TARGET_TRIPLE}")
+      list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${AMDCLANG_LIBDIR} -lomp")
+    else()
+      list( APPEND COMMON_LINK_LIBS "libomp")
     endif()
   endif()
 

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -116,13 +116,40 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
 
   # if it fails to find OpenMP compile and link flags in strange configurations it can just use non-parallel reference computation
   # if there is no omp.h to find the client compilation will fail and this should be obvious, used to be REQUIRED
-  find_package(OpenMP)
+  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
+    find_package(OpenMP)
+    if (TARGET OpenMP::OpenMP_CXX)
+      set( LIBOMP_FOUND OpenMP::OpenMP_CXX)
+      get_filename_component(LIBOMP_PATH "${OpenMP_omp_LIBRARY}" PATH)
+    endif()
+  # Support for using gnu as cmake compiler.
+  else()
+    # libomp.so may be in a target subdirectory directory.
+    execute_process(
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      COMMAND bash -c "${HIP_CLANG_ROOT}/bin/amdclang --version | grep -oP '(?<=Target: ).+'"
+      OUTPUT_VARIABLE LLVM_TARGET_TRIPLE
+    )
+    find_library(LIBOMP_FOUND omp PATHS ${HIP_CLANG_ROOT}/lib PATH_SUFFIXES ${LLVM_TARGET_TRIPLE} NO_DEFAULT_PATH)
+    if (LIBOMP_FOUND)
+      get_filename_component(LIBOMP_PATH "${LIBOMP_FOUND}" PATH)
+    endif()
+  endif()
 
-  if (TARGET OpenMP::OpenMP_CXX)
-    set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
-    if(HIP_PLATFORM STREQUAL amd)
-      list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
+  if(HIP_PLATFORM STREQUAL amd)
+    if(LIBOMP_FOUND)
+      set( COMMON_LINK_LIBS ${LIBOMP_FOUND})
       if (NOT WIN32)
+        list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${LIBOMP_PATH}")
+      endif()
+    # If cmake cannot find the proper libomp.so, use HIP_CLANG_ROOT as fallback.
+    else()
+      # Add library search paths.
+      list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib/${LLVM_TARGET_TRIPLE}\"")
+      list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
+      if(NOT WIN32)
+        # Add rpath.
+        list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib/${LLVM_TARGET_TRIPLE}")
         list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib -lomp")
       else()
         list( APPEND COMMON_LINK_LIBS "libomp")


### PR DESCRIPTION
An upstream llvm change enables
LLVM_ENABLE_PER_TARGET_RUNTIME_DIR by default for the openmp build. This installs the openmp libraries into
`/opt/rocm-ver/llvm/lib/x86_64-unknown-linux-gnu` instead of `/opt/rocm-ver/llvm/lib`. Currenty, hipBLAS only uses /lib.

Since hipBLAS uses gcc by default, `find_package(OpenMP)` will locate libgomp from the gnu installation. We would prefer to use libomp from the ROCm install. Query amdclang to find LLVM_TARGET_TRIPLE and use as a suffix for `find_library(omp)`.

On the other hand, the user can choose to use hipcc, which allows `find_package(OpenMP)` to properly locate libomp inside ROCm llvm.

To include legacy support, I left the hardcoded `-L HIP_CLANG_ROOT` as a fallback.

This would be much simpler if hipBLAS defaulted to hipcc as the cmake compiler.

Summary of proposed changes:
- If compiler is gcc, query amdclang for LLVM_TARGET_TRIPLE and use as suffix for `find_library(omp)`.
- If compiler is hipcc, use `find_package(OpenMP)`.
- If cmake cannot find libomp.so then fallback to using `-L HIP_CLANG_ROOT/lib`.
- Allow proper detection of new lib installation subdirectory (i.e. x86_64-unknown-linux-gnu).
- Removed dependency on `find_package(LLVM)` due to `rocm-llvm-dev/devel` not being installed by default on various operating systems, which would not have the cmake config files.
