### PR TITLE
Fixes for static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,12 @@ if(DEFINED USE_CUDA)
 endif()
 
 # Hip headers required of all clients; clients use hip to allocate device memory
+if( NOT BUILD_SHARED_LIBS )
+    # potentially a bug in hip, if AMDGPU_TARGETS is not set, it uses amdgpu-arch to find
+    # archs on the machine, but doesn't work with static builds
+    # trying this workaround out for now
+    set (AMDGPU_TARGETS "gfx000")
+endif()
 find_package( hip CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm )
 
 # support for cuda backend with hip < 6.0

--- a/install.sh
+++ b/install.sh
@@ -567,7 +567,7 @@ fi
 
 # this can be removed and be done in rmake.py once --cuda flag support is gone
 if [[ "${build_cuda}" != true ]]; then
-  export HIP_PLATFORM="$(hipconfig --platform)"
+  export HIP_PLATFORM="$(${rocm_path}/bin/hipconfig --platform)"
 fi
 
 if [[ "${rmake_invoked}" == false ]]; then


### PR DESCRIPTION
With this and #877, static builds should work. Will delete #873 and have simple merge back from 6.2 -> develop after these are in.