### PR TITLE
Use jenkins xml over standard preset node config

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -31,7 +31,9 @@ ci: {
                         "rocm-docker":[]]
     propertyList = auxiliary.appendPropertyList(propertyList)
 
-    def jobNameList = auxiliary.appendJobNameList(jobNameList)
+    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":([]),
+                       "rocm-docker":([])]
+    jobNameList = auxiliary.appendJobNameList(jobNameList)
 
     propertyList.each
     {

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -31,8 +31,7 @@ ci: {
                         "rocm-docker":[]]
     propertyList = auxiliary.appendPropertyList(propertyList)
 
-    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":([]),
-                       "rocm-docker":([])]
+    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":([])]
     jobNameList = auxiliary.appendJobNameList(jobNameList)
 
     propertyList.each

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -31,7 +31,7 @@ ci: {
                         "rocm-docker":[]]
     propertyList = auxiliary.appendPropertyList(propertyList)
 
-    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":([])]
+    def jobNameList = [""]
     jobNameList = auxiliary.appendJobNameList(jobNameList)
 
     propertyList.each

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -27,6 +27,21 @@ def runCI =
 ci: {
     String urlJobName = auxiliary.getTopJobName(env.BUILD_URL)
 
+    def propertyList = ["compute-rocm-dkms-no-npi-hipclang":[pipelineTriggers([cron('0 1 * * 0')])],
+                        "rocm-docker":[]]
+    propertyList = auxiliary.appendPropertyList(propertyList)
+
+    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":([ubuntu18:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx908']]),
+                       "rocm-docker":([ubuntu18:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']])]
+    jobNameList = auxiliary.appendJobNameList(jobNameList)
+
+    propertyList.each
+    {
+        jobName, property->
+        if (urlJobName == jobName)
+            properties(auxiliary.addCommonProperties(property))
+    }
+
     properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * 2')])]))
     stage(urlJobName) {
         runCI([ubuntu20:['any']], urlJobName)

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -31,9 +31,7 @@ ci: {
                         "rocm-docker":[]]
     propertyList = auxiliary.appendPropertyList(propertyList)
 
-    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":([ubuntu18:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx908']]),
-                       "rocm-docker":([ubuntu18:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx906']])]
-    jobNameList = auxiliary.appendJobNameList(jobNameList)
+    def jobNameList = auxiliary.appendJobNameList(jobNameList)
 
     propertyList.each
     {

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -42,8 +42,12 @@ ci: {
             properties(auxiliary.addCommonProperties(property))
     }
 
-    properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * 2')])]))
-    stage(urlJobName) {
-        runCI([ubuntu20:['any']], urlJobName)
+    jobNameList.each
+    {
+        jobName, nodeDetails->
+        if (urlJobName == jobName)
+            stage(jobName) {
+                runCI(nodeDetails, jobName)
+            }
     }
 }

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -31,7 +31,7 @@ ci: {
                         "rocm-docker":[]]
     propertyList = auxiliary.appendPropertyList(propertyList)
 
-    def jobNameList = [""]
+    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":[]]
     jobNameList = auxiliary.appendJobNameList(jobNameList)
 
     propertyList.each


### PR DESCRIPTION
Math-CI wants to be able to set node configs for static analysis job instead of the default ubuntu20:['any']
