### PR TITLE
Find gtest in clients CMakeLists

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -195,6 +195,11 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     set( BLIS_CPP ../common/blis_interface.cpp )
   endif()
 
+  if(EXISTS  "${BUILD_DIR}/deps/deps-install/lib/libgtest.a")
+    set( GTEST_ROOT "${BUILD_DIR}/deps/deps-install")
+  endif()
+  find_package( GTest REQUIRED )
+
   message(STATUS "Build Dir: ${BUILD_DIR}")
   message(STATUS "Linking Ref. Libs: ${BLAS_LIBRARY}")
 

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -82,8 +82,8 @@ target_include_directories( hipblas_v2-bench
     $<BUILD_INTERFACE:${FLAME_INCLUDE_DIR}>
 )
 
-target_link_libraries( hipblas-bench PRIVATE roc::hipblas )
-target_link_libraries( hipblas_v2-bench PRIVATE roc::hipblas )
+target_link_libraries( hipblas-bench PRIVATE roc::hipblas ${GTEST_BOTH_LIBRARIES} )
+target_link_libraries( hipblas_v2-bench PRIVATE roc::hipblas ${GTEST_BOTH_LIBRARIES} )
 
 if (NOT WIN32)
     target_link_libraries( hipblas-bench PRIVATE hipblas_fortran_client )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -31,11 +31,6 @@ if( NOT TARGET hipblas )
   find_package( hipblas REQUIRED CONFIG PATHS /opt/rocm/hipblas )
 endif( )
 
-if(EXISTS  "${BUILD_DIR}/deps/deps-install/lib/libgtest.a")
-  set( GTEST_ROOT "${BUILD_DIR}/deps/deps-install")
-endif()
-find_package( GTest REQUIRED )
-
 set(hipblas_test_source
   hipblas_gtest_main.cpp
   hipblas_test.cpp
@@ -161,8 +156,8 @@ target_include_directories( hipblas_v2-test
     ${ROCM_PATH}/include
 )
 
-target_link_libraries( hipblas-test PRIVATE roc::hipblas GTest::GTest )
-target_link_libraries( hipblas_v2-test PRIVATE roc::hipblas GTest::GTest )
+target_link_libraries( hipblas-test PRIVATE roc::hipblas ${GTEST_BOTH_LIBRARIES} )
+target_link_libraries( hipblas_v2-test PRIVATE roc::hipblas ${GTEST_BOTH_LIBRARIES} )
 
 if (NOT WIN32)
     target_link_libraries( hipblas-test PRIVATE hipblas_fortran_client )


### PR DESCRIPTION
Shouldn't need gtest_main from GTEST_BOTH_LIBRARIES I don't think, but this matches rocblas.