### PR TITLE
Cherrypick - Start using hipblas-common package (#889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ Documentation for hipBLAS is available at
 
 ## (Unreleased) hipBLAS 2.3.0
 
-### Added 
+### Added
 
-* Level 3 functions have additional ILP64 API for both C and FORTRAN (_64 name suffix) with int64_t function arguments. 
+* Level 3 functions have additional ILP64 API for both C and FORTRAN (_64 name suffix) with int64_t function arguments.
 
-### Changed 
+### Changed
 
-* amdclang used as default compiler instead of g++ 
+* amdclang used as default compiler instead of g++
 
 ## hipBLAS 2.2.0 for ROCm 6.2.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,9 @@ if(HIP_PLATFORM STREQUAL amd)
   rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocblas-static-dev >= ${rocblas_minimum}" "rocsolver-static-dev >= ${rocsolver_minimum}")
 endif( )
 
+set(hipblas_common_minimum 1.0.0)
+rocm_package_add_dependencies(DEPENDS "hipblas-common >= ${hipblas_common_minimum}")
+
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md" )
 set( CPACK_RPM_PACKAGE_LICENSE "MIT")
 

--- a/docs/install/Linux_Install_Guide.rst
+++ b/docs/install/Linux_Install_Guide.rst
@@ -14,6 +14,7 @@ Prerequisites
 * If using the rocBLAS backend on an AMD machine:
 
   * A ROCm enabled platform. Find more information on the :doc:`System requirements (Linux) <rocm-install-on-linux:reference/system-requirements>` page.
+  * A compatible version of hipblas-common.
   * A compatible version of rocBLAS.
   * A compatible version of rocSOLVER and its dependencies, rocSPARSE and rocPRIM, for full functionality.
 
@@ -161,8 +162,8 @@ in the table below.
 Dependencies for building library
 ==================================
 
-Use ``rmake.py`` with ``-d`` option to install dependencies required to build the library. This will not install the rocBLAS, rocSOLVER, rocSPARSE, and rocPRIM dependencies.
-When building hipBLAS it is important to note version dependencies of other libraries. The rocBLAS and rocSOLVER versions needed for an AMD backend build are listed in the top level CMakeLists.txt file.
+Use ``rmake.py`` with ``-d`` option to install dependencies required to build the library. This will not install the hipblas-common, rocBLAS, rocSOLVER, rocSPARSE, and rocPRIM dependencies.
+When building hipBLAS it is important to note version dependencies of other libraries. The hipblas-common, rocBLAS and rocSOLVER versions needed for an AMD backend build are listed in the top level CMakeLists.txt file.
 rocSPARSE and rocPRIM are currently dependencies of rocSOLVER. To build these libraries from source, please visit the :doc:`rocBLAS Documentation <rocBLAS:index>`,
 :doc:`rocSOLVER Documentation <rocSOLVER:index>`, :doc:`rocSPARSE Documentation <rocSPARSE:index>`, and :doc:`rocPRIM Documentation <rocPRIM:index>`.
 

--- a/docs/install/Windows_Install_Guide.rst
+++ b/docs/install/Windows_Install_Guide.rst
@@ -14,6 +14,7 @@ Prerequisites
 * If using the rocBLAS backend on an AMD machine:
 
   * An AMD HIP SDK enabled platform. Find more information on the :doc:`System requirements (Windows) <rocm-install-on-windows:reference/system-requirements>` page.
+  * A compatible version of hipblas-common.
   * A compatible version of rocBLAS.
   * A compatible version of rocSOLVER and its dependencies, rocSPARSE and rocPRIM, for full functionality.
   * hipBLAS is supported on the same Windows versions and toolchains that are supported by the HIP SDK.
@@ -196,8 +197,8 @@ in the table below.
 Dependencies for building library
 ==================================
 
-Use ``rmake.py`` with ``-d`` option to install dependencies required to build the library. This will not install the rocBLAS, rocSOLVER, rocSPARSE, and rocPRIM dependencies.
-When building hipBLAS it is important to note version dependencies of other libraries. The rocBLAS and rocSOLVER versions needed for an AMD backend build are listed in the top level CMakeLists.txt file.
+Use ``rmake.py`` with ``-d`` option to install dependencies required to build the library. This will not install the hipblas-common, rocBLAS, rocSOLVER, rocSPARSE, and rocPRIM dependencies.
+When building hipBLAS it is important to note version dependencies of other libraries. The hipblas-common, rocBLAS and rocSOLVER versions needed for an AMD backend build are listed in the top level CMakeLists.txt file.
 rocSPARSE and rocPRIM are currently dependencies of rocSOLVER. To build these libraries from source, please visit the :doc:`rocBLAS Documentation <rocBLAS:index>`,
 :doc:`rocSOLVER Documentation <rocSOLVER:index>`, :doc:`rocSPARSE Documentation <rocSPARSE:index>`, and :doc:`rocPRIM Documentation <rocPRIM:index>`.
 

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -37,6 +37,7 @@
 #include <hip/hip_complex.h>
 #include <hip/hip_runtime_api.h>
 #include <hip/library_types.h>
+#include <hipblas-common/hipblas-common.h>
 #include <stdint.h>
 
 #ifdef __HIP_PLATFORM_NVCC__
@@ -398,47 +399,12 @@ static_assert(sizeof(hipblasComplex) == sizeof(float) * 2
               "Sizes of hipblasComplex or hipblasDoubleComplex are inconsistent");
 #endif
 
-/*! \brief hipblas status codes definition */
-typedef enum
-{
-    HIPBLAS_STATUS_SUCCESS           = 0, /**< Function succeeds */
-    HIPBLAS_STATUS_NOT_INITIALIZED   = 1, /**< HIPBLAS library not initialized */
-    HIPBLAS_STATUS_ALLOC_FAILED      = 2, /**< resource allocation failed */
-    HIPBLAS_STATUS_INVALID_VALUE     = 3, /**< unsupported numerical value was passed to function */
-    HIPBLAS_STATUS_MAPPING_ERROR     = 4, /**< access to GPU memory space failed */
-    HIPBLAS_STATUS_EXECUTION_FAILED  = 5, /**< GPU program failed to execute */
-    HIPBLAS_STATUS_INTERNAL_ERROR    = 6, /**< an internal HIPBLAS operation failed */
-    HIPBLAS_STATUS_NOT_SUPPORTED     = 7, /**< function not implemented */
-    HIPBLAS_STATUS_ARCH_MISMATCH     = 8, /**< architecture mismatch */
-    HIPBLAS_STATUS_HANDLE_IS_NULLPTR = 9, /**< hipBLAS handle is null pointer */
-    HIPBLAS_STATUS_INVALID_ENUM      = 10, /**<  unsupported enum value was passed to function */
-    HIPBLAS_STATUS_UNKNOWN           = 11, /**<  back-end returned an unsupported status code */
-} hipblasStatus_t;
-
 /*! \brief Indicates if scalar pointers are on host or device. This is used for scalars alpha and beta and for scalar function return values. */
 typedef enum
 {
     HIPBLAS_POINTER_MODE_HOST, /**< Scalar values affected by this variable will be located on the host. */
     HIPBLAS_POINTER_MODE_DEVICE /**<  Scalar values affected by this variable will be located on the device. */
 } hipblasPointerMode_t;
-
-// set the values of enum constants to be the same as those used in cblas
-
-#ifndef HIPBLAS_OPERATION_DECLARED
-#define HIPBLAS_OPERATION_DECLARED
-/*! \brief Used to specify whether the matrix is to be transposed or not. */
-typedef enum
-{
-    HIPBLAS_OP_N = 111, /**<  Operate with the matrix. */
-    HIPBLAS_OP_T = 112, /**<  Operate with the transpose of the matrix. */
-    HIPBLAS_OP_C = 113 /**< Operate with the conjugate transpose of the matrix. */
-} hipblasOperation_t;
-
-#elif __cplusplus >= 201103L
-static_assert(HIPBLAS_OP_N == 111, "Inconsistent declaration of HIPBLAS_OP_N");
-static_assert(HIPBLAS_OP_T == 112, "Inconsistent declaration of HIPBLAS_OP_T");
-static_assert(HIPBLAS_OP_C == 113, "Inconsistent declaration of HIPBLAS_OP_C");
-#endif // HIPBLAS_OPERATION_DECLARED
 
 #ifndef HIPBLAS_FILL_MODE_DECLARED
 #define HIPBLAS_FILL_MODE_DECLARED
@@ -552,26 +518,6 @@ typedef enum
 } hipblasDatatype_t;
 
 #endif
-
-/*! \brief The compute type to be used. Currently only used with GemmEx with the HIPBLAS_V2 interface.
- *         Note that support for compute types is largely dependent on backend. */
-typedef enum
-{
-    // Note that these types are taken from cuBLAS. With the rocBLAS backend, currently hipBLAS will
-    // convert to rocBLAS types to get equivalent functionality where supported.
-    HIPBLAS_COMPUTE_16F           = 0, /**< compute will be at least 16-bit precision */
-    HIPBLAS_COMPUTE_16F_PEDANTIC  = 1, /**< compute will be exactly 16-bit precision */
-    HIPBLAS_COMPUTE_32F           = 2, /**< compute will be at least 32-bit precision */
-    HIPBLAS_COMPUTE_32F_PEDANTIC  = 3, /**< compute will be exactly 32-bit precision */
-    HIPBLAS_COMPUTE_32F_FAST_16F  = 4, /**< 32-bit input can use 16-bit compute */
-    HIPBLAS_COMPUTE_32F_FAST_16BF = 5, /**< 32-bit input can is bf16 compute */
-    HIPBLAS_COMPUTE_32F_FAST_TF32
-    = 6, /**< 32-bit input can use tensor cores w/ TF32 compute. Only supported with cuBLAS backend currently */
-    HIPBLAS_COMPUTE_64F          = 7, /**< compute will be at least 64-bit precision */
-    HIPBLAS_COMPUTE_64F_PEDANTIC = 8, /**< compute will be exactly 64-bit precision */
-    HIPBLAS_COMPUTE_32I          = 9, /**< compute will be at least 32-bit integer precision */
-    HIPBLAS_COMPUTE_32I_PEDANTIC = 10, /**< compute will be exactly 32-bit integer precision */
-} hipblasComputeType_t;
 
 /*! \brief Indicates if layer is active with bitmask. */
 typedef enum

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -196,6 +196,7 @@ else( )
   rocm_export_targets(
     TARGETS roc::hipblas
     DEPENDS PACKAGE HIP
+    DEPENDS PACKAGE hipblas-common
     NAMESPACE roc::
   )
 endif( )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -66,6 +66,8 @@ add_library( roc::hipblas ALIAS hipblas )
 
 set(static_depends)
 
+find_package( hipblas-common REQUIRED CONFIG PATHS ${ROCM_PATH})
+
 # Build hipblas from source on AMD platform
 if(HIP_PLATFORM STREQUAL amd)
   if( NOT TARGET rocblas )
@@ -136,6 +138,7 @@ target_include_directories( hipblas
           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/hipblas>
           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+          $<BUILD_INTERFACE:${HIPBLAS-COMMON_INCLUDE_DIRS}>
   PRIVATE
           ${CMAKE_CURRENT_SOURCE_DIR}/include
           ${CMAKE_CURRENT_SOURCE_DIR}
@@ -185,6 +188,7 @@ if(HIP_PLATFORM STREQUAL amd)
     rocm_export_targets(
         TARGETS roc::hipblas
 	DEPENDS PACKAGE hip
+  DEPENDS PACKAGE HIP roc::hipblas-common
 	STATIC_DEPENDS ${static_depends}
 	NAMESPACE roc::
     )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -184,20 +184,20 @@ rocm_install_targets(
 )
 #         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
 
-if(HIP_PLATFORM STREQUAL amd)
-    rocm_export_targets(
-        TARGETS roc::hipblas
-	DEPENDS PACKAGE hip
-  DEPENDS PACKAGE HIP roc::hipblas-common
-	STATIC_DEPENDS ${static_depends}
-	NAMESPACE roc::
-    )
+if(HIP_PLATFORM STREQUAL amd )
+  rocm_export_targets(
+    TARGETS roc::hipblas
+    DEPENDS PACKAGE hip
+    DEPENDS PACKAGE hipblas-common
+    STATIC_DEPENDS ${static_depends}
+    NAMESPACE roc::
+  )
 else( )
-    rocm_export_targets(
-        TARGETS roc::hipblas
-	DEPENDS PACKAGE HIP
-	NAMESPACE roc::
-    )
+  rocm_export_targets(
+    TARGETS roc::hipblas
+    DEPENDS PACKAGE HIP
+    NAMESPACE roc::
+  )
 endif( )
 
 # Force installation of .f90 module files


### PR DESCRIPTION
resolves: hipBLASLt build dependency on hipBLAS by utilizing the hipBLAS-common package.

Summary of proposed changes:

Removes datatypes that exist within hipBLAS-common package from hipBLAS Adds hipblas-common as a dependency to hipBLAS.
