### PR TITLE
Dependency on hipblas-common-dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,8 +212,8 @@ if(HIP_PLATFORM STREQUAL amd)
 endif( )
 
 set(hipblas_common_minimum 1.0.0)
-rocm_package_add_rpm_dependencies(DEPENDS "hipblas-common-devel >= ${hipblas_common_minimum}")
-rocm_package_add_deb_dependencies(DEPENDS "hipblas-common-dev >= ${hipblas_common_minimum}")
+rocm_package_add_deb_dependencies(COMPONENT devel DEPENDS "hipblas-common-dev >= ${hipblas_common_minimum}") 
+rocm_package_add_rpm_dependencies(COMPONENT devel DEPENDS "hipblas-common-devel >= ${hipblas_common_minimum}")
 
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md" )
 set( CPACK_RPM_PACKAGE_LICENSE "MIT")


### PR DESCRIPTION
resolves #SWDEV-487853

Summary of proposed changes:

The dependency on [hipblas-common](https://github.com/ROCm/hipBLAS-common) actually needs to point to the hipblas-common-dev package.

With this change, hipblas-dev package will now list hipblas-common-dev as a dependency.

Thanks to @lawruble13 for the fix!
