### PR TITLE
Make hipblas-common transitively dependent

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library( roc::hipblas ALIAS hipblas )
 set(static_depends)
 
 find_package( hipblas-common REQUIRED CONFIG PATHS ${ROCM_PATH})
+target_link_libraries( hipblas PUBLIC roc::hipblas-common )
 
 # Build hipblas from source on AMD platform
 if(HIP_PLATFORM STREQUAL amd)


### PR DESCRIPTION
Summary of proposed changes:
- `target_link_libraries(hipblas PUBLIC roc::hipblas-common)` to ensure `hipblas-common` headers are included when `hipblas` headers are used.

Rationale:
When a library depends on `hipblas`, it needs a dependency on `hipblas-common` too because `hipblas` headers depends on `hipblas-common` headers. This commit enables CMake to handle this transitive dependency relation, such that any target that depends on `hipblas` would automatically have a dependency on `hipblas-common`.

This problem was previously not discovered because the package prefix paths of `hipblas` and `hipblas-common` are the same (i.e. `/opt/rocm`), so the flag to include `hipblas` (i.e. `-I/opt/rocm`) would also allow the compiler to find `hipblas-common`.

However, on NixOS where each package has its own prefix, any package that depends on `hipblas` would fail to build because the compiler is unable to find `#include <hipblas-common/hipblas-common.h>`.
