### PR TITLE
Using BUILD_SOLVER_TESTS cmake variable in prep of runtime solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ option( BUILD_VERBOSE "Output additional build information" OFF )
 
 option( BUILD_WITH_SOLVER "Add additional functions from rocSOLVER" ON )
 
+option(BUILD_SOLVER_TESTS "Build additional tests to cover LAPACK functionality provided by rocSOLVER with AMD backend" ON)
+
 if( BUILD_WITH_SOLVER )
     add_definitions( -D__HIP_PLATFORM_SOLVER__ )
 endif( )
@@ -124,7 +126,6 @@ if(BUILD_ADDRESS_SANITIZER)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -shared-libasan")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
 endif()
-
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
 option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -94,8 +94,9 @@ endif()
 
 if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_SAMPLES )
   if( NOT WIN32 )
-    if( BUILD_WITH_SOLVER )
+    if( BUILD_SOLVER_TESTS )
       add_library(hipblas_fortran_client STATIC ${hipblas_f90_source_clients_solver})
+
     else()
       add_library(hipblas_fortran_client STATIC ${hipblas_f90_source_clients_no_solver})
     endif()

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -100,6 +100,11 @@ target_compile_options(hipblas_v2-bench PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COMM
 target_compile_definitions( hipblas-bench PRIVATE HIPBLAS_BENCH ${COMMON_DEFINES} ${BLIS_DEFINES} )
 target_compile_definitions( hipblas_v2-bench PRIVATE HIPBLAS_BENCH ${COMMON_DEFINES} ${BLIS_DEFINES} HIPBLAS_V2 )
 
+if(BUILD_SOLVER_TESTS)
+  target_compile_definitions(hipblas-bench PRIVATE -DBUILD_SOLVER_TESTS)
+  target_compile_definitions(hipblas_v2-bench PRIVATE -DBUILD_SOLVER_TESTS)
+endif()
+
 target_link_libraries( hipblas-bench PRIVATE ${BLAS_LIBRARY} ${COMMON_LINK_LIBS} )
 target_link_libraries( hipblas_v2-bench PRIVATE ${BLAS_LIBRARY} ${COMMON_LINK_LIBS} )
 if (NOT WIN32)

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -3916,7 +3916,7 @@ void ref_trmm<hipblasDoubleComplex>(hipblasSideMode_t           side,
  * ===========================================================================
  */
 
-#ifdef __HIP_PLATFORM_SOLVER__
+#ifdef BUILD_SOLVER_TESTS
 
 class ipiv_wrapper : public host_vector<int64_t>
 {

--- a/clients/common/clients_common.cpp
+++ b/clients/common/clients_common.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -221,7 +221,7 @@
 #include "blas_ex/testing_trsm_ex.hpp"
 #include "blas_ex/testing_trsm_strided_batched_ex.hpp"
 // solver functions
-#ifdef __HIP_PLATFORM_SOLVER__
+#ifdef BUILD_SOLVER_TESTS
 #include "solver/testing_gels.hpp"
 #include "solver/testing_gels_batched.hpp"
 #include "solver/testing_gels_strided_batched.hpp"
@@ -459,7 +459,7 @@ void get_test_name(const Arguments& arg, std::string& name)
         {"trtri_batched", testname_trtri_batched},
         {"trtri_strided_batched", testname_trtri_strided_batched},
 
-#ifdef __HIP_PLATFORM_SOLVER__
+#ifdef BUILD_SOLVER_TESTS
         {"geqrf", testname_geqrf},
         {"geqrf_batched", testname_geqrf_batched},
         {"geqrf_strided_batched", testname_geqrf_strided_batched},
@@ -677,7 +677,7 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, float>{} || std::is_same
             {"trsm_strided_batched", testing_trsm_strided_batched<T>},
             {"trsm_strided_batched_ex", testing_trsm_strided_batched_ex<T>},
 
-#ifdef __HIP_PLATFORM_SOLVER__
+#ifdef BUILD_SOLVER_TESTS
             {"geqrf", testing_geqrf<T>},
             {"geqrf_batched", testing_geqrf_batched<T>},
             {"geqrf_strided_batched", testing_geqrf_strided_batched<T>},
@@ -899,7 +899,7 @@ struct perf_blas<
             {"trmm_batched", testing_trmm_batched<T>},
             {"trmm_strided_batched", testing_trmm_strided_batched<T>},
 
-#ifdef __HIP_PLATFORM_SOLVER__
+#ifdef BUILD_SOLVER_TESTS
             {"geqrf", testing_geqrf<T>},
             {"geqrf_batched", testing_geqrf_batched<T>},
             {"geqrf_strided_batched", testing_geqrf_strided_batched<T>},
@@ -934,34 +934,24 @@ struct perf_blas_axpy_ex<
     Tx,
     Ty,
     Tex,
-    std::enable_if_t<
-        (std::is_same_v<
-             Ta,
-             float> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
-        || (std::is_same_v<
-                Ta,
-                double> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
-        || (std::is_same_v<
-                Ta,
-                hipblasHalf> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
-        || (std::is_same_v<
-                Ta,
-                hipblasComplex> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
-        || (std::is_same_v<
-                Ta,
-                hipblasDoubleComplex> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
-        || (std::is_same_v<
-                Ta,
-                hipblasHalf> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Tex, float>)
-        || (std::is_same_v<
-                Ta,
-                float> && std::is_same_v<Tx, hipblasHalf> && std::is_same_v<Ta, Tex> && std::is_same_v<Tx, Ty>)
-        || (std::is_same_v<
-                Ta,
-                hipblasBfloat16> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Tex, float>)
-        || (std::is_same_v<
-                Ta,
-                float> && std::is_same_v<Tx, hipblasBfloat16> && std::is_same_v<Tx, Ty> && std::is_same_v<Ta, Tex>)>>
+    std::enable_if_t<(std::is_same_v<Ta, float> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty>
+                      && std::is_same_v<Ty, Tex>)
+                     || (std::is_same_v<Ta, double> && std::is_same_v<Ta, Tx>
+                         && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
+                     || (std::is_same_v<Ta, hipblasHalf> && std::is_same_v<Ta, Tx>
+                         && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
+                     || (std::is_same_v<Ta, hipblasComplex> && std::is_same_v<Ta, Tx>
+                         && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
+                     || (std::is_same_v<Ta, hipblasDoubleComplex> && std::is_same_v<Ta, Tx>
+                         && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
+                     || (std::is_same_v<Ta, hipblasHalf> && std::is_same_v<Ta, Tx>
+                         && std::is_same_v<Tx, Ty> && std::is_same_v<Tex, float>)
+                     || (std::is_same_v<Ta, float> && std::is_same_v<Tx, hipblasHalf>
+                         && std::is_same_v<Ta, Tex> && std::is_same_v<Tx, Ty>)
+                     || (std::is_same_v<Ta, hipblasBfloat16> && std::is_same_v<Ta, Tx>
+                         && std::is_same_v<Tx, Ty> && std::is_same_v<Tex, float>)
+                     || (std::is_same_v<Ta, float> && std::is_same_v<Tx, hipblasBfloat16>
+                         && std::is_same_v<Tx, Ty> && std::is_same_v<Ta, Tex>)>>
     : hipblas_test_valid
 {
     void operator()(const Arguments& arg)

--- a/clients/common/hipblas_template_specialization.cpp
+++ b/clients/common/hipblas_template_specialization.cpp
@@ -13798,7 +13798,7 @@ hipblasStatus_t hipblasZgeamStridedBatchedCast_64(hipblasHandle_t             ha
                                          batchCount);
 }
 
-#ifdef __HIP_PLATFORM_SOLVER__
+#ifdef BUILD_SOLVER_TESTS
 
 // getrf
 hipblasStatus_t hipblasCgetrfCast(

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -97,7 +97,7 @@ set(hipblas_test_source
   blas_ex/gemm_ex_gtest.cpp
 )
 
-if( BUILD_WITH_SOLVER )
+if( BUILD_SOLVER_TESTS )
   set( hipblas_solver_test_source
     solver/getrf_gtest.cpp
     solver/getrs_gtest.cpp
@@ -178,6 +178,11 @@ target_compile_options(hipblas_v2-test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COMMO
 
 target_compile_definitions( hipblas-test PRIVATE ${COMMON_DEFINES} )
 target_compile_definitions( hipblas_v2-test PRIVATE ${COMMON_DEFINES} HIPBLAS_V2 )
+
+if(BUILD_SOLVER_TESTS)
+  target_compile_definitions(hipblas-test PRIVATE -DBUILD_SOLVER_TESTS)
+  target_compile_definitions(hipblas_v2-test PRIVATE -DBUILD_SOLVER_TESTS)
+endif()
 
 target_link_libraries( hipblas-test PRIVATE ${BLAS_LIBRARY} ${COMMON_LINK_LIBS} )
 target_link_libraries( hipblas_v2-test PRIVATE ${BLAS_LIBRARY} ${COMMON_LINK_LIBS} )
@@ -275,7 +280,7 @@ set( HIPBLAS_L3_YAML_DATA blas3/dgmm_gtest.yaml blas3/geam_gtest.yaml blas3/gemm
 set( HIPBLAS_EX_YAML_DATA blas_ex/axpy_ex_gtest.yaml blas_ex/dot_ex_gtest.yaml blas_ex/nrm2_ex_gtest.yaml
                           blas_ex/rot_ex_gtest.yaml blas_ex/scal_ex_gtest.yaml blas_ex/gemm_ex_gtest.yaml blas_ex/trsm_ex_gtest.yaml )
 
-if( BUILD_WITH_SOLVER )
+if( BUILD_SOLVER_TESTS )
   set( HIPBLAS_SOLVER_YAML_DATA solver/gels_gtest.yaml solver/geqrf_gtest.yaml solver/getrf_gtest.yaml solver/getri_gtest.yaml solver/getrs_gtest.yaml )
 endif()
 

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -798,7 +798,7 @@ void ref_trmm(hipblasSideMode_t  side,
  * ===========================================================================
  */
 
-#ifdef __HIP_PLATFORM_SOLVER__
+#ifdef BUILD_SOLVER_TESTS
 
 // potrf
 template <typename T>

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -11884,7 +11884,7 @@ namespace
     MAP2CF_V2(hipblasTrtriStridedBatched, hipblasComplex, hipblasCtrtriStridedBatched);
     MAP2CF_V2(hipblasTrtriStridedBatched, hipblasDoubleComplex, hipblasZtrtriStridedBatched);
 
-#ifdef __HIP_PLATFORM_SOLVER__
+#ifdef BUILD_SOLVER_TESTS
 
     // getrf
     template <typename T, bool FORTRAN = false>

--- a/install.sh
+++ b/install.sh
@@ -391,6 +391,7 @@ install_dependencies=false
 install_prefix=hipblas-install
 build_clients=false
 build_solver=true
+build_solver_tests=true
 build_release=true
 install_cuda=false
 cuda_version_install=default
@@ -443,6 +444,7 @@ while true; do
         shift ;;
     -n|--no-solver)
         build_solver=false
+        build_solver_tests=false
         shift ;;
     -g|--debug)
         build_release=false

--- a/rmake.py
+++ b/rmake.py
@@ -292,11 +292,16 @@ def config_cmd():
         if os.environ['HIP_PLATFORM'] == 'amd':
             cmake_options.append( f"-DLINK_BLIS=ON")
 
-
+    # In an upcoming change, build_solver will be OFF by default, and rocSOLVER will not be
+    # enabled at build time. This will be overriden by a new rmake/install param --solver-at-buildtime (name TBD).
+    # The --no-solver flag will be changed to turn off the building of rocSOLVER tests and will not impact
+    # finding rocSOLVER at runtime.
     if args.build_solver:
-        cmake_options.append (f"-DBUILD_WITH_SOLVER=ON")
+        cmake_options.append(f"-DBUILD_WITH_SOLVER=ON")
+        cmake_options.append(f"-DBUILD_SOLVER_TESTS=ON")
     else:
         cmake_options.append(f"-DBUILD_WITH_SOLVER=OFF")
+        cmake_options.append(f"-DBUILD_SOLVER_TESTS=OFF")
 
     if args.rocblas_path is not None:
         # "Custom" rocblas


### PR DESCRIPTION
This change is in preparation for adding the feature of finding rocSOLVER at runtime using dlopen.

This change adds a new cmake option BUILD_SOLVER_TESTS to enable rocSOLVER tests. Currently in our install scripts, this simply follows BUILD_WITH_SOLVER which is disabled by the --no-solver flag. In a future commit, though, BUILD_WITH_SOLVER will be OFF by default, and will only specify whether solver should be found at buildtime. BUILD_SOLVER_TESTS will be ON by default, and the --no-solver flag will turn these tests off.

Will wait for #898 to go through to get new versioning, and will run CI with solver and w/o solver.