### PR TITLE
HipBLAS-common required for non-amd packages

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -196,6 +196,7 @@ else( )
   rocm_export_targets(
     TARGETS roc::hipblas
     DEPENDS PACKAGE HIP
+    DEPENDS PACKAGE hipblas-common
     NAMESPACE roc::
   )
 endif( )


### PR DESCRIPTION
resolves issues with packaging HipBLAS-common with non-amd builds, as per https://github.com/ROCm/hipBLAS/pull/904#discussion_r1722481893

Summary of proposed changes:
- Non-amd packages of HipBLAS now export HipBLAS-common
