### PR TITLE
Cherry pick - Use jenkins xml over standard preset node config (#944)

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -27,8 +27,26 @@ def runCI =
 ci: {
     String urlJobName = auxiliary.getTopJobName(env.BUILD_URL)
 
-    properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * 2')])]))
-    stage(urlJobName) {
-        runCI([ubuntu20:['any']], urlJobName)
+    def propertyList = ["compute-rocm-dkms-no-npi-hipclang":[pipelineTriggers([cron('0 1 * * 0')])],
+                        "rocm-docker":[]]
+    propertyList = auxiliary.appendPropertyList(propertyList)
+
+    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":[]]
+    jobNameList = auxiliary.appendJobNameList(jobNameList)
+
+    propertyList.each
+    {
+        jobName, property->
+        if (urlJobName == jobName)
+            properties(auxiliary.addCommonProperties(property))
+    }
+
+    jobNameList.each
+    {
+        jobName, nodeDetails->
+        if (urlJobName == jobName)
+            stage(jobName) {
+                runCI(nodeDetails, jobName)
+            }
     }
 }


### PR DESCRIPTION
Cherry pick of https://github.com/ROCm/hipBLAS/pull/944

to set node configs for static analysis job instead of the default ubuntu20:['any']