### PR TITLE
Make hipblas-common transitively dependent (#952)

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library( roc::hipblas ALIAS hipblas )
 set(static_depends)
 
 find_package( hipblas-common REQUIRED CONFIG PATHS ${ROCM_PATH})
+target_link_libraries( hipblas PUBLIC roc::hipblas-common )
 
 # Build hipblas from source on AMD platform
 if(HIP_PLATFORM STREQUAL amd)


### PR DESCRIPTION
When a library depends on `hipblas`, it needs a dependency on `hipblas-common` too because `hipblas` headers depends on `hipblas-common` headers. This commit enables CMake to handle this transitive dependency relation, such that any target that depends on `hipblas` would automatically have a
dependency on `hipblas-common`.

This problem was previously not discovered because the package prefix paths of `hipblas` and `hipblas-common` are the same (i.e. `/opt/rocm`).

However, on NixOS where each package has its own prefix, any package that depends on `hipblas` would fail to build because the compiler is unable to find `#include <hipblas-common/hipblas-common.h>`.

Signed-off-by: Gavin Zhao <git@gzgz.dev>
(cherry picked from commit c8bdbe64d8e6527367d3f134d18ed33c6531f2ff)

