### PR TITLE
Add data type support page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ The hipBLAS public repository is located at  `<https://github.com/ROCm/hipBLAS>`
 
   .. grid-item-card:: API Reference
 
+    * :doc:`Data type support <./reference/data-type-support>`
     * :doc:`hipBLAS API <./reference/hipblas-api-functions>`
     * :doc:`Deprecations by version <./reference/deprecation>`
 

--- a/docs/reference/data-type-support.rst
+++ b/docs/reference/data-type-support.rst
@@ -300,10 +300,10 @@ Level-2 functions perform matrix-vector operations.
         *
           - :ref:`GERU and GERC <hipblas_ger>`
           - Generalized rank-1 update for unconjugated or conjugated complex numbers: :math:`A = \alpha x y^T + A`
-          - ❌
-          - ❌
-          - ❌
-          - ❌
+          - NA
+          - NA
+          - NA
+          - NA
 
         *
           - :ref:`SBMV <hipblas_sbmv>`, :ref:`SPMV <hipblas_spmv>`
@@ -424,8 +424,8 @@ Level-2 functions perform matrix-vector operations.
         *
           - :ref:`GER <hipblas_ger>`
           - Generalized rank-1 update: :math:`A = \alpha x y^T + A`
-          - ❌
-          - ❌
+          - NA
+          - NA
 
         *
           - :ref:`GERU and GERC <hipblas_ger>`
@@ -679,8 +679,8 @@ libraries for Level-3 GEMMs (matrix matrix multiplication).
         * 
           - :ref:`TRTRI <hipblas_trtri>`
           - Triangular matrix inversion.
-          - ❌
-          - ❌
+          - ✅
+          - ✅
 
         * 
           - :ref:`DGMM <hipblas_dgmm>`
@@ -742,8 +742,8 @@ inverses, and performing matrix factorizations.
           - Compute the inverse of a matrix using its LU factorization.
           - ❌
           - ❌
-          - ✅
-          - ✅
+          - ⚠️ [#getri]_
+          - ⚠️ [#getri]_
 
         * 
           - :ref:`GEQRF <hipblas_geqrf>`
@@ -789,8 +789,8 @@ inverses, and performing matrix factorizations.
         * 
           - :ref:`GETRI <hipblas_getri>`
           - Compute the inverse of a matrix using its LU factorization.
-          - ✅
-          - ✅
+          - ⚠️ [#getri]_
+          - ⚠️ [#getri]_
 
         * 
           - :ref:`GEQRF <hipblas_geqrf>`
@@ -803,3 +803,7 @@ inverses, and performing matrix factorizations.
           - Solve overdetermined or underdetermined linear systems using the QR factorization of a matrix.
           - ✅
           - ✅
+
+.. rubric:: Footnotes
+
+.. [#getri] Only the batched GETR functions are supported.

--- a/docs/reference/data-type-support.rst
+++ b/docs/reference/data-type-support.rst
@@ -1,0 +1,805 @@
+.. meta::
+  :description: hipBLAS library data type support
+  :keywords: hipBLAS, ROCm, API, Linear Algebra, documentation, data type support
+
+.. _data-types-support:
+
+********************************************************************
+Data type support
+********************************************************************
+
+This topic lists the data type support for the hipBLAS library on AMD GPUs for
+different levels of BLAS operations :ref:`Level 1 <level-1>`,
+:ref:`Level 2 <level-2>`, and :ref:`Level 3 <level-3>`. 
+
+The hipBLAS library functions are also available with ILP64 interfaces. With
+these interfaces, all ``int`` arguments are replaced by the type name
+``int64_t``. For more information on these ``_64`` functions, see the 
+:ref:`ILP64 API` section.
+
+The icons representing different levels of support are explained in the
+following table.
+
+.. list-table::
+    :header-rows: 1
+
+    *
+      -  Icon
+      - Definition
+
+    *
+      - NA
+      - Not applicable
+
+    *
+      - ❌
+      - Not supported
+
+    *
+      - ⚠️
+      - Partial support
+
+    *
+      - ✅
+      - Full support
+
+
+For more information about data type support for the other ROCm libraries, see 
+:doc:`Data types and precision support page <rocm:reference/precision-support>`. 
+
+.. _custom_types:
+
+Custom types
+============
+
+hipBlas defines the ``hipblasBfloat16`` and uses the HIP types ``hipComplex``
+and ``hipDoubleComplex``.
+
+.. _hipblas_bfloat16:
+
+The bfloat 16 data type
+-----------------------
+
+hipBLAS defines a ``hipblasBfloat16`` data type. This type is exposed as a
+struct containing 16 bits of data. There is also a C++ ``hipblasBfloat16`` class
+defined which provides slightly more functionality, including conversion to and
+from a 32-bit float data type.
+This class can be used in C++11 or newer by defining ``HIPBLAS_BFLOAT16_CLASS``
+before including the header file ``<hipblas.h>``.
+
+There is also an option to interpret the API as using the ``hip_bfloat16`` data
+type. This is provided to avoid casting when using the ``hip_bfloat16`` data
+type. To expose the API using ``hip_bfloat16``, define 
+``HIPBLAS_USE_HIP_BFLOAT16`` before including the header file ``<hipblas.h>``.
+
+.. note::
+
+   The ``hip_bfloat16`` data type is only supported on AMD platforms.
+
+.. _hipblas_complex:
+
+Complex data types
+------------------
+
+hipBLAS uses the HIP types ``hipComplex`` and ``hipDoubleComplex`` in its API.
+
+Functions data type support
+=======================================
+
+This section collects the data type support tables of BLAS functions and
+solver functions. The cuBLAS backend does not support all the functions and all
+the types. For more information, see :ref:`cuBLAS backend <hipblas-backend>`.
+
+Level 1 functions - vector operations
+-------------------------------------
+
+Level-1 functions perform scalar, vector, and vector-vector operations.
+
+.. tab-set::
+
+  .. tab-item:: Float types
+    :sync: float-type
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 15, 45, 10, 10, 10, 10
+
+        * 
+          - Function
+          - Description
+          - float16
+          - bfloat16
+          - float
+          - double
+
+        *
+          - :ref:`AMax <hipblas_amax>`, :ref:`AMin <hipblas_amin>`, :ref:`ASum <hipblas_asum>`
+          - Finds the first index of the element of minimum or maximum magnitude of a vector x or computes the sum of the magnitudes of elements of a real vector x.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`AXPY <hipblas_axpy>`
+          - Scales a vector and adds it to another: :math:`y = \alpha x + y`
+          - ✅
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Copy <hipblas_copy>`
+          - Copies vector x to y: :math:`y = x`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Dot <hipblas_dot>`
+          - Computes the dot product: :math:`result = x^T y`
+          - ✅
+          - ✅
+          - ✅
+          - ✅    
+
+        *
+          - :ref:`NRM2 <hipblas_nrm2>`
+          - Computes the Euclidean norm of a vector.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Rot <hipblas_rot>`, :ref:`Rotg <hipblas_rotg>`
+          - Applies and generates a Givens rotation matrix.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Rotm <hipblas_rotm>`, :ref:`Rotmg <hipblas_rotmg>`
+          - Applies and generates a modified Givens rotation matrix.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Scal <hipblas_scal>`
+          - Scales a vector by a scalar: :math:`x = \alpha x`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Swap <hipblas_swap>`
+          - Swaps corresponding elements of two vectors x and y: :math:`x_i \leftrightarrow y_i \quad \text{for} \quad i = 0, 1, 2, \ldots, n - 1`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+  .. tab-item:: Complex types
+    :sync: complex-type
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 15, 55, 10, 20 
+
+        * 
+          - Function
+          - Description
+          - complex
+          - double complex
+
+        *
+          - :ref:`AMax <hipblas_amax>`, :ref:`AMin <hipblas_amin>`, :ref:`ASum <hipblas_asum>`
+          - Finds the first index of the element of minimum or maximum magnitude of a vector x or computes the sum of the magnitudes of elements of a real vector x.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`AXPY <hipblas_axpy>`
+          - Scales a vector and adds it to another: :math:`y = \alpha x + y`
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Copy <hipblas_copy>`
+          - Copies vector x to y: :math:`y = x`
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Dot <hipblas_dot>`
+          - Computes the dot product: :math:`result = x^T y`
+          - ✅
+          - ✅      
+
+        *
+          - :ref:`NRM2 <hipblas_nrm2>`
+          - Computes the Euclidean norm of a vector.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Rot <hipblas_rot>`, :ref:`Rotg <hipblas_rotg>`
+          - Applies and generates a Givens rotation matrix.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Rotm <hipblas_rotm>`, :ref:`Rotmg <hipblas_rotmg>`
+          - Applies and generates a modified Givens rotation matrix.
+          - ❌
+          - ❌
+
+        *
+          - :ref:`Scal <hipblas_scal>`
+          - Scales a vector by a scalar: :math:`x = \alpha x`
+          - ✅
+          - ✅
+
+        *
+          - :ref:`Swap <hipblas_swap>`
+          - Swaps corresponding elements of two vectors x and y: :math:`x_i \leftrightarrow y_i \quad \text{for} \quad i = 0, 1, 2, \ldots, n - 1`
+          - ✅
+          - ✅
+
+Level 2 functions - matrix-vector operations
+--------------------------------------------
+
+Level-2 functions perform matrix-vector operations.
+
+.. tab-set::
+
+  .. tab-item:: Float types
+    :sync: float-type
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 15, 45, 10, 10, 10, 10
+
+        * 
+          - Function
+          - Description
+          - float16
+          - bfloat16
+          - float
+          - double
+
+        *
+          - :ref:`GBMV <hipblas_gbmv>`
+          - General band matrix-vector multiplication: :math:`y = \alpha A x + \beta y`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`GEMV <hipblas_gemv>`
+          - General matrix-vector multiplication: :math:`y = \alpha A x + \beta y`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`GER <hipblas_ger>`
+          - Generalized rank-1 update: :math:`A = \alpha x y^T + A`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`GERU and GERC <hipblas_ger>`
+          - Generalized rank-1 update for unconjugated or conjugated complex numbers: :math:`A = \alpha x y^T + A`
+          - ❌
+          - ❌
+          - ❌
+          - ❌
+
+        *
+          - :ref:`SBMV <hipblas_sbmv>`, :ref:`SPMV <hipblas_spmv>`
+          - Symmetric Band matrix-vector multiplication: :math:`y = \alpha A x + \beta y`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`SPR <hipblas_spr>`
+          - Symmetric packed rank-1 update.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`SPR2 <hipblas_spr2>`
+          - Symmetric packed rank-2 update.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`SYMV <hipblas_symv>`
+          - Symmetric matrix-vector multiplication: :math:`y = \alpha A x + \beta y`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`SYR <hipblas_syr>`, :ref:`SYR2 <hipblas_syr2>`
+          - Symmetric matrix rank-1 or rank-2 update.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`TBMV <hipblas_tbmv>`, :ref:`TBSV <hipblas_tbsv>`
+          - Triangular band matrix-vector multiplication, triangular band solve.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`TPMV <hipblas_tpmv>`, :ref:`TPSV <hipblas_tpsv>`
+          - Triangular packed matrix-vector multiplication, triangular packed solve.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`TRMV <hipblas_trmv>`, :ref:`TRSV <hipblas_trsv>`
+          - Triangular matrix-vector multiplication, triangular solve.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        *
+          - :ref:`HEMV <hipblas_hemv>`, :ref:`HBMV <hipblas_hbmv>`, :ref:`HPMV <hipblas_hpmv>`
+          - Hermitian matrix-vector multiplication.
+          - NA
+          - NA
+          - NA
+          - NA
+
+        *
+          - :ref:`HER <hipblas_her>`, :ref:`HER2 <hipblas_her2>`
+          - Hermitian rank-1 and rank-2 update.
+          - NA
+          - NA
+          - NA
+          - NA
+
+
+        *
+          - :ref:`HPR <hipblas_hpr>`, :ref:`HPR2 <hipblas_hpr2>`
+          - Hermitian packed rank-1 and rank-2 update of packed.
+          - NA
+          - NA
+          - NA
+          - NA
+
+
+
+  .. tab-item:: Complex types
+    :sync: complex-type
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 15, 55, 10, 20 
+
+        * 
+          - Function
+          - Description
+          - complex
+          - double complex
+
+        *
+          - :ref:`GBMV <hipblas_gbmv>`
+          - General band matrix-vector multiplication: :math:`y = \alpha A x + \beta y`
+          - ✅
+          - ✅
+
+        *
+          - :ref:`GEMV <hipblas_gemv>`
+          - General matrix-vector multiplication: :math:`y = \alpha A x + \beta y`
+          - ✅
+          - ✅
+
+        *
+          - :ref:`GER <hipblas_ger>`
+          - Generalized rank-1 update: :math:`A = \alpha x y^T + A`
+          - ❌
+          - ❌
+
+        *
+          - :ref:`GERU and GERC <hipblas_ger>`
+          - Generalized rank-1 update for unconjugated or conjugated complex numbers: :math:`A = \alpha x y^T + A`
+          - ✅
+          - ✅          
+
+        *
+          - :ref:`SBMV <hipblas_sbmv>`, :ref:`SPMV <hipblas_spmv>`
+          - Symmetric Band matrix-vector multiplication: :math:`y = \alpha A x + \beta y`
+          - ❌
+          - ❌
+
+        *
+          - :ref:`SPR <hipblas_spr>`
+          - Symmetric packed rank-1 update.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`SPR2 <hipblas_spr2>`
+          - Symmetric packed rank-2 update.
+          - ❌
+          - ❌
+
+        *
+          - :ref:`SYMV <hipblas_symv>`
+          - Symmetric matrix-vector multiplication: :math:`y = \alpha A x + \beta y`
+          - ✅
+          - ✅
+
+        *
+          - :ref:`SYR <hipblas_syr>`, :ref:`SYR2 <hipblas_syr2>`
+          - Symmetric matrix rank-1 or rank-2 update.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`TBMV <hipblas_tbmv>`, :ref:`TBSV <hipblas_tbsv>`
+          - Triangular band matrix-vector multiplication, triangular band solve.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`TPMV <hipblas_tpmv>`, :ref:`TPSV <hipblas_tpsv>`
+          - Triangular packed matrix-vector multiplication, triangular packed solve.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`TRMV <hipblas_trmv>`, :ref:`TRSV <hipblas_trsv>`
+          - Triangular matrix-vector multiplication, triangular solve.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`HEMV <hipblas_hemv>`, :ref:`HBMV <hipblas_hbmv>`, :ref:`HPMV <hipblas_hpmv>`
+          - Hermitian matrix-vector multiplication.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`HER <hipblas_her>`, :ref:`HER2 <hipblas_her2>`
+          - Hermitian rank-1 and rank-2 update.
+          - ✅
+          - ✅
+
+        *
+          - :ref:`HPR <hipblas_hpr>`, :ref:`HPR2 <hipblas_hpr2>`
+          - Hermitian packed rank-1 and rank-2 update.
+          - ✅
+          - ✅
+ 
+Level 3 functions - matrix-matrix operations
+--------------------------------------------
+
+Level-3 functions perform matix-matrix operations. hipBLAS calls the AMD 
+:doc:`Tensile <tensile:src/index>` and :doc:`hipBLASLt <hipblaslt:index>`
+libraries for Level-3 GEMMs (matrix matrix multiplication).
+
+.. tab-set::
+
+  .. tab-item:: Float types
+    :sync: float-type
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 15, 45, 10, 10, 10, 10
+
+        * 
+          - Function
+          - Description
+          - float16
+          - bfloat16
+          - float
+          - double
+
+        * 
+          - :ref:`GEMM <hipblas_gemm>`
+          - General matrix-matrix multiplication: :math:`C = \alpha A B + \beta C`
+          - ✅
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`SYMM <hipblas_symm>`
+          - Symmetric matrix-matrix multiplication: :math:`C = \alpha A B + \beta C`
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`SYRK <hipblas_syrk>`, :ref:`SYR2K <hipblas_syr2k>`
+          - Update symmetric matrix with one matrix product or by using two matrices.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`SYRKX <hipblas_syrkx>`
+          - SYRKX adds an extra matrix multiplication step before updating the symmetric matrix.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`TRMM <hipblas_trmm>`
+          - Triangular matrix-matrix multiplication.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`TRSM <hipblas_trsm>`
+          - Triangular solve with multiple right-hand sides.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+        * 
+          - :ref:`HEMM <hipblas_hemm>`
+          - Hermitian matrix-matrix multiplication.
+          - NA
+          - NA
+          - NA
+          - NA
+
+        * 
+          - :ref:`HERK <hipblas_herk>`, :ref:`HER2K <hipblas_her2k>`
+          - Update Hermitian matrix with one matrix product or by using two matrices.
+          - NA
+          - NA
+          - NA
+          - NA
+
+        * 
+          - :ref:`HERKX <hipblas_herkx>`
+          - HERKX adds an extra matrix multiplication step before updating the Hermitian matrix.
+          - NA
+          - NA
+          - NA
+          - NA
+
+        * 
+          - :ref:`TRTRI <hipblas_trtri>`
+          - Triangular matrix inversion.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`DGMM <hipblas_dgmm>`
+          - Diagonal matrix matrix multiplication.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+  .. tab-item:: Complex types
+    :sync: complex-type
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 15, 55, 10, 20
+
+        * 
+          - Function
+          - Description
+          - complex
+          - double complex
+
+        * 
+          - :ref:`GEMM <hipblas_gemm>`
+          - General matrix-matrix multiplication: :math:`C = \alpha A B + \beta C`
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`SYMM <hipblas_symm>`
+          - Symmetric matrix-matrix multiplication: :math:`C = \alpha A B + \beta C`
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`SYRK <hipblas_syrk>`, :ref:`SYR2K <hipblas_syr2k>`
+          - Update symmetric matrix with one matrix product or by using two matrices.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`SYRKX <hipblas_syrkx>`
+          - SYRKX adds an extra matrix multiplication step before updating the symmetric matrix.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`TRMM <hipblas_trmm>`
+          - Triangular matrix-matrix multiplication.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`TRSM <hipblas_trsm>`
+          - Triangular solve with multiple right-hand sides.
+          - ✅
+          - ✅
+        * 
+          - :ref:`HEMM <hipblas_hemm>`
+          - Hermitian matrix-matrix multiplication.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`HERK <hipblas_herk>`, :ref:`HER2K <hipblas_her2k>`
+          - Update Hermitian matrix with one matrix product or by using two matrices.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`HERKX <hipblas_herkx>`
+          - HERKX adds an extra matrix multiplication step before updating the Hermitian matrix.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`TRTRI <hipblas_trtri>`
+          - Triangular matrix inversion.
+          - ❌
+          - ❌
+
+        * 
+          - :ref:`DGMM <hipblas_dgmm>`
+          - Diagonal matrix matrix multiplication.
+          - ✅
+          - ✅
+
+
+Extensions
+----------
+
+The :ref:`extension functions <hipblas_extension>` data type support is listed
+separately for every function for the different backends in the
+:ref:`rocBLAS extensions <rocblas:extension>` and
+`cuBLAS extensions <https://docs.nvidia.com/cuda/cublas/index.html#blas-like-extension>`_ 
+documentation.
+
+SOLVER API
+----------
+
+:ref:`Solver API <solver_api>` is for solving linear systems, computing matrix
+inverses, and performing matrix factorizations.
+
+.. tab-set::
+
+  .. tab-item:: Float types
+    :sync: float-type
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 15, 45, 10, 10, 10, 10
+
+        * 
+          - Function
+          - Description
+          - float16
+          - bfloat16
+          - float
+          - double
+
+        * 
+          - :ref:`GETRF <hipblas_getrf>`
+          - Compute the LU factorization of a general matrix using partial pivoting with row interchanges.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`GETRS <hipblas_getrs>`
+          - Solve a system of linear equations :math:`AxX=B` after performing an LU factorization using GETRF.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`GETRI <hipblas_getri>`
+          - Compute the inverse of a matrix using its LU factorization.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`GEQRF <hipblas_geqrf>`
+          - QR factorization of a general matrix.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`GELS <hipblas_gels>`
+          - Solve overdetermined or underdetermined linear systems using the QR factorization of a matrix.
+          - ❌
+          - ❌
+          - ✅
+          - ✅
+
+  .. tab-item:: Complex types
+    :sync: complex-type
+
+    .. list-table::
+        :header-rows: 1
+        :widths: 15, 55, 10, 20
+
+        * 
+          - Function
+          - Description
+          - complex
+          - double complex
+
+        * 
+          - :ref:`GETRF <hipblas_getrf>`
+          - Compute the LU factorization of a general matrix using partial pivoting with row interchanges.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`GETRS <hipblas_getrs>`
+          - Solve a system of linear equations :math:`AxX=B` after performing an LU factorization using GETRF.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`GETRI <hipblas_getri>`
+          - Compute the inverse of a matrix using its LU factorization.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`GEQRF <hipblas_geqrf>`
+          - QR factorization of a general matrix.
+          - ✅
+          - ✅
+
+        * 
+          - :ref:`GELS <hipblas_gels>`
+          - Solve overdetermined or underdetermined linear systems using the QR factorization of a matrix.
+          - ✅
+          - ✅

--- a/docs/reference/data-type-support.rst
+++ b/docs/reference/data-type-support.rst
@@ -806,4 +806,4 @@ inverses, and performing matrix factorizations.
 
 .. rubric:: Footnotes
 
-.. [#getri] Only the batched GETR functions are supported.
+.. [#getri] Only the batched GETRI functions are supported.

--- a/docs/reference/hipblas-api-functions.rst
+++ b/docs/reference/hipblas-api-functions.rst
@@ -139,10 +139,8 @@ Similarly, if CUDA cuBLAS is the backend, see the cuBLAS documentation.
 Custom data types
 =================
 
-hipBlas defines the ``hipblasBfloat16``, ``hipblasComplex``, and
-``hipblasDoubleComplex`` data types.
-
-For more details, see :ref:`custom_types`.
+hipBlas defines the ``hipblasBfloat16``. For more details, see
+:ref:`custom_types`.
 
 *************
 hipBLAS types

--- a/docs/reference/hipblas-api-functions.rst
+++ b/docs/reference/hipblas-api-functions.rst
@@ -72,6 +72,35 @@ hipBLAS function uses the following notations to denote precisions:
 *  c  = single complex
 *  z  = double complex
 
+.. _hipblas-backend:
+
+hipBLAS backends
+================
+
+hipBLAS has multiple backends for different platforms: cuBLAS for the NVIDIA
+platform and rocBLAS for the AMD platform. The cuBLAS backend does not support
+all the functions and only returns the ``HIPBLAS_STATUS_NOT_SUPPORTED`` status
+code.
+
+The following level 1-3 and solver functions are not supported with the cuBLAS
+backend:
+
+* :ref:`AXPY <hipblas_axpy>` functions with half.
+* :ref:`DOT <hipblas_dot>` functions with half and bfloat16.
+* :ref:`SPR <hipblas_spr>` functions with ``std:complex<float>`` and
+  ``std:complex<double>``.
+* All the batched functions except for :ref:`TRSM <hipblas_trsm>`,
+  :ref:`GEMV <hipblas_gemv>`, and :ref:`GEMM <hipblas_gemm>` and 
+  :ref:`solver functions <solver_api>`
+  (:ref:`GETRF <hipblas_getrf>`, :ref:`GETRS <hipblas_getrs>`,
+  :ref:`GEQRF <hipblas_geqrf>`, :ref:`GELS <hipblas_gels>`).
+* All the strided_batched functions except for :ref:`GEMV <hipblas_gemv>` and
+  :ref:`GEMM <hipblas_gemm>`.
+* :ref:`TRTRI <hipblas_trtri>` and :ref:`TRSMEX <hipblas_trsmex>` functions.
+* :ref:`GETRF <hipblas_getrf>`, :ref:`GETRS <hipblas_getrs>`, 
+  :ref:`GEQRF <hipblas_geqrf>`, and :ref:`GELS <hipblas_gels>` non-batched and
+  strided_batched functions.
+
 .. _ILP64 API:
 
 ILP64 interfaces
@@ -90,28 +119,6 @@ The functionality of the ILP64 interfaces depends on the backend being used,
 see the :doc:`rocBLAS <rocblas:index>` or NVIDIA CUDA cuBLAS documentation for more
 information about support for ILP64 interfaces.
 
-The bfloat 16 data type
-=======================
-
-hipBLAS defines a ``hipblasBfloat16`` data type. This type is exposed as a struct
-containing 16 bits of data. There is also a C++ ``hipblasBfloat16`` class defined
-which provides slightly more functionality, including conversion to and from a 32-bit float data type.
-This class can be used in C++11 or newer by defining
-``HIPBLAS_BFLOAT16_CLASS`` before including the header file ``<hipblas.h>``.
-
-There is also an option to interpret the API as using the ``hip_bfloat16`` data type.
-This is provided to avoid casting when using the ``hip_bfloat16`` data type. To expose the API
-using ``hip_bfloat16``, define ``HIPBLAS_USE_HIP_BFLOAT16`` before including the header file ``<hipblas.h>``.
-
-.. note::
-
-   The ``hip_bfloat16`` data type is only supported on AMD platforms.
-
-Complex data types
-==================
-
-hipBLAS uses the HIP types ``hipComplex`` and ``hipDoubleComplex`` in its API.
-
 Atomic operations
 =================
 
@@ -128,6 +135,14 @@ Graph support for hipBLAS
 Graph support (also referred to as stream capture support) for hipBLAS depends on the backend being used.
 If rocBLAS is the backend, see the :doc:`rocBLAS <rocblas:index>` documentation.
 Similarly, if CUDA cuBLAS is the backend, see the cuBLAS documentation.
+
+Custom data types
+=================
+
+hipBlas defines the ``hipblasBfloat16``, ``hipblasComplex``, and
+``hipblasDoubleComplex`` data types.
+
+For more details, see :ref:`custom_types`.
 
 *************
 hipBLAS types
@@ -169,6 +184,7 @@ hipblasDoubleComplex
 
 Enums
 =====
+
 Enumeration constants have numbering that is consistent with CBLAS, ACML, and most standard C BLAS libraries.
 
 hipblasStatus_t
@@ -219,12 +235,16 @@ hipblasAtomicsMode_t
 hipBLAS functions
 *****************
 
+.. _level-1:
+
 Level 1 BLAS
 ============
 
 .. contents:: List of Level-1 BLAS functions
    :local:
    :backlinks: top
+
+.. _hipblas_amax:
 
 hipblasIXamax + Batched, StridedBatched
 -----------------------------------------
@@ -258,6 +278,7 @@ The ``amaxBatched`` function supports the 64-bit integer interface. See the :ref
 
 The ``amaxStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_amin:
 
 hipblasIXamin + Batched, StridedBatched
 -----------------------------------------
@@ -291,6 +312,8 @@ The ``aminBatched`` function supports the 64-bit integer interface. See the :ref
 
 The ``aminStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_asum:
+
 hipblasXasum + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSasum
@@ -322,6 +345,8 @@ The ``asumBatched`` function supports the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasDzasumStridedBatched
 
 The ``asumStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_axpy:
 
 hipblasXaxpy + Batched, StridedBatched
 ----------------------------------------
@@ -361,6 +386,8 @@ The ``axpyBatched`` function supports the 64-bit integer interface. See the :ref
 
 The ``axpyStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_copy:
+
 hipblasXcopy + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasScopy
@@ -392,6 +419,8 @@ The ``copyBatched`` function supports the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZcopyStridedBatched
 
 The ``copyStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_dot:
 
 hipblasXdot + Batched, StridedBatched
 ---------------------------------------
@@ -449,6 +478,8 @@ The ``dotBatched`` function supports the 64-bit integer interface. See the :ref:
 
 The ``dotStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_nrm2:
+
 hipblasXnrm2 + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSnrm2
@@ -480,6 +511,8 @@ The ``nrm2Batched`` function supports the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasDznrm2StridedBatched
 
 The ``nrm2StridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_rot:
 
 hipblasXrot + Batched, StridedBatched
 ---------------------------------------
@@ -525,6 +558,8 @@ The ``rotBatched`` function supports the 64-bit integer interface. See the :ref:
 
 The ``rotStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_rotg:
+
 hipblasXrotg + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSrotg
@@ -557,6 +592,8 @@ The ``rotgBatched`` function supports the 64-bit integer interface. See the :ref
 
 The ``rotgStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_rotm:
+
 hipblasXrotm + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSrotm
@@ -577,6 +614,8 @@ The ``rotmBatched`` function supports the 64-bit integer interface. See the :ref
 
 The ``rotmStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_rotmg:
+
 hipblasXrotmg + Batched, StridedBatched
 -----------------------------------------
 .. doxygenfunction:: hipblasSrotmg
@@ -596,6 +635,8 @@ The ``rotmgBatched`` function supports the 64-bit integer interface. See the :re
 .. doxygenfunction:: hipblasDrotmgStridedBatched
 
 The ``rotmgStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_scal:
 
 hipblasXscal + Batched, StridedBatched
 ----------------------------------------
@@ -641,6 +682,8 @@ The ``scalBatched`` function supports the 64-bit integer interface. See the :ref
 
 The ``scalStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_swap:
+
 hipblasXswap + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSswap
@@ -673,11 +716,15 @@ The ``swapBatched`` function supports the 64-bit integer interface. See the :ref
 
 The ``swapStridedBatched`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _level-2:
+
 Level 2 BLAS
 ============
 .. contents:: List of Level-2 BLAS functions
    :local:
    :backlinks: top
+
+.. _hipblas_gbmv:
 
 hipblasXgbmv + Batched, StridedBatched
 ----------------------------------------
@@ -711,6 +758,8 @@ The ``gbmvBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``gbmvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_gemv:
+
 hipblasXgemv + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSgemv
@@ -742,6 +791,8 @@ The ``gemvBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZgemvStridedBatched
 
 The ``gemvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_ger:
 
 hipblasXger + Batched, StridedBatched
 ----------------------------------------
@@ -787,6 +838,8 @@ The ``gerBatched`` functions support the 64-bit integer interface. See the :ref:
 
 The ``gerStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_hbmv:
+
 hipblasXhbmv + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasChbmv
@@ -806,6 +859,8 @@ The ``hbmvBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZhbmvStridedBatched
 
 The ``hbmvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_hemv:
 
 hipblasXhemv + Batched, StridedBatched
 ----------------------------------------
@@ -827,6 +882,8 @@ The ``hemvBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``hemvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_her:
+
 hipblasXher + Batched, StridedBatched
 ---------------------------------------
 .. doxygenfunction:: hipblasCher
@@ -846,6 +903,8 @@ The ``herBatched`` functions support the 64-bit integer interface. See the :ref:
 .. doxygenfunction:: hipblasZherStridedBatched
 
 The ``herStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_her2:
 
 hipblasXher2 + Batched, StridedBatched
 ----------------------------------------
@@ -867,6 +926,8 @@ The ``her2Batched`` functions support the 64-bit integer interface. See the :ref
 
 The ``her2StridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_hpmv:
+
 hipblasXhpmv + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasChpmv
@@ -886,6 +947,8 @@ The ``hpmvBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZhpmvStridedBatched
 
 The ``hpmvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_hpr:
 
 hipblasXhpr + Batched, StridedBatched
 ---------------------------------------
@@ -907,6 +970,8 @@ The ``hprBatched`` functions support the 64-bit integer interface. See the :ref:
 
 The ``hprStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_hpr2:
+
 hipblasXhpr2 + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasChpr2
@@ -926,6 +991,8 @@ The ``hpr2Batched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZhpr2StridedBatched
 
 The ``hpr2StridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_sbmv:
 
 hipblasXsbmv + Batched, StridedBatched
 ----------------------------------------
@@ -947,6 +1014,8 @@ The ``sbmvBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``sbmvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_spmv:
+
 hipblasXspmv + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSspmv
@@ -966,6 +1035,8 @@ The ``spmvBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasDspmvStridedBatched
 
 The ``spmvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_spr:
 
 hipblasXspr + Batched, StridedBatched
 ----------------------------------------
@@ -999,6 +1070,8 @@ The ``sprBatched`` functions support the 64-bit integer interface. See the :ref:
 
 The ``sprStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_spr2:
+
 hipblasXspr2 + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSspr2
@@ -1018,6 +1091,8 @@ The ``spr2Batched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasDspr2StridedBatched
 
 The ``spr2StridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_symv:
 
 hipblasXsymv + Batched, StridedBatched
 ----------------------------------------
@@ -1051,6 +1126,8 @@ The ``symvBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``symvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_syr:
+
 hipblasXsyr + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSsyr
@@ -1082,6 +1159,8 @@ The ``syrBatched`` functions support the 64-bit integer interface. See the :ref:
 .. doxygenfunction:: hipblasZsyrStridedBatched
 
 The ``syrStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_syr2:
 
 hipblasXsyr2 + Batched, StridedBatched
 ----------------------------------------
@@ -1115,6 +1194,8 @@ The ``syr2Batched`` functions support the 64-bit integer interface. See the :ref
 
 The ``syr2StridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_tbmv:
+
 hipblasXtbmv + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasStbmv
@@ -1146,6 +1227,8 @@ The ``tbmvBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZtbmvStridedBatched
 
 The ``tbmvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_tbsv:
 
 hipblasXtbsv + Batched, StridedBatched
 ----------------------------------------
@@ -1179,6 +1262,8 @@ The ``tbsvBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``tbsvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_tpmv:
+
 hipblasXtpmv + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasStpmv
@@ -1210,6 +1295,8 @@ The ``tpmvBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZtpmvStridedBatched
 
 The ``tpmvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_tpsv:
 
 hipblasXtpsv + Batched, StridedBatched
 ----------------------------------------
@@ -1243,6 +1330,8 @@ The ``tpsvBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``tpsvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_trmv:
+
 hipblasXtrmv + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasStrmv
@@ -1274,6 +1363,8 @@ The ``trmvBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZtrmvStridedBatched
 
 The ``trmvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_trsv:
 
 hipblasXtrsv + Batched, StridedBatched
 ----------------------------------------
@@ -1307,12 +1398,15 @@ The ``trsvBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``trsvStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _level-3:
+
 Level 3 BLAS
 ============
 .. contents:: List of Level-3 BLAS functions
    :local:
    :backlinks: top
 
+.. _hipblas_gemm:
 
 hipblasXgemm + Batched, StridedBatched
 ----------------------------------------
@@ -1352,6 +1446,8 @@ The ``gemmBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``gemmStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_herk:
+
 hipblasXherk + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasCherk
@@ -1371,6 +1467,8 @@ The ``herkBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZherkStridedBatched
 
 The ``herkStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_herkx:
 
 hipblasXherkx + Batched, StridedBatched
 -----------------------------------------
@@ -1392,6 +1490,8 @@ The ``herkxBatched`` functions support the 64-bit integer interface. See the :re
 
 The ``herkxStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_her2k:
+
 hipblasXher2k + Batched, StridedBatched
 -----------------------------------------
 .. doxygenfunction:: hipblasCher2k
@@ -1411,6 +1511,8 @@ The ``her2kBatched`` functions support the 64-bit integer interface. See the :re
 .. doxygenfunction:: hipblasZher2kStridedBatched
 
 The ``her2kStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_symm:
 
 hipblasXsymm + Batched, StridedBatched
 ----------------------------------------
@@ -1444,6 +1546,8 @@ The ``symmBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``symmStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_syrk:
+
 hipblasXsyrk + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasSsyrk
@@ -1475,6 +1579,8 @@ The ``syrkBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZsyrkStridedBatched
 
 The ``syrkStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_syr2k:
 
 hipblasXsyr2k + Batched, StridedBatched
 -----------------------------------------
@@ -1508,6 +1614,8 @@ The ``syr2kBatched`` functions support the 64-bit integer interface. See the :re
 
 The ``syr2kStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_syrkx:
+
 hipblasXsyrkx + Batched, StridedBatched
 -----------------------------------------
 .. doxygenfunction:: hipblasSsyrkx
@@ -1539,6 +1647,8 @@ The ``syrkxBatched`` functions support the 64-bit integer interface. See the :re
 .. doxygenfunction:: hipblasZsyrkxStridedBatched
 
 The ``syrkxStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_geam:
 
 hipblasXgeam + Batched, StridedBatched
 ----------------------------------------
@@ -1572,6 +1682,8 @@ The ``geamBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``geamStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_hemm:
+
 hipblasXhemm + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasChemm
@@ -1591,6 +1703,8 @@ The ``hemmBatched`` functions support the 64-bit integer interface. See the :ref
 .. doxygenfunction:: hipblasZhemmStridedBatched
 
 The ``hemmStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_trmm:
 
 hipblasXtrmm + Batched, StridedBatched
 ----------------------------------------
@@ -1624,6 +1738,8 @@ The ``trmmBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``trmmStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_trsm:
+
 hipblasXtrsm + Batched, StridedBatched
 ----------------------------------------
 .. doxygenfunction:: hipblasStrsm
@@ -1656,6 +1772,8 @@ The ``trsmBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``trsmStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_trtri:
+
 hipblasXtrtri + Batched, StridedBatched
 -----------------------------------------
 .. doxygenfunction:: hipblasStrtri
@@ -1681,6 +1799,8 @@ hipblasXtrtri + Batched, StridedBatched
 .. doxygenfunction:: hipblasCtrtriStridedBatched
     :outline:
 .. doxygenfunction:: hipblasZtrtriStridedBatched
+
+.. _hipblas_dgmm:
 
 hipblasXdgmm + Batched, StridedBatched
 ----------------------------------------
@@ -1714,11 +1834,15 @@ The ``dgmmBatched`` functions support the 64-bit integer interface. See the :ref
 
 The ``dgmmStridedBatched`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_extension:
+
 BLAS extensions
 ===============
 .. contents:: List of BLAS extension functions
    :local:
    :backlinks: top
+
+.. _hipblas_gemmex:
 
 hipblasGemmEx + Batched, StridedBatched
 ------------------------------------------
@@ -1728,11 +1852,15 @@ hipblasGemmEx + Batched, StridedBatched
 
 The ``gemmEx``, ``gemmBatchedEx``, and ``gemmStridedBatchedEx`` functions support the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_trsmex:
+
 hipblasTrsmEx + Batched, StridedBatched
 ------------------------------------------
 .. doxygenfunction:: hipblasTrsmEx
 .. doxygenfunction:: hipblasTrsmBatchedEx
 .. doxygenfunction:: hipblasTrsmStridedBatchedEx
+
+.. _hipblas_axpyex:
 
 hipblasAxpyEx + Batched, StridedBatched
 ------------------------------------------
@@ -1748,6 +1876,8 @@ The ``axpyBatchedEx`` function supports the 64-bit integer interface. See the :r
 
 The ``axpyStridedBatchedEx`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_dotex:
+
 hipblasDotEx + Batched, StridedBatched
 ------------------------------------------
 .. doxygenfunction:: hipblasDotEx
@@ -1761,6 +1891,8 @@ The ``dotBatchedEx`` function supports the 64-bit integer interface. See the :re
 .. doxygenfunction:: hipblasDotStridedBatchedEx
 
 The ``dotStridedBatchedEx`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_dotcex:
 
 hipblasDotcEx + Batched, StridedBatched
 ------------------------------------------
@@ -1776,6 +1908,8 @@ The ``dotcBatchedEx`` function supports the 64-bit integer interface. See the :r
 
 The ``dotcStridedBatchedEx`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_nrm2ex:
+
 hipblasNrm2Ex + Batched, StridedBatched
 ------------------------------------------
 .. doxygenfunction:: hipblasNrm2Ex
@@ -1789,6 +1923,8 @@ The ``nrm2BatchedEx`` function supports the 64-bit integer interface. See the :r
 .. doxygenfunction:: hipblasNrm2StridedBatchedEx
 
 The ``nrm2StridedBatchedEx`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
+
+.. _hipblas_rotex:
 
 hipblasRotEx + Batched, StridedBatched
 ------------------------------------------
@@ -1804,6 +1940,8 @@ The ``rotBatchedEx`` function supports the 64-bit integer interface. See the :re
 
 The ``rotStridedBatchedEx`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _hipblas_scalex:
+
 hipblasScalEx + Batched, StridedBatched
 ------------------------------------------
 .. doxygenfunction:: hipblasScalEx
@@ -1818,12 +1956,15 @@ The ``scalBatchedEx`` function supports the 64-bit integer interface. See the :r
 
 The ``scalStridedBatchedEx`` function supports the 64-bit integer interface. See the :ref:`ILP64 API` section.
 
+.. _solver_api:
+
 SOLVER API
 ===========
 .. contents:: List of SOLVER APIs
    :local:
    :backlinks: top
 
+.. _hipblas_getrf:
 
 hipblasXgetrf + Batched, stridedBatched
 ----------------------------------------
@@ -1851,6 +1992,7 @@ hipblasXgetrf + Batched, stridedBatched
     :outline:
 .. doxygenfunction:: hipblasZgetrfStridedBatched
 
+.. _hipblas_getrs:
 
 hipblasXgetrs + Batched, stridedBatched
 ----------------------------------------
@@ -1878,6 +2020,8 @@ hipblasXgetrs + Batched, stridedBatched
     :outline:
 .. doxygenfunction:: hipblasZgetrsStridedBatched
 
+.. _hipblas_getri:
+
 hipblasXgetri + Batched, stridedBatched
 ----------------------------------------
 
@@ -1888,6 +2032,8 @@ hipblasXgetri + Batched, stridedBatched
 .. doxygenfunction:: hipblasCgetriBatched
     :outline:
 .. doxygenfunction:: hipblasZgetriBatched
+
+.. _hipblas_geqrf:
 
 hipblasXgeqrf + Batched, stridedBatched
 ----------------------------------------
@@ -1914,6 +2060,8 @@ hipblasXgeqrf + Batched, stridedBatched
 .. doxygenfunction:: hipblasCgeqrfStridedBatched
     :outline:
 .. doxygenfunction:: hipblasZgeqrfStridedBatched
+
+.. _hipblas_gels:
 
 hipblasXgels + Batched, StridedBatched
 ----------------------------------------

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -26,6 +26,8 @@ subtrees:
     title: hipBLAS client examples
 - caption: API Reference
   entries:
+    - file: reference/data-type-support
+      title: Data type support
     - file: reference/hipblas-api-functions
       title: hipBLAS API
     - file: reference/deprecation


### PR DESCRIPTION
Summary of proposed changes:

We are collecting the supported precision support types of ROCm libraries. We have a short summary page, and we create a detailed page at library document.

Short summary page:
https://rocm.docs.amd.com/en/latest/reference/precision-support.html

Summary of proposed changes:

- Add supported data types page
- List the different levels supported types
- Link the reference section on data type support page.