### PR TITLE
Update changelog for ROCm 6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,30 @@
 Documentation for hipBLAS is available at
 [https://rocm.docs.amd.com/projects/hipBLAS/en/latest/](https://rocm.docs.amd.com/projects/hipBLAS/en/latest/).
 
-## (Unreleased) hipBLAS 2.4.0
+## (Unreleased) hipBLAS 2.5.0
+
+### Added
+
+* Added hipblasSetWorkspace() API
+
+### Changed
+
+* Documentation updates
+
+### Removed
+
+* Support code for non-production gfx targets
+
+### Resolved issues
+
+* Build time `CMake` configuration for dependency on `hipBLAS-common` fixed
+
+### Upcoming changes
+
+* Deprecated hipblasDatatype_t will be replaced with hipDataType in the near future as announced in hipBLAS 2.0.0
+* Deprecated hipblasComplex types will be replaced with hipComplex types in the near future as announced in hipBLAS 2.0.0
+
+##  hipBLAS 2.4.0 for ROCm 6.4.0
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Documentation for hipBLAS is available at
 
 ### Added
 
-* Added hipblasSetWorkspace() API
+* Added the `hipblasSetWorkspace()` API
 
 ### Changed
 
@@ -19,12 +19,12 @@ Documentation for hipBLAS is available at
 
 ### Resolved issues
 
-* Build time `CMake` configuration for dependency on `hipBLAS-common` fixed
+* The build time `CMake` configuration for the dependency on `hipBLAS-common` is fixed
 
 ### Upcoming changes
 
-* Deprecated hipblasDatatype_t will be replaced with hipDataType in the near future as announced in hipBLAS 2.0.0
-* Deprecated hipblasComplex types will be replaced with hipComplex types in the near future as announced in hipBLAS 2.0.0
+* The deprecated `hipblasDatatype_t` will be replaced with `hipDataType` in the near future, as announced in hipBLAS 2.0.0
+* The deprecated `hipblasComplex` types will be replaced with `hipComplex` types in the near future, as announced in hipBLAS 2.0.0
 
 ##  hipBLAS 2.4.0 for ROCm 6.4.0
 


### PR DESCRIPTION
I've reiterated some deprecations from ROCm 6.0 in the "Upcoming changes" section since they should be coming in the next release. Let me know if you think I should remove that section.