### PR TITLE
merge release-staging/rocm-rel-6.2 into develop and hipconfig path change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for hipBLAS is available at
 [https://rocm.docs.amd.com/projects/hipBLAS/en/latest/](https://rocm.docs.amd.com/projects/hipBLAS/en/latest/).
 
-## (Unreleased) hipBLAS 2.2.0
+## hipBLAS 2.2.0 for ROCm 6.2.0
 
 ### Additions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,11 @@ endif( )
 
 # Package specific CPACK vars
 if(HIP_PLATFORM STREQUAL amd)
-  rocm_package_add_dependencies(DEPENDS "rocblas >= 4.2.0" "rocsolver >= 3.26.0")
+  set(rocblas_minimum 4.2.0)
+  set(rocsolver_minimum 3.26.0)
+  rocm_package_add_dependencies(SHARED_DEPENDS "rocblas >= ${rocblas_minimum}" "rocsolver >= ${rocsolver_minimum}")
+  rocm_package_add_rpm_dependencies(STATIC_DEPENDS "rocblas-static-devel >= ${rocblas_minimum}" "rocsolver-static-devel >= ${rocsolver_minimum}")
+  rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocblas-static-dev >= ${rocblas_minimum}" "rocsolver-static-dev >= ${rocsolver_minimum}")
 endif( )
 
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md" )
@@ -301,4 +305,3 @@ if(BUILD_CODE_COVERAGE)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,14 @@ if (NOT WIN32)
     set( fortran_language "Fortran" )
 endif( )
 
-project( hipblas LANGUAGES CXX ${fortran_language} )
+# BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
+option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
+
+if( NOT BUILD_SHARED_LIBS )
+    project( hipblas LANGUAGES C CXX ${fortran_language} )
+else()
+    project( hipblas LANGUAGES CXX ${fortran_language} )
+endif()
 
 if (NOT python)
     set(python "python3") # default for linux
@@ -76,9 +83,6 @@ option( BUILD_WITH_SOLVER "Add additional functions from rocSOLVER" ON )
 if( BUILD_WITH_SOLVER )
     add_definitions( -D__HIP_PLATFORM_SOLVER__ )
 endif( )
-
-# BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
-option( BUILD_SHARED_LIBS "Build hipBLAS as a shared library" ON )
 
 # Deprecated USE_CUDA option
 if(DEFINED USE_CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,12 @@ if(DEFINED USE_CUDA)
 endif()
 
 # Hip headers required of all clients; clients use hip to allocate device memory
+if( NOT BUILD_SHARED_LIBS )
+    # potentially a bug in hip, if AMDGPU_TARGETS is not set, it uses amdgpu-arch to find
+    # archs on the machine, but doesn't work with static builds
+    # trying this workaround out for now
+    set (AMDGPU_TARGETS "gfx000")
+endif()
 find_package( hip CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm )
 
 # support for cuda backend with hip < 6.0

--- a/install.sh
+++ b/install.sh
@@ -567,7 +567,7 @@ fi
 
 # this can be removed and be done in rmake.py once --cuda flag support is gone
 if [[ "${build_cuda}" != true ]]; then
-  export HIP_PLATFORM="$(hipconfig --platform)"
+  export HIP_PLATFORM="$(${rocm_path}/bin/hipconfig --platform)"
 fi
 
 if [[ "${rmake_invoked}" == false ]]; then

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -483,6 +483,11 @@ typedef enum
     = 142, /**< Multiply general matrix by symmetric, Hermitian or triangular matrix on the right. */
     HIPBLAS_SIDE_BOTH = 143
 } hipblasSideMode_t;
+#elif __cplusplus >= 201103L
+static_assert(HIPBLAS_SIDE_LEFT == 141, "Inconsistent declaration of HIPBLAS_SIDE_LEFT");
+static_assert(HIPBLAS_SIDE_RIGHT == 142, "Inconsistent declaration of HIPBLAS_SIDE_RIGHT");
+static_assert(HIPBLAS_SIDE_BOTH == 143, "Inconsistent declaration of HIPBLAS_SIDE_BOTH");
+#endif // HIPBLAS_SIDE_MODE_DECLARED
 
 typedef enum
 {
@@ -493,12 +498,6 @@ typedef enum
     HIPBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION, /* see cuBLAS documentation, not supported in rocBLAS */
     HIPBLAS_TENSOR_OP_MATH /* DEPRECATED, use Tensor Core operations with cuBLAS backend */
 } hipblasMath_t;
-
-#elif __cplusplus >= 201103L
-static_assert(HIPBLAS_SIDE_LEFT == 141, "Inconsistent declaration of HIPBLAS_SIDE_LEFT");
-static_assert(HIPBLAS_SIDE_RIGHT == 142, "Inconsistent declaration of HIPBLAS_SIDE_RIGHT");
-static_assert(HIPBLAS_SIDE_BOTH == 143, "Inconsistent declaration of HIPBLAS_SIDE_BOTH");
-#endif // HIPBLAS_SIDE_MODE_DECLARED
 
 #ifdef HIPBLAS_V2
 


### PR DESCRIPTION
merge release-staging/rocm-rel-6.2 into develop plus changing path install.sh looks for hipconfig to potentially fix static CI failures; not sure if it'll work. Could potentially change CI to just use rmake.py instead.