### PR TITLE
Add hipblas-common as dep for Jenkins

### DIFF
--- a/.jenkins/multicompiler.groovy
+++ b/.jenkins/multicompiler.groovy
@@ -20,11 +20,11 @@ def runCI =
 
     if (env.BRANCH_NAME ==~ /PR-\d+/ && pullRequest.labels.contains("noSolver"))
     {
-        prj.libraryDependencies = ['rocBLAS']
+        prj.libraryDependencies = ['rocBLAS', 'hipBLAS-common']
     }
     else
     {
-        prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER']
+        prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER', 'hipBLAS-common']
     }
 
     // Define test architectures, optional rocm version argument is available

--- a/.jenkins/precheckin-cuda.groovy
+++ b/.jenkins/precheckin-cuda.groovy
@@ -17,7 +17,7 @@ def runCI =
 
     //customize for project
     prj.paths.build_command = buildCommand
-    prj.libraryDependencies = []
+    prj.libraryDependencies = ['hipBLAS-common']
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -17,11 +17,11 @@ def runCI =
 
     if (env.BRANCH_NAME ==~ /PR-\d+/ && pullRequest.labels.contains("noSolver"))
     {
-        prj.libraryDependencies = ['rocBLAS']
+        prj.libraryDependencies = ['rocBLAS', 'hipBLAS-common']
     }
     else
     {
-        prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER']
+        prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER', 'hipBLAS-common']
     }
 
     if (env.BRANCH_NAME ==~ /PR-\d+/ && pullRequest.labels.contains('hipcc'))

--- a/.jenkins/static.groovy
+++ b/.jenkins/static.groovy
@@ -18,11 +18,11 @@ def runCI =
 
     if (env.BRANCH_NAME ==~ /PR-\d+/ && pullRequest.labels.contains("noSolver"))
     {
-        prj.libraryDependencies = ['rocBLAS']
+        prj.libraryDependencies = ['rocBLAS', 'hipBLAS-common']
     }
     else
     {
-        prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER', 'rocPRIM']
+        prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocSOLVER', 'rocPRIM', 'hipBLAS-common']
     }
 
     // Define test architectures, optional rocm version argument is available


### PR DESCRIPTION
Summary of proposed changes:
- Use hipblas-common as dependency for Jenkins jobs
- Affected jobs includes
  - multicompiler
  - precheckin
  - precheckin cuda
  - static
