### PR TITLE
Use std::complex for clients

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,14 +46,14 @@ extern "C" {
 
 void spotrf_(char* uplo, int64_t* m, float* A, int64_t* lda, int64_t* info);
 void dpotrf_(char* uplo, int64_t* m, double* A, int64_t* lda, int64_t* info);
-void cpotrf_(char* uplo, int64_t* m, hipblasComplex* A, int64_t* lda, int64_t* info);
-void zpotrf_(char* uplo, int64_t* m, hipblasDoubleComplex* A, int64_t* lda, int64_t* info);
+void cpotrf_(char* uplo, int64_t* m, std::complex<float>* A, int64_t* lda, int64_t* info);
+void zpotrf_(char* uplo, int64_t* m, std::complex<double>* A, int64_t* lda, int64_t* info);
 
 void sgetrf_(int64_t* m, int64_t* n, float* A, int64_t* lda, int64_t* ipiv, int64_t* info);
 void dgetrf_(int64_t* m, int64_t* n, double* A, int64_t* lda, int64_t* ipiv, int64_t* info);
-void cgetrf_(int64_t* m, int64_t* n, hipblasComplex* A, int64_t* lda, int64_t* ipiv, int64_t* info);
+void cgetrf_(int64_t* m, int64_t* n, std::complex<float>* A, int64_t* lda, int64_t* ipiv, int64_t* info);
 void zgetrf_(
-    int64_t* m, int64_t* n, hipblasDoubleComplex* A, int64_t* lda, int64_t* ipiv, int64_t* info);
+    int64_t* m, int64_t* n, std::complex<double>* A, int64_t* lda, int64_t* ipiv, int64_t* info);
 
 void sgetrs_(char*    trans,
              int64_t* n,
@@ -76,19 +76,19 @@ void dgetrs_(char*    trans,
 void cgetrs_(char*           trans,
              int64_t*        n,
              int64_t*        nrhs,
-             hipblasComplex* A,
+             std::complex<float>* A,
              int64_t*        lda,
              int64_t*        ipiv,
-             hipblasComplex* B,
+             std::complex<float>* B,
              int64_t*        ldb,
              int64_t*        info);
 void zgetrs_(char*                 trans,
              int64_t*              n,
              int64_t*              nrhs,
-             hipblasDoubleComplex* A,
+             std::complex<double>* A,
              int64_t*              lda,
              int64_t*              ipiv,
-             hipblasDoubleComplex* B,
+             std::complex<double>* B,
              int64_t*              ldb,
              int64_t*              info);
 
@@ -102,17 +102,17 @@ void dgetri_(int64_t* n,
              int64_t* lwork,
              int64_t* info);
 void cgetri_(int64_t*        n,
-             hipblasComplex* A,
+             std::complex<float>* A,
              int64_t*        lda,
              int64_t*        ipiv,
-             hipblasComplex* work,
+             std::complex<float>* work,
              int64_t*        lwork,
              int64_t*        info);
 void zgetri_(int64_t*              n,
-             hipblasDoubleComplex* A,
+             std::complex<double>* A,
              int64_t*              lda,
              int64_t*              ipiv,
-             hipblasDoubleComplex* work,
+             std::complex<double>* work,
              int64_t*              lwork,
              int64_t*              info);
 
@@ -134,18 +134,18 @@ void dgeqrf_(int64_t* m,
              int64_t* info);
 void cgeqrf_(int64_t*        m,
              int64_t*        n,
-             hipblasComplex* A,
+             std::complex<float>* A,
              int64_t*        lda,
-             hipblasComplex* tau,
-             hipblasComplex* work,
+             std::complex<float>* tau,
+             std::complex<float>* work,
              int64_t*        lwork,
              int64_t*        info);
 void zgeqrf_(int64_t*              m,
              int64_t*              n,
-             hipblasDoubleComplex* A,
+             std::complex<double>* A,
              int64_t*              lda,
-             hipblasDoubleComplex* tau,
-             hipblasDoubleComplex* work,
+             std::complex<double>* tau,
+             std::complex<double>* work,
              int64_t*              lwork,
              int64_t*              info);
 
@@ -175,76 +175,76 @@ void cgels_(char*           trans,
             int64_t*        m,
             int64_t*        n,
             int64_t*        nrhs,
-            hipblasComplex* A,
+            std::complex<float>* A,
             int64_t*        lda,
-            hipblasComplex* B,
+            std::complex<float>* B,
             int64_t*        ldb,
-            hipblasComplex* work,
+            std::complex<float>* work,
             int64_t*        lwork,
             int64_t*        info);
 void zgels_(char*                 trans,
             int64_t*              m,
             int64_t*              n,
             int64_t*              nrhs,
-            hipblasDoubleComplex* A,
+            std::complex<double>* A,
             int64_t*              lda,
-            hipblasDoubleComplex* B,
+            std::complex<double>* B,
             int64_t*              ldb,
-            hipblasDoubleComplex* work,
+            std::complex<double>* work,
             int64_t*              lwork,
             int64_t*              info);
 
 /*
 void strtri_(char* uplo, char* diag, int64_t* n, float* A, int64_t* lda, int64_t* info);
 void dtrtri_(char* uplo, char* diag, int64_t* n, double* A, int64_t* lda, int64_t* info);
-void ctrtri_(char* uplo, char* diag, int64_t* n, hipblasComplex* A, int64_t* lda, int64_t* info);
-void ztrtri_(char* uplo, char* diag, int64_t* n, hipblasDoubleComplex* A, int64_t* lda, int64_t* info);
+void ctrtri_(char* uplo, char* diag, int64_t* n, std::complex<float>* A, int64_t* lda, int64_t* info);
+void ztrtri_(char* uplo, char* diag, int64_t* n, std::complex<double>* A, int64_t* lda, int64_t* info);
 
 void cspr_(
-    char* uplo, int64_t* n, hipblasComplex* alpha, hipblasComplex* x, int64_t* incx, hipblasComplex* A);
+    char* uplo, int64_t* n, std::complex<float>* alpha, std::complex<float>* x, int64_t* incx, std::complex<float>* A);
 
 void zspr_(char*                 uplo,
            int64_t*                  n,
-           hipblasDoubleComplex* alpha,
-           hipblasDoubleComplex* x,
+           std::complex<double>* alpha,
+           std::complex<double>* x,
            int64_t*                  incx,
-           hipblasDoubleComplex* A);
+           std::complex<double>* A);
 
 void csyr_(char*           uplo,
            int64_t*            n,
-           hipblasComplex* alpha,
-           hipblasComplex* x,
+           std::complex<float>* alpha,
+           std::complex<float>* x,
            int64_t*            incx,
-           hipblasComplex* a,
+           std::complex<float>* a,
            int64_t*            lda);
 void zsyr_(char*                 uplo,
            int64_t*                  n,
-           hipblasDoubleComplex* alpha,
-           hipblasDoubleComplex* x,
+           std::complex<double>* alpha,
+           std::complex<double>* x,
            int64_t*                  incx,
-           hipblasDoubleComplex* a,
+           std::complex<double>* a,
            int64_t*                  lda);
 
 void csymv_(char*           uplo,
             int64_t*            n,
-            hipblasComplex* alpha,
-            hipblasComplex* A,
+            std::complex<float>* alpha,
+            std::complex<float>* A,
             int64_t*            lda,
-            hipblasComplex* x,
+            std::complex<float>* x,
             int64_t*            incx,
-            hipblasComplex* beta,
-            hipblasComplex* y,
+            std::complex<float>* beta,
+            std::complex<float>* y,
             int64_t*            incy);
 
 void zsymv_(char*                 uplo,
             int64_t*                  n,
-            hipblasDoubleComplex* alpha,
-            hipblasDoubleComplex* A,
+            std::complex<double>* alpha,
+            std::complex<double>* A,
             int64_t*                  lda,
-            hipblasDoubleComplex* x,
+            std::complex<double>* x,
             int64_t*                  incx,
-            hipblasDoubleComplex* beta,
-            hipblasDoubleComplex* y,
+            std::complex<double>* beta,
+            std::complex<double>* y,
             int64_t*                  incy);
 */
 
@@ -380,22 +380,22 @@ void ref_axpy<double, double>(
 }
 
 template <>
-void ref_axpy<hipblasComplex, hipblasComplex>(int64_t               n,
-                                              const hipblasComplex  alpha,
-                                              const hipblasComplex* x,
+void ref_axpy<std::complex<float>, std::complex<float>>(int64_t               n,
+                                              const std::complex<float>  alpha,
+                                              const std::complex<float>* x,
                                               int64_t               incx,
-                                              hipblasComplex*       y,
+                                              std::complex<float>*       y,
                                               int64_t               incy)
 {
     cblas_caxpy(n, &alpha, x, incx, y, incy);
 }
 
 template <>
-void ref_axpy<hipblasDoubleComplex, hipblasDoubleComplex>(int64_t                     n,
-                                                          const hipblasDoubleComplex  alpha,
-                                                          const hipblasDoubleComplex* x,
+void ref_axpy<std::complex<double>, std::complex<double>>(int64_t                     n,
+                                                          const std::complex<double>  alpha,
+                                                          const std::complex<double>* x,
                                                           int64_t                     incx,
-                                                          hipblasDoubleComplex*       y,
+                                                          std::complex<double>*       y,
                                                           int64_t                     incy)
 {
     cblas_zaxpy(n, &alpha, x, incx, y, incy);
@@ -515,33 +515,33 @@ void ref_scal<double>(int64_t n, const double alpha, double* x, int64_t incx)
 }
 
 template <>
-void ref_scal<hipblasComplex>(int64_t              n,
-                              const hipblasComplex alpha,
-                              hipblasComplex*      x,
+void ref_scal<std::complex<float>>(int64_t              n,
+                              const std::complex<float> alpha,
+                              std::complex<float>*      x,
                               int64_t              incx)
 {
     cblas_cscal(n, &alpha, x, incx);
 }
 
 template <>
-void ref_scal<hipblasComplex, float>(int64_t n, const float alpha, hipblasComplex* x, int64_t incx)
+void ref_scal<std::complex<float>, float>(int64_t n, const float alpha, std::complex<float>* x, int64_t incx)
 {
     cblas_csscal(n, alpha, x, incx);
 }
 
 template <>
-void ref_scal<hipblasDoubleComplex>(int64_t                    n,
-                                    const hipblasDoubleComplex alpha,
-                                    hipblasDoubleComplex*      x,
+void ref_scal<std::complex<double>>(int64_t                    n,
+                                    const std::complex<double> alpha,
+                                    std::complex<double>*      x,
                                     int64_t                    incx)
 {
     cblas_zscal(n, &alpha, x, incx);
 }
 
 template <>
-void ref_scal<hipblasDoubleComplex, double>(int64_t               n,
+void ref_scal<std::complex<double>, double>(int64_t               n,
                                             const double          alpha,
-                                            hipblasDoubleComplex* x,
+                                            std::complex<double>* x,
                                             int64_t               incx)
 {
     cblas_zdscal(n, alpha, x, incx);
@@ -561,15 +561,15 @@ void ref_copy<double>(int64_t n, double* x, int64_t incx, double* y, int64_t inc
 }
 
 template <>
-void ref_copy<hipblasComplex>(
-    int64_t n, hipblasComplex* x, int64_t incx, hipblasComplex* y, int64_t incy)
+void ref_copy<std::complex<float>>(
+    int64_t n, std::complex<float>* x, int64_t incx, std::complex<float>* y, int64_t incy)
 {
     cblas_ccopy(n, x, incx, y, incy);
 }
 
 template <>
-void ref_copy<hipblasDoubleComplex>(
-    int64_t n, hipblasDoubleComplex* x, int64_t incx, hipblasDoubleComplex* y, int64_t incy)
+void ref_copy<std::complex<double>>(
+    int64_t n, std::complex<double>* x, int64_t incx, std::complex<double>* y, int64_t incy)
 {
     cblas_zcopy(n, x, incx, y, incy);
 }
@@ -588,15 +588,15 @@ void ref_swap<double>(int64_t n, double* x, int64_t incx, double* y, int64_t inc
 }
 
 template <>
-void ref_swap<hipblasComplex>(
-    int64_t n, hipblasComplex* x, int64_t incx, hipblasComplex* y, int64_t incy)
+void ref_swap<std::complex<float>>(
+    int64_t n, std::complex<float>* x, int64_t incx, std::complex<float>* y, int64_t incy)
 {
     cblas_cswap(n, x, incx, y, incy);
 }
 
 template <>
-void ref_swap<hipblasDoubleComplex>(
-    int64_t n, hipblasDoubleComplex* x, int64_t incx, hipblasDoubleComplex* y, int64_t incy)
+void ref_swap<std::complex<double>>(
+    int64_t n, std::complex<double>* x, int64_t incx, std::complex<double>* y, int64_t incy)
 {
     cblas_zswap(n, x, incx, y, incy);
 }
@@ -659,23 +659,23 @@ void ref_dot<double>(
 }
 
 template <>
-void ref_dot<hipblasComplex>(int64_t               n,
-                             const hipblasComplex* x,
+void ref_dot<std::complex<float>>(int64_t               n,
+                             const std::complex<float>* x,
                              int64_t               incx,
-                             const hipblasComplex* y,
+                             const std::complex<float>* y,
                              int64_t               incy,
-                             hipblasComplex*       result)
+                             std::complex<float>*       result)
 {
     cblas_cdotu_sub(n, x, incx, y, incy, result);
 }
 
 template <>
-void ref_dot<hipblasDoubleComplex>(int64_t                     n,
-                                   const hipblasDoubleComplex* x,
+void ref_dot<std::complex<double>>(int64_t                     n,
+                                   const std::complex<double>* x,
                                    int64_t                     incx,
-                                   const hipblasDoubleComplex* y,
+                                   const std::complex<double>* y,
                                    int64_t                     incy,
-                                   hipblasDoubleComplex*       result)
+                                   std::complex<double>*       result)
 {
     cblas_zdotu_sub(n, x, incx, y, incy, result);
 }
@@ -721,23 +721,23 @@ void ref_dotc<double>(
 }
 
 template <>
-void ref_dotc<hipblasComplex>(int64_t               n,
-                              const hipblasComplex* x,
+void ref_dotc<std::complex<float>>(int64_t               n,
+                              const std::complex<float>* x,
                               int64_t               incx,
-                              const hipblasComplex* y,
+                              const std::complex<float>* y,
                               int64_t               incy,
-                              hipblasComplex*       result)
+                              std::complex<float>*       result)
 {
     cblas_cdotc_sub(n, x, incx, y, incy, result);
 }
 
 template <>
-void ref_dotc<hipblasDoubleComplex>(int64_t                     n,
-                                    const hipblasDoubleComplex* x,
+void ref_dotc<std::complex<double>>(int64_t                     n,
+                                    const std::complex<double>* x,
                                     int64_t                     incx,
-                                    const hipblasDoubleComplex* y,
+                                    const std::complex<double>* y,
                                     int64_t                     incy,
-                                    hipblasDoubleComplex*       result)
+                                    std::complex<double>*       result)
 {
     cblas_zdotc_sub(n, x, incx, y, incy, result);
 }
@@ -790,8 +790,8 @@ void ref_nrm2<double, double>(int64_t n, const double* x, int64_t incx, double* 
 }
 
 template <>
-void ref_nrm2<hipblasComplex, float>(int64_t               n,
-                                     const hipblasComplex* x,
+void ref_nrm2<std::complex<float>, float>(int64_t               n,
+                                     const std::complex<float>* x,
                                      int64_t               incx,
                                      float*                result)
 {
@@ -799,8 +799,8 @@ void ref_nrm2<hipblasComplex, float>(int64_t               n,
 }
 
 template <>
-void ref_nrm2<hipblasDoubleComplex, double>(int64_t                     n,
-                                            const hipblasDoubleComplex* x,
+void ref_nrm2<std::complex<double>, double>(int64_t                     n,
+                                            const std::complex<double>* x,
                                             int64_t                     incx,
                                             double*                     result)
 {
@@ -813,36 +813,36 @@ void ref_nrm2<hipblasDoubleComplex, double>(int64_t                     n,
 // LAPACK fortran library functionality
 extern "C" {
 void crot_(const int64_t*        n,
-           hipblasComplex*       cx,
+           std::complex<float>*       cx,
            const int64_t*        incx,
-           hipblasComplex*       cy,
+           std::complex<float>*       cy,
            const int64_t*        incy,
            const float*          c,
-           const hipblasComplex* s);
+           const std::complex<float>* s);
 void csrot_(const int64_t*  n,
-            hipblasComplex* cx,
+            std::complex<float>* cx,
             const int64_t*  incx,
-            hipblasComplex* cy,
+            std::complex<float>* cy,
             const int64_t*  incy,
             const float*    c,
             const float*    s);
 void zrot_(const int64_t*              n,
-           hipblasDoubleComplex*       cx,
+           std::complex<double>*       cx,
            const int64_t*              incx,
-           hipblasDoubleComplex*       cy,
+           std::complex<double>*       cy,
            const int64_t*              incy,
            const double*               c,
-           const hipblasDoubleComplex* s);
+           const std::complex<double>* s);
 void zdrot_(const int64_t*        n,
-            hipblasDoubleComplex* cx,
+            std::complex<double>* cx,
             const int64_t*        incx,
-            hipblasDoubleComplex* cy,
+            std::complex<double>* cy,
             const int64_t*        incy,
             const double*         c,
             const double*         s);
 
-void crotg_(hipblasComplex* a, hipblasComplex* b, float* c, hipblasComplex* s);
-void zrotg_(hipblasDoubleComplex* a, hipblasDoubleComplex* b, double* c, hipblasDoubleComplex* s);
+void crotg_(std::complex<float>* a, std::complex<float>* b, float* c, std::complex<float>* s);
+void zrotg_(std::complex<double>* a, std::complex<double>* b, double* c, std::complex<double>* s);
 }
 
 // rot
@@ -936,67 +936,67 @@ void ref_rot<double>(
 }
 
 template <>
-void ref_rot<hipblasComplex>(int64_t         n,
-                             hipblasComplex* x,
+void ref_rot<std::complex<float>>(int64_t         n,
+                             std::complex<float>* x,
                              int64_t         incx,
-                             hipblasComplex* y,
+                             std::complex<float>* y,
                              int64_t         incy,
-                             hipblasComplex  c,
-                             hipblasComplex  s)
+                             std::complex<float>  c,
+                             std::complex<float>  s)
 {
     float c_real = std::real(c);
     lapack_xrot(n, x, incx, y, incy, c_real, s);
 }
 
 template <>
-void ref_rot<hipblasComplex, float>(int64_t         n,
-                                    hipblasComplex* x,
+void ref_rot<std::complex<float>, float>(int64_t         n,
+                                    std::complex<float>* x,
                                     int64_t         incx,
-                                    hipblasComplex* y,
+                                    std::complex<float>* y,
                                     int64_t         incy,
                                     float           c,
-                                    hipblasComplex  s)
+                                    std::complex<float>  s)
 {
     lapack_xrot(n, x, incx, y, incy, c, s);
 }
 
 template <>
-void ref_rot<hipblasComplex, float, float>(
-    int64_t n, hipblasComplex* x, int64_t incx, hipblasComplex* y, int64_t incy, float c, float s)
+void ref_rot<std::complex<float>, float, float>(
+    int64_t n, std::complex<float>* x, int64_t incx, std::complex<float>* y, int64_t incy, float c, float s)
 {
     lapack_xrot(n, x, incx, y, incy, c, s);
 }
 
 template <>
-void ref_rot<hipblasDoubleComplex>(int64_t               n,
-                                   hipblasDoubleComplex* x,
+void ref_rot<std::complex<double>>(int64_t               n,
+                                   std::complex<double>* x,
                                    int64_t               incx,
-                                   hipblasDoubleComplex* y,
+                                   std::complex<double>* y,
                                    int64_t               incy,
-                                   hipblasDoubleComplex  c,
-                                   hipblasDoubleComplex  s)
+                                   std::complex<double>  c,
+                                   std::complex<double>  s)
 {
     double c_real = std::real(c);
     lapack_xrot(n, x, incx, y, incy, c_real, s);
 }
 
 template <>
-void ref_rot<hipblasDoubleComplex, double>(int64_t               n,
-                                           hipblasDoubleComplex* x,
+void ref_rot<std::complex<double>, double>(int64_t               n,
+                                           std::complex<double>* x,
                                            int64_t               incx,
-                                           hipblasDoubleComplex* y,
+                                           std::complex<double>* y,
                                            int64_t               incy,
                                            double                c,
-                                           hipblasDoubleComplex  s)
+                                           std::complex<double>  s)
 {
     lapack_xrot(n, x, incx, y, incy, c, s);
 }
 
 template <>
-void ref_rot<hipblasDoubleComplex, double, double>(int64_t               n,
-                                                   hipblasDoubleComplex* x,
+void ref_rot<std::complex<double>, double, double>(int64_t               n,
+                                                   std::complex<double>* x,
                                                    int64_t               incx,
-                                                   hipblasDoubleComplex* y,
+                                                   std::complex<double>* y,
                                                    int64_t               incy,
                                                    double                c,
                                                    double                s)
@@ -1018,19 +1018,19 @@ void ref_rotg<double>(double* a, double* b, double* c, double* s)
 }
 
 template <>
-void ref_rotg<hipblasComplex, float>(hipblasComplex* a,
-                                     hipblasComplex* b,
+void ref_rotg<std::complex<float>, float>(std::complex<float>* a,
+                                     std::complex<float>* b,
                                      float*          c,
-                                     hipblasComplex* s)
+                                     std::complex<float>* s)
 {
     lapack_xrotg(*a, *b, *c, *s);
 }
 
 template <>
-void ref_rotg<hipblasDoubleComplex, double>(hipblasDoubleComplex* a,
-                                            hipblasDoubleComplex* b,
+void ref_rotg<std::complex<double>, double>(std::complex<double>* a,
+                                            std::complex<double>* b,
                                             double*               c,
-                                            hipblasDoubleComplex* s)
+                                            std::complex<double>* s)
 {
     lapack_xrotg(*a, *b, *c, *s);
 }
@@ -1050,8 +1050,8 @@ void ref_asum<double, double>(int64_t n, const double* x, int64_t incx, double* 
 }
 
 template <>
-void ref_asum<hipblasComplex, float>(int64_t               n,
-                                       const hipblasComplex* x,
+void ref_asum<std::complex<float>, float>(int64_t               n,
+                                       const std::complex<float>* x,
                                        int64_t               incx,
                                        float*                result)
 {
@@ -1059,8 +1059,8 @@ void ref_asum<hipblasComplex, float>(int64_t               n,
 }
 
 template <>
-void ref_asum<hipblasDoubleComplex, double>(int64_t                     n,
-                                              const hipblasDoubleComplex* x,
+void ref_asum<std::complex<double>, double>(int64_t                     n,
+                                              const std::complex<double>* x,
                                               int64_t                     incx,
                                               double*                     result)
 {
@@ -1086,14 +1086,14 @@ void ref_iamax<double>(int64_t n, const double* x, int64_t incx, int64_t* result
 }
 
 template <>
-void ref_iamax<hipblasComplex>(int64_t n, const hipblasComplex* x, int64_t incx, int64_t* result)
+void ref_iamax<std::complex<float>>(int64_t n, const std::complex<float>* x, int64_t incx, int64_t* result)
 {
     *result = (int64_t)cblas_icamax(n, x, incx);
 }
 
 template <>
-void ref_iamax<hipblasDoubleComplex>(int64_t                     n,
-                                     const hipblasDoubleComplex* x,
+void ref_iamax<std::complex<double>>(int64_t                     n,
+                                     const std::complex<double>* x,
                                      int64_t                     incx,
                                      int64_t*                    result)
 {
@@ -1110,13 +1110,13 @@ double hipblas_magnitude(T val)
 }
 
 template <>
-double hipblas_magnitude(hipblasComplex val)
+double hipblas_magnitude(std::complex<float> val)
 {
     return std::abs(val.real()) + std::abs(val.imag());
 }
 
 template <>
-double hipblas_magnitude(hipblasDoubleComplex val)
+double hipblas_magnitude(std::complex<double> val)
 {
     return std::abs(val.real()) + std::abs(val.imag());
 }
@@ -1155,14 +1155,14 @@ void ref_iamin<double>(int64_t n, const double* x, int64_t incx, int64_t* result
 }
 
 template <>
-void ref_iamin<hipblasComplex>(int64_t n, const hipblasComplex* x, int64_t incx, int64_t* result)
+void ref_iamin<std::complex<float>>(int64_t n, const std::complex<float>* x, int64_t incx, int64_t* result)
 {
     *result = (int64_t)ref_iamin_helper(n, x, incx);
 }
 
 template <>
-void ref_iamin<hipblasDoubleComplex>(int64_t                     n,
-                                     const hipblasDoubleComplex* x,
+void ref_iamin<std::complex<double>>(int64_t                     n,
+                                     const std::complex<double>* x,
                                      int64_t                     incx,
                                      int64_t*                    result)
 {
@@ -1240,18 +1240,18 @@ void ref_gbmv<double>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gbmv<hipblasComplex>(hipblasOperation_t transA,
+void ref_gbmv<std::complex<float>>(hipblasOperation_t transA,
                               int64_t            m,
                               int64_t            n,
                               int64_t            kl,
                               int64_t            ku,
-                              hipblasComplex     alpha,
-                              hipblasComplex*    A,
+                              std::complex<float>     alpha,
+                              std::complex<float>*    A,
                               int64_t            lda,
-                              hipblasComplex*    x,
+                              std::complex<float>*    x,
                               int64_t            incx,
-                              hipblasComplex     beta,
-                              hipblasComplex*    y,
+                              std::complex<float>     beta,
+                              std::complex<float>*    y,
                               int64_t            incy)
 {
     cblas_cgbmv(CblasColMajor,
@@ -1271,18 +1271,18 @@ void ref_gbmv<hipblasComplex>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gbmv<hipblasDoubleComplex>(hipblasOperation_t    transA,
+void ref_gbmv<std::complex<double>>(hipblasOperation_t    transA,
                                     int64_t               m,
                                     int64_t               n,
                                     int64_t               kl,
                                     int64_t               ku,
-                                    hipblasDoubleComplex  alpha,
-                                    hipblasDoubleComplex* A,
+                                    std::complex<double>  alpha,
+                                    std::complex<double>* A,
                                     int64_t               lda,
-                                    hipblasDoubleComplex* x,
+                                    std::complex<double>* x,
                                     int64_t               incx,
-                                    hipblasDoubleComplex  beta,
-                                    hipblasDoubleComplex* y,
+                                    std::complex<double>  beta,
+                                    std::complex<double>* y,
                                     int64_t               incy)
 {
     cblas_zgbmv(CblasColMajor,
@@ -1337,16 +1337,16 @@ void ref_gemv<double>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gemv<hipblasComplex>(hipblasOperation_t transA,
+void ref_gemv<std::complex<float>>(hipblasOperation_t transA,
                               int64_t            m,
                               int64_t            n,
-                              hipblasComplex     alpha,
-                              hipblasComplex*    A,
+                              std::complex<float>     alpha,
+                              std::complex<float>*    A,
                               int64_t            lda,
-                              hipblasComplex*    x,
+                              std::complex<float>*    x,
                               int64_t            incx,
-                              hipblasComplex     beta,
-                              hipblasComplex*    y,
+                              std::complex<float>     beta,
+                              std::complex<float>*    y,
                               int64_t            incy)
 {
     cblas_cgemv(
@@ -1354,16 +1354,16 @@ void ref_gemv<hipblasComplex>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gemv<hipblasDoubleComplex>(hipblasOperation_t    transA,
+void ref_gemv<std::complex<double>>(hipblasOperation_t    transA,
                                     int64_t               m,
                                     int64_t               n,
-                                    hipblasDoubleComplex  alpha,
-                                    hipblasDoubleComplex* A,
+                                    std::complex<double>  alpha,
+                                    std::complex<double>* A,
                                     int64_t               lda,
-                                    hipblasDoubleComplex* x,
+                                    std::complex<double>* x,
                                     int64_t               incx,
-                                    hipblasDoubleComplex  beta,
-                                    hipblasDoubleComplex* y,
+                                    std::complex<double>  beta,
+                                    std::complex<double>* y,
                                     int64_t               incy)
 {
     cblas_zgemv(
@@ -1400,56 +1400,56 @@ void ref_ger<double, false>(int64_t m,
 }
 
 template <>
-void ref_ger<hipblasComplex, false>(int64_t         m,
+void ref_ger<std::complex<float>, false>(int64_t         m,
                                     int64_t         n,
-                                    hipblasComplex  alpha,
-                                    hipblasComplex* x,
+                                    std::complex<float>  alpha,
+                                    std::complex<float>* x,
                                     int64_t         incx,
-                                    hipblasComplex* y,
+                                    std::complex<float>* y,
                                     int64_t         incy,
-                                    hipblasComplex* A,
+                                    std::complex<float>* A,
                                     int64_t         lda)
 {
     cblas_cgeru(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void ref_ger<hipblasComplex, true>(int64_t         m,
+void ref_ger<std::complex<float>, true>(int64_t         m,
                                    int64_t         n,
-                                   hipblasComplex  alpha,
-                                   hipblasComplex* x,
+                                   std::complex<float>  alpha,
+                                   std::complex<float>* x,
                                    int64_t         incx,
-                                   hipblasComplex* y,
+                                   std::complex<float>* y,
                                    int64_t         incy,
-                                   hipblasComplex* A,
+                                   std::complex<float>* A,
                                    int64_t         lda)
 {
     cblas_cgerc(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void ref_ger<hipblasDoubleComplex, false>(int64_t               m,
+void ref_ger<std::complex<double>, false>(int64_t               m,
                                           int64_t               n,
-                                          hipblasDoubleComplex  alpha,
-                                          hipblasDoubleComplex* x,
+                                          std::complex<double>  alpha,
+                                          std::complex<double>* x,
                                           int64_t               incx,
-                                          hipblasDoubleComplex* y,
+                                          std::complex<double>* y,
                                           int64_t               incy,
-                                          hipblasDoubleComplex* A,
+                                          std::complex<double>* A,
                                           int64_t               lda)
 {
     cblas_zgeru(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void ref_ger<hipblasDoubleComplex, true>(int64_t               m,
+void ref_ger<std::complex<double>, true>(int64_t               m,
                                          int64_t               n,
-                                         hipblasDoubleComplex  alpha,
-                                         hipblasDoubleComplex* x,
+                                         std::complex<double>  alpha,
+                                         std::complex<double>* x,
                                          int64_t               incx,
-                                         hipblasDoubleComplex* y,
+                                         std::complex<double>* y,
                                          int64_t               incy,
-                                         hipblasDoubleComplex* A,
+                                         std::complex<double>* A,
                                          int64_t               lda)
 {
     cblas_zgerc(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
@@ -1457,32 +1457,32 @@ void ref_ger<hipblasDoubleComplex, true>(int64_t               m,
 
 // hbmv
 template <>
-void ref_hbmv<hipblasComplex>(hipblasFillMode_t uplo,
+void ref_hbmv<std::complex<float>>(hipblasFillMode_t uplo,
                               int64_t           n,
                               int64_t           k,
-                              hipblasComplex    alpha,
-                              hipblasComplex*   A,
+                              std::complex<float>    alpha,
+                              std::complex<float>*   A,
                               int64_t           lda,
-                              hipblasComplex*   x,
+                              std::complex<float>*   x,
                               int64_t           incx,
-                              hipblasComplex    beta,
-                              hipblasComplex*   y,
+                              std::complex<float>    beta,
+                              std::complex<float>*   y,
                               int64_t           incy)
 {
     cblas_chbmv(CblasColMajor, (CBLAS_UPLO)uplo, n, k, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 template <>
-void ref_hbmv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+void ref_hbmv<std::complex<double>>(hipblasFillMode_t     uplo,
                                     int64_t               n,
                                     int64_t               k,
-                                    hipblasDoubleComplex  alpha,
-                                    hipblasDoubleComplex* A,
+                                    std::complex<double>  alpha,
+                                    std::complex<double>* A,
                                     int64_t               lda,
-                                    hipblasDoubleComplex* x,
+                                    std::complex<double>* x,
                                     int64_t               incx,
-                                    hipblasDoubleComplex  beta,
-                                    hipblasDoubleComplex* y,
+                                    std::complex<double>  beta,
+                                    std::complex<double>* y,
                                     int64_t               incy)
 {
     cblas_zhbmv(CblasColMajor, (CBLAS_UPLO)uplo, n, k, &alpha, A, lda, x, incx, &beta, y, incy);
@@ -1490,30 +1490,30 @@ void ref_hbmv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
 
 // hemv
 template <>
-void ref_hemv<hipblasComplex>(hipblasFillMode_t uplo,
+void ref_hemv<std::complex<float>>(hipblasFillMode_t uplo,
                               int64_t           n,
-                              hipblasComplex    alpha,
-                              hipblasComplex*   A,
+                              std::complex<float>    alpha,
+                              std::complex<float>*   A,
                               int64_t           lda,
-                              hipblasComplex*   x,
+                              std::complex<float>*   x,
                               int64_t           incx,
-                              hipblasComplex    beta,
-                              hipblasComplex*   y,
+                              std::complex<float>    beta,
+                              std::complex<float>*   y,
                               int64_t           incy)
 {
     cblas_chemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
 
 template <>
-void ref_hemv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+void ref_hemv<std::complex<double>>(hipblasFillMode_t     uplo,
                                     int64_t               n,
-                                    hipblasDoubleComplex  alpha,
-                                    hipblasDoubleComplex* A,
+                                    std::complex<double>  alpha,
+                                    std::complex<double>* A,
                                     int64_t               lda,
-                                    hipblasDoubleComplex* x,
+                                    std::complex<double>* x,
                                     int64_t               incx,
-                                    hipblasDoubleComplex  beta,
-                                    hipblasDoubleComplex* y,
+                                    std::complex<double>  beta,
+                                    std::complex<double>* y,
                                     int64_t               incy)
 {
     cblas_zhemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
@@ -1521,24 +1521,24 @@ void ref_hemv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
 
 // her
 template <>
-void ref_her<hipblasComplex, float>(hipblasFillMode_t uplo,
+void ref_her<std::complex<float>, float>(hipblasFillMode_t uplo,
                                     int64_t           n,
                                     float             alpha,
-                                    hipblasComplex*   x,
+                                    std::complex<float>*   x,
                                     int64_t           incx,
-                                    hipblasComplex*   A,
+                                    std::complex<float>*   A,
                                     int64_t           lda)
 {
     cblas_cher(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
 }
 
 template <>
-void ref_her<hipblasDoubleComplex, double>(hipblasFillMode_t     uplo,
+void ref_her<std::complex<double>, double>(hipblasFillMode_t     uplo,
                                            int64_t               n,
                                            double                alpha,
-                                           hipblasDoubleComplex* x,
+                                           std::complex<double>* x,
                                            int64_t               incx,
-                                           hipblasDoubleComplex* A,
+                                           std::complex<double>* A,
                                            int64_t               lda)
 {
     cblas_zher(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
@@ -1546,28 +1546,28 @@ void ref_her<hipblasDoubleComplex, double>(hipblasFillMode_t     uplo,
 
 // her2
 template <>
-void ref_her2<hipblasComplex>(hipblasFillMode_t uplo,
+void ref_her2<std::complex<float>>(hipblasFillMode_t uplo,
                               int64_t           n,
-                              hipblasComplex    alpha,
-                              hipblasComplex*   x,
+                              std::complex<float>    alpha,
+                              std::complex<float>*   x,
                               int64_t           incx,
-                              hipblasComplex*   y,
+                              std::complex<float>*   y,
                               int64_t           incy,
-                              hipblasComplex*   A,
+                              std::complex<float>*   A,
                               int64_t           lda)
 {
     cblas_cher2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void ref_her2<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+void ref_her2<std::complex<double>>(hipblasFillMode_t     uplo,
                                     int64_t               n,
-                                    hipblasDoubleComplex  alpha,
-                                    hipblasDoubleComplex* x,
+                                    std::complex<double>  alpha,
+                                    std::complex<double>* x,
                                     int64_t               incx,
-                                    hipblasDoubleComplex* y,
+                                    std::complex<double>* y,
                                     int64_t               incy,
-                                    hipblasDoubleComplex* A,
+                                    std::complex<double>* A,
                                     int64_t               lda)
 {
     cblas_zher2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, A, lda);
@@ -1575,28 +1575,28 @@ void ref_her2<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
 
 // hpmv
 template <>
-void ref_hpmv<hipblasComplex>(hipblasFillMode_t uplo,
+void ref_hpmv<std::complex<float>>(hipblasFillMode_t uplo,
                               int64_t           n,
-                              hipblasComplex    alpha,
-                              hipblasComplex*   AP,
-                              hipblasComplex*   x,
+                              std::complex<float>    alpha,
+                              std::complex<float>*   AP,
+                              std::complex<float>*   x,
                               int64_t           incx,
-                              hipblasComplex    beta,
-                              hipblasComplex*   y,
+                              std::complex<float>    beta,
+                              std::complex<float>*   y,
                               int64_t           incy)
 {
     cblas_chpmv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, AP, x, incx, &beta, y, incy);
 }
 
 template <>
-void ref_hpmv<hipblasDoubleComplex>(hipblasFillMode_t     uplo,
+void ref_hpmv<std::complex<double>>(hipblasFillMode_t     uplo,
                                     int64_t               n,
-                                    hipblasDoubleComplex  alpha,
-                                    hipblasDoubleComplex* AP,
-                                    hipblasDoubleComplex* x,
+                                    std::complex<double>  alpha,
+                                    std::complex<double>* AP,
+                                    std::complex<double>* x,
                                     int64_t               incx,
-                                    hipblasDoubleComplex  beta,
-                                    hipblasDoubleComplex* y,
+                                    std::complex<double>  beta,
+                                    std::complex<double>* y,
                                     int64_t               incy)
 {
     cblas_zhpmv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, AP, x, incx, &beta, y, incy);
@@ -1607,9 +1607,9 @@ template <>
 void ref_hpr(hipblasFillMode_t uplo,
              int64_t           n,
              float             alpha,
-             hipblasComplex*   x,
+             std::complex<float>*   x,
              int64_t           incx,
-             hipblasComplex*   AP)
+             std::complex<float>*   AP)
 {
     cblas_chpr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, AP);
 }
@@ -1618,9 +1618,9 @@ template <>
 void ref_hpr(hipblasFillMode_t     uplo,
              int64_t               n,
              double                alpha,
-             hipblasDoubleComplex* x,
+             std::complex<double>* x,
              int64_t               incx,
-             hipblasDoubleComplex* AP)
+             std::complex<double>* AP)
 {
     cblas_zhpr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, AP);
 }
@@ -1629,12 +1629,12 @@ void ref_hpr(hipblasFillMode_t     uplo,
 template <>
 void ref_hpr2(hipblasFillMode_t uplo,
               int64_t           n,
-              hipblasComplex    alpha,
-              hipblasComplex*   x,
+              std::complex<float>    alpha,
+              std::complex<float>*   x,
               int64_t           incx,
-              hipblasComplex*   y,
+              std::complex<float>*   y,
               int64_t           incy,
-              hipblasComplex*   AP)
+              std::complex<float>*   AP)
 {
     cblas_chpr2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, AP);
 }
@@ -1642,12 +1642,12 @@ void ref_hpr2(hipblasFillMode_t uplo,
 template <>
 void ref_hpr2(hipblasFillMode_t     uplo,
               int64_t               n,
-              hipblasDoubleComplex  alpha,
-              hipblasDoubleComplex* x,
+              std::complex<double>  alpha,
+              std::complex<double>* x,
               int64_t               incx,
-              hipblasDoubleComplex* y,
+              std::complex<double>* y,
               int64_t               incy,
-              hipblasDoubleComplex* AP)
+              std::complex<double>* AP)
 {
     cblas_zhpr2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, AP);
 }
@@ -1730,10 +1730,10 @@ void ref_spr(hipblasFillMode_t uplo, int64_t n, double alpha, double* x, int64_t
 template <>
 void ref_spr(hipblasFillMode_t uplo,
              int64_t           n,
-             hipblasComplex    alpha,
-             hipblasComplex*   x,
+             std::complex<float>    alpha,
+             std::complex<float>*   x,
              int64_t           incx,
-             hipblasComplex*   AP)
+             std::complex<float>*   AP)
 {
     lapack_xspr(uplo, n, alpha, x, incx, AP);
 }
@@ -1741,10 +1741,10 @@ void ref_spr(hipblasFillMode_t uplo,
 template <>
 void ref_spr(hipblasFillMode_t     uplo,
              int64_t               n,
-             hipblasDoubleComplex  alpha,
-             hipblasDoubleComplex* x,
+             std::complex<double>  alpha,
+             std::complex<double>* x,
              int64_t               incx,
-             hipblasDoubleComplex* AP)
+             std::complex<double>* AP)
 {
     lapack_xspr(uplo, n, alpha, x, incx, AP);
 }
@@ -1810,13 +1810,13 @@ void ref_symv(hipblasFillMode_t uplo,
 template <>
 void ref_symv(hipblasFillMode_t uplo,
               int64_t           n,
-              hipblasComplex    alpha,
-              hipblasComplex*   A,
+              std::complex<float>    alpha,
+              std::complex<float>*   A,
               int64_t           lda,
-              hipblasComplex*   x,
+              std::complex<float>*   x,
               int64_t           incx,
-              hipblasComplex    beta,
-              hipblasComplex*   y,
+              std::complex<float>    beta,
+              std::complex<float>*   y,
               int64_t           incy)
 {
     lapack_xsymv(uplo, n, alpha, A, lda, x, incx, beta, y, incy);
@@ -1825,13 +1825,13 @@ void ref_symv(hipblasFillMode_t uplo,
 template <>
 void ref_symv(hipblasFillMode_t     uplo,
               int64_t               n,
-              hipblasDoubleComplex  alpha,
-              hipblasDoubleComplex* A,
+              std::complex<double>  alpha,
+              std::complex<double>* A,
               int64_t               lda,
-              hipblasDoubleComplex* x,
+              std::complex<double>* x,
               int64_t               incx,
-              hipblasDoubleComplex  beta,
-              hipblasDoubleComplex* y,
+              std::complex<double>  beta,
+              std::complex<double>* y,
               int64_t               incy)
 {
     lapack_xsymv(uplo, n, alpha, A, lda, x, incx, beta, y, incy);
@@ -1860,10 +1860,10 @@ void ref_syr<double>(hipblasFillMode_t uplo,
 template <>
 void ref_syr(hipblasFillMode_t uplo,
              int64_t           n,
-             hipblasComplex    alpha,
-             hipblasComplex*   xa,
+             std::complex<float>    alpha,
+             std::complex<float>*   xa,
              int64_t           incx,
-             hipblasComplex*   A,
+             std::complex<float>*   A,
              int64_t           lda)
 {
     lapack_xsyr(uplo, n, alpha, xa, incx, A, lda);
@@ -1872,10 +1872,10 @@ void ref_syr(hipblasFillMode_t uplo,
 template <>
 void ref_syr(hipblasFillMode_t     uplo,
              int64_t               n,
-             hipblasDoubleComplex  alpha,
-             hipblasDoubleComplex* xa,
+             std::complex<double>  alpha,
+             std::complex<double>* xa,
              int64_t               incx,
-             hipblasDoubleComplex* A,
+             std::complex<double>* A,
              int64_t               lda)
 {
     lapack_xsyr(uplo, n, alpha, xa, incx, A, lda);
@@ -1914,12 +1914,12 @@ void ref_syr2(hipblasFillMode_t uplo,
 template <>
 void ref_syr2(hipblasFillMode_t uplo,
               int64_t           n,
-              hipblasComplex    alpha,
-              hipblasComplex*   x,
+              std::complex<float>    alpha,
+              std::complex<float>*   x,
               int64_t           incx,
-              hipblasComplex*   y,
+              std::complex<float>*   y,
               int64_t           incy,
-              hipblasComplex*   A,
+              std::complex<float>*   A,
               int64_t           lda)
 {
     lapack_xsyr2(uplo, n, alpha, x, incx, y, incy, A, lda);
@@ -1928,12 +1928,12 @@ void ref_syr2(hipblasFillMode_t uplo,
 template <>
 void ref_syr2(hipblasFillMode_t     uplo,
               int64_t               n,
-              hipblasDoubleComplex  alpha,
-              hipblasDoubleComplex* x,
+              std::complex<double>  alpha,
+              std::complex<double>* x,
               int64_t               incx,
-              hipblasDoubleComplex* y,
+              std::complex<double>* y,
               int64_t               incy,
-              hipblasDoubleComplex* A,
+              std::complex<double>* A,
               int64_t               lda)
 {
     lapack_xsyr2(uplo, n, alpha, x, incx, y, incy, A, lda);
@@ -1987,14 +1987,14 @@ void ref_tbmv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_tbmv<hipblasComplex>(hipblasFillMode_t     uplo,
+void ref_tbmv<std::complex<float>>(hipblasFillMode_t     uplo,
                               hipblasOperation_t    transA,
                               hipblasDiagType_t     diag,
                               int64_t               m,
                               int64_t               k,
-                              const hipblasComplex* A,
+                              const std::complex<float>* A,
                               int64_t               lda,
-                              hipblasComplex*       x,
+                              std::complex<float>*       x,
                               int64_t               incx)
 {
     cblas_ctbmv(CblasColMajor,
@@ -2010,14 +2010,14 @@ void ref_tbmv<hipblasComplex>(hipblasFillMode_t     uplo,
 }
 
 template <>
-void ref_tbmv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
+void ref_tbmv<std::complex<double>>(hipblasFillMode_t           uplo,
                                     hipblasOperation_t          transA,
                                     hipblasDiagType_t           diag,
                                     int64_t                     m,
                                     int64_t                     k,
-                                    const hipblasDoubleComplex* A,
+                                    const std::complex<double>* A,
                                     int64_t                     lda,
-                                    hipblasDoubleComplex*       x,
+                                    std::complex<double>*       x,
                                     int64_t                     incx)
 {
     cblas_ztbmv(CblasColMajor,
@@ -2080,14 +2080,14 @@ void ref_tbsv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_tbsv<hipblasComplex>(hipblasFillMode_t     uplo,
+void ref_tbsv<std::complex<float>>(hipblasFillMode_t     uplo,
                               hipblasOperation_t    transA,
                               hipblasDiagType_t     diag,
                               int64_t               m,
                               int64_t               k,
-                              const hipblasComplex* A,
+                              const std::complex<float>* A,
                               int64_t               lda,
-                              hipblasComplex*       x,
+                              std::complex<float>*       x,
                               int64_t               incx)
 {
     cblas_ctbsv(CblasColMajor,
@@ -2103,14 +2103,14 @@ void ref_tbsv<hipblasComplex>(hipblasFillMode_t     uplo,
 }
 
 template <>
-void ref_tbsv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
+void ref_tbsv<std::complex<double>>(hipblasFillMode_t           uplo,
                                     hipblasOperation_t          transA,
                                     hipblasDiagType_t           diag,
                                     int64_t                     m,
                                     int64_t                     k,
-                                    const hipblasDoubleComplex* A,
+                                    const std::complex<double>* A,
                                     int64_t                     lda,
-                                    hipblasDoubleComplex*       x,
+                                    std::complex<double>*       x,
                                     int64_t                     incx)
 {
     cblas_ztbsv(CblasColMajor,
@@ -2157,8 +2157,8 @@ void ref_tpmv(hipblasFillMode_t     uplo,
               hipblasOperation_t    transA,
               hipblasDiagType_t     diag,
               int64_t               m,
-              const hipblasComplex* A,
-              hipblasComplex*       x,
+              const std::complex<float>* A,
+              std::complex<float>*       x,
               int64_t               incx)
 {
     cblas_ctpmv(
@@ -2170,8 +2170,8 @@ void ref_tpmv(hipblasFillMode_t           uplo,
               hipblasOperation_t          transA,
               hipblasDiagType_t           diag,
               int64_t                     m,
-              const hipblasDoubleComplex* A,
-              hipblasDoubleComplex*       x,
+              const std::complex<double>* A,
+              std::complex<double>*       x,
               int64_t                     incx)
 {
     cblas_ztpmv(
@@ -2210,8 +2210,8 @@ void ref_tpsv(hipblasFillMode_t     uplo,
               hipblasOperation_t    transA,
               hipblasDiagType_t     diag,
               int64_t               n,
-              const hipblasComplex* AP,
-              hipblasComplex*       x,
+              const std::complex<float>* AP,
+              std::complex<float>*       x,
               int64_t               incx)
 {
     cblas_ctpsv(
@@ -2223,8 +2223,8 @@ void ref_tpsv(hipblasFillMode_t           uplo,
               hipblasOperation_t          transA,
               hipblasDiagType_t           diag,
               int64_t                     n,
-              const hipblasDoubleComplex* AP,
-              hipblasDoubleComplex*       x,
+              const std::complex<double>* AP,
+              std::complex<double>*       x,
               int64_t                     incx)
 {
     cblas_ztpsv(
@@ -2275,13 +2275,13 @@ void ref_trmv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_trmv<hipblasComplex>(hipblasFillMode_t     uplo,
+void ref_trmv<std::complex<float>>(hipblasFillMode_t     uplo,
                               hipblasOperation_t    transA,
                               hipblasDiagType_t     diag,
                               int64_t               m,
-                              const hipblasComplex* A,
+                              const std::complex<float>* A,
                               int64_t               lda,
-                              hipblasComplex*       x,
+                              std::complex<float>*       x,
                               int64_t               incx)
 {
     cblas_ctrmv(CblasColMajor,
@@ -2296,13 +2296,13 @@ void ref_trmv<hipblasComplex>(hipblasFillMode_t     uplo,
 }
 
 template <>
-void ref_trmv<hipblasDoubleComplex>(hipblasFillMode_t           uplo,
+void ref_trmv<std::complex<double>>(hipblasFillMode_t           uplo,
                                     hipblasOperation_t          transA,
                                     hipblasDiagType_t           diag,
                                     int64_t                     m,
-                                    const hipblasDoubleComplex* A,
+                                    const std::complex<double>* A,
                                     int64_t                     lda,
-                                    hipblasDoubleComplex*       x,
+                                    std::complex<double>*       x,
                                     int64_t                     incx)
 {
     cblas_ztrmv(CblasColMajor,
@@ -2362,14 +2362,14 @@ void ref_trsv<double>(hipblasHandle_t    handle,
 }
 
 template <>
-void ref_trsv<hipblasComplex>(hipblasHandle_t       handle,
+void ref_trsv<std::complex<float>>(hipblasHandle_t       handle,
                               hipblasFillMode_t     uplo,
                               hipblasOperation_t    transA,
                               hipblasDiagType_t     diag,
                               int64_t               m,
-                              const hipblasComplex* A,
+                              const std::complex<float>* A,
                               int64_t               lda,
-                              hipblasComplex*       x,
+                              std::complex<float>*       x,
                               int64_t               incx)
 {
     cblas_ctrsv(CblasColMajor,
@@ -2384,14 +2384,14 @@ void ref_trsv<hipblasComplex>(hipblasHandle_t       handle,
 }
 
 template <>
-void ref_trsv<hipblasDoubleComplex>(hipblasHandle_t             handle,
+void ref_trsv<std::complex<double>>(hipblasHandle_t             handle,
                                     hipblasFillMode_t           uplo,
                                     hipblasOperation_t          transA,
                                     hipblasDiagType_t           diag,
                                     int64_t                     m,
-                                    const hipblasDoubleComplex* A,
+                                    const std::complex<double>* A,
                                     int64_t                     lda,
-                                    hipblasDoubleComplex*       x,
+                                    std::complex<double>*       x,
                                     int64_t                     incx)
 {
     cblas_ztrsv(CblasColMajor,
@@ -2436,10 +2436,13 @@ void ref_geam_helper(hipblasOperation_t transA,
         {
             T a_val = A[i * inc1_A + j * inc2_A];
             T b_val = B[i * inc1_B + j * inc2_B];
-            if(transA == HIPBLAS_OP_C)
-                a_val = std::conj(a_val);
-            if(transB == HIPBLAS_OP_C)
-                b_val = std::conj(b_val);
+            if constexpr(is_complex<T>)
+            {
+                if(transA == HIPBLAS_OP_C)
+                    a_val = std::conj(a_val);
+                if(transB == HIPBLAS_OP_C)
+                    b_val = std::conj(b_val);
+            }
             C[i + j * ldc] = alpha * a_val + beta * b_val;
         }
     }
@@ -2506,11 +2509,11 @@ template <>
 void ref_dgmm(hipblasSideMode_t     side,
               int64_t               M,
               int64_t               N,
-              const hipblasComplex* A,
+              const std::complex<float>* A,
               int64_t               lda,
-              const hipblasComplex* x,
+              const std::complex<float>* x,
               int64_t               incx,
-              hipblasComplex*       C,
+              std::complex<float>*       C,
               int64_t               ldc)
 {
     ref_dgmm_helper(side, M, N, A, lda, x, incx, C, ldc);
@@ -2520,11 +2523,11 @@ template <>
 void ref_dgmm(hipblasSideMode_t           side,
               int64_t                     M,
               int64_t                     N,
-              const hipblasDoubleComplex* A,
+              const std::complex<double>* A,
               int64_t                     lda,
-              const hipblasDoubleComplex* x,
+              const std::complex<double>* x,
               int64_t                     incx,
-              hipblasDoubleComplex*       C,
+              std::complex<double>*       C,
               int64_t                     ldc)
 {
     ref_dgmm_helper(side, M, N, A, lda, x, incx, C, ldc);
@@ -2570,13 +2573,13 @@ void ref_geam(hipblasOperation_t transa,
               hipblasOperation_t transb,
               int64_t            m,
               int64_t            n,
-              hipblasComplex*    alpha,
-              hipblasComplex*    A,
+              std::complex<float>*    alpha,
+              std::complex<float>*    A,
               int64_t            lda,
-              hipblasComplex*    beta,
-              hipblasComplex*    B,
+              std::complex<float>*    beta,
+              std::complex<float>*    B,
               int64_t            ldb,
-              hipblasComplex*    C,
+              std::complex<float>*    C,
               int64_t            ldc)
 {
     return ref_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
@@ -2587,13 +2590,13 @@ void ref_geam(hipblasOperation_t    transa,
               hipblasOperation_t    transb,
               int64_t               m,
               int64_t               n,
-              hipblasDoubleComplex* alpha,
-              hipblasDoubleComplex* A,
+              std::complex<double>* alpha,
+              std::complex<double>* A,
               int64_t               lda,
-              hipblasDoubleComplex* beta,
-              hipblasDoubleComplex* B,
+              std::complex<double>* beta,
+              std::complex<double>* B,
               int64_t               ldb,
-              hipblasDoubleComplex* C,
+              std::complex<double>* C,
               int64_t               ldc)
 {
     return ref_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
@@ -2955,18 +2958,18 @@ void ref_gemm<double>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gemm<hipblasComplex>(hipblasOperation_t transA,
+void ref_gemm<std::complex<float>>(hipblasOperation_t transA,
                               hipblasOperation_t transB,
                               int64_t            m,
                               int64_t            n,
                               int64_t            k,
-                              hipblasComplex     alpha,
-                              hipblasComplex*    A,
+                              std::complex<float>     alpha,
+                              std::complex<float>*    A,
                               int64_t            lda,
-                              hipblasComplex*    B,
+                              std::complex<float>*    B,
                               int64_t            ldb,
-                              hipblasComplex     beta,
-                              hipblasComplex*    C,
+                              std::complex<float>     beta,
+                              std::complex<float>*    C,
                               int64_t            ldc)
 {
     //just directly cast, since transA, transB are integers in the enum
@@ -2987,18 +2990,18 @@ void ref_gemm<hipblasComplex>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gemm<hipblasDoubleComplex>(hipblasOperation_t    transA,
+void ref_gemm<std::complex<double>>(hipblasOperation_t    transA,
                                     hipblasOperation_t    transB,
                                     int64_t               m,
                                     int64_t               n,
                                     int64_t               k,
-                                    hipblasDoubleComplex  alpha,
-                                    hipblasDoubleComplex* A,
+                                    std::complex<double>  alpha,
+                                    std::complex<double>* A,
                                     int64_t               lda,
-                                    hipblasDoubleComplex* B,
+                                    std::complex<double>* B,
                                     int64_t               ldb,
-                                    hipblasDoubleComplex  beta,
-                                    hipblasDoubleComplex* C,
+                                    std::complex<double>  beta,
+                                    std::complex<double>* C,
                                     int64_t               ldc)
 {
     cblas_zgemm(CblasColMajor,
@@ -3081,13 +3084,13 @@ void ref_hemm(hipblasSideMode_t side,
               hipblasFillMode_t uplo,
               int64_t           m,
               int64_t           n,
-              hipblasComplex    alpha,
-              hipblasComplex*   A,
+              std::complex<float>    alpha,
+              std::complex<float>*   A,
               int64_t           lda,
-              hipblasComplex*   B,
+              std::complex<float>*   B,
               int64_t           ldb,
-              hipblasComplex    beta,
-              hipblasComplex*   C,
+              std::complex<float>    beta,
+              std::complex<float>*   C,
               int64_t           ldc)
 {
     cblas_chemm(CblasColMajor,
@@ -3110,13 +3113,13 @@ void ref_hemm(hipblasSideMode_t     side,
               hipblasFillMode_t     uplo,
               int64_t               m,
               int64_t               n,
-              hipblasDoubleComplex  alpha,
-              hipblasDoubleComplex* A,
+              std::complex<double>  alpha,
+              std::complex<double>* A,
               int64_t               lda,
-              hipblasDoubleComplex* B,
+              std::complex<double>* B,
               int64_t               ldb,
-              hipblasDoubleComplex  beta,
-              hipblasDoubleComplex* C,
+              std::complex<double>  beta,
+              std::complex<double>* C,
               int64_t               ldc)
 {
     cblas_zhemm(CblasColMajor,
@@ -3141,10 +3144,10 @@ void ref_herk(hipblasFillMode_t  uplo,
               int64_t            n,
               int64_t            k,
               float              alpha,
-              hipblasComplex*    A,
+              std::complex<float>*    A,
               int64_t            lda,
               float              beta,
-              hipblasComplex*    C,
+              std::complex<float>*    C,
               int64_t            ldc)
 {
     cblas_cherk(CblasColMajor,
@@ -3166,10 +3169,10 @@ void ref_herk(hipblasFillMode_t     uplo,
               int64_t               n,
               int64_t               k,
               double                alpha,
-              hipblasDoubleComplex* A,
+              std::complex<double>* A,
               int64_t               lda,
               double                beta,
-              hipblasDoubleComplex* C,
+              std::complex<double>* C,
               int64_t               ldc)
 {
     cblas_zherk(CblasColMajor,
@@ -3274,13 +3277,13 @@ void ref_herkx(hipblasFillMode_t  uplo,
                hipblasOperation_t transA,
                int64_t            n,
                int64_t            k,
-               hipblasComplex     alpha,
-               hipblasComplex*    A,
+               std::complex<float>     alpha,
+               std::complex<float>*    A,
                int64_t            lda,
-               hipblasComplex*    B,
+               std::complex<float>*    B,
                int64_t            ldb,
                float              beta,
-               hipblasComplex*    C,
+               std::complex<float>*    C,
                int64_t            ldc)
 {
     ref_herkx_local(uplo, transA, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
@@ -3291,13 +3294,13 @@ void ref_herkx(hipblasFillMode_t     uplo,
                hipblasOperation_t    transA,
                int64_t               n,
                int64_t               k,
-               hipblasDoubleComplex  alpha,
-               hipblasDoubleComplex* A,
+               std::complex<double>  alpha,
+               std::complex<double>* A,
                int64_t               lda,
-               hipblasDoubleComplex* B,
+               std::complex<double>* B,
                int64_t               ldb,
                double                beta,
-               hipblasDoubleComplex* C,
+               std::complex<double>* C,
                int64_t               ldc)
 {
     ref_herkx_local(uplo, transA, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
@@ -3309,13 +3312,13 @@ void ref_her2k(hipblasFillMode_t  uplo,
                hipblasOperation_t transA,
                int64_t            n,
                int64_t            k,
-               hipblasComplex     alpha,
-               hipblasComplex*    A,
+               std::complex<float>     alpha,
+               std::complex<float>*    A,
                int64_t            lda,
-               hipblasComplex*    B,
+               std::complex<float>*    B,
                int64_t            ldb,
                float              beta,
-               hipblasComplex*    C,
+               std::complex<float>*    C,
                int64_t            ldc)
 {
     cblas_cher2k(CblasColMajor,
@@ -3338,13 +3341,13 @@ void ref_her2k(hipblasFillMode_t     uplo,
                hipblasOperation_t    transA,
                int64_t               n,
                int64_t               k,
-               hipblasDoubleComplex  alpha,
-               hipblasDoubleComplex* A,
+               std::complex<double>  alpha,
+               std::complex<double>* A,
                int64_t               lda,
-               hipblasDoubleComplex* B,
+               std::complex<double>* B,
                int64_t               ldb,
                double                beta,
-               hipblasDoubleComplex* C,
+               std::complex<double>* C,
                int64_t               ldc)
 {
     cblas_zher2k(CblasColMajor,
@@ -3426,13 +3429,13 @@ void ref_symm(hipblasSideMode_t side,
               hipblasFillMode_t uplo,
               int64_t           m,
               int64_t           n,
-              hipblasComplex    alpha,
-              hipblasComplex*   A,
+              std::complex<float>    alpha,
+              std::complex<float>*   A,
               int64_t           lda,
-              hipblasComplex*   B,
+              std::complex<float>*   B,
               int64_t           ldb,
-              hipblasComplex    beta,
-              hipblasComplex*   C,
+              std::complex<float>    beta,
+              std::complex<float>*   C,
               int64_t           ldc)
 {
     cblas_csymm(CblasColMajor,
@@ -3455,13 +3458,13 @@ void ref_symm(hipblasSideMode_t     side,
               hipblasFillMode_t     uplo,
               int64_t               m,
               int64_t               n,
-              hipblasDoubleComplex  alpha,
-              hipblasDoubleComplex* A,
+              std::complex<double>  alpha,
+              std::complex<double>* A,
               int64_t               lda,
-              hipblasDoubleComplex* B,
+              std::complex<double>* B,
               int64_t               ldb,
-              hipblasDoubleComplex  beta,
-              hipblasDoubleComplex* C,
+              std::complex<double>  beta,
+              std::complex<double>* C,
               int64_t               ldc)
 {
     cblas_zsymm(CblasColMajor,
@@ -3535,11 +3538,11 @@ void ref_syrk(hipblasFillMode_t  uplo,
               hipblasOperation_t transA,
               int64_t            n,
               int64_t            k,
-              hipblasComplex     alpha,
-              hipblasComplex*    A,
+              std::complex<float>     alpha,
+              std::complex<float>*    A,
               int64_t            lda,
-              hipblasComplex     beta,
-              hipblasComplex*    C,
+              std::complex<float>     beta,
+              std::complex<float>*    C,
               int64_t            ldc)
 {
     cblas_csyrk(CblasColMajor,
@@ -3560,11 +3563,11 @@ void ref_syrk(hipblasFillMode_t     uplo,
               hipblasOperation_t    transA,
               int64_t               n,
               int64_t               k,
-              hipblasDoubleComplex  alpha,
-              hipblasDoubleComplex* A,
+              std::complex<double>  alpha,
+              std::complex<double>* A,
               int64_t               lda,
-              hipblasDoubleComplex  beta,
-              hipblasDoubleComplex* C,
+              std::complex<double>  beta,
+              std::complex<double>* C,
               int64_t               ldc)
 {
     cblas_zsyrk(CblasColMajor,
@@ -3644,13 +3647,13 @@ void ref_syr2k(hipblasFillMode_t  uplo,
                hipblasOperation_t transA,
                int64_t            n,
                int64_t            k,
-               hipblasComplex     alpha,
-               hipblasComplex*    A,
+               std::complex<float>     alpha,
+               std::complex<float>*    A,
                int64_t            lda,
-               hipblasComplex*    B,
+               std::complex<float>*    B,
                int64_t            ldb,
-               hipblasComplex     beta,
-               hipblasComplex*    C,
+               std::complex<float>     beta,
+               std::complex<float>*    C,
                int64_t            ldc)
 {
     cblas_csyr2k(CblasColMajor,
@@ -3673,13 +3676,13 @@ void ref_syr2k(hipblasFillMode_t     uplo,
                hipblasOperation_t    transA,
                int64_t               n,
                int64_t               k,
-               hipblasDoubleComplex  alpha,
-               hipblasDoubleComplex* A,
+               std::complex<double>  alpha,
+               std::complex<double>* A,
                int64_t               lda,
-               hipblasDoubleComplex* B,
+               std::complex<double>* B,
                int64_t               ldb,
-               hipblasDoubleComplex  beta,
-               hipblasDoubleComplex* C,
+               std::complex<double>  beta,
+               std::complex<double>* C,
                int64_t               ldc)
 {
     cblas_zsyr2k(CblasColMajor,
@@ -3759,16 +3762,16 @@ void ref_trsm<double>(hipblasSideMode_t  side,
 }
 
 template <>
-void ref_trsm<hipblasComplex>(hipblasSideMode_t     side,
+void ref_trsm<std::complex<float>>(hipblasSideMode_t     side,
                               hipblasFillMode_t     uplo,
                               hipblasOperation_t    transA,
                               hipblasDiagType_t     diag,
                               int64_t               m,
                               int64_t               n,
-                              hipblasComplex        alpha,
-                              const hipblasComplex* A,
+                              std::complex<float>        alpha,
+                              const std::complex<float>* A,
                               int64_t               lda,
-                              hipblasComplex*       B,
+                              std::complex<float>*       B,
                               int64_t               ldb)
 {
     cblas_ctrsm(CblasColMajor,
@@ -3786,16 +3789,16 @@ void ref_trsm<hipblasComplex>(hipblasSideMode_t     side,
 }
 
 template <>
-void ref_trsm<hipblasDoubleComplex>(hipblasSideMode_t           side,
+void ref_trsm<std::complex<double>>(hipblasSideMode_t           side,
                                     hipblasFillMode_t           uplo,
                                     hipblasOperation_t          transA,
                                     hipblasDiagType_t           diag,
                                     int64_t                     m,
                                     int64_t                     n,
-                                    hipblasDoubleComplex        alpha,
-                                    const hipblasDoubleComplex* A,
+                                    std::complex<double>        alpha,
+                                    const std::complex<double>* A,
                                     int64_t                     lda,
-                                    hipblasDoubleComplex*       B,
+                                    std::complex<double>*       B,
                                     int64_t                     ldb)
 {
     cblas_ztrsm(CblasColMajor,
@@ -3828,14 +3831,14 @@ void ref_trtri<double>(char uplo, char diag, int64_t n, double* A, int64_t lda)
 }
 
 template <>
-void ref_trtri<hipblasComplex>(char uplo, char diag, int64_t n, hipblasComplex* A, int64_t lda)
+void ref_trtri<std::complex<float>>(char uplo, char diag, int64_t n, std::complex<float>* A, int64_t lda)
 {
     lapack_xtrtri(uplo, diag, n, A, lda);
 }
 
 template <>
-void ref_trtri<hipblasDoubleComplex>(
-    char uplo, char diag, int64_t n, hipblasDoubleComplex* A, int64_t lda)
+void ref_trtri<std::complex<double>>(
+    char uplo, char diag, int64_t n, std::complex<double>* A, int64_t lda)
 {
     lapack_xtrtri(uplo, diag, n, A, lda);
 }
@@ -3898,16 +3901,16 @@ void ref_trmm<double>(hipblasSideMode_t  side,
 }
 
 template <>
-void ref_trmm<hipblasComplex>(hipblasSideMode_t     side,
+void ref_trmm<std::complex<float>>(hipblasSideMode_t     side,
                               hipblasFillMode_t     uplo,
                               hipblasOperation_t    transA,
                               hipblasDiagType_t     diag,
                               int64_t               m,
                               int64_t               n,
-                              hipblasComplex        alpha,
-                              const hipblasComplex* A,
+                              std::complex<float>        alpha,
+                              const std::complex<float>* A,
                               int64_t               lda,
-                              hipblasComplex*       B,
+                              std::complex<float>*       B,
                               int64_t               ldb)
 {
     cblas_ctrmm(CblasColMajor,
@@ -3925,16 +3928,16 @@ void ref_trmm<hipblasComplex>(hipblasSideMode_t     side,
 }
 
 template <>
-void ref_trmm<hipblasDoubleComplex>(hipblasSideMode_t           side,
+void ref_trmm<std::complex<double>>(hipblasSideMode_t           side,
                                     hipblasFillMode_t           uplo,
                                     hipblasOperation_t          transA,
                                     hipblasDiagType_t           diag,
                                     int64_t                     m,
                                     int64_t                     n,
-                                    hipblasDoubleComplex        alpha,
-                                    const hipblasDoubleComplex* A,
+                                    std::complex<double>        alpha,
+                                    const std::complex<double>* A,
                                     int64_t                     lda,
-                                    hipblasDoubleComplex*       B,
+                                    std::complex<double>*       B,
                                     int64_t                     ldb)
 {
     cblas_ztrmm(CblasColMajor,
@@ -3989,7 +3992,7 @@ int64_t ref_potrf(char uplo, int64_t m, double* A, int64_t lda)
 }
 
 template <>
-int64_t ref_potrf(char uplo, int64_t m, hipblasComplex* A, int64_t lda)
+int64_t ref_potrf(char uplo, int64_t m, std::complex<float>* A, int64_t lda)
 {
     int64_t info;
 
@@ -4003,7 +4006,7 @@ int64_t ref_potrf(char uplo, int64_t m, hipblasComplex* A, int64_t lda)
 }
 
 template <>
-int64_t ref_potrf(char uplo, int64_t m, hipblasDoubleComplex* A, int64_t lda)
+int64_t ref_potrf(char uplo, int64_t m, std::complex<double>* A, int64_t lda)
 {
     int64_t info;
 
@@ -4047,29 +4050,29 @@ int64_t ref_getrf<double>(int64_t m, int64_t n, double* A, int64_t lda, int64_t*
 
 template <>
 int64_t
-    ref_getrf<hipblasComplex>(int64_t m, int64_t n, hipblasComplex* A, int64_t lda, int64_t* ipiv)
+    ref_getrf<std::complex<float>>(int64_t m, int64_t n, std::complex<float>* A, int64_t lda, int64_t* ipiv)
 {
     int64_t info;
 
 #ifdef FLA_ENABLE_ILP64
     info = LAPACKE_cgetrf(LAPACK_COL_MAJOR, m, n, (lapack_complex_float*)A, lda, ipiv);
 #else
-    cgetrf_(&m, &n, (hipblasComplex*)A, &lda, ipiv, &info);
+    cgetrf_(&m, &n, (std::complex<float>*)A, &lda, ipiv, &info);
 #endif
 
     return info;
 }
 
 template <>
-int64_t ref_getrf<hipblasDoubleComplex>(
-    int64_t m, int64_t n, hipblasDoubleComplex* A, int64_t lda, int64_t* ipiv)
+int64_t ref_getrf<std::complex<double>>(
+    int64_t m, int64_t n, std::complex<double>* A, int64_t lda, int64_t* ipiv)
 {
     int64_t info;
 
 #ifdef FLA_ENABLE_ILP64
     info = LAPACKE_zgetrf(LAPACK_COL_MAJOR, m, n, (lapack_complex_double*)A, lda, ipiv);
 #else
-    zgetrf_(&m, &n, (hipblasDoubleComplex*)A, &lda, ipiv, &info);
+    zgetrf_(&m, &n, (std::complex<double>*)A, &lda, ipiv, &info);
 #endif
 
     return info;
@@ -4119,13 +4122,13 @@ int64_t ref_getrs<double>(char     trans,
 }
 
 template <>
-int64_t ref_getrs<hipblasComplex>(char            trans,
+int64_t ref_getrs<std::complex<float>>(char            trans,
                                   int64_t         n,
                                   int64_t         nrhs,
-                                  hipblasComplex* A,
+                                  std::complex<float>* A,
                                   int64_t         lda,
                                   int64_t*        ipiv,
-                                  hipblasComplex* B,
+                                  std::complex<float>* B,
                                   int64_t         ldb)
 {
     int64_t info;
@@ -4141,20 +4144,20 @@ int64_t ref_getrs<hipblasComplex>(char            trans,
                           (lapack_complex_float*)B,
                           ldb);
 #else
-    cgetrs_(&trans, &n, &nrhs, (hipblasComplex*)A, &lda, ipiv, (hipblasComplex*)B, &ldb, &info);
+    cgetrs_(&trans, &n, &nrhs, (std::complex<float>*)A, &lda, ipiv, (std::complex<float>*)B, &ldb, &info);
 #endif
 
     return info;
 }
 
 template <>
-int64_t ref_getrs<hipblasDoubleComplex>(char                  trans,
+int64_t ref_getrs<std::complex<double>>(char                  trans,
                                         int64_t               n,
                                         int64_t               nrhs,
-                                        hipblasDoubleComplex* A,
+                                        std::complex<double>* A,
                                         int64_t               lda,
                                         int64_t*              ipiv,
-                                        hipblasDoubleComplex* B,
+                                        std::complex<double>* B,
                                         int64_t               ldb)
 {
 
@@ -4174,10 +4177,10 @@ int64_t ref_getrs<hipblasDoubleComplex>(char                  trans,
     zgetrs_(&trans,
             &n,
             &nrhs,
-            (hipblasDoubleComplex*)A,
+            (std::complex<double>*)A,
             &lda,
             ipiv,
-            (hipblasDoubleComplex*)B,
+            (std::complex<double>*)B,
             &ldb,
             &info);
 #endif
@@ -4217,8 +4220,8 @@ int64_t
 }
 
 template <>
-int64_t ref_getri<hipblasComplex>(
-    int64_t n, hipblasComplex* A, int64_t lda, int64_t* ipiv, hipblasComplex* work, int64_t lwork)
+int64_t ref_getri<std::complex<float>>(
+    int64_t n, std::complex<float>* A, int64_t lda, int64_t* ipiv, std::complex<float>* work, int64_t lwork)
 {
     int64_t info;
 
@@ -4238,11 +4241,11 @@ int64_t ref_getri<hipblasComplex>(
 }
 
 template <>
-int64_t ref_getri<hipblasDoubleComplex>(int64_t               n,
-                                        hipblasDoubleComplex* A,
+int64_t ref_getri<std::complex<double>>(int64_t               n,
+                                        std::complex<double>* A,
                                         int64_t               lda,
                                         int64_t*              ipiv,
-                                        hipblasDoubleComplex* work,
+                                        std::complex<double>* work,
                                         int64_t               lwork)
 {
     int64_t info;
@@ -4293,12 +4296,12 @@ int64_t ref_geqrf<double>(
     return info;
 }
 template <>
-int64_t ref_geqrf<hipblasComplex>(int64_t         m,
+int64_t ref_geqrf<std::complex<float>>(int64_t         m,
                                   int64_t         n,
-                                  hipblasComplex* A,
+                                  std::complex<float>* A,
                                   int64_t         lda,
-                                  hipblasComplex* tau,
-                                  hipblasComplex* work,
+                                  std::complex<float>* tau,
+                                  std::complex<float>* work,
                                   int64_t         lwork)
 {
     int64_t info;
@@ -4320,12 +4323,12 @@ int64_t ref_geqrf<hipblasComplex>(int64_t         m,
 }
 
 template <>
-int64_t ref_geqrf<hipblasDoubleComplex>(int64_t               m,
+int64_t ref_geqrf<std::complex<double>>(int64_t               m,
                                         int64_t               n,
-                                        hipblasDoubleComplex* A,
+                                        std::complex<double>* A,
                                         int64_t               lda,
-                                        hipblasDoubleComplex* tau,
-                                        hipblasDoubleComplex* work,
+                                        std::complex<double>* tau,
+                                        std::complex<double>* work,
                                         int64_t               lwork)
 {
     int64_t info;
@@ -4394,15 +4397,15 @@ int64_t ref_gels<double>(char    trans,
 }
 
 template <>
-int64_t ref_gels<hipblasComplex>(char            trans,
+int64_t ref_gels<std::complex<float>>(char            trans,
                                  int64_t         m,
                                  int64_t         n,
                                  int64_t         nrhs,
-                                 hipblasComplex* A,
+                                 std::complex<float>* A,
                                  int64_t         lda,
-                                 hipblasComplex* B,
+                                 std::complex<float>* B,
                                  int64_t         ldb,
-                                 hipblasComplex* work,
+                                 std::complex<float>* work,
                                  int64_t         lwork)
 {
     int64_t info;
@@ -4426,15 +4429,15 @@ int64_t ref_gels<hipblasComplex>(char            trans,
 }
 
 template <>
-int64_t ref_gels<hipblasDoubleComplex>(char                  trans,
+int64_t ref_gels<std::complex<double>>(char                  trans,
                                        int64_t               m,
                                        int64_t               n,
                                        int64_t               nrhs,
-                                       hipblasDoubleComplex* A,
+                                       std::complex<double>* A,
                                        int64_t               lda,
-                                       hipblasDoubleComplex* B,
+                                       std::complex<double>* B,
                                        int64_t               ldb,
-                                       hipblasDoubleComplex* work,
+                                       std::complex<double>* work,
                                        int64_t               lwork)
 {
     int64_t info;

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -51,7 +51,8 @@ void zpotrf_(char* uplo, int64_t* m, std::complex<double>* A, int64_t* lda, int6
 
 void sgetrf_(int64_t* m, int64_t* n, float* A, int64_t* lda, int64_t* ipiv, int64_t* info);
 void dgetrf_(int64_t* m, int64_t* n, double* A, int64_t* lda, int64_t* ipiv, int64_t* info);
-void cgetrf_(int64_t* m, int64_t* n, std::complex<float>* A, int64_t* lda, int64_t* ipiv, int64_t* info);
+void cgetrf_(
+    int64_t* m, int64_t* n, std::complex<float>* A, int64_t* lda, int64_t* ipiv, int64_t* info);
 void zgetrf_(
     int64_t* m, int64_t* n, std::complex<double>* A, int64_t* lda, int64_t* ipiv, int64_t* info);
 
@@ -73,15 +74,15 @@ void dgetrs_(char*    trans,
              double*  B,
              int64_t* ldb,
              int64_t* info);
-void cgetrs_(char*           trans,
-             int64_t*        n,
-             int64_t*        nrhs,
+void cgetrs_(char*                trans,
+             int64_t*             n,
+             int64_t*             nrhs,
              std::complex<float>* A,
-             int64_t*        lda,
-             int64_t*        ipiv,
+             int64_t*             lda,
+             int64_t*             ipiv,
              std::complex<float>* B,
-             int64_t*        ldb,
-             int64_t*        info);
+             int64_t*             ldb,
+             int64_t*             info);
 void zgetrs_(char*                 trans,
              int64_t*              n,
              int64_t*              nrhs,
@@ -101,13 +102,13 @@ void dgetri_(int64_t* n,
              double*  work,
              int64_t* lwork,
              int64_t* info);
-void cgetri_(int64_t*        n,
+void cgetri_(int64_t*             n,
              std::complex<float>* A,
-             int64_t*        lda,
-             int64_t*        ipiv,
+             int64_t*             lda,
+             int64_t*             ipiv,
              std::complex<float>* work,
-             int64_t*        lwork,
-             int64_t*        info);
+             int64_t*             lwork,
+             int64_t*             info);
 void zgetri_(int64_t*              n,
              std::complex<double>* A,
              int64_t*              lda,
@@ -132,14 +133,14 @@ void dgeqrf_(int64_t* m,
              double*  work,
              int64_t* lwork,
              int64_t* info);
-void cgeqrf_(int64_t*        m,
-             int64_t*        n,
+void cgeqrf_(int64_t*             m,
+             int64_t*             n,
              std::complex<float>* A,
-             int64_t*        lda,
+             int64_t*             lda,
              std::complex<float>* tau,
              std::complex<float>* work,
-             int64_t*        lwork,
-             int64_t*        info);
+             int64_t*             lwork,
+             int64_t*             info);
 void zgeqrf_(int64_t*              m,
              int64_t*              n,
              std::complex<double>* A,
@@ -171,17 +172,17 @@ void dgels_(char*    trans,
             double*  work,
             int64_t* lwork,
             int64_t* info);
-void cgels_(char*           trans,
-            int64_t*        m,
-            int64_t*        n,
-            int64_t*        nrhs,
+void cgels_(char*                trans,
+            int64_t*             m,
+            int64_t*             n,
+            int64_t*             nrhs,
             std::complex<float>* A,
-            int64_t*        lda,
+            int64_t*             lda,
             std::complex<float>* B,
-            int64_t*        ldb,
+            int64_t*             ldb,
             std::complex<float>* work,
-            int64_t*        lwork,
-            int64_t*        info);
+            int64_t*             lwork,
+            int64_t*             info);
 void zgels_(char*                 trans,
             int64_t*              m,
             int64_t*              n,
@@ -380,12 +381,12 @@ void ref_axpy<double, double>(
 }
 
 template <>
-void ref_axpy<std::complex<float>, std::complex<float>>(int64_t               n,
-                                              const std::complex<float>  alpha,
-                                              const std::complex<float>* x,
-                                              int64_t               incx,
-                                              std::complex<float>*       y,
-                                              int64_t               incy)
+void ref_axpy<std::complex<float>, std::complex<float>>(int64_t                    n,
+                                                        const std::complex<float>  alpha,
+                                                        const std::complex<float>* x,
+                                                        int64_t                    incx,
+                                                        std::complex<float>*       y,
+                                                        int64_t                    incy)
 {
     cblas_caxpy(n, &alpha, x, incx, y, incy);
 }
@@ -515,16 +516,19 @@ void ref_scal<double>(int64_t n, const double alpha, double* x, int64_t incx)
 }
 
 template <>
-void ref_scal<std::complex<float>>(int64_t              n,
-                              const std::complex<float> alpha,
-                              std::complex<float>*      x,
-                              int64_t              incx)
+void ref_scal<std::complex<float>>(int64_t                   n,
+                                   const std::complex<float> alpha,
+                                   std::complex<float>*      x,
+                                   int64_t                   incx)
 {
     cblas_cscal(n, &alpha, x, incx);
 }
 
 template <>
-void ref_scal<std::complex<float>, float>(int64_t n, const float alpha, std::complex<float>* x, int64_t incx)
+void ref_scal<std::complex<float>, float>(int64_t              n,
+                                          const float          alpha,
+                                          std::complex<float>* x,
+                                          int64_t              incx)
 {
     cblas_csscal(n, alpha, x, incx);
 }
@@ -659,12 +663,12 @@ void ref_dot<double>(
 }
 
 template <>
-void ref_dot<std::complex<float>>(int64_t               n,
-                             const std::complex<float>* x,
-                             int64_t               incx,
-                             const std::complex<float>* y,
-                             int64_t               incy,
-                             std::complex<float>*       result)
+void ref_dot<std::complex<float>>(int64_t                    n,
+                                  const std::complex<float>* x,
+                                  int64_t                    incx,
+                                  const std::complex<float>* y,
+                                  int64_t                    incy,
+                                  std::complex<float>*       result)
 {
     cblas_cdotu_sub(n, x, incx, y, incy, result);
 }
@@ -721,12 +725,12 @@ void ref_dotc<double>(
 }
 
 template <>
-void ref_dotc<std::complex<float>>(int64_t               n,
-                              const std::complex<float>* x,
-                              int64_t               incx,
-                              const std::complex<float>* y,
-                              int64_t               incy,
-                              std::complex<float>*       result)
+void ref_dotc<std::complex<float>>(int64_t                    n,
+                                   const std::complex<float>* x,
+                                   int64_t                    incx,
+                                   const std::complex<float>* y,
+                                   int64_t                    incy,
+                                   std::complex<float>*       result)
 {
     cblas_cdotc_sub(n, x, incx, y, incy, result);
 }
@@ -790,10 +794,10 @@ void ref_nrm2<double, double>(int64_t n, const double* x, int64_t incx, double* 
 }
 
 template <>
-void ref_nrm2<std::complex<float>, float>(int64_t               n,
-                                     const std::complex<float>* x,
-                                     int64_t               incx,
-                                     float*                result)
+void ref_nrm2<std::complex<float>, float>(int64_t                    n,
+                                          const std::complex<float>* x,
+                                          int64_t                    incx,
+                                          float*                     result)
 {
     *result = cblas_scnrm2(n, x, incx);
 }
@@ -812,20 +816,20 @@ void ref_nrm2<std::complex<double>, double>(int64_t                     n,
 ///////////////////
 // LAPACK fortran library functionality
 extern "C" {
-void crot_(const int64_t*        n,
+void crot_(const int64_t*             n,
            std::complex<float>*       cx,
-           const int64_t*        incx,
+           const int64_t*             incx,
            std::complex<float>*       cy,
-           const int64_t*        incy,
-           const float*          c,
+           const int64_t*             incy,
+           const float*               c,
            const std::complex<float>* s);
-void csrot_(const int64_t*  n,
+void csrot_(const int64_t*       n,
             std::complex<float>* cx,
-            const int64_t*  incx,
+            const int64_t*       incx,
             std::complex<float>* cy,
-            const int64_t*  incy,
-            const float*    c,
-            const float*    s);
+            const int64_t*       incy,
+            const float*         c,
+            const float*         s);
 void zrot_(const int64_t*              n,
            std::complex<double>*       cx,
            const int64_t*              incx,
@@ -936,33 +940,38 @@ void ref_rot<double>(
 }
 
 template <>
-void ref_rot<std::complex<float>>(int64_t         n,
-                             std::complex<float>* x,
-                             int64_t         incx,
-                             std::complex<float>* y,
-                             int64_t         incy,
-                             std::complex<float>  c,
-                             std::complex<float>  s)
+void ref_rot<std::complex<float>>(int64_t              n,
+                                  std::complex<float>* x,
+                                  int64_t              incx,
+                                  std::complex<float>* y,
+                                  int64_t              incy,
+                                  std::complex<float>  c,
+                                  std::complex<float>  s)
 {
     float c_real = std::real(c);
     lapack_xrot(n, x, incx, y, incy, c_real, s);
 }
 
 template <>
-void ref_rot<std::complex<float>, float>(int64_t         n,
-                                    std::complex<float>* x,
-                                    int64_t         incx,
-                                    std::complex<float>* y,
-                                    int64_t         incy,
-                                    float           c,
-                                    std::complex<float>  s)
+void ref_rot<std::complex<float>, float>(int64_t              n,
+                                         std::complex<float>* x,
+                                         int64_t              incx,
+                                         std::complex<float>* y,
+                                         int64_t              incy,
+                                         float                c,
+                                         std::complex<float>  s)
 {
     lapack_xrot(n, x, incx, y, incy, c, s);
 }
 
 template <>
-void ref_rot<std::complex<float>, float, float>(
-    int64_t n, std::complex<float>* x, int64_t incx, std::complex<float>* y, int64_t incy, float c, float s)
+void ref_rot<std::complex<float>, float, float>(int64_t              n,
+                                                std::complex<float>* x,
+                                                int64_t              incx,
+                                                std::complex<float>* y,
+                                                int64_t              incy,
+                                                float                c,
+                                                float                s)
 {
     lapack_xrot(n, x, incx, y, incy, c, s);
 }
@@ -1019,9 +1028,9 @@ void ref_rotg<double>(double* a, double* b, double* c, double* s)
 
 template <>
 void ref_rotg<std::complex<float>, float>(std::complex<float>* a,
-                                     std::complex<float>* b,
-                                     float*          c,
-                                     std::complex<float>* s)
+                                          std::complex<float>* b,
+                                          float*               c,
+                                          std::complex<float>* s)
 {
     lapack_xrotg(*a, *b, *c, *s);
 }
@@ -1240,19 +1249,19 @@ void ref_gbmv<double>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gbmv<std::complex<float>>(hipblasOperation_t transA,
-                              int64_t            m,
-                              int64_t            n,
-                              int64_t            kl,
-                              int64_t            ku,
-                              std::complex<float>     alpha,
-                              std::complex<float>*    A,
-                              int64_t            lda,
-                              std::complex<float>*    x,
-                              int64_t            incx,
-                              std::complex<float>     beta,
-                              std::complex<float>*    y,
-                              int64_t            incy)
+void ref_gbmv<std::complex<float>>(hipblasOperation_t   transA,
+                                   int64_t              m,
+                                   int64_t              n,
+                                   int64_t              kl,
+                                   int64_t              ku,
+                                   std::complex<float>  alpha,
+                                   std::complex<float>* A,
+                                   int64_t              lda,
+                                   std::complex<float>* x,
+                                   int64_t              incx,
+                                   std::complex<float>  beta,
+                                   std::complex<float>* y,
+                                   int64_t              incy)
 {
     cblas_cgbmv(CblasColMajor,
                 (CBLAS_TRANSPOSE)transA,
@@ -1337,17 +1346,17 @@ void ref_gemv<double>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gemv<std::complex<float>>(hipblasOperation_t transA,
-                              int64_t            m,
-                              int64_t            n,
-                              std::complex<float>     alpha,
-                              std::complex<float>*    A,
-                              int64_t            lda,
-                              std::complex<float>*    x,
-                              int64_t            incx,
-                              std::complex<float>     beta,
-                              std::complex<float>*    y,
-                              int64_t            incy)
+void ref_gemv<std::complex<float>>(hipblasOperation_t   transA,
+                                   int64_t              m,
+                                   int64_t              n,
+                                   std::complex<float>  alpha,
+                                   std::complex<float>* A,
+                                   int64_t              lda,
+                                   std::complex<float>* x,
+                                   int64_t              incx,
+                                   std::complex<float>  beta,
+                                   std::complex<float>* y,
+                                   int64_t              incy)
 {
     cblas_cgemv(
         CblasColMajor, (CBLAS_TRANSPOSE)transA, m, n, &alpha, A, lda, x, incx, &beta, y, incy);
@@ -1400,29 +1409,29 @@ void ref_ger<double, false>(int64_t m,
 }
 
 template <>
-void ref_ger<std::complex<float>, false>(int64_t         m,
-                                    int64_t         n,
-                                    std::complex<float>  alpha,
-                                    std::complex<float>* x,
-                                    int64_t         incx,
-                                    std::complex<float>* y,
-                                    int64_t         incy,
-                                    std::complex<float>* A,
-                                    int64_t         lda)
+void ref_ger<std::complex<float>, false>(int64_t              m,
+                                         int64_t              n,
+                                         std::complex<float>  alpha,
+                                         std::complex<float>* x,
+                                         int64_t              incx,
+                                         std::complex<float>* y,
+                                         int64_t              incy,
+                                         std::complex<float>* A,
+                                         int64_t              lda)
 {
     cblas_cgeru(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
 
 template <>
-void ref_ger<std::complex<float>, true>(int64_t         m,
-                                   int64_t         n,
-                                   std::complex<float>  alpha,
-                                   std::complex<float>* x,
-                                   int64_t         incx,
-                                   std::complex<float>* y,
-                                   int64_t         incy,
-                                   std::complex<float>* A,
-                                   int64_t         lda)
+void ref_ger<std::complex<float>, true>(int64_t              m,
+                                        int64_t              n,
+                                        std::complex<float>  alpha,
+                                        std::complex<float>* x,
+                                        int64_t              incx,
+                                        std::complex<float>* y,
+                                        int64_t              incy,
+                                        std::complex<float>* A,
+                                        int64_t              lda)
 {
     cblas_cgerc(CblasColMajor, m, n, &alpha, x, incx, y, incy, A, lda);
 }
@@ -1457,17 +1466,17 @@ void ref_ger<std::complex<double>, true>(int64_t               m,
 
 // hbmv
 template <>
-void ref_hbmv<std::complex<float>>(hipblasFillMode_t uplo,
-                              int64_t           n,
-                              int64_t           k,
-                              std::complex<float>    alpha,
-                              std::complex<float>*   A,
-                              int64_t           lda,
-                              std::complex<float>*   x,
-                              int64_t           incx,
-                              std::complex<float>    beta,
-                              std::complex<float>*   y,
-                              int64_t           incy)
+void ref_hbmv<std::complex<float>>(hipblasFillMode_t    uplo,
+                                   int64_t              n,
+                                   int64_t              k,
+                                   std::complex<float>  alpha,
+                                   std::complex<float>* A,
+                                   int64_t              lda,
+                                   std::complex<float>* x,
+                                   int64_t              incx,
+                                   std::complex<float>  beta,
+                                   std::complex<float>* y,
+                                   int64_t              incy)
 {
     cblas_chbmv(CblasColMajor, (CBLAS_UPLO)uplo, n, k, &alpha, A, lda, x, incx, &beta, y, incy);
 }
@@ -1490,16 +1499,16 @@ void ref_hbmv<std::complex<double>>(hipblasFillMode_t     uplo,
 
 // hemv
 template <>
-void ref_hemv<std::complex<float>>(hipblasFillMode_t uplo,
-                              int64_t           n,
-                              std::complex<float>    alpha,
-                              std::complex<float>*   A,
-                              int64_t           lda,
-                              std::complex<float>*   x,
-                              int64_t           incx,
-                              std::complex<float>    beta,
-                              std::complex<float>*   y,
-                              int64_t           incy)
+void ref_hemv<std::complex<float>>(hipblasFillMode_t    uplo,
+                                   int64_t              n,
+                                   std::complex<float>  alpha,
+                                   std::complex<float>* A,
+                                   int64_t              lda,
+                                   std::complex<float>* x,
+                                   int64_t              incx,
+                                   std::complex<float>  beta,
+                                   std::complex<float>* y,
+                                   int64_t              incy)
 {
     cblas_chemv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, A, lda, x, incx, &beta, y, incy);
 }
@@ -1521,13 +1530,13 @@ void ref_hemv<std::complex<double>>(hipblasFillMode_t     uplo,
 
 // her
 template <>
-void ref_her<std::complex<float>, float>(hipblasFillMode_t uplo,
-                                    int64_t           n,
-                                    float             alpha,
-                                    std::complex<float>*   x,
-                                    int64_t           incx,
-                                    std::complex<float>*   A,
-                                    int64_t           lda)
+void ref_her<std::complex<float>, float>(hipblasFillMode_t    uplo,
+                                         int64_t              n,
+                                         float                alpha,
+                                         std::complex<float>* x,
+                                         int64_t              incx,
+                                         std::complex<float>* A,
+                                         int64_t              lda)
 {
     cblas_cher(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, A, lda);
 }
@@ -1546,15 +1555,15 @@ void ref_her<std::complex<double>, double>(hipblasFillMode_t     uplo,
 
 // her2
 template <>
-void ref_her2<std::complex<float>>(hipblasFillMode_t uplo,
-                              int64_t           n,
-                              std::complex<float>    alpha,
-                              std::complex<float>*   x,
-                              int64_t           incx,
-                              std::complex<float>*   y,
-                              int64_t           incy,
-                              std::complex<float>*   A,
-                              int64_t           lda)
+void ref_her2<std::complex<float>>(hipblasFillMode_t    uplo,
+                                   int64_t              n,
+                                   std::complex<float>  alpha,
+                                   std::complex<float>* x,
+                                   int64_t              incx,
+                                   std::complex<float>* y,
+                                   int64_t              incy,
+                                   std::complex<float>* A,
+                                   int64_t              lda)
 {
     cblas_cher2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, A, lda);
 }
@@ -1575,15 +1584,15 @@ void ref_her2<std::complex<double>>(hipblasFillMode_t     uplo,
 
 // hpmv
 template <>
-void ref_hpmv<std::complex<float>>(hipblasFillMode_t uplo,
-                              int64_t           n,
-                              std::complex<float>    alpha,
-                              std::complex<float>*   AP,
-                              std::complex<float>*   x,
-                              int64_t           incx,
-                              std::complex<float>    beta,
-                              std::complex<float>*   y,
-                              int64_t           incy)
+void ref_hpmv<std::complex<float>>(hipblasFillMode_t    uplo,
+                                   int64_t              n,
+                                   std::complex<float>  alpha,
+                                   std::complex<float>* AP,
+                                   std::complex<float>* x,
+                                   int64_t              incx,
+                                   std::complex<float>  beta,
+                                   std::complex<float>* y,
+                                   int64_t              incy)
 {
     cblas_chpmv(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, AP, x, incx, &beta, y, incy);
 }
@@ -1604,12 +1613,12 @@ void ref_hpmv<std::complex<double>>(hipblasFillMode_t     uplo,
 
 // hpr
 template <>
-void ref_hpr(hipblasFillMode_t uplo,
-             int64_t           n,
-             float             alpha,
-             std::complex<float>*   x,
-             int64_t           incx,
-             std::complex<float>*   AP)
+void ref_hpr(hipblasFillMode_t    uplo,
+             int64_t              n,
+             float                alpha,
+             std::complex<float>* x,
+             int64_t              incx,
+             std::complex<float>* AP)
 {
     cblas_chpr(CblasColMajor, (CBLAS_UPLO)uplo, n, alpha, x, incx, AP);
 }
@@ -1627,14 +1636,14 @@ void ref_hpr(hipblasFillMode_t     uplo,
 
 // hpr2
 template <>
-void ref_hpr2(hipblasFillMode_t uplo,
-              int64_t           n,
-              std::complex<float>    alpha,
-              std::complex<float>*   x,
-              int64_t           incx,
-              std::complex<float>*   y,
-              int64_t           incy,
-              std::complex<float>*   AP)
+void ref_hpr2(hipblasFillMode_t    uplo,
+              int64_t              n,
+              std::complex<float>  alpha,
+              std::complex<float>* x,
+              int64_t              incx,
+              std::complex<float>* y,
+              int64_t              incy,
+              std::complex<float>* AP)
 {
     cblas_chpr2(CblasColMajor, (CBLAS_UPLO)uplo, n, &alpha, x, incx, y, incy, AP);
 }
@@ -1728,12 +1737,12 @@ void ref_spr(hipblasFillMode_t uplo, int64_t n, double alpha, double* x, int64_t
 }
 
 template <>
-void ref_spr(hipblasFillMode_t uplo,
-             int64_t           n,
-             std::complex<float>    alpha,
-             std::complex<float>*   x,
-             int64_t           incx,
-             std::complex<float>*   AP)
+void ref_spr(hipblasFillMode_t    uplo,
+             int64_t              n,
+             std::complex<float>  alpha,
+             std::complex<float>* x,
+             int64_t              incx,
+             std::complex<float>* AP)
 {
     lapack_xspr(uplo, n, alpha, x, incx, AP);
 }
@@ -1808,16 +1817,16 @@ void ref_symv(hipblasFillMode_t uplo,
 }
 
 template <>
-void ref_symv(hipblasFillMode_t uplo,
-              int64_t           n,
-              std::complex<float>    alpha,
-              std::complex<float>*   A,
-              int64_t           lda,
-              std::complex<float>*   x,
-              int64_t           incx,
-              std::complex<float>    beta,
-              std::complex<float>*   y,
-              int64_t           incy)
+void ref_symv(hipblasFillMode_t    uplo,
+              int64_t              n,
+              std::complex<float>  alpha,
+              std::complex<float>* A,
+              int64_t              lda,
+              std::complex<float>* x,
+              int64_t              incx,
+              std::complex<float>  beta,
+              std::complex<float>* y,
+              int64_t              incy)
 {
     lapack_xsymv(uplo, n, alpha, A, lda, x, incx, beta, y, incy);
 }
@@ -1858,13 +1867,13 @@ void ref_syr<double>(hipblasFillMode_t uplo,
 }
 
 template <>
-void ref_syr(hipblasFillMode_t uplo,
-             int64_t           n,
-             std::complex<float>    alpha,
-             std::complex<float>*   xa,
-             int64_t           incx,
-             std::complex<float>*   A,
-             int64_t           lda)
+void ref_syr(hipblasFillMode_t    uplo,
+             int64_t              n,
+             std::complex<float>  alpha,
+             std::complex<float>* xa,
+             int64_t              incx,
+             std::complex<float>* A,
+             int64_t              lda)
 {
     lapack_xsyr(uplo, n, alpha, xa, incx, A, lda);
 }
@@ -1912,15 +1921,15 @@ void ref_syr2(hipblasFillMode_t uplo,
 }
 
 template <>
-void ref_syr2(hipblasFillMode_t uplo,
-              int64_t           n,
-              std::complex<float>    alpha,
-              std::complex<float>*   x,
-              int64_t           incx,
-              std::complex<float>*   y,
-              int64_t           incy,
-              std::complex<float>*   A,
-              int64_t           lda)
+void ref_syr2(hipblasFillMode_t    uplo,
+              int64_t              n,
+              std::complex<float>  alpha,
+              std::complex<float>* x,
+              int64_t              incx,
+              std::complex<float>* y,
+              int64_t              incy,
+              std::complex<float>* A,
+              int64_t              lda)
 {
     lapack_xsyr2(uplo, n, alpha, x, incx, y, incy, A, lda);
 }
@@ -1987,15 +1996,15 @@ void ref_tbmv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_tbmv<std::complex<float>>(hipblasFillMode_t     uplo,
-                              hipblasOperation_t    transA,
-                              hipblasDiagType_t     diag,
-                              int64_t               m,
-                              int64_t               k,
-                              const std::complex<float>* A,
-                              int64_t               lda,
-                              std::complex<float>*       x,
-                              int64_t               incx)
+void ref_tbmv<std::complex<float>>(hipblasFillMode_t          uplo,
+                                   hipblasOperation_t         transA,
+                                   hipblasDiagType_t          diag,
+                                   int64_t                    m,
+                                   int64_t                    k,
+                                   const std::complex<float>* A,
+                                   int64_t                    lda,
+                                   std::complex<float>*       x,
+                                   int64_t                    incx)
 {
     cblas_ctbmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2080,15 +2089,15 @@ void ref_tbsv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_tbsv<std::complex<float>>(hipblasFillMode_t     uplo,
-                              hipblasOperation_t    transA,
-                              hipblasDiagType_t     diag,
-                              int64_t               m,
-                              int64_t               k,
-                              const std::complex<float>* A,
-                              int64_t               lda,
-                              std::complex<float>*       x,
-                              int64_t               incx)
+void ref_tbsv<std::complex<float>>(hipblasFillMode_t          uplo,
+                                   hipblasOperation_t         transA,
+                                   hipblasDiagType_t          diag,
+                                   int64_t                    m,
+                                   int64_t                    k,
+                                   const std::complex<float>* A,
+                                   int64_t                    lda,
+                                   std::complex<float>*       x,
+                                   int64_t                    incx)
 {
     cblas_ctbsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2153,13 +2162,13 @@ void ref_tpmv(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_tpmv(hipblasFillMode_t     uplo,
-              hipblasOperation_t    transA,
-              hipblasDiagType_t     diag,
-              int64_t               m,
+void ref_tpmv(hipblasFillMode_t          uplo,
+              hipblasOperation_t         transA,
+              hipblasDiagType_t          diag,
+              int64_t                    m,
               const std::complex<float>* A,
               std::complex<float>*       x,
-              int64_t               incx)
+              int64_t                    incx)
 {
     cblas_ctpmv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), m, A, x, incx);
@@ -2206,13 +2215,13 @@ void ref_tpsv(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_tpsv(hipblasFillMode_t     uplo,
-              hipblasOperation_t    transA,
-              hipblasDiagType_t     diag,
-              int64_t               n,
+void ref_tpsv(hipblasFillMode_t          uplo,
+              hipblasOperation_t         transA,
+              hipblasDiagType_t          diag,
+              int64_t                    n,
               const std::complex<float>* AP,
               std::complex<float>*       x,
-              int64_t               incx)
+              int64_t                    incx)
 {
     cblas_ctpsv(
         CblasColMajor, CBLAS_UPLO(uplo), CBLAS_TRANSPOSE(transA), CBLAS_DIAG(diag), n, AP, x, incx);
@@ -2275,14 +2284,14 @@ void ref_trmv<double>(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_trmv<std::complex<float>>(hipblasFillMode_t     uplo,
-                              hipblasOperation_t    transA,
-                              hipblasDiagType_t     diag,
-                              int64_t               m,
-                              const std::complex<float>* A,
-                              int64_t               lda,
-                              std::complex<float>*       x,
-                              int64_t               incx)
+void ref_trmv<std::complex<float>>(hipblasFillMode_t          uplo,
+                                   hipblasOperation_t         transA,
+                                   hipblasDiagType_t          diag,
+                                   int64_t                    m,
+                                   const std::complex<float>* A,
+                                   int64_t                    lda,
+                                   std::complex<float>*       x,
+                                   int64_t                    incx)
 {
     cblas_ctrmv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2362,15 +2371,15 @@ void ref_trsv<double>(hipblasHandle_t    handle,
 }
 
 template <>
-void ref_trsv<std::complex<float>>(hipblasHandle_t       handle,
-                              hipblasFillMode_t     uplo,
-                              hipblasOperation_t    transA,
-                              hipblasDiagType_t     diag,
-                              int64_t               m,
-                              const std::complex<float>* A,
-                              int64_t               lda,
-                              std::complex<float>*       x,
-                              int64_t               incx)
+void ref_trsv<std::complex<float>>(hipblasHandle_t            handle,
+                                   hipblasFillMode_t          uplo,
+                                   hipblasOperation_t         transA,
+                                   hipblasDiagType_t          diag,
+                                   int64_t                    m,
+                                   const std::complex<float>* A,
+                                   int64_t                    lda,
+                                   std::complex<float>*       x,
+                                   int64_t                    incx)
 {
     cblas_ctrsv(CblasColMajor,
                 CBLAS_UPLO(uplo),
@@ -2506,15 +2515,15 @@ void ref_dgmm(hipblasSideMode_t side,
 }
 
 template <>
-void ref_dgmm(hipblasSideMode_t     side,
-              int64_t               M,
-              int64_t               N,
+void ref_dgmm(hipblasSideMode_t          side,
+              int64_t                    M,
+              int64_t                    N,
               const std::complex<float>* A,
-              int64_t               lda,
+              int64_t                    lda,
               const std::complex<float>* x,
-              int64_t               incx,
+              int64_t                    incx,
               std::complex<float>*       C,
-              int64_t               ldc)
+              int64_t                    ldc)
 {
     ref_dgmm_helper(side, M, N, A, lda, x, incx, C, ldc);
 }
@@ -2569,18 +2578,18 @@ void ref_geam(hipblasOperation_t transa,
 }
 
 template <>
-void ref_geam(hipblasOperation_t transa,
-              hipblasOperation_t transb,
-              int64_t            m,
-              int64_t            n,
-              std::complex<float>*    alpha,
-              std::complex<float>*    A,
-              int64_t            lda,
-              std::complex<float>*    beta,
-              std::complex<float>*    B,
-              int64_t            ldb,
-              std::complex<float>*    C,
-              int64_t            ldc)
+void ref_geam(hipblasOperation_t   transa,
+              hipblasOperation_t   transb,
+              int64_t              m,
+              int64_t              n,
+              std::complex<float>* alpha,
+              std::complex<float>* A,
+              int64_t              lda,
+              std::complex<float>* beta,
+              std::complex<float>* B,
+              int64_t              ldb,
+              std::complex<float>* C,
+              int64_t              ldc)
 {
     return ref_geam_helper(transa, transb, m, n, *alpha, A, lda, *beta, B, ldb, C, ldc);
 }
@@ -2958,19 +2967,19 @@ void ref_gemm<double>(hipblasOperation_t transA,
 }
 
 template <>
-void ref_gemm<std::complex<float>>(hipblasOperation_t transA,
-                              hipblasOperation_t transB,
-                              int64_t            m,
-                              int64_t            n,
-                              int64_t            k,
-                              std::complex<float>     alpha,
-                              std::complex<float>*    A,
-                              int64_t            lda,
-                              std::complex<float>*    B,
-                              int64_t            ldb,
-                              std::complex<float>     beta,
-                              std::complex<float>*    C,
-                              int64_t            ldc)
+void ref_gemm<std::complex<float>>(hipblasOperation_t   transA,
+                                   hipblasOperation_t   transB,
+                                   int64_t              m,
+                                   int64_t              n,
+                                   int64_t              k,
+                                   std::complex<float>  alpha,
+                                   std::complex<float>* A,
+                                   int64_t              lda,
+                                   std::complex<float>* B,
+                                   int64_t              ldb,
+                                   std::complex<float>  beta,
+                                   std::complex<float>* C,
+                                   int64_t              ldc)
 {
     //just directly cast, since transA, transB are integers in the enum
     cblas_cgemm(CblasColMajor,
@@ -3080,18 +3089,18 @@ void ref_gemm<int8_t, int32_t, int32_t>(hipblasOperation_t transA,
 
 // hemm
 template <>
-void ref_hemm(hipblasSideMode_t side,
-              hipblasFillMode_t uplo,
-              int64_t           m,
-              int64_t           n,
-              std::complex<float>    alpha,
-              std::complex<float>*   A,
-              int64_t           lda,
-              std::complex<float>*   B,
-              int64_t           ldb,
-              std::complex<float>    beta,
-              std::complex<float>*   C,
-              int64_t           ldc)
+void ref_hemm(hipblasSideMode_t    side,
+              hipblasFillMode_t    uplo,
+              int64_t              m,
+              int64_t              n,
+              std::complex<float>  alpha,
+              std::complex<float>* A,
+              int64_t              lda,
+              std::complex<float>* B,
+              int64_t              ldb,
+              std::complex<float>  beta,
+              std::complex<float>* C,
+              int64_t              ldc)
 {
     cblas_chemm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3139,16 +3148,16 @@ void ref_hemm(hipblasSideMode_t     side,
 
 // herk
 template <>
-void ref_herk(hipblasFillMode_t  uplo,
-              hipblasOperation_t transA,
-              int64_t            n,
-              int64_t            k,
-              float              alpha,
-              std::complex<float>*    A,
-              int64_t            lda,
-              float              beta,
-              std::complex<float>*    C,
-              int64_t            ldc)
+void ref_herk(hipblasFillMode_t    uplo,
+              hipblasOperation_t   transA,
+              int64_t              n,
+              int64_t              k,
+              float                alpha,
+              std::complex<float>* A,
+              int64_t              lda,
+              float                beta,
+              std::complex<float>* C,
+              int64_t              ldc)
 {
     cblas_cherk(CblasColMajor,
                 (CBLAS_UPLO)uplo,
@@ -3273,18 +3282,18 @@ void ref_herkx_local(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_herkx(hipblasFillMode_t  uplo,
-               hipblasOperation_t transA,
-               int64_t            n,
-               int64_t            k,
-               std::complex<float>     alpha,
-               std::complex<float>*    A,
-               int64_t            lda,
-               std::complex<float>*    B,
-               int64_t            ldb,
-               float              beta,
-               std::complex<float>*    C,
-               int64_t            ldc)
+void ref_herkx(hipblasFillMode_t    uplo,
+               hipblasOperation_t   transA,
+               int64_t              n,
+               int64_t              k,
+               std::complex<float>  alpha,
+               std::complex<float>* A,
+               int64_t              lda,
+               std::complex<float>* B,
+               int64_t              ldb,
+               float                beta,
+               std::complex<float>* C,
+               int64_t              ldc)
 {
     ref_herkx_local(uplo, transA, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
 }
@@ -3308,18 +3317,18 @@ void ref_herkx(hipblasFillMode_t     uplo,
 
 // her2k
 template <>
-void ref_her2k(hipblasFillMode_t  uplo,
-               hipblasOperation_t transA,
-               int64_t            n,
-               int64_t            k,
-               std::complex<float>     alpha,
-               std::complex<float>*    A,
-               int64_t            lda,
-               std::complex<float>*    B,
-               int64_t            ldb,
-               float              beta,
-               std::complex<float>*    C,
-               int64_t            ldc)
+void ref_her2k(hipblasFillMode_t    uplo,
+               hipblasOperation_t   transA,
+               int64_t              n,
+               int64_t              k,
+               std::complex<float>  alpha,
+               std::complex<float>* A,
+               int64_t              lda,
+               std::complex<float>* B,
+               int64_t              ldb,
+               float                beta,
+               std::complex<float>* C,
+               int64_t              ldc)
 {
     cblas_cher2k(CblasColMajor,
                  (CBLAS_UPLO)uplo,
@@ -3425,18 +3434,18 @@ void ref_symm(hipblasSideMode_t side,
 }
 
 template <>
-void ref_symm(hipblasSideMode_t side,
-              hipblasFillMode_t uplo,
-              int64_t           m,
-              int64_t           n,
-              std::complex<float>    alpha,
-              std::complex<float>*   A,
-              int64_t           lda,
-              std::complex<float>*   B,
-              int64_t           ldb,
-              std::complex<float>    beta,
-              std::complex<float>*   C,
-              int64_t           ldc)
+void ref_symm(hipblasSideMode_t    side,
+              hipblasFillMode_t    uplo,
+              int64_t              m,
+              int64_t              n,
+              std::complex<float>  alpha,
+              std::complex<float>* A,
+              int64_t              lda,
+              std::complex<float>* B,
+              int64_t              ldb,
+              std::complex<float>  beta,
+              std::complex<float>* C,
+              int64_t              ldc)
 {
     cblas_csymm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -3534,16 +3543,16 @@ void ref_syrk(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_syrk(hipblasFillMode_t  uplo,
-              hipblasOperation_t transA,
-              int64_t            n,
-              int64_t            k,
-              std::complex<float>     alpha,
-              std::complex<float>*    A,
-              int64_t            lda,
-              std::complex<float>     beta,
-              std::complex<float>*    C,
-              int64_t            ldc)
+void ref_syrk(hipblasFillMode_t    uplo,
+              hipblasOperation_t   transA,
+              int64_t              n,
+              int64_t              k,
+              std::complex<float>  alpha,
+              std::complex<float>* A,
+              int64_t              lda,
+              std::complex<float>  beta,
+              std::complex<float>* C,
+              int64_t              ldc)
 {
     cblas_csyrk(CblasColMajor,
                 (CBLAS_UPLO)uplo,
@@ -3643,18 +3652,18 @@ void ref_syr2k(hipblasFillMode_t  uplo,
 }
 
 template <>
-void ref_syr2k(hipblasFillMode_t  uplo,
-               hipblasOperation_t transA,
-               int64_t            n,
-               int64_t            k,
-               std::complex<float>     alpha,
-               std::complex<float>*    A,
-               int64_t            lda,
-               std::complex<float>*    B,
-               int64_t            ldb,
-               std::complex<float>     beta,
-               std::complex<float>*    C,
-               int64_t            ldc)
+void ref_syr2k(hipblasFillMode_t    uplo,
+               hipblasOperation_t   transA,
+               int64_t              n,
+               int64_t              k,
+               std::complex<float>  alpha,
+               std::complex<float>* A,
+               int64_t              lda,
+               std::complex<float>* B,
+               int64_t              ldb,
+               std::complex<float>  beta,
+               std::complex<float>* C,
+               int64_t              ldc)
 {
     cblas_csyr2k(CblasColMajor,
                  (CBLAS_UPLO)uplo,
@@ -3831,7 +3840,8 @@ void ref_trtri<double>(char uplo, char diag, int64_t n, double* A, int64_t lda)
 }
 
 template <>
-void ref_trtri<std::complex<float>>(char uplo, char diag, int64_t n, std::complex<float>* A, int64_t lda)
+void ref_trtri<std::complex<float>>(
+    char uplo, char diag, int64_t n, std::complex<float>* A, int64_t lda)
 {
     lapack_xtrtri(uplo, diag, n, A, lda);
 }
@@ -3901,17 +3911,17 @@ void ref_trmm<double>(hipblasSideMode_t  side,
 }
 
 template <>
-void ref_trmm<std::complex<float>>(hipblasSideMode_t     side,
-                              hipblasFillMode_t     uplo,
-                              hipblasOperation_t    transA,
-                              hipblasDiagType_t     diag,
-                              int64_t               m,
-                              int64_t               n,
-                              std::complex<float>        alpha,
-                              const std::complex<float>* A,
-                              int64_t               lda,
-                              std::complex<float>*       B,
-                              int64_t               ldb)
+void ref_trmm<std::complex<float>>(hipblasSideMode_t          side,
+                                   hipblasFillMode_t          uplo,
+                                   hipblasOperation_t         transA,
+                                   hipblasDiagType_t          diag,
+                                   int64_t                    m,
+                                   int64_t                    n,
+                                   std::complex<float>        alpha,
+                                   const std::complex<float>* A,
+                                   int64_t                    lda,
+                                   std::complex<float>*       B,
+                                   int64_t                    ldb)
 {
     cblas_ctrmm(CblasColMajor,
                 (CBLAS_SIDE)side,
@@ -4049,8 +4059,8 @@ int64_t ref_getrf<double>(int64_t m, int64_t n, double* A, int64_t lda, int64_t*
 }
 
 template <>
-int64_t
-    ref_getrf<std::complex<float>>(int64_t m, int64_t n, std::complex<float>* A, int64_t lda, int64_t* ipiv)
+int64_t ref_getrf<std::complex<float>>(
+    int64_t m, int64_t n, std::complex<float>* A, int64_t lda, int64_t* ipiv)
 {
     int64_t info;
 
@@ -4122,14 +4132,14 @@ int64_t ref_getrs<double>(char     trans,
 }
 
 template <>
-int64_t ref_getrs<std::complex<float>>(char            trans,
-                                  int64_t         n,
-                                  int64_t         nrhs,
-                                  std::complex<float>* A,
-                                  int64_t         lda,
-                                  int64_t*        ipiv,
-                                  std::complex<float>* B,
-                                  int64_t         ldb)
+int64_t ref_getrs<std::complex<float>>(char                 trans,
+                                       int64_t              n,
+                                       int64_t              nrhs,
+                                       std::complex<float>* A,
+                                       int64_t              lda,
+                                       int64_t*             ipiv,
+                                       std::complex<float>* B,
+                                       int64_t              ldb)
 {
     int64_t info;
 
@@ -4144,7 +4154,15 @@ int64_t ref_getrs<std::complex<float>>(char            trans,
                           (lapack_complex_float*)B,
                           ldb);
 #else
-    cgetrs_(&trans, &n, &nrhs, (std::complex<float>*)A, &lda, ipiv, (std::complex<float>*)B, &ldb, &info);
+    cgetrs_(&trans,
+            &n,
+            &nrhs,
+            (std::complex<float>*)A,
+            &lda,
+            ipiv,
+            (std::complex<float>*)B,
+            &ldb,
+            &info);
 #endif
 
     return info;
@@ -4220,8 +4238,12 @@ int64_t
 }
 
 template <>
-int64_t ref_getri<std::complex<float>>(
-    int64_t n, std::complex<float>* A, int64_t lda, int64_t* ipiv, std::complex<float>* work, int64_t lwork)
+int64_t ref_getri<std::complex<float>>(int64_t              n,
+                                       std::complex<float>* A,
+                                       int64_t              lda,
+                                       int64_t*             ipiv,
+                                       std::complex<float>* work,
+                                       int64_t              lwork)
 {
     int64_t info;
 
@@ -4296,13 +4318,13 @@ int64_t ref_geqrf<double>(
     return info;
 }
 template <>
-int64_t ref_geqrf<std::complex<float>>(int64_t         m,
-                                  int64_t         n,
-                                  std::complex<float>* A,
-                                  int64_t         lda,
-                                  std::complex<float>* tau,
-                                  std::complex<float>* work,
-                                  int64_t         lwork)
+int64_t ref_geqrf<std::complex<float>>(int64_t              m,
+                                       int64_t              n,
+                                       std::complex<float>* A,
+                                       int64_t              lda,
+                                       std::complex<float>* tau,
+                                       std::complex<float>* work,
+                                       int64_t              lwork)
 {
     int64_t info;
 
@@ -4397,16 +4419,16 @@ int64_t ref_gels<double>(char    trans,
 }
 
 template <>
-int64_t ref_gels<std::complex<float>>(char            trans,
-                                 int64_t         m,
-                                 int64_t         n,
-                                 int64_t         nrhs,
-                                 std::complex<float>* A,
-                                 int64_t         lda,
-                                 std::complex<float>* B,
-                                 int64_t         ldb,
-                                 std::complex<float>* work,
-                                 int64_t         lwork)
+int64_t ref_gels<std::complex<float>>(char                 trans,
+                                      int64_t              m,
+                                      int64_t              n,
+                                      int64_t              nrhs,
+                                      std::complex<float>* A,
+                                      int64_t              lda,
+                                      std::complex<float>* B,
+                                      int64_t              ldb,
+                                      std::complex<float>* work,
+                                      int64_t              lwork)
 {
     int64_t info;
 #ifdef FLA_ENABLE_ILP64

--- a/clients/common/clients_common.cpp
+++ b/clients/common/clients_common.cpp
@@ -743,11 +743,10 @@ struct perf_blas<T, U, std::enable_if_t<std::is_same<T, hipblasHalf>{}>> : hipbl
 };
 
 template <typename T, typename U>
-struct perf_blas<
-    T,
-    U,
-    std::enable_if_t<std::is_same<T, std::complex<double>>{} || std::is_same<T, std::complex<float>>{}>>
-    : hipblas_test_valid
+struct perf_blas<T,
+                 U,
+                 std::enable_if_t<std::is_same<T, std::complex<double>>{}
+                                  || std::is_same<T, std::complex<float>>{}>> : hipblas_test_valid
 {
     void operator()(const Arguments& arg)
     {
@@ -946,10 +945,12 @@ struct perf_blas_axpy_ex<
                 hipblasHalf> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
         || (std::is_same_v<
                 Ta,
-                std::complex<float>> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
+                std::complex<
+                    float>> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
         || (std::is_same_v<
                 Ta,
-                std::complex<double>> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
+                std::complex<
+                    double>> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
         || (std::is_same_v<
                 Ta,
                 hipblasHalf> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Tex, float>)
@@ -1164,7 +1165,8 @@ struct perf_blas_scal_ex<
         (std::is_same<Ta, float>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
         || (std::is_same<Ta, double>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
         || (std::is_same<Ta, hipblasHalf>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
-        || (std::is_same<Ta, std::complex<float>>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
+        || (std::is_same<Ta, std::complex<float>>{} && std::is_same<Ta, Tx>{}
+            && std::is_same<Tx, Tex>{})
         || (std::is_same<Ta, std::complex<double>>{} && std::is_same<Ta, Tx>{}
             && std::is_same<Tx, Tex>{})
         || (std::is_same<Ta, hipblasHalf>{} && std::is_same<Ta, Tx>{} && std::is_same<Tex, float>{})

--- a/clients/common/clients_common.cpp
+++ b/clients/common/clients_common.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -746,7 +746,7 @@ template <typename T, typename U>
 struct perf_blas<
     T,
     U,
-    std::enable_if_t<std::is_same<T, hipblasDoubleComplex>{} || std::is_same<T, hipblasComplex>{}>>
+    std::enable_if_t<std::is_same<T, std::complex<double>>{} || std::is_same<T, std::complex<float>>{}>>
     : hipblas_test_valid
 {
     void operator()(const Arguments& arg)
@@ -946,10 +946,10 @@ struct perf_blas_axpy_ex<
                 hipblasHalf> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
         || (std::is_same_v<
                 Ta,
-                hipblasComplex> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
+                std::complex<float>> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
         || (std::is_same_v<
                 Ta,
-                hipblasDoubleComplex> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
+                std::complex<double>> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Ty, Tex>)
         || (std::is_same_v<
                 Ta,
                 hipblasHalf> && std::is_same_v<Ta, Tx> && std::is_same_v<Tx, Ty> && std::is_same_v<Tex, float>)
@@ -992,9 +992,9 @@ struct perf_blas_dot_ex<
                          && std::is_same<Ty, Tr>{} && std::is_same<Tr, Tex>{})
                      || (std::is_same<Tx, hipblasHalf>{} && std::is_same<Tx, Ty>{}
                          && std::is_same<Ty, Tr>{} && std::is_same<Tr, Tex>{})
-                     || (std::is_same<Tx, hipblasComplex>{} && std::is_same<Tx, Ty>{}
+                     || (std::is_same<Tx, std::complex<float>>{} && std::is_same<Tx, Ty>{}
                          && std::is_same<Ty, Tr>{} && std::is_same<Tr, Tex>{})
-                     || (std::is_same<Tx, hipblasDoubleComplex>{} && std::is_same<Tx, Ty>{}
+                     || (std::is_same<Tx, std::complex<double>>{} && std::is_same<Tx, Ty>{}
                          && std::is_same<Ty, Tr>{} && std::is_same<Tr, Tex>{})
                      || (std::is_same<Tx, hipblasHalf>{} && std::is_same<Tx, Ty>{}
                          && std::is_same<Ty, Tr>{} && std::is_same<Tex, float>{})
@@ -1029,9 +1029,9 @@ struct perf_blas_nrm2_ex<
     std::enable_if_t<
         (std::is_same<Tx, float>{} && std::is_same<Tx, Tr>{} && std::is_same<Tr, Tex>{})
         || (std::is_same<Tx, double>{} && std::is_same<Tx, Tr>{} && std::is_same<Tr, Tex>{})
-        || (std::is_same<Tx, hipblasComplex>{} && std::is_same<Tr, float>{}
+        || (std::is_same<Tx, std::complex<float>>{} && std::is_same<Tr, float>{}
             && std::is_same<Tr, Tex>{})
-        || (std::is_same<Tx, hipblasDoubleComplex>{} && std::is_same<Tr, double>{}
+        || (std::is_same<Tx, std::complex<double>>{} && std::is_same<Tr, double>{}
             && std::is_same<Tr, Tex>{})
         || (std::is_same<Tx, hipblasHalf>{} && std::is_same<Tr, Tx>{} && std::is_same<Tex, float>{})
         || (std::is_same<Tx, hipblasBfloat16>{} && std::is_same<Tr, Tx>{}
@@ -1063,15 +1063,15 @@ struct perf_blas_rot_ex<
                       && std::is_same<Tcs, Tex>{})
                      || (std::is_same<Tx, double>{} && std::is_same<Ty, Tx>{}
                          && std::is_same<Ty, Tcs>{} && std::is_same<Tex, Tcs>{})
-                     || (std::is_same<Tx, hipblasComplex>{} && std::is_same<Ty, Tx>{}
+                     || (std::is_same<Tx, std::complex<float>>{} && std::is_same<Ty, Tx>{}
                          && std::is_same<Tcs, Ty>{} && std::is_same<Tcs, Tex>{})
-                     || (std::is_same<Tx, hipblasDoubleComplex>{} && std::is_same<Tx, Ty>{}
+                     || (std::is_same<Tx, std::complex<double>>{} && std::is_same<Tx, Ty>{}
                          && std::is_same<Tcs, Ty>{} && std::is_same<Tex, Tcs>{})
-                     || (std::is_same<Tx, hipblasComplex>{} && std::is_same<Ty, Tx>{}
-                         && std::is_same<Tcs, float>{} && std::is_same<Tex, hipblasComplex>{})
-                     || (std::is_same<Tx, hipblasDoubleComplex>{} && std::is_same<Tx, Ty>{}
+                     || (std::is_same<Tx, std::complex<float>>{} && std::is_same<Ty, Tx>{}
+                         && std::is_same<Tcs, float>{} && std::is_same<Tex, std::complex<float>>{})
+                     || (std::is_same<Tx, std::complex<double>>{} && std::is_same<Tx, Ty>{}
                          && std::is_same<Tcs, double>{}
-                         && std::is_same<Tex, hipblasDoubleComplex>{})
+                         && std::is_same<Tex, std::complex<double>>{})
                      || (std::is_same<Tx, hipblasHalf>{} && std::is_same<Ty, Tx>{}
                          && std::is_same<Tcs, Ty>{} && std::is_same<Tex, float>{})
                      || (std::is_same<Tx, hipblasBfloat16>{} && std::is_same<Ty, Tx>{}
@@ -1102,13 +1102,13 @@ struct perf_blas_rot<
     std::enable_if_t<(std::is_same<Ti, float>{} && std::is_same<Ti, To>{} && std::is_same<To, Tc>{})
                      || (std::is_same<Ti, double>{} && std::is_same<Ti, To>{}
                          && std::is_same<To, Tc>{})
-                     || (std::is_same<Ti, hipblasComplex>{} && std::is_same<To, float>{}
-                         && std::is_same<Tc, hipblasComplex>{})
-                     || (std::is_same<Ti, hipblasComplex>{} && std::is_same<To, float>{}
+                     || (std::is_same<Ti, std::complex<float>>{} && std::is_same<To, float>{}
+                         && std::is_same<Tc, std::complex<float>>{})
+                     || (std::is_same<Ti, std::complex<float>>{} && std::is_same<To, float>{}
                          && std::is_same<Tc, float>{})
-                     || (std::is_same<Ti, hipblasDoubleComplex>{} && std::is_same<To, double>{}
-                         && std::is_same<Tc, hipblasDoubleComplex>{})
-                     || (std::is_same<Ti, hipblasDoubleComplex>{} && std::is_same<To, double>{}
+                     || (std::is_same<Ti, std::complex<double>>{} && std::is_same<To, double>{}
+                         && std::is_same<Tc, std::complex<double>>{})
+                     || (std::is_same<Ti, std::complex<double>>{} && std::is_same<To, double>{}
                          && std::is_same<Tc, double>{})>> : hipblas_test_valid
 {
     void operator()(const Arguments& arg)
@@ -1131,12 +1131,12 @@ template <typename Ta, typename Tb>
 struct perf_blas_scal<
     Ta,
     Tb,
-    std::enable_if_t<(std::is_same<Ta, double>{} && std::is_same<Tb, hipblasDoubleComplex>{})
-                     || (std::is_same<Ta, float>{} && std::is_same<Tb, hipblasComplex>{})
+    std::enable_if_t<(std::is_same<Ta, double>{} && std::is_same<Tb, std::complex<double>>{})
+                     || (std::is_same<Ta, float>{} && std::is_same<Tb, std::complex<float>>{})
                      || (std::is_same<Ta, Tb>{} && std::is_same<Ta, float>{})
                      || (std::is_same<Ta, Tb>{} && std::is_same<Ta, double>{})
-                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, hipblasComplex>{})
-                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, hipblasDoubleComplex>{})>>
+                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, std::complex<float>>{})
+                     || (std::is_same<Ta, Tb>{} && std::is_same<Ta, std::complex<double>>{})>>
     : hipblas_test_valid
 {
     void operator()(const Arguments& arg)
@@ -1164,14 +1164,14 @@ struct perf_blas_scal_ex<
         (std::is_same<Ta, float>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
         || (std::is_same<Ta, double>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
         || (std::is_same<Ta, hipblasHalf>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
-        || (std::is_same<Ta, hipblasComplex>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
-        || (std::is_same<Ta, hipblasDoubleComplex>{} && std::is_same<Ta, Tx>{}
+        || (std::is_same<Ta, std::complex<float>>{} && std::is_same<Ta, Tx>{} && std::is_same<Tx, Tex>{})
+        || (std::is_same<Ta, std::complex<double>>{} && std::is_same<Ta, Tx>{}
             && std::is_same<Tx, Tex>{})
         || (std::is_same<Ta, hipblasHalf>{} && std::is_same<Ta, Tx>{} && std::is_same<Tex, float>{})
         || (std::is_same<Ta, float>{} && std::is_same<Tx, hipblasHalf>{} && std::is_same<Ta, Tex>{})
-        || (std::is_same<Ta, float>{} && std::is_same<Tx, hipblasComplex>{}
+        || (std::is_same<Ta, float>{} && std::is_same<Tx, std::complex<float>>{}
             && std::is_same<Tx, Tex>{})
-        || (std::is_same<Ta, double>{} && std::is_same<Tx, hipblasDoubleComplex>{}
+        || (std::is_same<Ta, double>{} && std::is_same<Tx, std::complex<double>>{}
             && std::is_same<Tx, Tex>{})
         || (std::is_same<Ta, hipblasBfloat16>{} && std::is_same<Ta, Tx>{}
             && std::is_same<Tex, float>{})

--- a/clients/common/near.cpp
+++ b/clients/common/near.cpp
@@ -127,8 +127,12 @@ void near_check_general(int64_t          M,
 }
 
 template <>
-void near_check_general(
-    int64_t M, int64_t N, int64_t lda, std::complex<float>* hCPU, std::complex<float>* hGPU, double abs_error)
+void near_check_general(int64_t              M,
+                        int64_t              N,
+                        int64_t              lda,
+                        std::complex<float>* hCPU,
+                        std::complex<float>* hGPU,
+                        double               abs_error)
 {
     abs_error *= sqrthalf;
     NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
@@ -212,14 +216,14 @@ void near_check_general(int64_t          M,
 }
 
 template <>
-void near_check_general(int64_t         M,
-                        int64_t         N,
-                        int64_t         batch_count,
-                        int64_t         lda,
-                        hipblasStride   strideA,
+void near_check_general(int64_t              M,
+                        int64_t              N,
+                        int64_t              batch_count,
+                        int64_t              lda,
+                        hipblasStride        strideA,
                         std::complex<float>* hCPU,
                         std::complex<float>* hGPU,
-                        double          abs_error)
+                        double               abs_error)
 {
     abs_error *= sqrthalf;
     NEAR_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
@@ -299,13 +303,13 @@ void near_check_general(int64_t             M,
 }
 
 template <>
-void near_check_general(int64_t                     M,
-                        int64_t                     N,
-                        int64_t                     batch_count,
-                        int64_t                     lda,
+void near_check_general(int64_t                          M,
+                        int64_t                          N,
+                        int64_t                          batch_count,
+                        int64_t                          lda,
                         host_vector<std::complex<float>> hCPU[],
                         host_vector<std::complex<float>> hGPU[],
-                        double                      abs_error)
+                        double                           abs_error)
 {
     abs_error *= sqrthalf;
     NEAR_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
@@ -385,13 +389,13 @@ void near_check_general(int64_t M,
 }
 
 template <>
-void near_check_general(int64_t         M,
-                        int64_t         N,
-                        int64_t         batch_count,
-                        int64_t         lda,
+void near_check_general(int64_t              M,
+                        int64_t              N,
+                        int64_t              batch_count,
+                        int64_t              lda,
                         std::complex<float>* hCPU[],
                         std::complex<float>* hGPU[],
-                        double          abs_error)
+                        double               abs_error)
 {
     abs_error *= sqrthalf;
     NEAR_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);

--- a/clients/common/near.cpp
+++ b/clients/common/near.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -128,7 +128,7 @@ void near_check_general(int64_t          M,
 
 template <>
 void near_check_general(
-    int64_t M, int64_t N, int64_t lda, hipblasComplex* hCPU, hipblasComplex* hGPU, double abs_error)
+    int64_t M, int64_t N, int64_t lda, std::complex<float>* hCPU, std::complex<float>* hGPU, double abs_error)
 {
     abs_error *= sqrthalf;
     NEAR_CHECK(M, N, 1, lda, 0, hCPU, hGPU, abs_error, NEAR_ASSERT_COMPLEX);
@@ -138,8 +138,8 @@ template <>
 void near_check_general(int64_t               M,
                         int64_t               N,
                         int64_t               lda,
-                        hipblasDoubleComplex* hCPU,
-                        hipblasDoubleComplex* hGPU,
+                        std::complex<double>* hCPU,
+                        std::complex<double>* hGPU,
                         double                abs_error)
 {
     abs_error *= sqrthalf;
@@ -217,8 +217,8 @@ void near_check_general(int64_t         M,
                         int64_t         batch_count,
                         int64_t         lda,
                         hipblasStride   strideA,
-                        hipblasComplex* hCPU,
-                        hipblasComplex* hGPU,
+                        std::complex<float>* hCPU,
+                        std::complex<float>* hGPU,
                         double          abs_error)
 {
     abs_error *= sqrthalf;
@@ -231,8 +231,8 @@ void near_check_general(int64_t               M,
                         int64_t               batch_count,
                         int64_t               lda,
                         hipblasStride         strideA,
-                        hipblasDoubleComplex* hCPU,
-                        hipblasDoubleComplex* hGPU,
+                        std::complex<double>* hCPU,
+                        std::complex<double>* hGPU,
                         double                abs_error)
 {
     abs_error *= sqrthalf;
@@ -303,8 +303,8 @@ void near_check_general(int64_t                     M,
                         int64_t                     N,
                         int64_t                     batch_count,
                         int64_t                     lda,
-                        host_vector<hipblasComplex> hCPU[],
-                        host_vector<hipblasComplex> hGPU[],
+                        host_vector<std::complex<float>> hCPU[],
+                        host_vector<std::complex<float>> hGPU[],
                         double                      abs_error)
 {
     abs_error *= sqrthalf;
@@ -316,8 +316,8 @@ void near_check_general(int64_t                           M,
                         int64_t                           N,
                         int64_t                           batch_count,
                         int64_t                           lda,
-                        host_vector<hipblasDoubleComplex> hCPU[],
-                        host_vector<hipblasDoubleComplex> hGPU[],
+                        host_vector<std::complex<double>> hCPU[],
+                        host_vector<std::complex<double>> hGPU[],
                         double                            abs_error)
 {
     abs_error *= sqrthalf;
@@ -389,8 +389,8 @@ void near_check_general(int64_t         M,
                         int64_t         N,
                         int64_t         batch_count,
                         int64_t         lda,
-                        hipblasComplex* hCPU[],
-                        hipblasComplex* hGPU[],
+                        std::complex<float>* hCPU[],
+                        std::complex<float>* hGPU[],
                         double          abs_error)
 {
     abs_error *= sqrthalf;
@@ -402,8 +402,8 @@ void near_check_general(int64_t               M,
                         int64_t               N,
                         int64_t               batch_count,
                         int64_t               lda,
-                        hipblasDoubleComplex* hCPU[],
-                        hipblasDoubleComplex* hGPU[],
+                        std::complex<double>* hCPU[],
+                        std::complex<double>* hGPU[],
                         double                abs_error)
 {
     abs_error *= sqrthalf;

--- a/clients/common/norm.cpp
+++ b/clients/common/norm.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,24 +48,24 @@ extern "C" {
 
 // float  slange_(char* norm_type, int* m, int* n, float* A, int* lda, float* work);
 // double dlange_(char* norm_type, int* m, int* n, double* A, int* lda, double* work);
-// float  clange_(char* norm_type, int* m, int* n, hipblasComplex* A, int* lda, float* work);
-// double zlange_(char* norm_type, int* m, int* n, hipblasDoubleComplex* A, int* lda, double* work);
+// float  clange_(char* norm_type, int* m, int* n, std::complex<float>* A, int* lda, float* work);
+// double zlange_(char* norm_type, int* m, int* n, std::complex<double>* A, int* lda, double* work);
 
 // float  slansy_(char* norm_type, char* uplo, int* n, float* A, int* lda, float* work);
 // double dlansy_(char* norm_type, char* uplo, int* n, double* A, int* lda, double* work);
-//  float  clanhe_(char* norm_type, char* uplo, int* n, hipblasComplex* A, int* lda, float* work);
-//  double zlanhe_(char* norm_type, char* uplo, int* n, hipblasDoubleComplex* A, int* lda, double*
+//  float  clanhe_(char* norm_type, char* uplo, int* n, std::complex<float>* A, int* lda, float* work);
+//  double zlanhe_(char* norm_type, char* uplo, int* n, std::complex<double>* A, int* lda, double*
 //  work);
 
 // void m_axpy_64(int* n, float* alpha, float* x, int* incx, float* y, int* incy);
 // void m_axpy_64(int* n, double* alpha, double* x, int* incx, double* y, int* incy);
 // void m_axpy_64(
-//     int* n, hipblasComplex* alpha, hipblasComplex* x, int* incx, hipblasComplex* y, int* incy);
+//     int* n, std::complex<float>* alpha, std::complex<float>* x, int* incx, std::complex<float>* y, int* incy);
 // void m_axpy_64(int*                  n,
-//             hipblasDoubleComplex* alpha,
-//             hipblasDoubleComplex* x,
+//             std::complex<double>* alpha,
+//             std::complex<double>* x,
 //             int*                  incx,
-//             hipblasDoubleComplex* y,
+//             std::complex<double>* y,
 //             int*                  incy);
 
 #ifdef __cplusplus
@@ -124,14 +124,14 @@ double norm_check_general<double>(
 }
 
 template <>
-double norm_check_general<hipblasComplex>(
-    char norm_type, int64_t M, int64_t N, int64_t lda, hipblasComplex* hCPU, hipblasComplex* hGPU)
+double norm_check_general<std::complex<float>>(
+    char norm_type, int64_t M, int64_t N, int64_t lda, std::complex<float>* hCPU, std::complex<float>* hGPU)
 {
     //norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
     host_vector<double> work(std::max(int64_t(1), M));
     int64_t             incx  = 1;
-    hipblasComplex      alpha = -1.0f;
+    std::complex<float>      alpha = -1.0f;
     int64_t             size  = lda * N;
 
     double cpu_norm = lapack_xlange(norm_type, M, N, hCPU, lda, work.data());
@@ -142,18 +142,18 @@ double norm_check_general<hipblasComplex>(
 }
 
 template <>
-double norm_check_general<hipblasDoubleComplex>(char                  norm_type,
+double norm_check_general<std::complex<double>>(char                  norm_type,
                                                 int64_t               M,
                                                 int64_t               N,
                                                 int64_t               lda,
-                                                hipblasDoubleComplex* hCPU,
-                                                hipblasDoubleComplex* hGPU)
+                                                std::complex<double>* hCPU,
+                                                std::complex<double>* hGPU)
 {
     //norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
     host_vector<double>  work(std::max(int64_t(1), M));
     int64_t              incx  = 1;
-    hipblasDoubleComplex alpha = -1.0;
+    std::complex<double> alpha = -1.0;
     int64_t              size  = lda * N;
 
     double cpu_norm = lapack_xlange(norm_type, M, N, hCPU, lda, work.data());
@@ -321,14 +321,14 @@ double norm_check_symmetric<double>(
 */
 
 // template<>
-// double norm_check_symmetric<hipblasComplex>(char norm_type, char uplo, int64_t N, int64_t lda, hipblasComplex
-// *hCPU, hipblasComplex *hGPU)
+// double norm_check_symmetric<std::complex<float>>(char norm_type, char uplo, int64_t N, int64_t lda, std::complex<float>
+// *hCPU, std::complex<float> *hGPU)
 //{
 ////norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 //
 //    float work[1];
 //    int64_t incx = 1;
-//    hipblasComplex alpha = -1.0f;
+//    std::complex<float> alpha = -1.0f;
 //    int64_t size = lda * N;
 //
 //    float cpu_norm = clanhe_(&norm_type, &uplo, &N, hCPU, &lda, work);
@@ -340,14 +340,14 @@ double norm_check_symmetric<double>(
 //}
 //
 // template<>
-// double norm_check_symmetric<hipblasDoubleComplex>(char norm_type, char uplo, int64_t N, int64_t lda,
-// hipblasDoubleComplex *hCPU, hipblasDoubleComplex *hGPU)
+// double norm_check_symmetric<std::complex<double>>(char norm_type, char uplo, int64_t N, int64_t lda,
+// std::complex<double> *hCPU, std::complex<double> *hGPU)
 //{
 ////norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 //
 //    double work[1];
 //    int64_t incx = 1;
-//    hipblasDoubleComplex alpha = -1.0;
+//    std::complex<double> alpha = -1.0;
 //    int64_t size = lda * N;
 //
 //    double cpu_norm = zlanhe_(&norm_type, &uplo, &N, hCPU, &lda, work);

--- a/clients/common/norm.cpp
+++ b/clients/common/norm.cpp
@@ -124,14 +124,18 @@ double norm_check_general<double>(
 }
 
 template <>
-double norm_check_general<std::complex<float>>(
-    char norm_type, int64_t M, int64_t N, int64_t lda, std::complex<float>* hCPU, std::complex<float>* hGPU)
+double norm_check_general<std::complex<float>>(char                 norm_type,
+                                               int64_t              M,
+                                               int64_t              N,
+                                               int64_t              lda,
+                                               std::complex<float>* hCPU,
+                                               std::complex<float>* hGPU)
 {
     //norm type can be M', 'I', 'F', 'l': 'F' (Frobenius norm) is used mostly
 
     host_vector<double> work(std::max(int64_t(1), M));
     int64_t             incx  = 1;
-    std::complex<float>      alpha = -1.0f;
+    std::complex<float> alpha = -1.0f;
     int64_t             size  = lda * N;
 
     double cpu_norm = lapack_xlange(norm_type, M, N, hCPU, lda, work.data());

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -204,10 +204,10 @@ void unit_check_general(
 }
 
 template <>
-void unit_check_general(int64_t          M,
-                        int64_t          N,
-                        int64_t          batch_count,
-                        int64_t          lda,
+void unit_check_general(int64_t               M,
+                        int64_t               N,
+                        int64_t               batch_count,
+                        int64_t               lda,
                         std::complex<float>** hCPU,
                         std::complex<float>** hGPU)
 {
@@ -282,10 +282,10 @@ void unit_check_general(int64_t             M,
 }
 
 template <>
-void unit_check_general(int64_t                     M,
-                        int64_t                     N,
-                        int64_t                     batch_count,
-                        int64_t                     lda,
+void unit_check_general(int64_t                          M,
+                        int64_t                          N,
+                        int64_t                          batch_count,
+                        int64_t                          lda,
                         host_vector<std::complex<float>> hCPU[],
                         host_vector<std::complex<float>> hGPU[])
 {
@@ -353,11 +353,11 @@ void unit_check_general(int64_t       M,
 }
 
 template <>
-void unit_check_general(int64_t         M,
-                        int64_t         N,
-                        int64_t         batch_count,
-                        int64_t         lda,
-                        hipblasStride   strideA,
+void unit_check_general(int64_t              M,
+                        int64_t              N,
+                        int64_t              batch_count,
+                        int64_t              lda,
+                        hipblasStride        strideA,
                         std::complex<float>* hCPU,
                         std::complex<float>* hGPU)
 {

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -118,7 +118,7 @@ void unit_check_general(int64_t M, int64_t N, int64_t lda, double* hCPU, double*
 
 template <>
 void unit_check_general(
-    int64_t M, int64_t N, int64_t lda, hipblasComplex* hCPU, hipblasComplex* hGPU)
+    int64_t M, int64_t N, int64_t lda, std::complex<float>* hCPU, std::complex<float>* hGPU)
 {
 #ifdef GOOGLE_TEST
     for(int64_t j = 0; j < N; j++)
@@ -132,7 +132,7 @@ void unit_check_general(
 
 template <>
 void unit_check_general(
-    int64_t M, int64_t N, int64_t lda, hipblasDoubleComplex* hCPU, hipblasDoubleComplex* hGPU)
+    int64_t M, int64_t N, int64_t lda, std::complex<double>* hCPU, std::complex<double>* hGPU)
 {
 #ifdef GOOGLE_TEST
     for(int64_t j = 0; j < N; j++)
@@ -208,8 +208,8 @@ void unit_check_general(int64_t          M,
                         int64_t          N,
                         int64_t          batch_count,
                         int64_t          lda,
-                        hipblasComplex** hCPU,
-                        hipblasComplex** hGPU)
+                        std::complex<float>** hCPU,
+                        std::complex<float>** hGPU)
 {
     UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, ASSERT_FLOAT_COMPLEX_EQ);
 }
@@ -219,8 +219,8 @@ void unit_check_general(int64_t                M,
                         int64_t                N,
                         int64_t                batch_count,
                         int64_t                lda,
-                        hipblasDoubleComplex** hCPU,
-                        hipblasDoubleComplex** hGPU)
+                        std::complex<double>** hCPU,
+                        std::complex<double>** hGPU)
 {
     UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, ASSERT_DOUBLE_COMPLEX_EQ);
 }
@@ -286,8 +286,8 @@ void unit_check_general(int64_t                     M,
                         int64_t                     N,
                         int64_t                     batch_count,
                         int64_t                     lda,
-                        host_vector<hipblasComplex> hCPU[],
-                        host_vector<hipblasComplex> hGPU[])
+                        host_vector<std::complex<float>> hCPU[],
+                        host_vector<std::complex<float>> hGPU[])
 {
     UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, ASSERT_FLOAT_COMPLEX_EQ);
 }
@@ -297,8 +297,8 @@ void unit_check_general(int64_t                           M,
                         int64_t                           N,
                         int64_t                           batch_count,
                         int64_t                           lda,
-                        host_vector<hipblasDoubleComplex> hCPU[],
-                        host_vector<hipblasDoubleComplex> hGPU[])
+                        host_vector<std::complex<double>> hCPU[],
+                        host_vector<std::complex<double>> hGPU[])
 {
     UNIT_CHECK_B(M, N, batch_count, lda, hCPU, hGPU, ASSERT_DOUBLE_COMPLEX_EQ);
 }
@@ -358,8 +358,8 @@ void unit_check_general(int64_t         M,
                         int64_t         batch_count,
                         int64_t         lda,
                         hipblasStride   strideA,
-                        hipblasComplex* hCPU,
-                        hipblasComplex* hGPU)
+                        std::complex<float>* hCPU,
+                        std::complex<float>* hGPU)
 {
     UNIT_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, ASSERT_FLOAT_COMPLEX_EQ);
 }
@@ -370,8 +370,8 @@ void unit_check_general(int64_t               M,
                         int64_t               batch_count,
                         int64_t               lda,
                         hipblasStride         strideA,
-                        hipblasDoubleComplex* hCPU,
-                        hipblasDoubleComplex* hGPU)
+                        std::complex<double>* hCPU,
+                        std::complex<double>* hGPU)
 {
     UNIT_CHECK(M, N, batch_count, lda, strideA, hCPU, hGPU, ASSERT_DOUBLE_COMPLEX_EQ);
 }

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -80,12 +80,12 @@ char type2char<double>()
 }
 
 //  template<>
-//  char type2char<hipblasComplex>(){
+//  char type2char<std::complex<float>>(){
 //      return 'c';
 //  }
 
 //  template<>
-//  char type2char<hipblasDoubleComplex>(){
+//  char type2char<std::complex<double>>(){
 //      return 'z';
 //  }
 
@@ -102,13 +102,13 @@ int type2int<double>(double val)
 }
 
 template <>
-int type2int<hipblasComplex>(hipblasComplex val)
+int type2int<std::complex<float>>(std::complex<float> val)
 {
     return (int)val.real();
 }
 
 template <>
-int type2int<hipblasDoubleComplex>(hipblasDoubleComplex val)
+int type2int<std::complex<double>>(std::complex<double> val)
 {
     return (int)val.real();
 }

--- a/clients/gtest/auxil/set_get_matrix_vector_gtest.cpp
+++ b/clients/gtest/auxil/set_get_matrix_vector_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -111,7 +111,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas1/asum_gtest.cpp
+++ b/clients/gtest/blas1/asum_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,7 +81,7 @@ namespace
           || BLAS1 == blas1::asum_strided_batched)
          && std::is_same_v<
              Ti,
-             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasComplex> || std::is_same_v<Ti, hipblasDoubleComplex> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
+             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, std::complex<float>> || std::is_same_v<Ti, std::complex<double>> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/axpy_gtest.cpp
+++ b/clients/gtest/blas1/axpy_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,7 +81,7 @@ namespace
           || BLAS1 == blas1::axpy_strided_batched)
          && std::is_same_v<
              Ti,
-             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasHalf> || std::is_same_v<Ti, hipblasComplex> || std::is_same_v<Ti, hipblasDoubleComplex> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
+             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasHalf> || std::is_same_v<Ti, std::complex<float>> || std::is_same_v<Ti, std::complex<double>> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/copy_gtest.cpp
+++ b/clients/gtest/blas1/copy_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,7 +81,7 @@ namespace
           || BLAS1 == blas1::copy_strided_batched)
          && std::is_same_v<
              Ti,
-             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasComplex> || std::is_same_v<Ti, hipblasDoubleComplex> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
+             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, std::complex<float>> || std::is_same_v<Ti, std::complex<double>> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/dot_gtest.cpp
+++ b/clients/gtest/blas1/dot_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,7 +86,7 @@ namespace
         ((BLAS1 == blas1::dot || BLAS1 == blas1::dot_batched || BLAS1 == blas1::dot_strided_batched)
              && (std::is_same_v<
                      Ti,
-                     To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasHalf> || std::is_same_v<Ti, hipblasComplex> || std::is_same_v<Ti, hipblasDoubleComplex> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))
+                     To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasHalf> || std::is_same_v<Ti, std::complex<float>> || std::is_same_v<Ti, std::complex<double>> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))
          || (std::is_same_v<
                  Ti,
                  To> && std::is_same_v<Ti, hipblasBfloat16> && std::is_same_v<Tc, float>))
@@ -95,7 +95,7 @@ namespace
                  || BLAS1 == blas1::dotc_strided_batched)
                 && std::is_same_v<
                     To,
-                    Ti> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasComplex> || std::is_same_v<Ti, hipblasDoubleComplex>))>;
+                    Ti> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, std::complex<float>> || std::is_same_v<Ti, std::complex<double>>))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/iamaxmin_gtest.cpp
+++ b/clients/gtest/blas1/iamaxmin_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -90,7 +90,7 @@ namespace
           || BLAS1 == blas1::iamin_batched || BLAS1 == blas1::iamin_strided_batched)
          && std::is_same_v<
              Ti,
-             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasComplex> || std::is_same_v<Ti, hipblasDoubleComplex> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
+             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, std::complex<float>> || std::is_same_v<Ti, std::complex<double>> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/nrm2_gtest.cpp
+++ b/clients/gtest/blas1/nrm2_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,7 +81,7 @@ namespace
           || BLAS1 == blas1::nrm2_strided_batched)
          && std::is_same_v<
              Ti,
-             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasComplex> || std::is_same_v<Ti, hipblasDoubleComplex> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
+             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, std::complex<float>> || std::is_same_v<Ti, std::complex<double>> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/rot_gtest.cpp
+++ b/clients/gtest/blas1/rot_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -111,23 +111,23 @@ namespace
                  || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To> && std::is_same_v<To, Tc>)
                  || (std::is_same_v<
                          Ti,
-                         hipblasComplex> && std::is_same_v<To, float> && std::is_same_v<Tc, hipblasComplex>)
+                         std::complex<float>> && std::is_same_v<To, float> && std::is_same_v<Tc, std::complex<float>>)
                  || (std::is_same_v<
                          Ti,
-                         hipblasComplex> && std::is_same_v<To, float> && std::is_same_v<Tc, float>)
+                         std::complex<float>> && std::is_same_v<To, float> && std::is_same_v<Tc, float>)
                  || (std::is_same_v<
                          Ti,
-                         hipblasDoubleComplex> && std::is_same_v<To, double> && std::is_same_v<Tc, hipblasDoubleComplex>)
+                         std::complex<double>> && std::is_same_v<To, double> && std::is_same_v<Tc, std::complex<double>>)
                  || (std::is_same_v<
                          Ti,
-                         hipblasDoubleComplex> && std::is_same_v<To, double> && std::is_same_v<Tc, double>)))
+                         std::complex<double>> && std::is_same_v<To, double> && std::is_same_v<Tc, double>)))
 
                 || ((BLAS1 == blas1::rotg || BLAS1 == blas1::rotg_batched
                      || BLAS1 == blas1::rotg_strided_batched)
                     && std::
                         is_same_v<
                             To,
-                            Tc> && ((std::is_same_v<Ti, float> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, hipblasComplex> && std::is_same_v<To, float>) || (std::is_same_v<Ti, hipblasDoubleComplex> && std::is_same_v<To, double>)))
+                            Tc> && ((std::is_same_v<Ti, float> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<float>> && std::is_same_v<To, float>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<To, double>)))
 
                 || ((BLAS1 == blas1::rotm || BLAS1 == blas1::rotm_batched
                      || BLAS1 == blas1::rotm_strided_batched)

--- a/clients/gtest/blas1/rot_gtest.cpp
+++ b/clients/gtest/blas1/rot_gtest.cpp
@@ -102,44 +102,44 @@ namespace
 
     // This tells whether the BLAS1 tests are enabled
     template <blas1 BLAS1, typename Ti, typename To, typename Tc>
-    using rot_enabled
-        = std::integral_constant<
-            bool,
-            ((BLAS1 == blas1::rot || BLAS1 == blas1::rot_batched
-              || BLAS1 == blas1::rot_strided_batched)
-             && ((std::is_same_v<Ti, float> && std::is_same_v<Ti, To> && std::is_same_v<To, Tc>)
-                 || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To> && std::is_same_v<To, Tc>)
-                 || (std::is_same_v<
-                         Ti,
-                         std::complex<float>> && std::is_same_v<To, float> && std::is_same_v<Tc, std::complex<float>>)
-                 || (std::is_same_v<
-                         Ti,
-                         std::complex<float>> && std::is_same_v<To, float> && std::is_same_v<Tc, float>)
-                 || (std::is_same_v<
-                         Ti,
-                         std::complex<double>> && std::is_same_v<To, double> && std::is_same_v<Tc, std::complex<double>>)
-                 || (std::is_same_v<
-                         Ti,
-                         std::complex<double>> && std::is_same_v<To, double> && std::is_same_v<Tc, double>)))
+    using rot_enabled = std::integral_constant<
+        bool,
+        ((BLAS1 == blas1::rot || BLAS1 == blas1::rot_batched || BLAS1 == blas1::rot_strided_batched)
+         && ((std::is_same_v<Ti, float> && std::is_same_v<Ti, To> && std::is_same_v<To, Tc>)
+             || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To> && std::is_same_v<To, Tc>)
+             || (std::is_same_v<
+                     Ti,
+                     std::complex<
+                         float>> && std::is_same_v<To, float> && std::is_same_v<Tc, std::complex<float>>)
+             || (std::is_same_v<
+                     Ti,
+                     std::complex<float>> && std::is_same_v<To, float> && std::is_same_v<Tc, float>)
+             || (std::is_same_v<
+                     Ti,
+                     std::complex<
+                         double>> && std::is_same_v<To, double> && std::is_same_v<Tc, std::complex<double>>)
+             || (std::is_same_v<
+                     Ti,
+                     std::complex<
+                         double>> && std::is_same_v<To, double> && std::is_same_v<Tc, double>)))
 
-                || ((BLAS1 == blas1::rotg || BLAS1 == blas1::rotg_batched
-                     || BLAS1 == blas1::rotg_strided_batched)
-                    && std::
-                        is_same_v<
-                            To,
-                            Tc> && ((std::is_same_v<Ti, float> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<float>> && std::is_same_v<To, float>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<To, double>)))
+            || ((BLAS1 == blas1::rotg || BLAS1 == blas1::rotg_batched
+                 || BLAS1 == blas1::rotg_strided_batched)
+                && std::
+                    is_same_v<To,
+                              Tc> && ((std::is_same_v<Ti, float> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<float>> && std::is_same_v<To, float>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<To, double>)))
 
-                || ((BLAS1 == blas1::rotm || BLAS1 == blas1::rotm_batched
-                     || BLAS1 == blas1::rotm_strided_batched)
-                    && std::is_same_v<
-                        To,
-                        Ti> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))
+            || ((BLAS1 == blas1::rotm || BLAS1 == blas1::rotm_batched
+                 || BLAS1 == blas1::rotm_strided_batched)
+                && std::is_same_v<
+                    To,
+                    Ti> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))
 
-                || ((BLAS1 == blas1::rotmg || BLAS1 == blas1::rotmg_batched
-                     || BLAS1 == blas1::rotmg_strided_batched)
-                    && std::is_same_v<
-                        To,
-                        Ti> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
+            || ((BLAS1 == blas1::rotmg || BLAS1 == blas1::rotmg_batched
+                 || BLAS1 == blas1::rotmg_strided_batched)
+                && std::is_same_v<
+                    To,
+                    Ti> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/scal_gtest.cpp
+++ b/clients/gtest/blas1/scal_gtest.cpp
@@ -75,14 +75,11 @@ namespace
 
     // This tells whether the BLAS1 tests are enabled
     template <blas1 BLAS1, typename Ti, typename To, typename Tc>
-    using scal_enabled = std::integral_constant<bool,
-                                                (
-                                                    (BLAS1 == blas1::scal
-                                                     || BLAS1 == blas1::scal_batched
-                                                     || BLAS1 == blas1::scal_strided_batched)
-                                                    && std::
-                                                        is_same_v<To,
-                                                                  Tc> && ((std::is_same_v<Ti, std::complex<float>> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, float> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<float>> && std::is_same_v<To, float>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<To, double>)))>;
+    using scal_enabled = std::
+        integral_constant<bool,
+                          ((BLAS1 == blas1::scal || BLAS1 == blas1::scal_batched
+                            || BLAS1 == blas1::scal_strided_batched)
+                           && std::is_same_v<To, Tc> && ((std::is_same_v<Ti, std::complex<float>> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, float> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<float>> && std::is_same_v<To, float>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<To, double>)))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/scal_gtest.cpp
+++ b/clients/gtest/blas1/scal_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -82,7 +82,7 @@ namespace
                                                      || BLAS1 == blas1::scal_strided_batched)
                                                     && std::
                                                         is_same_v<To,
-                                                                  Tc> && ((std::is_same_v<Ti, hipblasComplex> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, hipblasDoubleComplex> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, float> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, hipblasComplex> && std::is_same_v<To, float>) || (std::is_same_v<Ti, hipblasDoubleComplex> && std::is_same_v<To, double>)))>;
+                                                                  Tc> && ((std::is_same_v<Ti, std::complex<float>> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, float> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, double> && std::is_same_v<Ti, To>) || (std::is_same_v<Ti, std::complex<float>> && std::is_same_v<To, float>) || (std::is_same_v<Ti, std::complex<double>> && std::is_same_v<To, double>)))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas1/swap_gtest.cpp
+++ b/clients/gtest/blas1/swap_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,7 +81,7 @@ namespace
           || BLAS1 == blas1::swap_strided_batched)
          && std::is_same_v<
              Ti,
-             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, hipblasComplex> || std::is_same_v<Ti, hipblasDoubleComplex> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
+             To> && std::is_same_v<To, Tc> && (std::is_same_v<Ti, std::complex<float>> || std::is_same_v<Ti, std::complex<double>> || std::is_same_v<Ti, float> || std::is_same_v<Ti, double>))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas2/gbmv_gtest.cpp
+++ b/clients/gtest/blas2/gbmv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/gemv_gtest.cpp
+++ b/clients/gtest/blas2/gemv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -116,7 +116,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/ger_gtest.cpp
+++ b/clients/gtest/blas2/ger_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -157,7 +157,7 @@ namespace
     struct geru_testing<
         T,
         std::enable_if_t<(
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>)>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>)>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)
@@ -188,7 +188,7 @@ namespace
     struct gerc_testing<
         T,
         std::enable_if_t<(
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>)>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>)>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/hbmv_gtest.cpp
+++ b/clients/gtest/blas2/hbmv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct hbmv_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/hemv_gtest.cpp
+++ b/clients/gtest/blas2/hemv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct hemv_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/her2_gtest.cpp
+++ b/clients/gtest/blas2/her2_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct her2_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/her_gtest.cpp
+++ b/clients/gtest/blas2/her_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct her_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/hpmv_gtest.cpp
+++ b/clients/gtest/blas2/hpmv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct hpmv_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/hpr2_gtest.cpp
+++ b/clients/gtest/blas2/hpr2_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct hpr2_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/hpr_gtest.cpp
+++ b/clients/gtest/blas2/hpr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct hpr_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/spr_gtest.cpp
+++ b/clients/gtest/blas2/spr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/symv_gtest.cpp
+++ b/clients/gtest/blas2/symv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/syr2_gtest.cpp
+++ b/clients/gtest/blas2/syr2_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/syr_gtest.cpp
+++ b/clients/gtest/blas2/syr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/tbmv_gtest.cpp
+++ b/clients/gtest/blas2/tbmv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/tbsv_gtest.cpp
+++ b/clients/gtest/blas2/tbsv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/tpmv_gtest.cpp
+++ b/clients/gtest/blas2/tpmv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/tpsv_gtest.cpp
+++ b/clients/gtest/blas2/tpsv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/trmv_gtest.cpp
+++ b/clients/gtest/blas2/trmv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas2/trsv_gtest.cpp
+++ b/clients/gtest/blas2/trsv_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/dgmm_gtest.cpp
+++ b/clients/gtest/blas3/dgmm_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/geam_gtest.cpp
+++ b/clients/gtest/blas3/geam_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/gemm_gtest.cpp
+++ b/clients/gtest/blas3/gemm_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasHalf> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasHalf> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/hemm_gtest.cpp
+++ b/clients/gtest/blas3/hemm_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct hemm_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/her2k_gtest.cpp
+++ b/clients/gtest/blas3/her2k_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct her2k_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/herk_gtest.cpp
+++ b/clients/gtest/blas3/herk_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct herk_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/herkx_gtest.cpp
+++ b/clients/gtest/blas3/herkx_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,7 +105,7 @@ namespace
     struct herkx_testing<
         T,
         std::enable_if_t<
-            std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+            std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/symm_gtest.cpp
+++ b/clients/gtest/blas3/symm_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/syr2k_gtest.cpp
+++ b/clients/gtest/blas3/syr2k_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/syrk_gtest.cpp
+++ b/clients/gtest/blas3/syrk_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/syrkx_gtest.cpp
+++ b/clients/gtest/blas3/syrkx_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/trmm_gtest.cpp
+++ b/clients/gtest/blas3/trmm_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/trsm_gtest.cpp
+++ b/clients/gtest/blas3/trsm_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas3/trtri_gtest.cpp
+++ b/clients/gtest/blas3/trtri_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/blas_ex/axpy_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/axpy_ex_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -83,7 +83,7 @@ namespace
           || BLAS1_EX == blas1_ex::axpy_strided_batched_ex)
          && ((std::is_same_v<
                   T1,
-                  T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, hipblasComplex> || std::is_same_v<T1, hipblasDoubleComplex>))
+                  T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, std::complex<float>> || std::is_same_v<T1, std::complex<double>>))
              || (std::is_same_v<
                      T1,
                      T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasHalf> && std::is_same_v<T4, float>)

--- a/clients/gtest/blas_ex/axpy_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/axpy_ex_gtest.cpp
@@ -75,27 +75,27 @@ namespace
     // This tells whether the BLAS1_EX tests are enabled
     // Appears that we will need up to 4 template variables (see dot)
     template <blas1_ex BLAS1_EX, typename T1, typename T2, typename T3, typename T4>
-    using blas1_ex_enabled = std::integral_constant<
-        bool,
-        // axpy_ex
-        // T1 is alpha_type T2 is x_type, T3 is y_type, T4 is execution_type
-        ((BLAS1_EX == blas1_ex::axpy_ex || BLAS1_EX == blas1_ex::axpy_batched_ex
-          || BLAS1_EX == blas1_ex::axpy_strided_batched_ex)
-         && ((std::is_same_v<
-                  T1,
-                  T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, std::complex<float>> || std::is_same_v<T1, std::complex<double>>))
-             || (std::is_same_v<
-                     T1,
-                     T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasHalf> && std::is_same_v<T4, float>)
-             || (std::is_same_v<
-                     T2,
-                     T3> && std::is_same_v<T1, T4> && std::is_same_v<T2, hipblasHalf> && std::is_same_v<T1, float>)
-             || (std::is_same_v<
-                     T1,
-                     float> && std::is_same_v<T2, hipblasBfloat16> && std::is_same_v<T2, T3> && (std::is_same_v<T1, T4>))
-             || (std::is_same_v<
-                     T1,
-                     T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasBfloat16> && std::is_same_v<T4, float>)))>;
+    using blas1_ex_enabled
+        = std::integral_constant<
+            bool,
+            // axpy_ex
+            // T1 is alpha_type T2 is x_type, T3 is y_type, T4 is execution_type
+            (
+                (BLAS1_EX == blas1_ex::axpy_ex || BLAS1_EX == blas1_ex::axpy_batched_ex
+                 || BLAS1_EX == blas1_ex::axpy_strided_batched_ex)
+                && ((std::is_same_v<T1, T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, std::complex<float>> || std::is_same_v<T1, std::complex<double>>))
+                    || (std::is_same_v<
+                            T1,
+                            T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasHalf> && std::is_same_v<T4, float>)
+                    || (std::is_same_v<
+                            T2,
+                            T3> && std::is_same_v<T1, T4> && std::is_same_v<T2, hipblasHalf> && std::is_same_v<T1, float>)
+                    || (std::is_same_v<
+                            T1,
+                            float> && std::is_same_v<T2, hipblasBfloat16> && std::is_same_v<T2, T3> && (std::is_same_v<T1, T4>))
+                    || (std::is_same_v<
+                            T1,
+                            T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasBfloat16> && std::is_same_v<T4, float>)))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas_ex/dot_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/dot_ex_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,7 +91,7 @@ namespace
           || BLAS1_EX == blas1_ex::dotc_batched_ex || BLAS1_EX == blas1_ex::dotc_strided_batched_ex)
          && ((std::is_same_v<
                   T1,
-                  T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, hipblasComplex> || std::is_same_v<T1, hipblasDoubleComplex>))
+                  T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, std::complex<float>> || std::is_same_v<T1, std::complex<double>>))
              || (std::is_same_v<
                      T1,
                      T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasHalf> && std::is_same_v<T4, float>)

--- a/clients/gtest/blas_ex/dot_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/dot_ex_gtest.cpp
@@ -81,23 +81,24 @@ namespace
     // This tells whether the BLAS1_EX tests are enabled
     // Appears that we will need up to 4 template variables (see dot)
     template <blas1_ex BLAS1_EX, typename T1, typename T2, typename T3, typename T4>
-    using blas1_ex_enabled = std::integral_constant<
-        bool,
+    using blas1_ex_enabled
+        = std::integral_constant<
+            bool,
 
-        // dot_ex
-        // T1 is x_type, T2 is y_type, T3 is result_type, T4 is execution_type
-        ((BLAS1_EX == blas1_ex::dot_ex || BLAS1_EX == blas1_ex::dot_batched_ex
-          || BLAS1_EX == blas1_ex::dot_strided_batched_ex || BLAS1_EX == blas1_ex::dotc_ex
-          || BLAS1_EX == blas1_ex::dotc_batched_ex || BLAS1_EX == blas1_ex::dotc_strided_batched_ex)
-         && ((std::is_same_v<
-                  T1,
-                  T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, std::complex<float>> || std::is_same_v<T1, std::complex<double>>))
-             || (std::is_same_v<
-                     T1,
-                     T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasHalf> && std::is_same_v<T4, float>)
-             || (std::is_same_v<
-                     T1,
-                     T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasBfloat16> && std::is_same_v<T4, float>)))>;
+            // dot_ex
+            // T1 is x_type, T2 is y_type, T3 is result_type, T4 is execution_type
+            (
+                (BLAS1_EX == blas1_ex::dot_ex || BLAS1_EX == blas1_ex::dot_batched_ex
+                 || BLAS1_EX == blas1_ex::dot_strided_batched_ex || BLAS1_EX == blas1_ex::dotc_ex
+                 || BLAS1_EX == blas1_ex::dotc_batched_ex
+                 || BLAS1_EX == blas1_ex::dotc_strided_batched_ex)
+                && ((std::is_same_v<T1, T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, std::complex<float>> || std::is_same_v<T1, std::complex<double>>))
+                    || (std::is_same_v<
+                            T1,
+                            T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasHalf> && std::is_same_v<T4, float>)
+                    || (std::is_same_v<
+                            T1,
+                            T2> && std::is_same_v<T2, T3> && std::is_same_v<T1, hipblasBfloat16> && std::is_same_v<T4, float>)))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas_ex/nrm2_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/nrm2_ex_gtest.cpp
@@ -89,7 +89,8 @@ namespace
                      std::complex<float>> && std::is_same_v<T2, float> && std::is_same_v<T3, float>)
              || (std::is_same_v<
                      T1,
-                     std::complex<double>> && std::is_same_v<T2, double> && std::is_same_v<T3, double>)
+                     std::complex<
+                         double>> && std::is_same_v<T2, double> && std::is_same_v<T3, double>)
              || (std::is_same_v<
                      T1,
                      hipblasHalf> && std::is_same_v<T2, hipblasHalf> && std::is_same_v<T3, float>)

--- a/clients/gtest/blas_ex/nrm2_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/nrm2_ex_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,10 +86,10 @@ namespace
                   T2> && std::is_same_v<T2, T3> && (std::is_same_v<T1, float> || std::is_same_v<T1, double>))
              || (std::is_same_v<
                      T1,
-                     hipblasComplex> && std::is_same_v<T2, float> && std::is_same_v<T3, float>)
+                     std::complex<float>> && std::is_same_v<T2, float> && std::is_same_v<T3, float>)
              || (std::is_same_v<
                      T1,
-                     hipblasDoubleComplex> && std::is_same_v<T2, double> && std::is_same_v<T3, double>)
+                     std::complex<double>> && std::is_same_v<T2, double> && std::is_same_v<T3, double>)
              || (std::is_same_v<
                      T1,
                      hipblasHalf> && std::is_same_v<T2, hipblasHalf> && std::is_same_v<T3, float>)

--- a/clients/gtest/blas_ex/rot_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/rot_ex_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -84,7 +84,7 @@ namespace
          // regular calls where all types are the same
          && ((std::is_same_v<
                   T1,
-                  T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasComplex> || std::is_same_v<T1, hipblasDoubleComplex>))
+                  T2> && std::is_same_v<T2, T3> && std::is_same_v<T3, T4> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, std::complex<float>> || std::is_same_v<T1, std::complex<double>>))
              // float compute and float16/bfloat16 input/output
              || (std::is_same_v<
                      T1,
@@ -92,10 +92,10 @@ namespace
              // complex compute and x/y with real cs inputs
              || (std::is_same_v<
                      T1,
-                     T2> && std::is_same_v<T1, T4> && std::is_same_v<T1, hipblasComplex> && std::is_same_v<T3, float>)
+                     T2> && std::is_same_v<T1, T4> && std::is_same_v<T1, std::complex<float>> && std::is_same_v<T3, float>)
              || (std::is_same_v<
                      T1,
-                     T2> && std::is_same_v<T1, T4> && std::is_same_v<T1, hipblasDoubleComplex> && std::is_same_v<T3, double>)))>;
+                     T2> && std::is_same_v<T1, T4> && std::is_same_v<T1, std::complex<double>> && std::is_same_v<T3, double>)))>;
 
 // Creates tests for one of the BLAS 1 functions
 // ARG passes 1-3 template arguments to the testing_* function

--- a/clients/gtest/blas_ex/scal_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/scal_ex_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -83,13 +83,13 @@ namespace
           || BLAS1_EX == blas1_ex::scal_strided_batched_ex)
          && ((std::is_same_v<
                   T1,
-                  T2> && std::is_same_v<T2, T3> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, hipblasComplex> || std::is_same_v<T1, hipblasDoubleComplex>))
+                  T2> && std::is_same_v<T2, T3> && (std::is_same_v<T1, float> || std::is_same_v<T1, double> || std::is_same_v<T1, hipblasHalf> || std::is_same_v<T1, std::complex<float>> || std::is_same_v<T1, std::complex<double>>))
              || (std::is_same_v<
                      T2,
-                     T3> && std::is_same_v<T1, float> && std::is_same_v<T2, hipblasComplex>)
+                     T3> && std::is_same_v<T1, float> && std::is_same_v<T2, std::complex<float>>)
              || (std::is_same_v<
                      T2,
-                     T3> && std::is_same_v<T1, double> && std::is_same_v<T2, hipblasDoubleComplex>)
+                     T3> && std::is_same_v<T1, double> && std::is_same_v<T2, std::complex<double>>)
              || (std::is_same_v<T1,
                                 T2> && std::is_same_v<T1, hipblasHalf> && std::is_same_v<T3, float>)
              || (std::is_same_v<T1,

--- a/clients/gtest/blas_ex/trsm_ex_gtest.cpp
+++ b/clients/gtest/blas_ex/trsm_ex_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/solver/gels_gtest.cpp
+++ b/clients/gtest/solver/gels_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/solver/geqrf_gtest.cpp
+++ b/clients/gtest/solver/geqrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/solver/getrf_gtest.cpp
+++ b/clients/gtest/solver/getrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -128,7 +128,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/solver/getri_gtest.cpp
+++ b/clients/gtest/solver/getri_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -101,7 +101,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/gtest/solver/getrs_gtest.cpp
+++ b/clients/gtest/solver/getrs_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ namespace
         std::enable_if_t<
             std::is_same_v<
                 T,
-                float> || std::is_same_v<T, double> || std::is_same_v<T, hipblasComplex> || std::is_same_v<T, hipblasDoubleComplex>>>
+                float> || std::is_same_v<T, double> || std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>>>
         : hipblas_test_valid
     {
         void operator()(const Arguments& arg)

--- a/clients/include/blas1/hipblas_iamax_iamin_ref.hpp
+++ b/clients/include/blas1/hipblas_iamax_iamin_ref.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,13 +33,13 @@ namespace hipblas_iamax_iamin_ref
     }
 
     template <>
-    inline float iamax_iamin_abs(const hipblasComplex& c)
+    inline float iamax_iamin_abs(const std::complex<float>& c)
     {
         return hipblas_abs(c.real()) + hipblas_abs(c.imag());
     }
 
     template <>
-    inline double iamax_iamin_abs(const hipblasDoubleComplex& c)
+    inline double iamax_iamin_abs(const std::complex<double>& c)
     {
         return hipblas_abs(c.real()) + hipblas_abs(c.imag());
     }

--- a/clients/include/blas1/testing_axpy.hpp
+++ b/clients/include/blas1/testing_axpy.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ inline void testname_axpy(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_axpy_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyFn = FORTRAN ? hipblasAxpy<T, true> : hipblasAxpy<T, false>;
     auto hipblasAxpyFn_64
@@ -57,9 +58,9 @@ void testing_axpy_bad_arg(const Arguments& arg)
         device_vector<T> dx(N, incx);
         device_vector<T> dy(N, incy);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -99,6 +100,7 @@ void testing_axpy_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_axpy(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyFn = FORTRAN ? hipblasAxpy<T, true> : hipblasAxpy<T, false>;
     auto hipblasAxpyFn_64
@@ -166,7 +168,7 @@ void testing_axpy(const Arguments& arg)
         DAPI_CHECK(hipblasAxpyFn, (handle, N, d_alpha, dx, incx, dy_device, incy));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasAxpyFn, (handle, N, &alpha, dx, incx, dy_host, incy));
+        DAPI_CHECK(hipblasAxpyFn, (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx, dy_host, incy));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hy_host.transfer_from(dy_host));

--- a/clients/include/blas1/testing_axpy.hpp
+++ b/clients/include/blas1/testing_axpy.hpp
@@ -39,7 +39,7 @@ inline void testname_axpy(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_axpy_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyFn = FORTRAN ? hipblasAxpy<T, true> : hipblasAxpy<T, false>;
     auto hipblasAxpyFn_64
@@ -100,7 +100,7 @@ void testing_axpy_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_axpy(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyFn = FORTRAN ? hipblasAxpy<T, true> : hipblasAxpy<T, false>;
     auto hipblasAxpyFn_64
@@ -168,7 +168,8 @@ void testing_axpy(const Arguments& arg)
         DAPI_CHECK(hipblasAxpyFn, (handle, N, d_alpha, dx, incx, dy_device, incy));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasAxpyFn, (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx, dy_host, incy));
+        DAPI_CHECK(hipblasAxpyFn,
+                   (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx, dy_host, incy));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hy_host.transfer_from(dy_host));

--- a/clients/include/blas1/testing_axpy_batched.hpp
+++ b/clients/include/blas1/testing_axpy_batched.hpp
@@ -40,7 +40,7 @@ inline void testname_axpy_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_axpy_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyBatchedFn
         = FORTRAN ? hipblasAxpyBatched<T, true> : hipblasAxpyBatched<T, false>;
@@ -61,7 +61,7 @@ void testing_axpy_batched_bad_arg(const Arguments& arg)
         device_batch_vector<T> dx(N, incx, batch_count);
         device_batch_vector<T> dy(N, incy, batch_count);
 
-        const Ts h_alpha(1), h_zero(0);
+        const Ts  h_alpha(1), h_zero(0);
         const Ts* alpha = &h_alpha;
         const Ts* zero  = &h_zero;
 
@@ -104,7 +104,7 @@ void testing_axpy_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_axpy_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyBatchedFn
         = FORTRAN ? hipblasAxpyBatched<T, true> : hipblasAxpyBatched<T, false>;
@@ -169,9 +169,15 @@ void testing_axpy_batched(const Arguments& arg)
         CHECK_HIP_ERROR(dy.transfer_from(hy_host));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(
-            hipblasAxpyBatchedFn,
-            (handle, N, reinterpret_cast<Ts*>(&alpha), dx.ptr_on_device(), incx, dy.ptr_on_device(), incy, batch_count));
+        DAPI_CHECK(hipblasAxpyBatchedFn,
+                   (handle,
+                    N,
+                    reinterpret_cast<Ts*>(&alpha),
+                    dx.ptr_on_device(),
+                    incx,
+                    dy.ptr_on_device(),
+                    incy,
+                    batch_count));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
 

--- a/clients/include/blas1/testing_axpy_batched.hpp
+++ b/clients/include/blas1/testing_axpy_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_axpy_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_axpy_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyBatchedFn
         = FORTRAN ? hipblasAxpyBatched<T, true> : hipblasAxpyBatched<T, false>;
@@ -60,9 +61,9 @@ void testing_axpy_batched_bad_arg(const Arguments& arg)
         device_batch_vector<T> dx(N, incx, batch_count);
         device_batch_vector<T> dy(N, incy, batch_count);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -103,6 +104,7 @@ void testing_axpy_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_axpy_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyBatchedFn
         = FORTRAN ? hipblasAxpyBatched<T, true> : hipblasAxpyBatched<T, false>;
@@ -169,7 +171,7 @@ void testing_axpy_batched(const Arguments& arg)
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(
             hipblasAxpyBatchedFn,
-            (handle, N, &alpha, dx.ptr_on_device(), incx, dy.ptr_on_device(), incy, batch_count));
+            (handle, N, reinterpret_cast<Ts*>(&alpha), dx.ptr_on_device(), incx, dy.ptr_on_device(), incy, batch_count));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
 

--- a/clients/include/blas1/testing_axpy_strided_batched.hpp
+++ b/clients/include/blas1/testing_axpy_strided_batched.hpp
@@ -40,7 +40,7 @@ inline void testname_axpy_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_axpy_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyStridedBatchedFn
         = FORTRAN ? hipblasAxpyStridedBatched<T, true> : hipblasAxpyStridedBatched<T, false>;
@@ -112,7 +112,7 @@ void testing_axpy_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_axpy_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyStridedBatchedFn
         = FORTRAN ? hipblasAxpyStridedBatched<T, true> : hipblasAxpyStridedBatched<T, false>;
@@ -188,7 +188,16 @@ void testing_axpy_strided_batched(const Arguments& arg)
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasAxpyStridedBatchedFn,
-                   (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx, stride_x, dy, incy, stride_y, batch_count));
+                   (handle,
+                    N,
+                    reinterpret_cast<Ts*>(&alpha),
+                    dx,
+                    incx,
+                    stride_x,
+                    dy,
+                    incy,
+                    stride_y,
+                    batch_count));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));

--- a/clients/include/blas1/testing_axpy_strided_batched.hpp
+++ b/clients/include/blas1/testing_axpy_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_axpy_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_axpy_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyStridedBatchedFn
         = FORTRAN ? hipblasAxpyStridedBatched<T, true> : hipblasAxpyStridedBatched<T, false>;
@@ -63,9 +64,9 @@ void testing_axpy_strided_batched_bad_arg(const Arguments& arg)
         device_strided_batch_vector<T> dx(N, incx, stride_x, batch_count);
         device_strided_batch_vector<T> dy(N, incy, stride_y, batch_count);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -111,6 +112,7 @@ void testing_axpy_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_axpy_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasAxpyStridedBatchedFn
         = FORTRAN ? hipblasAxpyStridedBatched<T, true> : hipblasAxpyStridedBatched<T, false>;
@@ -186,7 +188,7 @@ void testing_axpy_strided_batched(const Arguments& arg)
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasAxpyStridedBatchedFn,
-                   (handle, N, &alpha, dx, incx, stride_x, dy, incy, stride_y, batch_count));
+                   (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx, stride_x, dy, incy, stride_y, batch_count));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));

--- a/clients/include/blas1/testing_dot.hpp
+++ b/clients/include/blas1/testing_dot.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -163,7 +163,7 @@ void testing_dot(const Arguments& arg)
         DAPI_CHECK(hipblasDotFn, (handle, N, dx, incx, dy, incy, d_hipblas_result));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasDotFn, (handle, N, dx, incx, dy, incy, &h_hipblas_result_1));
+        DAPI_CHECK(hipblasDotFn, (handle, N, dx, incx, dy, incy, reinterpret_cast<hipblas_internal_type<T>*>(&h_hipblas_result_1)));
 
         CHECK_HIP_ERROR(
             hipMemcpy(&h_hipblas_result_2, d_hipblas_result, sizeof(T), hipMemcpyDeviceToHost));

--- a/clients/include/blas1/testing_dot.hpp
+++ b/clients/include/blas1/testing_dot.hpp
@@ -163,7 +163,14 @@ void testing_dot(const Arguments& arg)
         DAPI_CHECK(hipblasDotFn, (handle, N, dx, incx, dy, incy, d_hipblas_result));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasDotFn, (handle, N, dx, incx, dy, incy, reinterpret_cast<hipblas_internal_type<T>*>(&h_hipblas_result_1)));
+        DAPI_CHECK(hipblasDotFn,
+                   (handle,
+                    N,
+                    dx,
+                    incx,
+                    dy,
+                    incy,
+                    reinterpret_cast<hipblas_internal_type<T>*>(&h_hipblas_result_1)));
 
         CHECK_HIP_ERROR(
             hipMemcpy(&h_hipblas_result_2, d_hipblas_result, sizeof(T), hipMemcpyDeviceToHost));

--- a/clients/include/blas1/testing_dot_batched.hpp
+++ b/clients/include/blas1/testing_dot_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -183,7 +183,7 @@ void testing_dot_batched(const Arguments& arg)
                     dy.ptr_on_device(),
                     incy,
                     batch_count,
-                    h_hipblas_result1));
+                    reinterpret_cast<hipblas_internal_type<T>*>(h_hipblas_result1.data())));
 
         CHECK_HIP_ERROR(hipMemcpy(
             h_hipblas_result2, d_hipblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));

--- a/clients/include/blas1/testing_dot_strided_batched.hpp
+++ b/clients/include/blas1/testing_dot_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -196,7 +196,7 @@ void testing_dot_strided_batched(const Arguments& arg)
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(
             hipblasDotStridedBatchedFn,
-            (handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, h_hipblas_result1));
+            (handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, reinterpret_cast<hipblas_internal_type<T>*>(h_hipblas_result1.data())));
 
         CHECK_HIP_ERROR(hipMemcpy(
             h_hipblas_result2, d_hipblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));

--- a/clients/include/blas1/testing_dot_strided_batched.hpp
+++ b/clients/include/blas1/testing_dot_strided_batched.hpp
@@ -194,9 +194,17 @@ void testing_dot_strided_batched(const Arguments& arg)
             (handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, d_hipblas_result));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(
-            hipblasDotStridedBatchedFn,
-            (handle, N, dx, incx, stridex, dy, incy, stridey, batch_count, reinterpret_cast<hipblas_internal_type<T>*>(h_hipblas_result1.data())));
+        DAPI_CHECK(hipblasDotStridedBatchedFn,
+                   (handle,
+                    N,
+                    dx,
+                    incx,
+                    stridex,
+                    dy,
+                    incy,
+                    stridey,
+                    batch_count,
+                    reinterpret_cast<hipblas_internal_type<T>*>(h_hipblas_result1.data())));
 
         CHECK_HIP_ERROR(hipMemcpy(
             h_hipblas_result2, d_hipblas_result, sizeof(T) * batch_count, hipMemcpyDeviceToHost));

--- a/clients/include/blas1/testing_rot.hpp
+++ b/clients/include/blas1/testing_rot.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -145,7 +145,7 @@ void testing_rot(const Arguments& arg)
             // copy data from CPU to device
             CHECK_HIP_ERROR(dx.transfer_from(hx));
             CHECK_HIP_ERROR(dy.transfer_from(hy));
-            DAPI_CHECK(hipblasRotFn, (handle, N, dx, incx, dy, incy, hc, hs));
+            DAPI_CHECK(hipblasRotFn, (handle, N, dx, incx, dy, incy, hc.internal_type(), hs.internal_type()));
 
             host_vector<T> rx(N, incx);
             host_vector<T> ry(N, incy);

--- a/clients/include/blas1/testing_rot.hpp
+++ b/clients/include/blas1/testing_rot.hpp
@@ -145,7 +145,8 @@ void testing_rot(const Arguments& arg)
             // copy data from CPU to device
             CHECK_HIP_ERROR(dx.transfer_from(hx));
             CHECK_HIP_ERROR(dy.transfer_from(hy));
-            DAPI_CHECK(hipblasRotFn, (handle, N, dx, incx, dy, incy, hc.internal_type(), hs.internal_type()));
+            DAPI_CHECK(hipblasRotFn,
+                       (handle, N, dx, incx, dy, incy, hc.internal_type(), hs.internal_type()));
 
             host_vector<T> rx(N, incx);
             host_vector<T> ry(N, incy);

--- a/clients/include/blas1/testing_rot_batched.hpp
+++ b/clients/include/blas1/testing_rot_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -161,8 +161,8 @@ void testing_rot_batched(const Arguments& arg)
                         incx,
                         dy.ptr_on_device(),
                         incy,
-                        hc,
-                        hs,
+                        hc.internal_type(),
+                        hs.internal_type(),
                         batch_count));
 
             host_batch_vector<T> rx(N, incx, batch_count);

--- a/clients/include/blas1/testing_rot_strided_batched.hpp
+++ b/clients/include/blas1/testing_rot_strided_batched.hpp
@@ -182,7 +182,17 @@ void testing_rot_strided_batched(const Arguments& arg)
             CHECK_HIP_ERROR(dx.transfer_from(hx));
             CHECK_HIP_ERROR(dy.transfer_from(hy));
             DAPI_CHECK(hipblasRotStridedBatchedFn,
-                       (handle, N, dx, incx, stride_x, dy, incy, stride_y, hc.internal_type(), hs.internal_type(), batch_count));
+                       (handle,
+                        N,
+                        dx,
+                        incx,
+                        stride_x,
+                        dy,
+                        incy,
+                        stride_y,
+                        hc.internal_type(),
+                        hs.internal_type(),
+                        batch_count));
 
             host_strided_batch_vector<T> rx(N, incx, stride_x, batch_count);
             host_strided_batch_vector<T> ry(N, incy, stride_y, batch_count);

--- a/clients/include/blas1/testing_rot_strided_batched.hpp
+++ b/clients/include/blas1/testing_rot_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -182,7 +182,7 @@ void testing_rot_strided_batched(const Arguments& arg)
             CHECK_HIP_ERROR(dx.transfer_from(hx));
             CHECK_HIP_ERROR(dy.transfer_from(hy));
             DAPI_CHECK(hipblasRotStridedBatchedFn,
-                       (handle, N, dx, incx, stride_x, dy, incy, stride_y, hc, hs, batch_count));
+                       (handle, N, dx, incx, stride_x, dy, incy, stride_y, hc.internal_type(), hs.internal_type(), batch_count));
 
             host_strided_batch_vector<T> rx(N, incx, stride_x, batch_count);
             host_strided_batch_vector<T> ry(N, incy, stride_y, batch_count);

--- a/clients/include/blas1/testing_rotg.hpp
+++ b/clients/include/blas1/testing_rotg.hpp
@@ -120,7 +120,12 @@ void testing_rotg(const Arguments& arg)
     if(arg.unit_check || arg.norm_check)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasRotgFn, (handle, ha.internal_type(), hb.internal_type(), hc.internal_type(), hs.internal_type()));
+        DAPI_CHECK(hipblasRotgFn,
+                   (handle,
+                    ha.internal_type(),
+                    hb.internal_type(),
+                    hc.internal_type(),
+                    hs.internal_type()));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         DAPI_CHECK(hipblasRotgFn, (handle, da, db, dc, ds));

--- a/clients/include/blas1/testing_rotg.hpp
+++ b/clients/include/blas1/testing_rotg.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -120,7 +120,7 @@ void testing_rotg(const Arguments& arg)
     if(arg.unit_check || arg.norm_check)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasRotgFn, (handle, ha, hb, hc, hs));
+        DAPI_CHECK(hipblasRotgFn, (handle, ha.internal_type(), hb.internal_type(), hc.internal_type(), hs.internal_type()));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         DAPI_CHECK(hipblasRotgFn, (handle, da, db, dc, ds));

--- a/clients/include/blas1/testing_rotg_batched.hpp
+++ b/clients/include/blas1/testing_rotg_batched.hpp
@@ -147,7 +147,13 @@ void testing_rotg_batched(const Arguments& arg)
         // hipBLAS
         // test host
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasRotgBatchedFn, (handle, ha.internal_type(), hb.internal_type(), hc.internal_type(), hs.internal_type(), batch_count));
+        DAPI_CHECK(hipblasRotgBatchedFn,
+                   (handle,
+                    ha.internal_type(),
+                    hb.internal_type(),
+                    hc.internal_type(),
+                    hs.internal_type(),
+                    batch_count));
 
         // test device
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/blas1/testing_rotg_batched.hpp
+++ b/clients/include/blas1/testing_rotg_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -147,7 +147,7 @@ void testing_rotg_batched(const Arguments& arg)
         // hipBLAS
         // test host
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasRotgBatchedFn, (handle, ha, hb, hc, hs, batch_count));
+        DAPI_CHECK(hipblasRotgBatchedFn, (handle, ha.internal_type(), hb.internal_type(), hc.internal_type(), hs.internal_type(), batch_count));
 
         // test device
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));

--- a/clients/include/blas1/testing_rotg_strided_batched.hpp
+++ b/clients/include/blas1/testing_rotg_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -156,7 +156,7 @@ void testing_rotg_strided_batched(const Arguments& arg)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasRotgStridedBatchedFn,
-                   (handle, ha, stride_a, hb, stride_b, hc, stride_c, hs, stride_s, batch_count));
+                   (handle, ha.internal_type(), stride_a, hb.internal_type(), stride_b, hc.internal_type(), stride_c, hs.internal_type(), stride_s, batch_count));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         DAPI_CHECK(hipblasRotgStridedBatchedFn,

--- a/clients/include/blas1/testing_rotg_strided_batched.hpp
+++ b/clients/include/blas1/testing_rotg_strided_batched.hpp
@@ -156,7 +156,16 @@ void testing_rotg_strided_batched(const Arguments& arg)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasRotgStridedBatchedFn,
-                   (handle, ha.internal_type(), stride_a, hb.internal_type(), stride_b, hc.internal_type(), stride_c, hs.internal_type(), stride_s, batch_count));
+                   (handle,
+                    ha.internal_type(),
+                    stride_a,
+                    hb.internal_type(),
+                    stride_b,
+                    hc.internal_type(),
+                    stride_c,
+                    hs.internal_type(),
+                    stride_s,
+                    batch_count));
 
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_DEVICE));
         DAPI_CHECK(hipblasRotgStridedBatchedFn,

--- a/clients/include/blas1/testing_scal.hpp
+++ b/clients/include/blas1/testing_scal.hpp
@@ -39,7 +39,7 @@ inline void testname_scal(const Arguments& arg, std::string& name)
 template <typename T, typename U = T>
 void testing_scal_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<U>;
+    using Ts           = hipblas_internal_type<U>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalFn = FORTRAN ? hipblasScal<T, U, true> : hipblasScal<T, U, false>;
     auto hipblasScalFn_64
@@ -47,7 +47,7 @@ void testing_scal_bad_arg(const Arguments& arg)
 
     int64_t N     = 100;
     int64_t incx  = 1;
-    Ts       alpha = (Ts)0.6;
+    Ts      alpha = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -60,14 +60,17 @@ void testing_scal_bad_arg(const Arguments& arg)
         // Notably scal differs from axpy such that x can /never/ be a nullptr, regardless of alpha.
 
         // None of these test cases will write to result so using device pointer is fine for both modes
-        DAPI_EXPECT(HIPBLAS_STATUS_NOT_INITIALIZED, hipblasScalFn, (nullptr, N, reinterpret_cast<Ts*>(&alpha), dx, incx));
+        DAPI_EXPECT(HIPBLAS_STATUS_NOT_INITIALIZED,
+                    hipblasScalFn,
+                    (nullptr, N, reinterpret_cast<Ts*>(&alpha), dx, incx));
 
         if(arg.bad_arg_all)
         {
             DAPI_EXPECT(
                 HIPBLAS_STATUS_INVALID_VALUE, hipblasScalFn, (handle, N, nullptr, dx, incx));
-            DAPI_EXPECT(
-                HIPBLAS_STATUS_INVALID_VALUE, hipblasScalFn, (handle, N, reinterpret_cast<Ts*>(&alpha), nullptr, incx));
+            DAPI_EXPECT(HIPBLAS_STATUS_INVALID_VALUE,
+                        hipblasScalFn,
+                        (handle, N, reinterpret_cast<Ts*>(&alpha), nullptr, incx));
         }
     }
 }
@@ -75,7 +78,7 @@ void testing_scal_bad_arg(const Arguments& arg)
 template <typename T, typename U = T>
 void testing_scal(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<U>;
+    using Ts           = hipblas_internal_type<U>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalFn = FORTRAN ? hipblasScal<T, U, true> : hipblasScal<T, U, false>;
     auto hipblasScalFn_64

--- a/clients/include/blas1/testing_scal.hpp
+++ b/clients/include/blas1/testing_scal.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ inline void testname_scal(const Arguments& arg, std::string& name)
 template <typename T, typename U = T>
 void testing_scal_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<U>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalFn = FORTRAN ? hipblasScal<T, U, true> : hipblasScal<T, U, false>;
     auto hipblasScalFn_64
@@ -46,7 +47,7 @@ void testing_scal_bad_arg(const Arguments& arg)
 
     int64_t N     = 100;
     int64_t incx  = 1;
-    U       alpha = (U)0.6;
+    Ts       alpha = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -59,14 +60,14 @@ void testing_scal_bad_arg(const Arguments& arg)
         // Notably scal differs from axpy such that x can /never/ be a nullptr, regardless of alpha.
 
         // None of these test cases will write to result so using device pointer is fine for both modes
-        DAPI_EXPECT(HIPBLAS_STATUS_NOT_INITIALIZED, hipblasScalFn, (nullptr, N, &alpha, dx, incx));
+        DAPI_EXPECT(HIPBLAS_STATUS_NOT_INITIALIZED, hipblasScalFn, (nullptr, N, reinterpret_cast<Ts*>(&alpha), dx, incx));
 
         if(arg.bad_arg_all)
         {
             DAPI_EXPECT(
                 HIPBLAS_STATUS_INVALID_VALUE, hipblasScalFn, (handle, N, nullptr, dx, incx));
             DAPI_EXPECT(
-                HIPBLAS_STATUS_INVALID_VALUE, hipblasScalFn, (handle, N, &alpha, nullptr, incx));
+                HIPBLAS_STATUS_INVALID_VALUE, hipblasScalFn, (handle, N, reinterpret_cast<Ts*>(&alpha), nullptr, incx));
         }
     }
 }
@@ -74,6 +75,7 @@ void testing_scal_bad_arg(const Arguments& arg)
 template <typename T, typename U = T>
 void testing_scal(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<U>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalFn = FORTRAN ? hipblasScal<T, U, true> : hipblasScal<T, U, false>;
     auto hipblasScalFn_64
@@ -121,7 +123,7 @@ void testing_scal(const Arguments& arg)
         /* =====================================================================
             HIPBLAS
         =================================================================== */
-        DAPI_CHECK(hipblasScalFn, (handle, N, &alpha, dx, incx));
+        DAPI_CHECK(hipblasScalFn, (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hx.transfer_from(dx));
@@ -157,7 +159,7 @@ void testing_scal(const Arguments& arg)
             if(iter == arg.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            DAPI_CHECK(hipblasScalFn, (handle, N, &alpha, dx, incx));
+            DAPI_CHECK(hipblasScalFn, (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 

--- a/clients/include/blas1/testing_scal_batched.hpp
+++ b/clients/include/blas1/testing_scal_batched.hpp
@@ -40,7 +40,7 @@ inline void testname_scal_batched(const Arguments& arg, std::string& name)
 template <typename T, typename U = T>
 void testing_scal_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<U>;
+    using Ts     = hipblas_internal_type<U>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalBatchedFn
         = FORTRAN ? hipblasScalBatched<T, U, true> : hipblasScalBatched<T, U, false>;
@@ -50,7 +50,7 @@ void testing_scal_batched_bad_arg(const Arguments& arg)
     int64_t N           = 100;
     int64_t incx        = 1;
     int64_t batch_count = 2;
-    Ts       alpha       = (Ts)0.6;
+    Ts      alpha       = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -78,7 +78,7 @@ void testing_scal_batched_bad_arg(const Arguments& arg)
 template <typename T, typename U = T>
 void testing_scal_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<U>;
+    using Ts     = hipblas_internal_type<U>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalBatchedFn
         = FORTRAN ? hipblasScalBatched<T, U, true> : hipblasScalBatched<T, U, false>;
@@ -126,8 +126,9 @@ void testing_scal_batched(const Arguments& arg)
         /* =====================================================================
             HIPBLAS
         =================================================================== */
-        DAPI_CHECK(hipblasScalBatchedFn,
-                   (handle, N, reinterpret_cast<Ts*>(&alpha), dx.ptr_on_device(), incx, batch_count));
+        DAPI_CHECK(
+            hipblasScalBatchedFn,
+            (handle, N, reinterpret_cast<Ts*>(&alpha), dx.ptr_on_device(), incx, batch_count));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hx.transfer_from(dx));
@@ -164,8 +165,9 @@ void testing_scal_batched(const Arguments& arg)
             if(iter == arg.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            DAPI_CHECK(hipblasScalBatchedFn,
-                       (handle, N, reinterpret_cast<Ts*>(&alpha), dx.ptr_on_device(), incx, batch_count));
+            DAPI_CHECK(
+                hipblasScalBatchedFn,
+                (handle, N, reinterpret_cast<Ts*>(&alpha), dx.ptr_on_device(), incx, batch_count));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 

--- a/clients/include/blas1/testing_scal_batched.hpp
+++ b/clients/include/blas1/testing_scal_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_scal_batched(const Arguments& arg, std::string& name)
 template <typename T, typename U = T>
 void testing_scal_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<U>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalBatchedFn
         = FORTRAN ? hipblasScalBatched<T, U, true> : hipblasScalBatched<T, U, false>;
@@ -49,7 +50,7 @@ void testing_scal_batched_bad_arg(const Arguments& arg)
     int64_t N           = 100;
     int64_t incx        = 1;
     int64_t batch_count = 2;
-    U       alpha       = (U)0.6;
+    Ts       alpha       = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -64,19 +65,20 @@ void testing_scal_batched_bad_arg(const Arguments& arg)
         // None of these test cases will write to result so using host pointer is fine for both modes
         DAPI_EXPECT(HIPBLAS_STATUS_NOT_INITIALIZED,
                     hipblasScalBatchedFn,
-                    (nullptr, N, &alpha, dx, incx, batch_count));
+                    (nullptr, N, reinterpret_cast<Ts*>(&alpha), dx, incx, batch_count));
         DAPI_EXPECT(HIPBLAS_STATUS_INVALID_VALUE,
                     hipblasScalBatchedFn,
                     (handle, N, nullptr, dx, incx, batch_count));
         DAPI_EXPECT(HIPBLAS_STATUS_INVALID_VALUE,
                     hipblasScalBatchedFn,
-                    (handle, N, &alpha, nullptr, incx, batch_count));
+                    (handle, N, reinterpret_cast<Ts*>(&alpha), nullptr, incx, batch_count));
     }
 }
 
 template <typename T, typename U = T>
 void testing_scal_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<U>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalBatchedFn
         = FORTRAN ? hipblasScalBatched<T, U, true> : hipblasScalBatched<T, U, false>;
@@ -125,7 +127,7 @@ void testing_scal_batched(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         DAPI_CHECK(hipblasScalBatchedFn,
-                   (handle, N, &alpha, dx.ptr_on_device(), incx, batch_count));
+                   (handle, N, reinterpret_cast<Ts*>(&alpha), dx.ptr_on_device(), incx, batch_count));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hx.transfer_from(dx));
@@ -163,7 +165,7 @@ void testing_scal_batched(const Arguments& arg)
                 gpu_time_used = get_time_us_sync(stream);
 
             DAPI_CHECK(hipblasScalBatchedFn,
-                       (handle, N, &alpha, dx.ptr_on_device(), incx, batch_count));
+                       (handle, N, reinterpret_cast<Ts*>(&alpha), dx.ptr_on_device(), incx, batch_count));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 

--- a/clients/include/blas1/testing_scal_strided_batched.hpp
+++ b/clients/include/blas1/testing_scal_strided_batched.hpp
@@ -40,7 +40,7 @@ inline void testname_scal_strided_batched(const Arguments& arg, std::string& nam
 template <typename T, typename U = T>
 void testing_scal_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<U>;
+    using Ts     = hipblas_internal_type<U>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalStridedBatchedFn
         = FORTRAN ? hipblasScalStridedBatched<T, U, true> : hipblasScalStridedBatched<T, U, false>;
@@ -52,7 +52,7 @@ void testing_scal_strided_batched_bad_arg(const Arguments& arg)
     int64_t       incx        = 1;
     int64_t       batch_count = 2;
     hipblasStride stride_x    = N * incx;
-    Ts             alpha       = (Ts)0.6;
+    Ts            alpha       = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -71,16 +71,17 @@ void testing_scal_strided_batched_bad_arg(const Arguments& arg)
         DAPI_EXPECT(HIPBLAS_STATUS_INVALID_VALUE,
                     hipblasScalStridedBatchedFn,
                     (handle, N, nullptr, dx, incx, stride_x, batch_count));
-        DAPI_EXPECT(HIPBLAS_STATUS_INVALID_VALUE,
-                    hipblasScalStridedBatchedFn,
-                    (handle, N, reinterpret_cast<Ts*>(&alpha), nullptr, incx, stride_x, batch_count));
+        DAPI_EXPECT(
+            HIPBLAS_STATUS_INVALID_VALUE,
+            hipblasScalStridedBatchedFn,
+            (handle, N, reinterpret_cast<Ts*>(&alpha), nullptr, incx, stride_x, batch_count));
     }
 }
 
 template <typename T, typename U = T>
 void testing_scal_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<U>;
+    using Ts     = hipblas_internal_type<U>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalStridedBatchedFn
         = FORTRAN ? hipblasScalStridedBatched<T, U, true> : hipblasScalStridedBatched<T, U, false>;

--- a/clients/include/blas1/testing_scal_strided_batched.hpp
+++ b/clients/include/blas1/testing_scal_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_scal_strided_batched(const Arguments& arg, std::string& nam
 template <typename T, typename U = T>
 void testing_scal_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<U>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalStridedBatchedFn
         = FORTRAN ? hipblasScalStridedBatched<T, U, true> : hipblasScalStridedBatched<T, U, false>;
@@ -51,7 +52,7 @@ void testing_scal_strided_batched_bad_arg(const Arguments& arg)
     int64_t       incx        = 1;
     int64_t       batch_count = 2;
     hipblasStride stride_x    = N * incx;
-    U             alpha       = (U)0.6;
+    Ts             alpha       = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -66,19 +67,20 @@ void testing_scal_strided_batched_bad_arg(const Arguments& arg)
         // None of these test cases will write to result so using device pointer is fine for both modes
         DAPI_EXPECT(HIPBLAS_STATUS_NOT_INITIALIZED,
                     hipblasScalStridedBatchedFn,
-                    (nullptr, N, &alpha, dx, incx, stride_x, batch_count));
+                    (nullptr, N, reinterpret_cast<Ts*>(&alpha), dx, incx, stride_x, batch_count));
         DAPI_EXPECT(HIPBLAS_STATUS_INVALID_VALUE,
                     hipblasScalStridedBatchedFn,
                     (handle, N, nullptr, dx, incx, stride_x, batch_count));
         DAPI_EXPECT(HIPBLAS_STATUS_INVALID_VALUE,
                     hipblasScalStridedBatchedFn,
-                    (handle, N, &alpha, nullptr, incx, stride_x, batch_count));
+                    (handle, N, reinterpret_cast<Ts*>(&alpha), nullptr, incx, stride_x, batch_count));
     }
 }
 
 template <typename T, typename U = T>
 void testing_scal_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<U>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasScalStridedBatchedFn
         = FORTRAN ? hipblasScalStridedBatched<T, U, true> : hipblasScalStridedBatched<T, U, false>;
@@ -133,7 +135,7 @@ void testing_scal_strided_batched(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         DAPI_CHECK(hipblasScalStridedBatchedFn,
-                   (handle, N, &alpha, dx, incx, stride_x, batch_count));
+                   (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx, stride_x, batch_count));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hx.transfer_from(dx));
@@ -167,7 +169,7 @@ void testing_scal_strided_batched(const Arguments& arg)
                 gpu_time_used = get_time_us_sync(stream);
 
             DAPI_CHECK(hipblasScalStridedBatchedFn,
-                       (handle, N, &alpha, dx, incx, stride_x, batch_count));
+                       (handle, N, reinterpret_cast<Ts*>(&alpha), dx, incx, stride_x, batch_count));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 

--- a/clients/include/blas2/testing_gbmv.hpp
+++ b/clients/include/blas2/testing_gbmv.hpp
@@ -50,7 +50,7 @@ inline void testname_gbmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gbmv_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvFn = FORTRAN ? hipblasGbmv<T, true> : hipblasGbmv<T, false>;
     auto hipblasGbmvFn_64
@@ -227,7 +227,7 @@ void testing_gbmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gbmv(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvFn = FORTRAN ? hipblasGbmv<T, true> : hipblasGbmv<T, false>;
     auto hipblasGbmvFn_64
@@ -336,9 +336,21 @@ void testing_gbmv(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(
-            hipblasGbmvFn,
-            (handle, transA, M, N, KL, KU, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
+        DAPI_CHECK(hipblasGbmvFn,
+                   (handle,
+                    transA,
+                    M,
+                    N,
+                    KL,
+                    KU,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dx,
+                    incx,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dy,
+                    incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_gbmv.hpp
+++ b/clients/include/blas2/testing_gbmv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_gbmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gbmv_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvFn = FORTRAN ? hipblasGbmv<T, true> : hipblasGbmv<T, false>;
     auto hipblasGbmvFn_64
@@ -72,11 +73,11 @@ void testing_gbmv_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -226,6 +227,7 @@ void testing_gbmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gbmv(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvFn = FORTRAN ? hipblasGbmv<T, true> : hipblasGbmv<T, false>;
     auto hipblasGbmvFn_64
@@ -336,7 +338,7 @@ void testing_gbmv(const Arguments& arg)
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(
             hipblasGbmvFn,
-            (handle, transA, M, N, KL, KU, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
+            (handle, transA, M, N, KL, KU, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_gbmv_batched.hpp
+++ b/clients/include/blas2/testing_gbmv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ inline void testname_gbmv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gbmv_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvBatchedFn
         = FORTRAN ? hipblasGbmvBatched<T, true> : hipblasGbmvBatched<T, false>;
@@ -76,11 +77,11 @@ void testing_gbmv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -342,6 +343,7 @@ void testing_gbmv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gbmv_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvBatchedFn
         = FORTRAN ? hipblasGbmvBatched<T, true> : hipblasGbmvBatched<T, false>;
@@ -459,12 +461,12 @@ void testing_gbmv_batched(const Arguments& arg)
                     N,
                     KL,
                     KU,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dx.ptr_on_device(),
                     incx,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy.ptr_on_device(),
                     incy,
                     batch_count));

--- a/clients/include/blas2/testing_gbmv_batched.hpp
+++ b/clients/include/blas2/testing_gbmv_batched.hpp
@@ -51,7 +51,7 @@ inline void testname_gbmv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gbmv_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvBatchedFn
         = FORTRAN ? hipblasGbmvBatched<T, true> : hipblasGbmvBatched<T, false>;
@@ -343,7 +343,7 @@ void testing_gbmv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gbmv_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvBatchedFn
         = FORTRAN ? hipblasGbmvBatched<T, true> : hipblasGbmvBatched<T, false>;

--- a/clients/include/blas2/testing_gbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_gbmv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@ inline void testname_gbmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_gbmv_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvStridedBatchedFn
         = FORTRAN ? hipblasGbmvStridedBatched<T, true> : hipblasGbmvStridedBatched<T, false>;
@@ -81,11 +82,11 @@ void testing_gbmv_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -386,6 +387,7 @@ void testing_gbmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gbmv_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvStridedBatchedFn
         = FORTRAN ? hipblasGbmvStridedBatched<T, true> : hipblasGbmvStridedBatched<T, false>;
@@ -516,14 +518,14 @@ void testing_gbmv_strided_batched(const Arguments& arg)
                     N,
                     KL,
                     KU,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dx,
                     incx,
                     stride_x,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy,
                     incy,
                     stride_y,

--- a/clients/include/blas2/testing_gbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_gbmv_strided_batched.hpp
@@ -52,7 +52,7 @@ inline void testname_gbmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_gbmv_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvStridedBatchedFn
         = FORTRAN ? hipblasGbmvStridedBatched<T, true> : hipblasGbmvStridedBatched<T, false>;
@@ -387,7 +387,7 @@ void testing_gbmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gbmv_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGbmvStridedBatchedFn
         = FORTRAN ? hipblasGbmvStridedBatched<T, true> : hipblasGbmvStridedBatched<T, false>;

--- a/clients/include/blas2/testing_gemv.hpp
+++ b/clients/include/blas2/testing_gemv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_gemv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gemv_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvFn = FORTRAN ? hipblasGemv<T, true> : hipblasGemv<T, false>;
     auto hipblasGemvFn_64
@@ -60,11 +61,11 @@ void testing_gemv_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -170,6 +171,7 @@ void testing_gemv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemv(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvFn = FORTRAN ? hipblasGemv<T, true> : hipblasGemv<T, false>;
     auto hipblasGemvFn_64
@@ -278,7 +280,7 @@ void testing_gemv(const Arguments& arg)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasGemvFn,
-                   (handle, transA, M, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
+                   (handle, transA, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_gemv.hpp
+++ b/clients/include/blas2/testing_gemv.hpp
@@ -41,7 +41,7 @@ inline void testname_gemv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gemv_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvFn = FORTRAN ? hipblasGemv<T, true> : hipblasGemv<T, false>;
     auto hipblasGemvFn_64
@@ -171,7 +171,7 @@ void testing_gemv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemv(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvFn = FORTRAN ? hipblasGemv<T, true> : hipblasGemv<T, false>;
     auto hipblasGemvFn_64
@@ -280,7 +280,18 @@ void testing_gemv(const Arguments& arg)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasGemvFn,
-                   (handle, transA, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
+                   (handle,
+                    transA,
+                    M,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dx,
+                    incx,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dy,
+                    incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_gemv_batched.hpp
+++ b/clients/include/blas2/testing_gemv_batched.hpp
@@ -49,7 +49,7 @@ inline void testname_gemv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gemv_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvBatchedFn
         = FORTRAN ? hipblasGemvBatched<T, true> : hipblasGemvBatched<T, false>;
@@ -314,7 +314,7 @@ void testing_gemv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemv_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvBatchedFn
         = FORTRAN ? hipblasGemvBatched<T, true> : hipblasGemvBatched<T, false>;

--- a/clients/include/blas2/testing_gemv_batched.hpp
+++ b/clients/include/blas2/testing_gemv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,7 @@ inline void testname_gemv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gemv_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvBatchedFn
         = FORTRAN ? hipblasGemvBatched<T, true> : hipblasGemvBatched<T, false>;
@@ -71,11 +72,11 @@ void testing_gemv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -313,6 +314,7 @@ void testing_gemv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemv_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvBatchedFn
         = FORTRAN ? hipblasGemvBatched<T, true> : hipblasGemvBatched<T, false>;
@@ -429,12 +431,12 @@ void testing_gemv_batched(const Arguments& arg)
                     transA,
                     M,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dx.ptr_on_device(),
                     incx,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy.ptr_on_device(),
                     incy,
                     batch_count));

--- a/clients/include/blas2/testing_gemv_strided_batched.hpp
+++ b/clients/include/blas2/testing_gemv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_gemv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_gemv_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvStridedBatchedFn
         = FORTRAN ? hipblasGemvStridedBatched<T, true> : hipblasGemvStridedBatched<T, false>;
@@ -77,11 +78,11 @@ void testing_gemv_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -359,6 +360,7 @@ void testing_gemv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemv_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvStridedBatchedFn
         = FORTRAN ? hipblasGemvStridedBatched<T, true> : hipblasGemvStridedBatched<T, false>;
@@ -486,14 +488,14 @@ void testing_gemv_strided_batched(const Arguments& arg)
                     transA,
                     M,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dx,
                     incx,
                     stride_x,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy,
                     incy,
                     stride_y,

--- a/clients/include/blas2/testing_gemv_strided_batched.hpp
+++ b/clients/include/blas2/testing_gemv_strided_batched.hpp
@@ -50,7 +50,7 @@ inline void testname_gemv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_gemv_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvStridedBatchedFn
         = FORTRAN ? hipblasGemvStridedBatched<T, true> : hipblasGemvStridedBatched<T, false>;
@@ -360,7 +360,7 @@ void testing_gemv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemv_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGemvStridedBatchedFn
         = FORTRAN ? hipblasGemvStridedBatched<T, true> : hipblasGemvStridedBatched<T, false>;

--- a/clients/include/blas2/testing_ger.hpp
+++ b/clients/include/blas2/testing_ger.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_ger(const Arguments& arg, std::string& name)
 template <typename T, bool CONJ = false>
 void testing_ger_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN      = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerFn = FORTRAN ? (CONJ ? hipblasGer<T, true, true> : hipblasGer<T, false, true>)
                                 : (CONJ ? hipblasGer<T, true, false> : hipblasGer<T, false, false>);
@@ -62,9 +63,9 @@ void testing_ger_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -133,6 +134,7 @@ void testing_ger_bad_arg(const Arguments& arg)
 template <typename T, bool CONJ>
 void testing_ger(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN      = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerFn = FORTRAN ? (CONJ ? hipblasGer<T, true, true> : hipblasGer<T, false, true>)
                                 : (CONJ ? hipblasGer<T, true, false> : hipblasGer<T, false, false>);
@@ -207,7 +209,7 @@ void testing_ger(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasGerFn, (handle, M, N, (T*)&h_alpha, dx, incx, dy, incy, dA, lda));
+        DAPI_CHECK(hipblasGerFn, (handle, M, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas2/testing_ger.hpp
+++ b/clients/include/blas2/testing_ger.hpp
@@ -40,7 +40,7 @@ inline void testname_ger(const Arguments& arg, std::string& name)
 template <typename T, bool CONJ = false>
 void testing_ger_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts          = hipblas_internal_type<T>;
     bool FORTRAN      = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerFn = FORTRAN ? (CONJ ? hipblasGer<T, true, true> : hipblasGer<T, false, true>)
                                 : (CONJ ? hipblasGer<T, true, false> : hipblasGer<T, false, false>);
@@ -134,7 +134,7 @@ void testing_ger_bad_arg(const Arguments& arg)
 template <typename T, bool CONJ>
 void testing_ger(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts          = hipblas_internal_type<T>;
     bool FORTRAN      = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerFn = FORTRAN ? (CONJ ? hipblasGer<T, true, true> : hipblasGer<T, false, true>)
                                 : (CONJ ? hipblasGer<T, true, false> : hipblasGer<T, false, false>);
@@ -209,7 +209,8 @@ void testing_ger(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasGerFn, (handle, M, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
+        DAPI_CHECK(hipblasGerFn,
+                   (handle, M, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas2/testing_ger_batched.hpp
+++ b/clients/include/blas2/testing_ger_batched.hpp
@@ -41,7 +41,7 @@ inline void testname_ger_batched(const Arguments& arg, std::string& name)
 template <typename T, bool CONJ = false>
 void testing_ger_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerBatchedFn
         = FORTRAN ? (CONJ ? hipblasGerBatched<T, true, true> : hipblasGerBatched<T, false, true>)
@@ -190,7 +190,7 @@ void testing_ger_batched_bad_arg(const Arguments& arg)
 template <typename T, bool CONJ>
 void testing_ger_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerBatchedFn
         = FORTRAN ? (CONJ ? hipblasGerBatched<T, true, true> : hipblasGerBatched<T, false, true>)

--- a/clients/include/blas2/testing_ger_batched.hpp
+++ b/clients/include/blas2/testing_ger_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_ger_batched(const Arguments& arg, std::string& name)
 template <typename T, bool CONJ = false>
 void testing_ger_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerBatchedFn
         = FORTRAN ? (CONJ ? hipblasGerBatched<T, true, true> : hipblasGerBatched<T, false, true>)
@@ -66,9 +67,9 @@ void testing_ger_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -189,6 +190,7 @@ void testing_ger_batched_bad_arg(const Arguments& arg)
 template <typename T, bool CONJ>
 void testing_ger_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerBatchedFn
         = FORTRAN ? (CONJ ? hipblasGerBatched<T, true, true> : hipblasGerBatched<T, false, true>)
@@ -271,7 +273,7 @@ void testing_ger_batched(const Arguments& arg)
                    (handle,
                     M,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx.ptr_on_device(),
                     incx,
                     dy.ptr_on_device(),

--- a/clients/include/blas2/testing_ger_strided_batched.hpp
+++ b/clients/include/blas2/testing_ger_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,7 @@ inline void testname_ger_strided_batched(const Arguments& arg, std::string& name
 template <typename T, bool CONJ = false>
 void testing_ger_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN                    = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerStridedBatchedFn = FORTRAN ? (CONJ ? hipblasGerStridedBatched<T, true, true>
                                                       : hipblasGerStridedBatched<T, false, true>)
@@ -78,9 +79,9 @@ void testing_ger_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -244,6 +245,7 @@ void testing_ger_strided_batched_bad_arg(const Arguments& arg)
 template <typename T, bool CONJ>
 void testing_ger_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN                    = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerStridedBatchedFn = FORTRAN ? (CONJ ? hipblasGerStridedBatched<T, true, true>
                                                       : hipblasGerStridedBatched<T, false, true>)
@@ -343,7 +345,7 @@ void testing_ger_strided_batched(const Arguments& arg)
                    (handle,
                     M,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx,
                     incx,
                     stride_x,

--- a/clients/include/blas2/testing_ger_strided_batched.hpp
+++ b/clients/include/blas2/testing_ger_strided_batched.hpp
@@ -48,7 +48,7 @@ inline void testname_ger_strided_batched(const Arguments& arg, std::string& name
 template <typename T, bool CONJ = false>
 void testing_ger_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                        = hipblas_internal_type<T>;
     bool FORTRAN                    = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerStridedBatchedFn = FORTRAN ? (CONJ ? hipblasGerStridedBatched<T, true, true>
                                                       : hipblasGerStridedBatched<T, false, true>)
@@ -245,7 +245,7 @@ void testing_ger_strided_batched_bad_arg(const Arguments& arg)
 template <typename T, bool CONJ>
 void testing_ger_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                        = hipblas_internal_type<T>;
     bool FORTRAN                    = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasGerStridedBatchedFn = FORTRAN ? (CONJ ? hipblasGerStridedBatched<T, true, true>
                                                       : hipblasGerStridedBatched<T, false, true>)

--- a/clients/include/blas2/testing_hbmv.hpp
+++ b/clients/include/blas2/testing_hbmv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_hbmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hbmv_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvFn = FORTRAN ? hipblasHbmv<T, true> : hipblasHbmv<T, false>;
     auto hipblasHbmvFn_64
@@ -60,11 +61,11 @@ void testing_hbmv_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -153,6 +154,7 @@ void testing_hbmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hbmv(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvFn = FORTRAN ? hipblasHbmv<T, true> : hipblasHbmv<T, false>;
     auto hipblasHbmvFn_64
@@ -233,7 +235,7 @@ void testing_hbmv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHbmvFn,
-                   (handle, uplo, N, K, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
+                   (handle, uplo, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_hbmv.hpp
+++ b/clients/include/blas2/testing_hbmv.hpp
@@ -41,7 +41,7 @@ inline void testname_hbmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hbmv_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvFn = FORTRAN ? hipblasHbmv<T, true> : hipblasHbmv<T, false>;
     auto hipblasHbmvFn_64
@@ -154,7 +154,7 @@ void testing_hbmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hbmv(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvFn = FORTRAN ? hipblasHbmv<T, true> : hipblasHbmv<T, false>;
     auto hipblasHbmvFn_64
@@ -235,7 +235,18 @@ void testing_hbmv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHbmvFn,
-                   (handle, uplo, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
+                   (handle,
+                    uplo,
+                    N,
+                    K,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dx,
+                    incx,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dy,
+                    incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_hbmv_batched.hpp
+++ b/clients/include/blas2/testing_hbmv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,7 @@ inline void testname_hbmv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hbmv_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvBatchedFn
         = FORTRAN ? hipblasHbmvBatched<T, true> : hipblasHbmvBatched<T, false>;
@@ -72,11 +73,11 @@ void testing_hbmv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -282,6 +283,7 @@ void testing_hbmv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hbmv_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvBatchedFn
         = FORTRAN ? hipblasHbmvBatched<T, true> : hipblasHbmvBatched<T, false>;
@@ -378,12 +380,12 @@ void testing_hbmv_batched(const Arguments& arg)
                     uplo,
                     N,
                     K,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dx.ptr_on_device(),
                     incx,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy.ptr_on_device(),
                     incy,
                     batch_count));

--- a/clients/include/blas2/testing_hbmv_batched.hpp
+++ b/clients/include/blas2/testing_hbmv_batched.hpp
@@ -49,7 +49,7 @@ inline void testname_hbmv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hbmv_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvBatchedFn
         = FORTRAN ? hipblasHbmvBatched<T, true> : hipblasHbmvBatched<T, false>;
@@ -283,7 +283,7 @@ void testing_hbmv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hbmv_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvBatchedFn
         = FORTRAN ? hipblasHbmvBatched<T, true> : hipblasHbmvBatched<T, false>;

--- a/clients/include/blas2/testing_hbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hbmv_strided_batched.hpp
@@ -50,7 +50,7 @@ inline void testname_hbmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hbmv_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvStridedBatchedFn
         = FORTRAN ? hipblasHbmvStridedBatched<T, true> : hipblasHbmvStridedBatched<T, false>;
@@ -334,7 +334,7 @@ void testing_hbmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hbmv_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
 
     auto hipblasHbmvStridedBatchedFn

--- a/clients/include/blas2/testing_hbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hbmv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_hbmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hbmv_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHbmvStridedBatchedFn
         = FORTRAN ? hipblasHbmvStridedBatched<T, true> : hipblasHbmvStridedBatched<T, false>;
@@ -77,11 +78,11 @@ void testing_hbmv_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -333,6 +334,7 @@ void testing_hbmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hbmv_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
 
     auto hipblasHbmvStridedBatchedFn
@@ -441,14 +443,14 @@ void testing_hbmv_strided_batched(const Arguments& arg)
                     uplo,
                     N,
                     K,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dx,
                     incx,
                     stride_x,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy,
                     incy,
                     stride_y,

--- a/clients/include/blas2/testing_hemv.hpp
+++ b/clients/include/blas2/testing_hemv.hpp
@@ -41,7 +41,7 @@ inline void testname_hemv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hemv_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvFn = FORTRAN ? hipblasHemv<T, true> : hipblasHemv<T, false>;
     auto hipblasHemvFn_64
@@ -139,7 +139,7 @@ void testing_hemv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemv(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvFn = FORTRAN ? hipblasHemv<T, true> : hipblasHemv<T, false>;
     auto hipblasHemvFn_64
@@ -217,7 +217,17 @@ void testing_hemv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHemvFn,
-                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
+                   (handle,
+                    uplo,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dx,
+                    incx,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dy,
+                    incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_hemv.hpp
+++ b/clients/include/blas2/testing_hemv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_hemv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hemv_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvFn = FORTRAN ? hipblasHemv<T, true> : hipblasHemv<T, false>;
     auto hipblasHemvFn_64
@@ -59,11 +60,11 @@ void testing_hemv_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -138,6 +139,7 @@ void testing_hemv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemv(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvFn = FORTRAN ? hipblasHemv<T, true> : hipblasHemv<T, false>;
     auto hipblasHemvFn_64
@@ -215,7 +217,7 @@ void testing_hemv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHemvFn,
-                   (handle, uplo, N, (T*)&h_alpha, dA, lda, dx, incx, (T*)&h_beta, dy, incy));
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_hemv_batched.hpp
+++ b/clients/include/blas2/testing_hemv_batched.hpp
@@ -41,7 +41,7 @@ inline void testname_hemv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hemv_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvBatchedFn
         = FORTRAN ? hipblasHemvBatched<T, true> : hipblasHemvBatched<T, false>;
@@ -252,7 +252,7 @@ void testing_hemv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemv_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvBatchedFn
         = FORTRAN ? hipblasHemvBatched<T, true> : hipblasHemvBatched<T, false>;

--- a/clients/include/blas2/testing_hemv_batched.hpp
+++ b/clients/include/blas2/testing_hemv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_hemv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hemv_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvBatchedFn
         = FORTRAN ? hipblasHemvBatched<T, true> : hipblasHemvBatched<T, false>;
@@ -62,11 +63,11 @@ void testing_hemv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -251,6 +252,7 @@ void testing_hemv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemv_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvBatchedFn
         = FORTRAN ? hipblasHemvBatched<T, true> : hipblasHemvBatched<T, false>;
@@ -346,12 +348,12 @@ void testing_hemv_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dx.ptr_on_device(),
                     incx,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy.ptr_on_device(),
                     incy,
                     batch_count));

--- a/clients/include/blas2/testing_hemv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hemv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,7 @@ inline void testname_hemv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hemv_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvStridedBatchedFn
         = FORTRAN ? hipblasHemvStridedBatched<T, true> : hipblasHemvStridedBatched<T, false>;
@@ -74,11 +75,11 @@ void testing_hemv_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -319,6 +320,7 @@ void testing_hemv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemv_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvStridedBatchedFn
         = FORTRAN ? hipblasHemvStridedBatched<T, true> : hipblasHemvStridedBatched<T, false>;
@@ -425,14 +427,14 @@ void testing_hemv_strided_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dx,
                     incx,
                     stride_x,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy,
                     incy,
                     stride_y,

--- a/clients/include/blas2/testing_hemv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hemv_strided_batched.hpp
@@ -48,7 +48,7 @@ inline void testname_hemv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hemv_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvStridedBatchedFn
         = FORTRAN ? hipblasHemvStridedBatched<T, true> : hipblasHemvStridedBatched<T, false>;
@@ -320,7 +320,7 @@ void testing_hemv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemv_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHemvStridedBatchedFn
         = FORTRAN ? hipblasHemvStridedBatched<T, true> : hipblasHemvStridedBatched<T, false>;

--- a/clients/include/blas2/testing_her2.hpp
+++ b/clients/include/blas2/testing_her2.hpp
@@ -40,7 +40,7 @@ inline void testname_her2(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_her2_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2Fn = FORTRAN ? hipblasHer2<T, true> : hipblasHer2<T, false>;
     auto hipblasHer2Fn_64
@@ -125,7 +125,7 @@ void testing_her2_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2Fn = FORTRAN ? hipblasHer2<T, true> : hipblasHer2<T, false>;
     auto hipblasHer2Fn_64
@@ -196,7 +196,8 @@ void testing_her2(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasHer2Fn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
+        DAPI_CHECK(hipblasHer2Fn,
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas2/testing_her2.hpp
+++ b/clients/include/blas2/testing_her2.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_her2(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_her2_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2Fn = FORTRAN ? hipblasHer2<T, true> : hipblasHer2<T, false>;
     auto hipblasHer2Fn_64
@@ -58,9 +59,9 @@ void testing_her2_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -124,6 +125,7 @@ void testing_her2_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2Fn = FORTRAN ? hipblasHer2<T, true> : hipblasHer2<T, false>;
     auto hipblasHer2Fn_64
@@ -194,7 +196,7 @@ void testing_her2(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasHer2Fn, (handle, uplo, N, (T*)&h_alpha, dx, incx, dy, incy, dA, lda));
+        DAPI_CHECK(hipblasHer2Fn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));
@@ -218,7 +220,7 @@ void testing_her2(const Arguments& arg)
             // NOTE: on cuBLAS, with alpha == 0 and alpha on the device, there is not a quick-return,
             // instead, the imaginary part of the diagonal elements are set to 0. in rocBLAS, we are quick-returning
             // as well as in our reference code. For this reason, I've disabled the check here.
-            if(h_alpha != 0)
+            if(h_alpha != T(0))
                 unit_check_general<T>(N, N, lda, hA_cpu.data(), hA_device.data());
         }
         if(arg.norm_check)

--- a/clients/include/blas2/testing_her2_batched.hpp
+++ b/clients/include/blas2/testing_her2_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_her2_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_her2_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2BatchedFn
         = FORTRAN ? hipblasHer2Batched<T, true> : hipblasHer2Batched<T, false>;
@@ -62,9 +63,9 @@ void testing_her2_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -199,6 +200,7 @@ void testing_her2_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2BatchedFn
         = FORTRAN ? hipblasHer2Batched<T, true> : hipblasHer2Batched<T, false>;
@@ -275,7 +277,7 @@ void testing_her2_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx.ptr_on_device(),
                     incx,
                     dy.ptr_on_device(),

--- a/clients/include/blas2/testing_her2_batched.hpp
+++ b/clients/include/blas2/testing_her2_batched.hpp
@@ -41,7 +41,7 @@ inline void testname_her2_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_her2_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2BatchedFn
         = FORTRAN ? hipblasHer2Batched<T, true> : hipblasHer2Batched<T, false>;
@@ -200,7 +200,7 @@ void testing_her2_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2BatchedFn
         = FORTRAN ? hipblasHer2Batched<T, true> : hipblasHer2Batched<T, false>;

--- a/clients/include/blas2/testing_her2_strided_batched.hpp
+++ b/clients/include/blas2/testing_her2_strided_batched.hpp
@@ -48,7 +48,7 @@ inline void testname_her2_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_her2_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2StridedBatchedFn
         = FORTRAN ? hipblasHer2StridedBatched<T, true> : hipblasHer2StridedBatched<T, false>;
@@ -269,7 +269,7 @@ void testing_her2_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2StridedBatchedFn
         = FORTRAN ? hipblasHer2StridedBatched<T, true> : hipblasHer2StridedBatched<T, false>;

--- a/clients/include/blas2/testing_her2_strided_batched.hpp
+++ b/clients/include/blas2/testing_her2_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,7 @@ inline void testname_her2_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_her2_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2StridedBatchedFn
         = FORTRAN ? hipblasHer2StridedBatched<T, true> : hipblasHer2StridedBatched<T, false>;
@@ -73,9 +74,9 @@ void testing_her2_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -268,6 +269,7 @@ void testing_her2_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHer2StridedBatchedFn
         = FORTRAN ? hipblasHer2StridedBatched<T, true> : hipblasHer2StridedBatched<T, false>;
@@ -358,7 +360,7 @@ void testing_her2_strided_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx,
                     incx,
                     stride_x,

--- a/clients/include/blas2/testing_hpmv.hpp
+++ b/clients/include/blas2/testing_hpmv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_hpmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hpmv_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvFn = FORTRAN ? hipblasHpmv<T, true> : hipblasHpmv<T, false>;
 
@@ -59,11 +60,11 @@ void testing_hpmv_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -155,6 +156,7 @@ void testing_hpmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpmv(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvFn = FORTRAN ? hipblasHpmv<T, true> : hipblasHpmv<T, false>;
     auto hipblasHpmvFn_64
@@ -238,7 +240,7 @@ void testing_hpmv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHpmvFn,
-                   (handle, uplo, N, (T*)&h_alpha, dAp, dx, incx, (T*)&h_beta, dy, incy));
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dAp, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_hpmv.hpp
+++ b/clients/include/blas2/testing_hpmv.hpp
@@ -40,7 +40,7 @@ inline void testname_hpmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hpmv_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvFn = FORTRAN ? hipblasHpmv<T, true> : hipblasHpmv<T, false>;
 
@@ -156,7 +156,7 @@ void testing_hpmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpmv(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvFn = FORTRAN ? hipblasHpmv<T, true> : hipblasHpmv<T, false>;
     auto hipblasHpmvFn_64
@@ -240,7 +240,16 @@ void testing_hpmv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHpmvFn,
-                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dAp, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
+                   (handle,
+                    uplo,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dAp,
+                    dx,
+                    incx,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dy,
+                    incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_hpmv_batched.hpp
+++ b/clients/include/blas2/testing_hpmv_batched.hpp
@@ -41,7 +41,7 @@ inline void testname_hpmv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hpmv_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvBatchedFn
         = FORTRAN ? hipblasHpmvBatched<T, true> : hipblasHpmvBatched<T, false>;
@@ -259,7 +259,7 @@ void testing_hpmv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpmv_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvBatchedFn
         = FORTRAN ? hipblasHpmvBatched<T, true> : hipblasHpmvBatched<T, false>;

--- a/clients/include/blas2/testing_hpmv_batched.hpp
+++ b/clients/include/blas2/testing_hpmv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_hpmv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hpmv_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvBatchedFn
         = FORTRAN ? hipblasHpmvBatched<T, true> : hipblasHpmvBatched<T, false>;
@@ -62,11 +63,11 @@ void testing_hpmv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -258,6 +259,7 @@ void testing_hpmv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpmv_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvBatchedFn
         = FORTRAN ? hipblasHpmvBatched<T, true> : hipblasHpmvBatched<T, false>;
@@ -353,11 +355,11 @@ void testing_hpmv_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dAp.ptr_on_device(),
                     dx.ptr_on_device(),
                     incx,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy.ptr_on_device(),
                     incy,
                     batch_count));

--- a/clients/include/blas2/testing_hpmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hpmv_strided_batched.hpp
@@ -48,7 +48,7 @@ inline void testname_hpmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hpmv_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
 
     auto hipblasHpmvStridedBatchedFn
@@ -329,7 +329,7 @@ void testing_hpmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpmv_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvStridedBatchedFn
         = FORTRAN ? hipblasHpmvStridedBatched<T, true> : hipblasHpmvStridedBatched<T, false>;

--- a/clients/include/blas2/testing_hpmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_hpmv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,7 @@ inline void testname_hpmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hpmv_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
 
     auto hipblasHpmvStridedBatchedFn
@@ -74,11 +75,11 @@ void testing_hpmv_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -328,6 +329,7 @@ void testing_hpmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpmv_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpmvStridedBatchedFn
         = FORTRAN ? hipblasHpmvStridedBatched<T, true> : hipblasHpmvStridedBatched<T, false>;
@@ -431,13 +433,13 @@ void testing_hpmv_strided_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dAp,
                     stride_A,
                     dx,
                     incx,
                     stride_x,
-                    (T*)&h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy,
                     incy,
                     stride_y,

--- a/clients/include/blas2/testing_hpr2.hpp
+++ b/clients/include/blas2/testing_hpr2.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_hpr2(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hpr2_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2Fn = FORTRAN ? hipblasHpr2<T, true> : hipblasHpr2<T, false>;
     auto hipblasHpr2Fn_64
@@ -58,9 +59,9 @@ void testing_hpr2_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -133,6 +134,7 @@ void testing_hpr2_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpr2(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2Fn = FORTRAN ? hipblasHpr2<T, true> : hipblasHpr2<T, false>;
     auto hipblasHpr2Fn_64
@@ -210,7 +212,7 @@ void testing_hpr2(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasHpr2Fn, (handle, uplo, N, (T*)&h_alpha, dx, incx, dy, incy, dAp));
+        DAPI_CHECK(hipblasHpr2Fn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dAp));
 
         CHECK_HIP_ERROR(hAp_host.transfer_from(dAp));
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));

--- a/clients/include/blas2/testing_hpr2.hpp
+++ b/clients/include/blas2/testing_hpr2.hpp
@@ -40,7 +40,7 @@ inline void testname_hpr2(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hpr2_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2Fn = FORTRAN ? hipblasHpr2<T, true> : hipblasHpr2<T, false>;
     auto hipblasHpr2Fn_64
@@ -134,7 +134,7 @@ void testing_hpr2_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpr2(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     bool FORTRAN       = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2Fn = FORTRAN ? hipblasHpr2<T, true> : hipblasHpr2<T, false>;
     auto hipblasHpr2Fn_64
@@ -212,7 +212,8 @@ void testing_hpr2(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasHpr2Fn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dAp));
+        DAPI_CHECK(hipblasHpr2Fn,
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dAp));
 
         CHECK_HIP_ERROR(hAp_host.transfer_from(dAp));
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));

--- a/clients/include/blas2/testing_hpr2_batched.hpp
+++ b/clients/include/blas2/testing_hpr2_batched.hpp
@@ -41,7 +41,7 @@ inline void testname_hpr2_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hpr2_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2BatchedFn
         = FORTRAN ? hipblasHpr2Batched<T, true> : hipblasHpr2Batched<T, false>;
@@ -215,7 +215,7 @@ void testing_hpr2_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpr2_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2BatchedFn
         = FORTRAN ? hipblasHpr2Batched<T, true> : hipblasHpr2Batched<T, false>;

--- a/clients/include/blas2/testing_hpr2_batched.hpp
+++ b/clients/include/blas2/testing_hpr2_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_hpr2_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hpr2_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2BatchedFn
         = FORTRAN ? hipblasHpr2Batched<T, true> : hipblasHpr2Batched<T, false>;
@@ -62,9 +63,9 @@ void testing_hpr2_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -214,6 +215,7 @@ void testing_hpr2_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpr2_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2BatchedFn
         = FORTRAN ? hipblasHpr2Batched<T, true> : hipblasHpr2Batched<T, false>;
@@ -293,7 +295,7 @@ void testing_hpr2_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx.ptr_on_device(),
                     incx,
                     dy.ptr_on_device(),

--- a/clients/include/blas2/testing_hpr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_hpr2_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_hpr2_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hpr2_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
 
     auto hipblasHpr2StridedBatchedFn
@@ -67,9 +68,9 @@ void testing_hpr2_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -279,6 +280,7 @@ void testing_hpr2_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpr2_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2StridedBatchedFn
         = FORTRAN ? hipblasHpr2StridedBatched<T, true> : hipblasHpr2StridedBatched<T, false>;
@@ -377,7 +379,7 @@ void testing_hpr2_strided_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    (T*)&h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx,
                     incx,
                     stride_x,

--- a/clients/include/blas2/testing_hpr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_hpr2_strided_batched.hpp
@@ -41,7 +41,7 @@ inline void testname_hpr2_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hpr2_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
 
     auto hipblasHpr2StridedBatchedFn
@@ -280,7 +280,7 @@ void testing_hpr2_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hpr2_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHpr2StridedBatchedFn
         = FORTRAN ? hipblasHpr2StridedBatched<T, true> : hipblasHpr2StridedBatched<T, false>;

--- a/clients/include/blas2/testing_sbmv.hpp
+++ b/clients/include/blas2/testing_sbmv.hpp
@@ -41,7 +41,7 @@ inline void testname_sbmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_sbmv_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSbmvFn = arg.api == FORTRAN ? hipblasSbmv<T, true> : hipblasSbmv<T, false>;
     auto hipblasSbmvFn_64
         = arg.api == FORTRAN_64 ? hipblasSbmv_64<T, true> : hipblasSbmv_64<T, false>;
@@ -164,7 +164,7 @@ void testing_sbmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_sbmv(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSbmvFn = arg.api == FORTRAN ? hipblasSbmv<T, true> : hipblasSbmv<T, false>;
     auto hipblasSbmvFn_64
         = arg.api == FORTRAN_64 ? hipblasSbmv_64<T, true> : hipblasSbmv_64<T, false>;
@@ -243,7 +243,18 @@ void testing_sbmv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSbmvFn,
-                   (handle, uplo, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
+                   (handle,
+                    uplo,
+                    N,
+                    K,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dx,
+                    incx,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dy,
+                    incy));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));

--- a/clients/include/blas2/testing_sbmv.hpp
+++ b/clients/include/blas2/testing_sbmv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_sbmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_sbmv_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSbmvFn = arg.api == FORTRAN ? hipblasSbmv<T, true> : hipblasSbmv<T, false>;
     auto hipblasSbmvFn_64
         = arg.api == FORTRAN_64 ? hipblasSbmv_64<T, true> : hipblasSbmv_64<T, false>;
@@ -60,11 +61,11 @@ void testing_sbmv_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -163,6 +164,7 @@ void testing_sbmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_sbmv(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSbmvFn = arg.api == FORTRAN ? hipblasSbmv<T, true> : hipblasSbmv<T, false>;
     auto hipblasSbmvFn_64
         = arg.api == FORTRAN_64 ? hipblasSbmv_64<T, true> : hipblasSbmv_64<T, false>;
@@ -241,7 +243,7 @@ void testing_sbmv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSbmvFn,
-                   (handle, uplo, N, K, &h_alpha, dA, lda, dx, incx, &h_beta, dy, incy));
+                   (handle, uplo, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));

--- a/clients/include/blas2/testing_sbmv_batched.hpp
+++ b/clients/include/blas2/testing_sbmv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,7 @@ inline void testname_sbmv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_sbmv_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSbmvBatchedFn
         = arg.api == FORTRAN ? hipblasSbmvBatched<T, true> : hipblasSbmvBatched<T, false>;
     auto hipblasSbmvBatchedFn_64
@@ -70,11 +71,11 @@ void testing_sbmv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -293,6 +294,7 @@ void testing_sbmv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_sbmv_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSbmvBatchedFn
         = arg.api == FORTRAN ? hipblasSbmvBatched<T, true> : hipblasSbmvBatched<T, false>;
     auto hipblasSbmvBatchedFn_64
@@ -390,12 +392,12 @@ void testing_sbmv_batched(const Arguments& arg)
                     uplo,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dx.ptr_on_device(),
                     incx,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy.ptr_on_device(),
                     incy,
                     batch_count));

--- a/clients/include/blas2/testing_sbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_sbmv_strided_batched.hpp
@@ -50,7 +50,7 @@ inline void testname_sbmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_sbmv_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSbmvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSbmvStridedBatched<T, true>
                                                              : hipblasSbmvStridedBatched<T, false>;
     auto hipblasSbmvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -349,7 +349,7 @@ void testing_sbmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_sbmv_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSbmvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSbmvStridedBatched<T, true>
                                                              : hipblasSbmvStridedBatched<T, false>;
     auto hipblasSbmvStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas2/testing_sbmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_sbmv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_sbmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_sbmv_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSbmvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSbmvStridedBatched<T, true>
                                                              : hipblasSbmvStridedBatched<T, false>;
     auto hipblasSbmvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -75,11 +76,11 @@ void testing_sbmv_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -348,6 +349,7 @@ void testing_sbmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_sbmv_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSbmvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSbmvStridedBatched<T, true>
                                                              : hipblasSbmvStridedBatched<T, false>;
     auto hipblasSbmvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -452,14 +454,14 @@ void testing_sbmv_strided_batched(const Arguments& arg)
                     uplo,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dx,
                     incx,
                     stride_x,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy,
                     incy,
                     stride_y,

--- a/clients/include/blas2/testing_spmv.hpp
+++ b/clients/include/blas2/testing_spmv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_spmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spmv_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpmvFn = arg.api == FORTRAN ? hipblasSpmv<T, true> : hipblasSpmv<T, false>;
     auto hipblasSpmvFn_64
         = arg.api == FORTRAN_64 ? hipblasSpmv_64<T, true> : hipblasSpmv_64<T, false>;
@@ -57,11 +58,11 @@ void testing_spmv_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -147,6 +148,7 @@ void testing_spmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spmv(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpmvFn = arg.api == FORTRAN ? hipblasSpmv<T, true> : hipblasSpmv<T, false>;
     auto hipblasSpmvFn_64
         = arg.api == FORTRAN_64 ? hipblasSpmv_64<T, true> : hipblasSpmv_64<T, false>;
@@ -178,6 +180,7 @@ void testing_spmv(const Arguments& arg)
     }
 
     T h_alpha = arg.get_alpha<T>();
+
     T h_beta  = arg.get_beta<T>();
 
     // Naming: `h` is in CPU (host) memory(eg hAp), `d` is in GPU (device) memory (eg dAp).
@@ -230,7 +233,7 @@ void testing_spmv(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSpmvFn, (handle, uplo, N, &h_alpha, dAp, dx, incx, &h_beta, dy, incy));
+        DAPI_CHECK(hipblasSpmvFn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dAp, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_spmv.hpp
+++ b/clients/include/blas2/testing_spmv.hpp
@@ -40,7 +40,7 @@ inline void testname_spmv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spmv_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSpmvFn = arg.api == FORTRAN ? hipblasSpmv<T, true> : hipblasSpmv<T, false>;
     auto hipblasSpmvFn_64
         = arg.api == FORTRAN_64 ? hipblasSpmv_64<T, true> : hipblasSpmv_64<T, false>;
@@ -148,7 +148,7 @@ void testing_spmv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spmv(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSpmvFn = arg.api == FORTRAN ? hipblasSpmv<T, true> : hipblasSpmv<T, false>;
     auto hipblasSpmvFn_64
         = arg.api == FORTRAN_64 ? hipblasSpmv_64<T, true> : hipblasSpmv_64<T, false>;
@@ -181,7 +181,7 @@ void testing_spmv(const Arguments& arg)
 
     T h_alpha = arg.get_alpha<T>();
 
-    T h_beta  = arg.get_beta<T>();
+    T h_beta = arg.get_beta<T>();
 
     // Naming: `h` is in CPU (host) memory(eg hAp), `d` is in GPU (device) memory (eg dAp).
     // Allocate host memory
@@ -233,7 +233,17 @@ void testing_spmv(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSpmvFn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dAp, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
+        DAPI_CHECK(hipblasSpmvFn,
+                   (handle,
+                    uplo,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dAp,
+                    dx,
+                    incx,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dy,
+                    incy));
 
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));
         CHECK_HIP_ERROR(dy.transfer_from(hy));

--- a/clients/include/blas2/testing_spmv_batched.hpp
+++ b/clients/include/blas2/testing_spmv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_spmv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spmv_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpmvBatchedFn
         = arg.api == FORTRAN ? hipblasSpmvBatched<T, true> : hipblasSpmvBatched<T, false>;
     auto hipblasSpmvBatchedFn_64
@@ -60,11 +61,11 @@ void testing_spmv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -250,6 +251,7 @@ void testing_spmv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spmv_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpmvBatchedFn
         = arg.api == FORTRAN ? hipblasSpmvBatched<T, true> : hipblasSpmvBatched<T, false>;
     auto hipblasSpmvBatchedFn_64
@@ -353,11 +355,11 @@ void testing_spmv_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dAp.ptr_on_device(),
                     dx.ptr_on_device(),
                     incx,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy.ptr_on_device(),
                     incy,
                     batch_count));

--- a/clients/include/blas2/testing_spmv_batched.hpp
+++ b/clients/include/blas2/testing_spmv_batched.hpp
@@ -61,7 +61,7 @@ void testing_spmv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const Ts h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
         const Ts* alpha = &h_alpha;
         const Ts* beta  = &h_beta;
         const Ts* one   = &h_one;

--- a/clients/include/blas2/testing_spmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_spmv_strided_batched.hpp
@@ -48,7 +48,7 @@ inline void testname_spmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_spmv_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSpmvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSpmvStridedBatched<T, true>
                                                              : hipblasSpmvStridedBatched<T, false>;
     auto hipblasSpmvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -319,7 +319,7 @@ void testing_spmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spmv_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSpmvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSpmvStridedBatched<T, true>
                                                              : hipblasSpmvStridedBatched<T, false>;
     auto hipblasSpmvStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas2/testing_spmv_strided_batched.hpp
+++ b/clients/include/blas2/testing_spmv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,7 @@ inline void testname_spmv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_spmv_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpmvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSpmvStridedBatched<T, true>
                                                              : hipblasSpmvStridedBatched<T, false>;
     auto hipblasSpmvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -71,11 +72,11 @@ void testing_spmv_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -318,6 +319,7 @@ void testing_spmv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spmv_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpmvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSpmvStridedBatched<T, true>
                                                              : hipblasSpmvStridedBatched<T, false>;
     auto hipblasSpmvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -430,13 +432,13 @@ void testing_spmv_strided_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dAp,
                     stride_A,
                     dx,
                     incx,
                     stride_x,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy,
                     incy,
                     stride_y,

--- a/clients/include/blas2/testing_spr.hpp
+++ b/clients/include/blas2/testing_spr.hpp
@@ -40,13 +40,13 @@ inline void testname_spr(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spr_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts             = hipblas_internal_type<T>;
     auto hipblasSprFn    = arg.api == FORTRAN ? hipblasSpr<T, true> : hipblasSpr<T, false>;
     auto hipblasSprFn_64 = arg.api == FORTRAN_64 ? hipblasSpr_64<T, true> : hipblasSpr_64<T, false>;
 
-    const Ts           h_alpha(1), h_zero(0);
-    const Ts*          alpha = &h_alpha;
-    const Ts*          zero  = &h_zero;
+    const Ts          h_alpha(1), h_zero(0);
+    const Ts*         alpha = &h_alpha;
+    const Ts*         zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -117,7 +117,7 @@ void testing_spr_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts             = hipblas_internal_type<T>;
     auto hipblasSprFn    = arg.api == FORTRAN ? hipblasSpr<T, true> : hipblasSpr<T, false>;
     auto hipblasSprFn_64 = arg.api == FORTRAN_64 ? hipblasSpr_64<T, true> : hipblasSpr_64<T, false>;
 

--- a/clients/include/blas2/testing_spr.hpp
+++ b/clients/include/blas2/testing_spr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,12 +40,13 @@ inline void testname_spr(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spr_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSprFn    = arg.api == FORTRAN ? hipblasSpr<T, true> : hipblasSpr<T, false>;
     auto hipblasSprFn_64 = arg.api == FORTRAN_64 ? hipblasSpr_64<T, true> : hipblasSpr_64<T, false>;
 
-    const T           h_alpha(1), h_zero(0);
-    const T*          alpha = &h_alpha;
-    const T*          zero  = &h_zero;
+    const Ts           h_alpha(1), h_zero(0);
+    const Ts*          alpha = &h_alpha;
+    const Ts*          zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -116,6 +117,7 @@ void testing_spr_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSprFn    = arg.api == FORTRAN ? hipblasSpr<T, true> : hipblasSpr<T, false>;
     auto hipblasSprFn_64 = arg.api == FORTRAN_64 ? hipblasSpr_64<T, true> : hipblasSpr_64<T, false>;
 
@@ -185,7 +187,7 @@ void testing_spr(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSprFn, (handle, uplo, N, &h_alpha, dx, incx, dAp));
+        DAPI_CHECK(hipblasSprFn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dAp));
 
         CHECK_HIP_ERROR(hAp_host.transfer_from(dAp));
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));

--- a/clients/include/blas2/testing_spr2.hpp
+++ b/clients/include/blas2/testing_spr2.hpp
@@ -40,14 +40,14 @@ inline void testname_spr2(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spr2_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSpr2Fn = arg.api == FORTRAN ? hipblasSpr2<T, true> : hipblasSpr2<T, false>;
     auto hipblasSpr2Fn_64
         = arg.api == FORTRAN_64 ? hipblasSpr2_64<T, true> : hipblasSpr2_64<T, false>;
 
-    const Ts           h_alpha(1), h_zero(0);
-    const Ts*          alpha = &h_alpha;
-    const Ts*          zero  = &h_zero;
+    const Ts          h_alpha(1), h_zero(0);
+    const Ts*         alpha = &h_alpha;
+    const Ts*         zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -126,7 +126,7 @@ void testing_spr2_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr2(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSpr2Fn = arg.api == FORTRAN ? hipblasSpr2<T, true> : hipblasSpr2<T, false>;
     auto hipblasSpr2Fn_64
         = arg.api == FORTRAN_64 ? hipblasSpr2_64<T, true> : hipblasSpr2_64<T, false>;
@@ -195,7 +195,8 @@ void testing_spr2(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSpr2Fn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dAp));
+        DAPI_CHECK(hipblasSpr2Fn,
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dAp));
 
         CHECK_HIP_ERROR(hAp_host.transfer_from(dAp));
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));

--- a/clients/include/blas2/testing_spr2.hpp
+++ b/clients/include/blas2/testing_spr2.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,13 +40,14 @@ inline void testname_spr2(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spr2_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpr2Fn = arg.api == FORTRAN ? hipblasSpr2<T, true> : hipblasSpr2<T, false>;
     auto hipblasSpr2Fn_64
         = arg.api == FORTRAN_64 ? hipblasSpr2_64<T, true> : hipblasSpr2_64<T, false>;
 
-    const T           h_alpha(1), h_zero(0);
-    const T*          alpha = &h_alpha;
-    const T*          zero  = &h_zero;
+    const Ts           h_alpha(1), h_zero(0);
+    const Ts*          alpha = &h_alpha;
+    const Ts*          zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -125,6 +126,7 @@ void testing_spr2_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr2(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpr2Fn = arg.api == FORTRAN ? hipblasSpr2<T, true> : hipblasSpr2<T, false>;
     auto hipblasSpr2Fn_64
         = arg.api == FORTRAN_64 ? hipblasSpr2_64<T, true> : hipblasSpr2_64<T, false>;
@@ -193,7 +195,7 @@ void testing_spr2(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSpr2Fn, (handle, uplo, N, &h_alpha, dx, incx, dy, incy, dAp));
+        DAPI_CHECK(hipblasSpr2Fn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dAp));
 
         CHECK_HIP_ERROR(hAp_host.transfer_from(dAp));
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));

--- a/clients/include/blas2/testing_spr2_batched.hpp
+++ b/clients/include/blas2/testing_spr2_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,14 +41,15 @@ inline void testname_spr2_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spr2_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpr2BatchedFn
         = arg.api == FORTRAN ? hipblasSpr2Batched<T, true> : hipblasSpr2Batched<T, false>;
     auto hipblasSpr2BatchedFn_64
         = arg.api == FORTRAN_64 ? hipblasSpr2Batched_64<T, true> : hipblasSpr2Batched_64<T, false>;
 
-    const T           h_alpha(1), h_zero(0);
-    const T*          alpha = &h_alpha;
-    const T*          zero  = &h_zero;
+    const Ts           h_alpha(1), h_zero(0);
+    const Ts*          alpha = &h_alpha;
+    const Ts*          zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -200,6 +201,7 @@ void testing_spr2_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr2_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpr2BatchedFn
         = arg.api == FORTRAN ? hipblasSpr2Batched<T, true> : hipblasSpr2Batched<T, false>;
     auto hipblasSpr2BatchedFn_64
@@ -288,7 +290,7 @@ void testing_spr2_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx.ptr_on_device(),
                     incx,
                     dy.ptr_on_device(),

--- a/clients/include/blas2/testing_spr2_batched.hpp
+++ b/clients/include/blas2/testing_spr2_batched.hpp
@@ -47,9 +47,9 @@ void testing_spr2_batched_bad_arg(const Arguments& arg)
     auto hipblasSpr2BatchedFn_64
         = arg.api == FORTRAN_64 ? hipblasSpr2Batched_64<T, true> : hipblasSpr2Batched_64<T, false>;
 
-    const Ts           h_alpha(1), h_zero(0);
-    const Ts*          alpha = &h_alpha;
-    const Ts*          zero  = &h_zero;
+    const Ts          h_alpha(1), h_zero(0);
+    const Ts*         alpha = &h_alpha;
+    const Ts*         zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})

--- a/clients/include/blas2/testing_spr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_spr2_strided_batched.hpp
@@ -41,16 +41,16 @@ inline void testname_spr2_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_spr2_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSpr2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSpr2StridedBatched<T, true>
                                                              : hipblasSpr2StridedBatched<T, false>;
     auto hipblasSpr2StridedBatchedFn_64 = arg.api == FORTRAN_64
                                               ? hipblasSpr2StridedBatched_64<T, true>
                                               : hipblasSpr2StridedBatched_64<T, false>;
 
-    const Ts           h_alpha(1), h_zero(0);
-    const Ts*          alpha = &h_alpha;
-    const Ts*          zero  = &h_zero;
+    const Ts          h_alpha(1), h_zero(0);
+    const Ts*         alpha = &h_alpha;
+    const Ts*         zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -266,7 +266,7 @@ void testing_spr2_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr2_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSpr2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSpr2StridedBatched<T, true>
                                                              : hipblasSpr2StridedBatched<T, false>;
     auto hipblasSpr2StridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas2/testing_spr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_spr2_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,15 +41,16 @@ inline void testname_spr2_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_spr2_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpr2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSpr2StridedBatched<T, true>
                                                              : hipblasSpr2StridedBatched<T, false>;
     auto hipblasSpr2StridedBatchedFn_64 = arg.api == FORTRAN_64
                                               ? hipblasSpr2StridedBatched_64<T, true>
                                               : hipblasSpr2StridedBatched_64<T, false>;
 
-    const T           h_alpha(1), h_zero(0);
-    const T*          alpha = &h_alpha;
-    const T*          zero  = &h_zero;
+    const Ts           h_alpha(1), h_zero(0);
+    const Ts*          alpha = &h_alpha;
+    const Ts*          zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -265,6 +266,7 @@ void testing_spr2_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr2_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSpr2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSpr2StridedBatched<T, true>
                                                              : hipblasSpr2StridedBatched<T, false>;
     auto hipblasSpr2StridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -373,7 +375,7 @@ void testing_spr2_strided_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx,
                     incx,
                     stride_x,

--- a/clients/include/blas2/testing_spr_batched.hpp
+++ b/clients/include/blas2/testing_spr_batched.hpp
@@ -46,9 +46,9 @@ void testing_spr_batched_bad_arg(const Arguments& arg)
     auto hipblasSprBatchedFn_64
         = arg.api == FORTRAN_64 ? hipblasSprBatched_64<T, true> : hipblasSprBatched_64<T, false>;
 
-    const Ts           h_alpha(1), h_zero(0);
-    const Ts*          alpha = &h_alpha;
-    const Ts*          zero  = &h_zero;
+    const Ts          h_alpha(1), h_zero(0);
+    const Ts*         alpha = &h_alpha;
+    const Ts*         zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})

--- a/clients/include/blas2/testing_spr_batched.hpp
+++ b/clients/include/blas2/testing_spr_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,14 +40,15 @@ inline void testname_spr_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_spr_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSprBatchedFn
         = arg.api == FORTRAN ? hipblasSprBatched<T, true> : hipblasSprBatched<T, false>;
     auto hipblasSprBatchedFn_64
         = arg.api == FORTRAN_64 ? hipblasSprBatched_64<T, true> : hipblasSprBatched_64<T, false>;
 
-    const T           h_alpha(1), h_zero(0);
-    const T*          alpha = &h_alpha;
-    const T*          zero  = &h_zero;
+    const Ts           h_alpha(1), h_zero(0);
+    const Ts*          alpha = &h_alpha;
+    const Ts*          zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -138,6 +139,7 @@ void testing_spr_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSprBatchedFn
         = arg.api == FORTRAN ? hipblasSprBatched<T, true> : hipblasSprBatched<T, false>;
     auto hipblasSprBatchedFn_64
@@ -222,7 +224,7 @@ void testing_spr_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx.ptr_on_device(),
                     incx,
                     dAp.ptr_on_device(),

--- a/clients/include/blas2/testing_spr_strided_batched.hpp
+++ b/clients/include/blas2/testing_spr_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,15 +41,16 @@ inline void testname_spr_strided_batched(const Arguments& arg, std::string& name
 template <typename T>
 void testing_spr_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSprStridedBatchedFn    = arg.api == FORTRAN ? hipblasSprStridedBatched<T, true>
                                                             : hipblasSprStridedBatched<T, false>;
     auto hipblasSprStridedBatchedFn_64 = arg.api == FORTRAN_64
                                              ? hipblasSprStridedBatched_64<T, true>
                                              : hipblasSprStridedBatched_64<T, false>;
 
-    const T           h_alpha(1), h_zero(0);
-    const T*          alpha = &h_alpha;
-    const T*          zero  = &h_zero;
+    const Ts           h_alpha(1), h_zero(0);
+    const Ts*          alpha = &h_alpha;
+    const Ts*          zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -149,6 +150,7 @@ void testing_spr_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSprStridedBatchedFn    = arg.api == FORTRAN ? hipblasSprStridedBatched<T, true>
                                                             : hipblasSprStridedBatched<T, false>;
     auto hipblasSprStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -235,7 +237,7 @@ void testing_spr_strided_batched(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSprStridedBatchedFn,
-                   (handle, uplo, N, &h_alpha, dx, incx, stride_x, dAp, stride_A, batch_count));
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, stride_x, dAp, stride_A, batch_count));
 
         CHECK_HIP_ERROR(hAp_host.transfer_from(dAp));
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));

--- a/clients/include/blas2/testing_spr_strided_batched.hpp
+++ b/clients/include/blas2/testing_spr_strided_batched.hpp
@@ -41,16 +41,16 @@ inline void testname_spr_strided_batched(const Arguments& arg, std::string& name
 template <typename T>
 void testing_spr_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                           = hipblas_internal_type<T>;
     auto hipblasSprStridedBatchedFn    = arg.api == FORTRAN ? hipblasSprStridedBatched<T, true>
                                                             : hipblasSprStridedBatched<T, false>;
     auto hipblasSprStridedBatchedFn_64 = arg.api == FORTRAN_64
                                              ? hipblasSprStridedBatched_64<T, true>
                                              : hipblasSprStridedBatched_64<T, false>;
 
-    const Ts           h_alpha(1), h_zero(0);
-    const Ts*          alpha = &h_alpha;
-    const Ts*          zero  = &h_zero;
+    const Ts          h_alpha(1), h_zero(0);
+    const Ts*         alpha = &h_alpha;
+    const Ts*         zero  = &h_zero;
     hipblasFillMode_t uplo  = HIPBLAS_FILL_MODE_UPPER;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -150,7 +150,7 @@ void testing_spr_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_spr_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                           = hipblas_internal_type<T>;
     auto hipblasSprStridedBatchedFn    = arg.api == FORTRAN ? hipblasSprStridedBatched<T, true>
                                                             : hipblasSprStridedBatched<T, false>;
     auto hipblasSprStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -237,7 +237,16 @@ void testing_spr_strided_batched(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSprStridedBatchedFn,
-                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, stride_x, dAp, stride_A, batch_count));
+                   (handle,
+                    uplo,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dx,
+                    incx,
+                    stride_x,
+                    dAp,
+                    stride_A,
+                    batch_count));
 
         CHECK_HIP_ERROR(hAp_host.transfer_from(dAp));
         CHECK_HIP_ERROR(dAp.transfer_from(hAp));

--- a/clients/include/blas2/testing_symv.hpp
+++ b/clients/include/blas2/testing_symv.hpp
@@ -41,7 +41,7 @@ inline void testname_symv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_symv_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSymvFn = arg.api == FORTRAN ? hipblasSymv<T, true> : hipblasSymv<T, false>;
     auto hipblasSymvFn_64
         = arg.api == FORTRAN_64 ? hipblasSymv_64<T, true> : hipblasSymv_64<T, false>;
@@ -150,7 +150,7 @@ void testing_symv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symv(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSymvFn = arg.api == FORTRAN ? hipblasSymv<T, true> : hipblasSymv<T, false>;
     auto hipblasSymvFn_64
         = arg.api == FORTRAN_64 ? hipblasSymv_64<T, true> : hipblasSymv_64<T, false>;
@@ -224,7 +224,17 @@ void testing_symv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSymvFn,
-                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
+                   (handle,
+                    uplo,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dx,
+                    incx,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dy,
+                    incy));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));

--- a/clients/include/blas2/testing_symv.hpp
+++ b/clients/include/blas2/testing_symv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_symv(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_symv_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymvFn = arg.api == FORTRAN ? hipblasSymv<T, true> : hipblasSymv<T, false>;
     auto hipblasSymvFn_64
         = arg.api == FORTRAN_64 ? hipblasSymv_64<T, true> : hipblasSymv_64<T, false>;
@@ -58,11 +59,11 @@ void testing_symv_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -149,6 +150,7 @@ void testing_symv_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symv(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymvFn = arg.api == FORTRAN ? hipblasSymv<T, true> : hipblasSymv<T, false>;
     auto hipblasSymvFn_64
         = arg.api == FORTRAN_64 ? hipblasSymv_64<T, true> : hipblasSymv_64<T, false>;
@@ -222,7 +224,7 @@ void testing_symv(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSymvFn,
-                   (handle, uplo, N, &h_alpha, dA, lda, dx, incx, &h_beta, dy, incy));
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dx, incx, reinterpret_cast<Ts*>(&h_beta), dy, incy));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hy_host.transfer_from(dy));

--- a/clients/include/blas2/testing_symv_batched.hpp
+++ b/clients/include/blas2/testing_symv_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_symv_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_symv_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymvBatchedFn
         = arg.api == FORTRAN ? hipblasSymvBatched<T, true> : hipblasSymvBatched<T, false>;
     auto hipblasSymvBatchedFn_64
@@ -60,11 +61,11 @@ void testing_symv_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -262,6 +263,7 @@ void testing_symv_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symv_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymvBatchedFn
         = arg.api == FORTRAN ? hipblasSymvBatched<T, true> : hipblasSymvBatched<T, false>;
     auto hipblasSymvBatchedFn_64
@@ -361,12 +363,12 @@ void testing_symv_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dx.ptr_on_device(),
                     incx,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy.ptr_on_device(),
                     incy,
                     batch_count));

--- a/clients/include/blas2/testing_symv_strided_batched.hpp
+++ b/clients/include/blas2/testing_symv_strided_batched.hpp
@@ -49,7 +49,7 @@ inline void testname_symv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_symv_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSymvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSymvStridedBatched<T, true>
                                                              : hipblasSymvStridedBatched<T, false>;
     auto hipblasSymvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -335,7 +335,7 @@ void testing_symv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symv_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSymvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSymvStridedBatched<T, true>
                                                              : hipblasSymvStridedBatched<T, false>;
     auto hipblasSymvStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas2/testing_symv_strided_batched.hpp
+++ b/clients/include/blas2/testing_symv_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,7 @@ inline void testname_symv_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_symv_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSymvStridedBatched<T, true>
                                                              : hipblasSymvStridedBatched<T, false>;
     auto hipblasSymvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -73,11 +74,11 @@ void testing_symv_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
 
-        const T  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* beta  = &h_beta;
-        const T* one   = &h_one;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* beta  = &h_beta;
+        const Ts* one   = &h_one;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -334,6 +335,7 @@ void testing_symv_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symv_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymvStridedBatchedFn    = arg.api == FORTRAN ? hipblasSymvStridedBatched<T, true>
                                                              : hipblasSymvStridedBatched<T, false>;
     auto hipblasSymvStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -442,14 +444,14 @@ void testing_symv_strided_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dx,
                     incx,
                     stride_x,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dy,
                     incy,
                     stride_y,

--- a/clients/include/blas2/testing_syr.hpp
+++ b/clients/include/blas2/testing_syr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_syr(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrFn    = arg.api == FORTRAN ? hipblasSyr<T, true> : hipblasSyr<T, false>;
     auto hipblasSyrFn_64 = arg.api == FORTRAN_64 ? hipblasSyr_64<T, true> : hipblasSyr_64<T, false>;
 
@@ -55,9 +56,9 @@ void testing_syr_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -116,6 +117,7 @@ void testing_syr_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrFn    = arg.api == FORTRAN ? hipblasSyr<T, true> : hipblasSyr<T, false>;
     auto hipblasSyrFn_64 = arg.api == FORTRAN_64 ? hipblasSyr_64<T, true> : hipblasSyr_64<T, false>;
 
@@ -180,7 +182,7 @@ void testing_syr(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSyrFn, (handle, uplo, N, &h_alpha, dx, incx, dA, lda));
+        DAPI_CHECK(hipblasSyrFn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dA, lda));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas2/testing_syr.hpp
+++ b/clients/include/blas2/testing_syr.hpp
@@ -40,7 +40,7 @@ inline void testname_syr(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts             = hipblas_internal_type<T>;
     auto hipblasSyrFn    = arg.api == FORTRAN ? hipblasSyr<T, true> : hipblasSyr<T, false>;
     auto hipblasSyrFn_64 = arg.api == FORTRAN_64 ? hipblasSyr_64<T, true> : hipblasSyr_64<T, false>;
 
@@ -117,7 +117,7 @@ void testing_syr_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts             = hipblas_internal_type<T>;
     auto hipblasSyrFn    = arg.api == FORTRAN ? hipblasSyr<T, true> : hipblasSyr<T, false>;
     auto hipblasSyrFn_64 = arg.api == FORTRAN_64 ? hipblasSyr_64<T, true> : hipblasSyr_64<T, false>;
 
@@ -182,7 +182,8 @@ void testing_syr(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSyrFn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dA, lda));
+        DAPI_CHECK(hipblasSyrFn,
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dA, lda));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas2/testing_syr2.hpp
+++ b/clients/include/blas2/testing_syr2.hpp
@@ -40,7 +40,7 @@ inline void testname_syr2(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr2_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSyr2Fn = arg.api == FORTRAN ? hipblasSyr2<T, true> : hipblasSyr2<T, false>;
     auto hipblasSyr2Fn_64
         = arg.api == FORTRAN_64 ? hipblasSyr2_64<T, true> : hipblasSyr2_64<T, false>;
@@ -135,7 +135,7 @@ void testing_syr2_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSyr2Fn = arg.api == FORTRAN ? hipblasSyr2<T, true> : hipblasSyr2<T, false>;
     auto hipblasSyr2Fn_64
         = arg.api == FORTRAN_64 ? hipblasSyr2_64<T, true> : hipblasSyr2_64<T, false>;
@@ -208,7 +208,8 @@ void testing_syr2(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSyr2Fn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
+        DAPI_CHECK(hipblasSyr2Fn,
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas2/testing_syr2.hpp
+++ b/clients/include/blas2/testing_syr2.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_syr2(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr2_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2Fn = arg.api == FORTRAN ? hipblasSyr2<T, true> : hipblasSyr2<T, false>;
     auto hipblasSyr2Fn_64
         = arg.api == FORTRAN_64 ? hipblasSyr2_64<T, true> : hipblasSyr2_64<T, false>;
@@ -57,9 +58,9 @@ void testing_syr2_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -134,6 +135,7 @@ void testing_syr2_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2Fn = arg.api == FORTRAN ? hipblasSyr2<T, true> : hipblasSyr2<T, false>;
     auto hipblasSyr2Fn_64
         = arg.api == FORTRAN_64 ? hipblasSyr2_64<T, true> : hipblasSyr2_64<T, false>;
@@ -206,7 +208,7 @@ void testing_syr2(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(hipblasSyr2Fn, (handle, uplo, N, &h_alpha, dx, incx, dy, incy, dA, lda));
+        DAPI_CHECK(hipblasSyr2Fn, (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, dy, incy, dA, lda));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas2/testing_syr2_batched.hpp
+++ b/clients/include/blas2/testing_syr2_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_syr2_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr2_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2BatchedFn
         = arg.api == FORTRAN ? hipblasSyr2Batched<T, true> : hipblasSyr2Batched<T, false>;
     auto hipblasSyr2BatchedFn_64
@@ -60,9 +61,9 @@ void testing_syr2_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -208,6 +209,7 @@ void testing_syr2_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2BatchedFn
         = arg.api == FORTRAN ? hipblasSyr2Batched<T, true> : hipblasSyr2Batched<T, false>;
     auto hipblasSyr2BatchedFn_64
@@ -296,7 +298,7 @@ void testing_syr2_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx.ptr_on_device(),
                     incx,
                     dy.ptr_on_device(),

--- a/clients/include/blas2/testing_syr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_syr2_strided_batched.hpp
@@ -48,7 +48,7 @@ inline void testname_syr2_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_syr2_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSyr2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSyr2StridedBatched<T, true>
                                                              : hipblasSyr2StridedBatched<T, false>;
     auto hipblasSyr2StridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -281,7 +281,7 @@ void testing_syr2_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSyr2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSyr2StridedBatched<T, true>
                                                              : hipblasSyr2StridedBatched<T, false>;
     auto hipblasSyr2StridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas2/testing_syr2_strided_batched.hpp
+++ b/clients/include/blas2/testing_syr2_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,7 @@ inline void testname_syr2_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_syr2_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSyr2StridedBatched<T, true>
                                                              : hipblasSyr2StridedBatched<T, false>;
     auto hipblasSyr2StridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -71,9 +72,9 @@ void testing_syr2_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -280,6 +281,7 @@ void testing_syr2_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSyr2StridedBatched<T, true>
                                                              : hipblasSyr2StridedBatched<T, false>;
     auto hipblasSyr2StridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -388,7 +390,7 @@ void testing_syr2_strided_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx,
                     incx,
                     stride_x,

--- a/clients/include/blas2/testing_syr_batched.hpp
+++ b/clients/include/blas2/testing_syr_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_syr_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrBatchedFn
         = arg.api == FORTRAN ? hipblasSyrBatched<T, true> : hipblasSyrBatched<T, false>;
     auto hipblasSyrBatchedFn_64
@@ -59,9 +60,9 @@ void testing_syr_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -162,6 +163,7 @@ void testing_syr_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrBatchedFn
         = arg.api == FORTRAN ? hipblasSyrBatched<T, true> : hipblasSyrBatched<T, false>;
     auto hipblasSyrBatchedFn_64
@@ -241,7 +243,7 @@ void testing_syr_batched(const Arguments& arg)
                    (handle,
                     uplo,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dx.ptr_on_device(),
                     incx,
                     dA.ptr_on_device(),

--- a/clients/include/blas2/testing_syr_strided_batched.hpp
+++ b/clients/include/blas2/testing_syr_strided_batched.hpp
@@ -41,7 +41,7 @@ inline void testname_syr_strided_batched(const Arguments& arg, std::string& name
 template <typename T>
 void testing_syr_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                           = hipblas_internal_type<T>;
     auto hipblasSyrStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrStridedBatched<T, true>
                                                             : hipblasSyrStridedBatched<T, false>;
     auto hipblasSyrStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -168,7 +168,7 @@ void testing_syr_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                           = hipblas_internal_type<T>;
     auto hipblasSyrStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrStridedBatched<T, true>
                                                             : hipblasSyrStridedBatched<T, false>;
     auto hipblasSyrStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -261,7 +261,17 @@ void testing_syr_strided_batched(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSyrStridedBatchedFn,
-                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, stride_x, dA, lda, stride_A, batch_count));
+                   (handle,
+                    uplo,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dx,
+                    incx,
+                    stride_x,
+                    dA,
+                    lda,
+                    stride_A,
+                    batch_count));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas2/testing_syr_strided_batched.hpp
+++ b/clients/include/blas2/testing_syr_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_syr_strided_batched(const Arguments& arg, std::string& name
 template <typename T>
 void testing_syr_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrStridedBatched<T, true>
                                                             : hipblasSyrStridedBatched<T, false>;
     auto hipblasSyrStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -62,9 +63,9 @@ void testing_syr_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> d_alpha(1), d_zero(1);
 
-        const T  h_alpha(1), h_zero(0);
-        const T* alpha = &h_alpha;
-        const T* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -167,6 +168,7 @@ void testing_syr_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrStridedBatched<T, true>
                                                             : hipblasSyrStridedBatched<T, false>;
     auto hipblasSyrStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -259,7 +261,7 @@ void testing_syr_strided_batched(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSyrStridedBatchedFn,
-                   (handle, uplo, N, &h_alpha, dx, incx, stride_x, dA, lda, stride_A, batch_count));
+                   (handle, uplo, N, reinterpret_cast<Ts*>(&h_alpha), dx, incx, stride_x, dA, lda, stride_A, batch_count));
 
         CHECK_HIP_ERROR(hA_host.transfer_from(dA));
         CHECK_HIP_ERROR(dA.transfer_from(hA));

--- a/clients/include/blas3/testing_geam.hpp
+++ b/clients/include/blas3/testing_geam.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +44,7 @@ inline void testname_geam(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_geam_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGeamFn = arg.api == FORTRAN ? hipblasGeam<T, true> : hipblasGeam<T, false>;
     auto hipblasGeamFn_64
         = arg.api == FORTRAN_64 ? hipblasGeam_64<T, true> : hipblasGeam_64<T, false>;
@@ -70,11 +71,11 @@ void testing_geam_bad_arg(const Arguments& arg)
     device_matrix<T> dC(M, N, ldc);
 
     device_vector<T> d_alpha(1), d_beta(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -237,6 +238,7 @@ void testing_geam_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_geam(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGeamFn = arg.api == FORTRAN ? hipblasGeam<T, true> : hipblasGeam<T, false>;
     auto hipblasGeamFn_64
         = arg.api == FORTRAN_64 ? hipblasGeam_64<T, true> : hipblasGeam_64<T, false>;
@@ -329,7 +331,7 @@ void testing_geam(const Arguments& arg)
             CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
             DAPI_CHECK(
                 hipblasGeamFn,
-                (handle, transA, transB, M, N, &h_alpha, dA, lda, &h_beta, dB, ldb, dC, ldc));
+                (handle, transA, transB, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, reinterpret_cast<Ts*>(&h_beta), dB, ldb, dC, ldc));
 
             CHECK_HIP_ERROR(hC_host.transfer_from(dC));
         }

--- a/clients/include/blas3/testing_geam.hpp
+++ b/clients/include/blas3/testing_geam.hpp
@@ -44,7 +44,7 @@ inline void testname_geam(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_geam_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasGeamFn = arg.api == FORTRAN ? hipblasGeam<T, true> : hipblasGeam<T, false>;
     auto hipblasGeamFn_64
         = arg.api == FORTRAN_64 ? hipblasGeam_64<T, true> : hipblasGeam_64<T, false>;
@@ -71,7 +71,7 @@ void testing_geam_bad_arg(const Arguments& arg)
     device_matrix<T> dC(M, N, ldc);
 
     device_vector<T> d_alpha(1), d_beta(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -238,7 +238,7 @@ void testing_geam_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_geam(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasGeamFn = arg.api == FORTRAN ? hipblasGeam<T, true> : hipblasGeam<T, false>;
     auto hipblasGeamFn_64
         = arg.api == FORTRAN_64 ? hipblasGeam_64<T, true> : hipblasGeam_64<T, false>;
@@ -329,9 +329,20 @@ void testing_geam(const Arguments& arg)
         {
             // &h_alpha and &h_beta are host pointers
             CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-            DAPI_CHECK(
-                hipblasGeamFn,
-                (handle, transA, transB, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, reinterpret_cast<Ts*>(&h_beta), dB, ldb, dC, ldc));
+            DAPI_CHECK(hipblasGeamFn,
+                       (handle,
+                        transA,
+                        transB,
+                        M,
+                        N,
+                        reinterpret_cast<Ts*>(&h_alpha),
+                        dA,
+                        lda,
+                        reinterpret_cast<Ts*>(&h_beta),
+                        dB,
+                        ldb,
+                        dC,
+                        ldc));
 
             CHECK_HIP_ERROR(hC_host.transfer_from(dC));
         }

--- a/clients/include/blas3/testing_geam_batched.hpp
+++ b/clients/include/blas3/testing_geam_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -53,6 +53,7 @@ inline void testname_geam_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_geam_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGeamBatchedFn
         = arg.api == FORTRAN ? hipblasGeamBatched<T, true> : hipblasGeamBatched<T, false>;
     auto hipblasGeamBatchedFn_64
@@ -81,11 +82,11 @@ void testing_geam_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(M, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -395,6 +396,7 @@ void testing_geam_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_geam_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGeamBatchedFn
         = arg.api == FORTRAN ? hipblasGeamBatched<T, true> : hipblasGeamBatched<T, false>;
     auto hipblasGeamBatchedFn_64
@@ -503,10 +505,10 @@ void testing_geam_batched(const Arguments& arg)
                         transB,
                         M,
                         N,
-                        &h_alpha,
+                        reinterpret_cast<Ts*>(&h_alpha),
                         dA.ptr_on_device(),
                         lda,
-                        &h_beta,
+                        reinterpret_cast<Ts*>(&h_beta),
                         dB.ptr_on_device(),
                         ldb,
                         dC.ptr_on_device(),

--- a/clients/include/blas3/testing_geam_batched.hpp
+++ b/clients/include/blas3/testing_geam_batched.hpp
@@ -82,7 +82,7 @@ void testing_geam_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(M, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;

--- a/clients/include/blas3/testing_geam_strided_batched.hpp
+++ b/clients/include/blas3/testing_geam_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,6 +54,7 @@ inline void testname_geam_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_geam_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGeamStridedBatchedFn    = arg.api == FORTRAN ? hipblasGeamStridedBatched<T, true>
                                                              : hipblasGeamStridedBatched<T, false>;
     auto hipblasGeamStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -87,11 +88,11 @@ void testing_geam_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -452,6 +453,7 @@ void testing_geam_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_geam_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGeamStridedBatchedFn    = arg.api == FORTRAN ? hipblasGeamStridedBatched<T, true>
                                                              : hipblasGeamStridedBatched<T, false>;
     auto hipblasGeamStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -568,11 +570,11 @@ void testing_geam_strided_batched(const Arguments& arg)
                         transB,
                         M,
                         N,
-                        &h_alpha,
+                        reinterpret_cast<Ts*>(&h_alpha),
                         dA,
                         lda,
                         stride_A,
-                        &h_beta,
+                        reinterpret_cast<Ts*>(&h_beta),
                         dB,
                         ldb,
                         stride_B,

--- a/clients/include/blas3/testing_geam_strided_batched.hpp
+++ b/clients/include/blas3/testing_geam_strided_batched.hpp
@@ -54,7 +54,7 @@ inline void testname_geam_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_geam_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasGeamStridedBatchedFn    = arg.api == FORTRAN ? hipblasGeamStridedBatched<T, true>
                                                              : hipblasGeamStridedBatched<T, false>;
     auto hipblasGeamStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -88,7 +88,7 @@ void testing_geam_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -453,7 +453,7 @@ void testing_geam_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_geam_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasGeamStridedBatchedFn    = arg.api == FORTRAN ? hipblasGeamStridedBatched<T, true>
                                                              : hipblasGeamStridedBatched<T, false>;
     auto hipblasGeamStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas3/testing_gemm.hpp
+++ b/clients/include/blas3/testing_gemm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ inline void testname_gemm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gemm_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGemmFn = arg.api == FORTRAN ? hipblasGemm<T, true> : hipblasGemm<T, false>;
     auto hipblasGemmFn_64
         = arg.api == FORTRAN_64 ? hipblasGemm_64<T, true> : hipblasGemm_64<T, false>;
@@ -78,15 +79,15 @@ void testing_gemm_bad_arg(const Arguments& arg)
     device_matrix<T> dC(M, N, ldc);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    T                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
         h_one = float_to_half(1.0f);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -268,6 +269,7 @@ void testing_gemm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemm(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGemmFn = arg.api == FORTRAN ? hipblasGemm<T, true> : hipblasGemm<T, false>;
     auto hipblasGemmFn_64
         = arg.api == FORTRAN_64 ? hipblasGemm_64<T, true> : hipblasGemm_64<T, false>;
@@ -365,7 +367,7 @@ void testing_gemm(const Arguments& arg)
 
         // library interface
         DAPI_CHECK(hipblasGemmFn,
-                   (handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+                   (handle, transA, transB, M, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));
@@ -437,7 +439,7 @@ void testing_gemm(const Arguments& arg)
 
             DAPI_DISPATCH(
                 hipblasGemmFn,
-                (handle, transA, transB, M, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+                (handle, transA, transB, M, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 

--- a/clients/include/blas3/testing_gemm.hpp
+++ b/clients/include/blas3/testing_gemm.hpp
@@ -51,7 +51,7 @@ inline void testname_gemm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gemm_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasGemmFn = arg.api == FORTRAN ? hipblasGemm<T, true> : hipblasGemm<T, false>;
     auto hipblasGemmFn_64
         = arg.api == FORTRAN_64 ? hipblasGemm_64<T, true> : hipblasGemm_64<T, false>;
@@ -79,7 +79,7 @@ void testing_gemm_bad_arg(const Arguments& arg)
     device_matrix<T> dC(M, N, ldc);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts               h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
         h_one = float_to_half(1.0f);
@@ -269,7 +269,7 @@ void testing_gemm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemm(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasGemmFn = arg.api == FORTRAN ? hipblasGemm<T, true> : hipblasGemm<T, false>;
     auto hipblasGemmFn_64
         = arg.api == FORTRAN_64 ? hipblasGemm_64<T, true> : hipblasGemm_64<T, false>;
@@ -367,7 +367,20 @@ void testing_gemm(const Arguments& arg)
 
         // library interface
         DAPI_CHECK(hipblasGemmFn,
-                   (handle, transA, transB, M, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
+                   (handle,
+                    transA,
+                    transB,
+                    M,
+                    N,
+                    K,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dC,
+                    ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));
@@ -437,9 +450,21 @@ void testing_gemm(const Arguments& arg)
             if(iter == arg.cold_iters)
                 gpu_time_used = get_time_us_sync(stream);
 
-            DAPI_DISPATCH(
-                hipblasGemmFn,
-                (handle, transA, transB, M, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
+            DAPI_DISPATCH(hipblasGemmFn,
+                          (handle,
+                           transA,
+                           transB,
+                           M,
+                           N,
+                           K,
+                           reinterpret_cast<Ts*>(&h_alpha),
+                           dA,
+                           lda,
+                           dB,
+                           ldb,
+                           reinterpret_cast<Ts*>(&h_beta),
+                           dC,
+                           ldc));
         }
         gpu_time_used = get_time_us_sync(stream) - gpu_time_used;
 

--- a/clients/include/blas3/testing_gemm_batched.hpp
+++ b/clients/include/blas3/testing_gemm_batched.hpp
@@ -83,7 +83,7 @@ void testing_gemm_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(M, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts               h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
         h_one = float_to_half(1.0f);

--- a/clients/include/blas3/testing_gemm_batched.hpp
+++ b/clients/include/blas3/testing_gemm_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -53,6 +53,7 @@ inline void testname_gemm_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_gemm_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGemmBatchedFn
         = arg.api == FORTRAN ? hipblasGemmBatched<T, true> : hipblasGemmBatched<T, false>;
     auto hipblasGemmBatchedFn_64
@@ -82,15 +83,15 @@ void testing_gemm_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(M, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    T                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
         h_one = float_to_half(1.0f);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -386,6 +387,7 @@ void testing_gemm_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemm_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGemmBatchedFn
         = arg.api == FORTRAN ? hipblasGemmBatched<T, true> : hipblasGemmBatched<T, false>;
     auto hipblasGemmBatchedFn_64
@@ -514,9 +516,9 @@ void testing_gemm_batched(const Arguments& arg)
                     N,
                     K,
                     d_alpha,
-                    (const T* const*)dA.ptr_on_device(),
+                    dA.ptr_on_device(),
                     lda,
-                    (const T* const*)dB.ptr_on_device(),
+                    dB.ptr_on_device(),
                     ldb,
                     d_beta,
                     dC.ptr_on_device(),
@@ -535,12 +537,12 @@ void testing_gemm_batched(const Arguments& arg)
                     M,
                     N,
                     K,
-                    &h_alpha,
-                    (const T* const*)dA.ptr_on_device(),
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA.ptr_on_device(),
                     lda,
-                    (const T* const*)dB.ptr_on_device(),
+                    dB.ptr_on_device(),
                     ldb,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC.ptr_on_device(),
                     ldc,
                     batch_count));
@@ -593,12 +595,12 @@ void testing_gemm_batched(const Arguments& arg)
                            M,
                            N,
                            K,
-                           &h_alpha,
-                           (const T* const*)dA.ptr_on_device(),
+                           reinterpret_cast<Ts*>(&h_alpha),
+                           dA.ptr_on_device(),
                            lda,
-                           (const T* const*)dB.ptr_on_device(),
+                           dB.ptr_on_device(),
                            ldb,
-                           &h_beta,
+                           reinterpret_cast<Ts*>(&h_beta),
                            dC.ptr_on_device(),
                            ldc,
                            batch_count));

--- a/clients/include/blas3/testing_gemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_gemm_strided_batched.hpp
@@ -54,7 +54,7 @@ inline void testname_gemm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_gemm_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasGemmStridedBatchedFn    = arg.api == FORTRAN ? hipblasGemmStridedBatched<T, true>
                                                              : hipblasGemmStridedBatched<T, false>;
     auto hipblasGemmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -89,7 +89,7 @@ void testing_gemm_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts               h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
         h_one = float_to_half(1.0f);
@@ -438,7 +438,7 @@ void testing_gemm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemm_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasGemmStridedBatchedFn    = arg.api == FORTRAN ? hipblasGemmStridedBatched<T, true>
                                                              : hipblasGemmStridedBatched<T, false>;
     auto hipblasGemmStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas3/testing_gemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_gemm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,6 +54,7 @@ inline void testname_gemm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_gemm_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGemmStridedBatchedFn    = arg.api == FORTRAN ? hipblasGemmStridedBatched<T, true>
                                                              : hipblasGemmStridedBatched<T, false>;
     auto hipblasGemmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -88,15 +89,15 @@ void testing_gemm_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    T                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
         h_one = float_to_half(1.0f);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -437,6 +438,7 @@ void testing_gemm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_gemm_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasGemmStridedBatchedFn    = arg.api == FORTRAN ? hipblasGemmStridedBatched<T, true>
                                                              : hipblasGemmStridedBatched<T, false>;
     auto hipblasGemmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -560,14 +562,14 @@ void testing_gemm_strided_batched(const Arguments& arg)
                     M,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dB,
                     ldb,
                     stride_B,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC,
                     ldc,
                     stride_C,
@@ -656,14 +658,14 @@ void testing_gemm_strided_batched(const Arguments& arg)
                            M,
                            N,
                            K,
-                           &h_alpha,
+                           reinterpret_cast<Ts*>(&h_alpha),
                            dA,
                            lda,
                            stride_A,
                            dB,
                            ldb,
                            stride_B,
-                           &h_beta,
+                           reinterpret_cast<Ts*>(&h_beta),
                            dC,
                            ldc,
                            stride_C,

--- a/clients/include/blas3/testing_hemm.hpp
+++ b/clients/include/blas3/testing_hemm.hpp
@@ -41,7 +41,7 @@ inline void testname_hemm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hemm_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasHemmFn = arg.api == FORTRAN ? hipblasHemm<T, true> : hipblasHemm<T, false>;
     auto hipblasHemmFn_64
         = arg.api == FORTRAN_64 ? hipblasHemm_64<T, true> : hipblasHemm_64<T, false>;
@@ -64,7 +64,7 @@ void testing_hemm_bad_arg(const Arguments& arg)
     device_matrix<T> dC(M, N, ldc);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -197,7 +197,7 @@ void testing_hemm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemm(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasHemmFn = arg.api == FORTRAN ? hipblasHemm<T, true> : hipblasHemm<T, false>;
     auto hipblasHemmFn_64
         = arg.api == FORTRAN_64 ? hipblasHemm_64<T, true> : hipblasHemm_64<T, false>;
@@ -274,7 +274,19 @@ void testing_hemm(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHemmFn,
-                   (handle, side, uplo, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
+                   (handle,
+                    side,
+                    uplo,
+                    M,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dC,
+                    ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_hemm.hpp
+++ b/clients/include/blas3/testing_hemm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_hemm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hemm_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHemmFn = arg.api == FORTRAN ? hipblasHemm<T, true> : hipblasHemm<T, false>;
     auto hipblasHemmFn_64
         = arg.api == FORTRAN_64 ? hipblasHemm_64<T, true> : hipblasHemm_64<T, false>;
@@ -63,12 +64,12 @@ void testing_hemm_bad_arg(const Arguments& arg)
     device_matrix<T> dC(M, N, ldc);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -196,6 +197,7 @@ void testing_hemm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemm(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHemmFn = arg.api == FORTRAN ? hipblasHemm<T, true> : hipblasHemm<T, false>;
     auto hipblasHemmFn_64
         = arg.api == FORTRAN_64 ? hipblasHemm_64<T, true> : hipblasHemm_64<T, false>;
@@ -272,7 +274,7 @@ void testing_hemm(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHemmFn,
-                   (handle, side, uplo, M, N, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+                   (handle, side, uplo, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_hemm_batched.hpp
+++ b/clients/include/blas3/testing_hemm_batched.hpp
@@ -75,7 +75,7 @@ void testing_hemm_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(M, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;

--- a/clients/include/blas3/testing_hemm_batched.hpp
+++ b/clients/include/blas3/testing_hemm_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_hemm_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_hemm_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHemmBatchedFn
         = arg.api == FORTRAN ? hipblasHemmBatched<T, true> : hipblasHemmBatched<T, false>;
     auto hipblasHemmBatchedFn_64
@@ -74,12 +75,12 @@ void testing_hemm_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(M, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -355,6 +356,7 @@ void testing_hemm_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemm_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHemmBatchedFn
         = arg.api == FORTRAN ? hipblasHemmBatched<T, true> : hipblasHemmBatched<T, false>;
     auto hipblasHemmBatchedFn_64
@@ -461,12 +463,12 @@ void testing_hemm_batched(const Arguments& arg)
                     uplo,
                     M,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dB.ptr_on_device(),
                     ldb,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC.ptr_on_device(),
                     ldc,
                     batch_count));

--- a/clients/include/blas3/testing_hemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_hemm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ inline void testname_hemm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hemm_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHemmStridedBatchedFn    = arg.api == FORTRAN ? hipblasHemmStridedBatched<T, true>
                                                              : hipblasHemmStridedBatched<T, false>;
     auto hipblasHemmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -80,12 +81,12 @@ void testing_hemm_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -406,6 +407,7 @@ void testing_hemm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemm_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHemmStridedBatchedFn    = arg.api == FORTRAN ? hipblasHemmStridedBatched<T, true>
                                                              : hipblasHemmStridedBatched<T, false>;
     auto hipblasHemmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -519,14 +521,14 @@ void testing_hemm_strided_batched(const Arguments& arg)
                     uplo,
                     M,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dB,
                     ldb,
                     stride_B,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC,
                     ldc,
                     stride_C,

--- a/clients/include/blas3/testing_hemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_hemm_strided_batched.hpp
@@ -51,7 +51,7 @@ inline void testname_hemm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_hemm_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasHemmStridedBatchedFn    = arg.api == FORTRAN ? hipblasHemmStridedBatched<T, true>
                                                              : hipblasHemmStridedBatched<T, false>;
     auto hipblasHemmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -81,7 +81,7 @@ void testing_hemm_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -407,7 +407,7 @@ void testing_hemm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_hemm_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasHemmStridedBatchedFn    = arg.api == FORTRAN ? hipblasHemmStridedBatched<T, true>
                                                              : hipblasHemmStridedBatched<T, false>;
     auto hipblasHemmStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas3/testing_her2k.hpp
+++ b/clients/include/blas3/testing_her2k.hpp
@@ -41,8 +41,8 @@ inline void testname_her2k(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_her2k_bad_arg(const Arguments& arg)
 {
-    using U = real_t<T>;
-    using Ts = hipblas_internal_type<T>;
+    using U             = real_t<T>;
+    using Ts            = hipblas_internal_type<T>;
     auto hipblasHer2kFn = arg.api == FORTRAN ? hipblasHer2k<T, U, true> : hipblasHer2k<T, U, false>;
     auto hipblasHer2kFn_64
         = arg.api == FORTRAN_64 ? hipblasHer2k_64<T, U, true> : hipblasHer2k_64<T, U, false>;
@@ -67,12 +67,12 @@ void testing_her2k_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
-    const U* beta  = &h_beta;
-    const U* one   = &h_one;
+    const U*  beta  = &h_beta;
+    const U*  one   = &h_one;
     const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -209,8 +209,8 @@ void testing_her2k_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2k(const Arguments& arg)
 {
-    using U = real_t<T>;
-    using Ts = hipblas_internal_type<T>;
+    using U             = real_t<T>;
+    using Ts            = hipblas_internal_type<T>;
     auto hipblasHer2kFn = arg.api == FORTRAN ? hipblasHer2k<T, U, true> : hipblasHer2k<T, U, false>;
     auto hipblasHer2kFn_64
         = arg.api == FORTRAN_64 ? hipblasHer2k_64<T, U, true> : hipblasHer2k_64<T, U, false>;
@@ -307,7 +307,19 @@ void testing_her2k(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHer2kFn,
-                   (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, &h_beta, dC, ldc));
+                   (handle,
+                    uplo,
+                    transA,
+                    N,
+                    K,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb,
+                    &h_beta,
+                    dC,
+                    ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_her2k.hpp
+++ b/clients/include/blas3/testing_her2k.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,7 +41,8 @@ inline void testname_her2k(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_her2k_bad_arg(const Arguments& arg)
 {
-    using U             = real_t<T>;
+    using U = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHer2kFn = arg.api == FORTRAN ? hipblasHer2k<T, U, true> : hipblasHer2k<T, U, false>;
     auto hipblasHer2kFn_64
         = arg.api == FORTRAN_64 ? hipblasHer2k_64<T, U, true> : hipblasHer2k_64<T, U, false>;
@@ -66,13 +67,13 @@ void testing_her2k_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
+    const Ts* alpha = &h_alpha;
     const U* beta  = &h_beta;
     const U* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -208,7 +209,8 @@ void testing_her2k_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2k(const Arguments& arg)
 {
-    using U             = real_t<T>;
+    using U = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHer2kFn = arg.api == FORTRAN ? hipblasHer2k<T, U, true> : hipblasHer2k<T, U, false>;
     auto hipblasHer2kFn_64
         = arg.api == FORTRAN_64 ? hipblasHer2k_64<T, U, true> : hipblasHer2k_64<T, U, false>;
@@ -305,7 +307,7 @@ void testing_her2k(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHer2kFn,
-                   (handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+                   (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, &h_beta, dC, ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_her2k_batched.hpp
+++ b/clients/include/blas3/testing_her2k_batched.hpp
@@ -50,7 +50,7 @@ inline void testname_her2k_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_her2k_batched_bad_arg(const Arguments& arg)
 {
-    using U = real_t<T>;
+    using U  = real_t<T>;
     using Ts = hipblas_internal_type<T>;
     auto hipblasHer2kBatchedFn
         = arg.api == FORTRAN ? hipblasHer2kBatched<T, U, true> : hipblasHer2kBatched<T, U, false>;
@@ -78,12 +78,12 @@ void testing_her2k_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
-    const U* beta  = &h_beta;
-    const U* one   = &h_one;
+    const U*  beta  = &h_beta;
+    const U*  one   = &h_one;
     const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -362,7 +362,7 @@ void testing_her2k_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_her2k_batched(const Arguments& arg)
 {
-    using U = real_t<T>;
+    using U  = real_t<T>;
     using Ts = hipblas_internal_type<T>;
     auto hipblasHer2kBatchedFn
         = arg.api == FORTRAN ? hipblasHer2kBatched<T, U, true> : hipblasHer2kBatched<T, U, false>;

--- a/clients/include/blas3/testing_her2k_batched.hpp
+++ b/clients/include/blas3/testing_her2k_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ template <typename T>
 void testing_her2k_batched_bad_arg(const Arguments& arg)
 {
     using U = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHer2kBatchedFn
         = arg.api == FORTRAN ? hipblasHer2kBatched<T, U, true> : hipblasHer2kBatched<T, U, false>;
     auto hipblasHer2kBatchedFn_64 = arg.api == FORTRAN_64 ? hipblasHer2kBatched_64<T, U, true>
@@ -77,13 +78,13 @@ void testing_her2k_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
+    const Ts* alpha = &h_alpha;
     const U* beta  = &h_beta;
     const U* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -362,6 +363,7 @@ template <typename T>
 void testing_her2k_batched(const Arguments& arg)
 {
     using U = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHer2kBatchedFn
         = arg.api == FORTRAN ? hipblasHer2kBatched<T, U, true> : hipblasHer2kBatched<T, U, false>;
     auto hipblasHer2kBatchedFn_64 = arg.api == FORTRAN_64 ? hipblasHer2kBatched_64<T, U, true>
@@ -470,7 +472,7 @@ void testing_her2k_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dB.ptr_on_device(),

--- a/clients/include/blas3/testing_her2k_strided_batched.hpp
+++ b/clients/include/blas3/testing_her2k_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@ template <typename T>
 void testing_her2k_strided_batched_bad_arg(const Arguments& arg)
 {
     using U                              = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHer2kStridedBatchedFn    = arg.api == FORTRAN
                                                ? hipblasHer2kStridedBatched<T, U, true>
                                                : hipblasHer2kStridedBatched<T, U, false>;
@@ -84,13 +85,13 @@ void testing_her2k_strided_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
+    const Ts* alpha = &h_alpha;
     const U* beta  = &h_beta;
     const U* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -414,6 +415,7 @@ template <typename T>
 void testing_her2k_strided_batched(const Arguments& arg)
 {
     using U                              = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHer2kStridedBatchedFn    = arg.api == FORTRAN
                                                ? hipblasHer2kStridedBatched<T, U, true>
                                                : hipblasHer2kStridedBatched<T, U, false>;
@@ -532,7 +534,7 @@ void testing_her2k_strided_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,

--- a/clients/include/blas3/testing_her2k_strided_batched.hpp
+++ b/clients/include/blas3/testing_her2k_strided_batched.hpp
@@ -52,7 +52,7 @@ template <typename T>
 void testing_her2k_strided_batched_bad_arg(const Arguments& arg)
 {
     using U                              = real_t<T>;
-    using Ts = hipblas_internal_type<T>;
+    using Ts                             = hipblas_internal_type<T>;
     auto hipblasHer2kStridedBatchedFn    = arg.api == FORTRAN
                                                ? hipblasHer2kStridedBatched<T, U, true>
                                                : hipblasHer2kStridedBatched<T, U, false>;
@@ -85,12 +85,12 @@ void testing_her2k_strided_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
-    const U* beta  = &h_beta;
-    const U* one   = &h_one;
+    const U*  beta  = &h_beta;
+    const U*  one   = &h_one;
     const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -415,7 +415,7 @@ template <typename T>
 void testing_her2k_strided_batched(const Arguments& arg)
 {
     using U                              = real_t<T>;
-    using Ts = hipblas_internal_type<T>;
+    using Ts                             = hipblas_internal_type<T>;
     auto hipblasHer2kStridedBatchedFn    = arg.api == FORTRAN
                                                ? hipblasHer2kStridedBatched<T, U, true>
                                                : hipblasHer2kStridedBatched<T, U, false>;

--- a/clients/include/blas3/testing_herkx.hpp
+++ b/clients/include/blas3/testing_herkx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,7 @@ template <typename T>
 void testing_herkx_bad_arg(const Arguments& arg)
 {
     using U             = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHerkxFn = arg.api == FORTRAN ? hipblasHerkx<T, U, true> : hipblasHerkx<T, U, false>;
     auto hipblasHerkxFn_64
         = arg.api == FORTRAN_64 ? hipblasHerkx_64<T, U, true> : hipblasHerkx_64<T, U, false>;
@@ -66,13 +67,13 @@ void testing_herkx_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
+    const Ts* alpha = &h_alpha;
     const U* beta  = &h_beta;
     const U* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -211,6 +212,7 @@ template <typename T>
 void testing_herkx(const Arguments& arg)
 {
     using U             = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHerkxFn = arg.api == FORTRAN ? hipblasHerkx<T, U, true> : hipblasHerkx<T, U, false>;
     auto hipblasHerkxFn_64
         = arg.api == FORTRAN_64 ? hipblasHerkx_64<T, U, true> : hipblasHerkx_64<T, U, false>;
@@ -306,7 +308,7 @@ void testing_herkx(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHerkxFn,
-                   (handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+                   (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, &h_beta, dC, ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_herkx.hpp
+++ b/clients/include/blas3/testing_herkx.hpp
@@ -42,7 +42,7 @@ template <typename T>
 void testing_herkx_bad_arg(const Arguments& arg)
 {
     using U             = real_t<T>;
-    using Ts = hipblas_internal_type<T>;
+    using Ts            = hipblas_internal_type<T>;
     auto hipblasHerkxFn = arg.api == FORTRAN ? hipblasHerkx<T, U, true> : hipblasHerkx<T, U, false>;
     auto hipblasHerkxFn_64
         = arg.api == FORTRAN_64 ? hipblasHerkx_64<T, U, true> : hipblasHerkx_64<T, U, false>;
@@ -67,12 +67,12 @@ void testing_herkx_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
-    const U* beta  = &h_beta;
-    const U* one   = &h_one;
+    const U*  beta  = &h_beta;
+    const U*  one   = &h_one;
     const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -212,7 +212,7 @@ template <typename T>
 void testing_herkx(const Arguments& arg)
 {
     using U             = real_t<T>;
-    using Ts = hipblas_internal_type<T>;
+    using Ts            = hipblas_internal_type<T>;
     auto hipblasHerkxFn = arg.api == FORTRAN ? hipblasHerkx<T, U, true> : hipblasHerkx<T, U, false>;
     auto hipblasHerkxFn_64
         = arg.api == FORTRAN_64 ? hipblasHerkx_64<T, U, true> : hipblasHerkx_64<T, U, false>;
@@ -308,7 +308,19 @@ void testing_herkx(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasHerkxFn,
-                   (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, &h_beta, dC, ldc));
+                   (handle,
+                    uplo,
+                    transA,
+                    N,
+                    K,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb,
+                    &h_beta,
+                    dC,
+                    ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_herkx_batched.hpp
+++ b/clients/include/blas3/testing_herkx_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ template <typename T>
 void testing_herkx_batched_bad_arg(const Arguments& arg)
 {
     using U = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHerkxBatchedFn
         = arg.api == FORTRAN ? hipblasHerkxBatched<T, U, true> : hipblasHerkxBatched<T, U, false>;
     auto hipblasHerkxBatchedFn_64 = arg.api == FORTRAN_64 ? hipblasHerkxBatched_64<T, U, true>
@@ -77,13 +78,13 @@ void testing_herkx_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
+    const Ts* alpha = &h_alpha;
     const U* beta  = &h_beta;
     const U* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -362,6 +363,7 @@ template <typename T>
 void testing_herkx_batched(const Arguments& arg)
 {
     using U = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHerkxBatchedFn
         = arg.api == FORTRAN ? hipblasHerkxBatched<T, U, true> : hipblasHerkxBatched<T, U, false>;
     auto hipblasHerkxBatchedFn_64 = arg.api == FORTRAN_64 ? hipblasHerkxBatched_64<T, U, true>
@@ -470,7 +472,7 @@ void testing_herkx_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dB.ptr_on_device(),

--- a/clients/include/blas3/testing_herkx_batched.hpp
+++ b/clients/include/blas3/testing_herkx_batched.hpp
@@ -50,7 +50,7 @@ inline void testname_herkx_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_herkx_batched_bad_arg(const Arguments& arg)
 {
-    using U = real_t<T>;
+    using U  = real_t<T>;
     using Ts = hipblas_internal_type<T>;
     auto hipblasHerkxBatchedFn
         = arg.api == FORTRAN ? hipblasHerkxBatched<T, U, true> : hipblasHerkxBatched<T, U, false>;
@@ -78,12 +78,12 @@ void testing_herkx_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
-    const U* beta  = &h_beta;
-    const U* one   = &h_one;
+    const U*  beta  = &h_beta;
+    const U*  one   = &h_one;
     const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -362,7 +362,7 @@ void testing_herkx_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_herkx_batched(const Arguments& arg)
 {
-    using U = real_t<T>;
+    using U  = real_t<T>;
     using Ts = hipblas_internal_type<T>;
     auto hipblasHerkxBatchedFn
         = arg.api == FORTRAN ? hipblasHerkxBatched<T, U, true> : hipblasHerkxBatched<T, U, false>;

--- a/clients/include/blas3/testing_herkx_strided_batched.hpp
+++ b/clients/include/blas3/testing_herkx_strided_batched.hpp
@@ -52,7 +52,7 @@ template <typename T>
 void testing_herkx_strided_batched_bad_arg(const Arguments& arg)
 {
     using U                              = real_t<T>;
-    using Ts = hipblas_internal_type<T>;
+    using Ts                             = hipblas_internal_type<T>;
     auto hipblasHerkxStridedBatchedFn    = arg.api == FORTRAN
                                                ? hipblasHerkxStridedBatched<T, U, true>
                                                : hipblasHerkxStridedBatched<T, U, false>;
@@ -85,12 +85,12 @@ void testing_herkx_strided_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
-    const U* beta  = &h_beta;
-    const U* one   = &h_one;
+    const U*  beta  = &h_beta;
+    const U*  one   = &h_one;
     const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
@@ -415,7 +415,7 @@ template <typename T>
 void testing_herkx_strided_batched(const Arguments& arg)
 {
     using U                              = real_t<T>;
-    using Ts = hipblas_internal_type<T>;
+    using Ts                             = hipblas_internal_type<T>;
     bool FORTRAN                         = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHerkxStridedBatchedFn    = arg.api == FORTRAN
                                                ? hipblasHerkxStridedBatched<T, U, true>

--- a/clients/include/blas3/testing_herkx_strided_batched.hpp
+++ b/clients/include/blas3/testing_herkx_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@ template <typename T>
 void testing_herkx_strided_batched_bad_arg(const Arguments& arg)
 {
     using U                              = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     auto hipblasHerkxStridedBatchedFn    = arg.api == FORTRAN
                                                ? hipblasHerkxStridedBatched<T, U, true>
                                                : hipblasHerkxStridedBatched<T, U, false>;
@@ -84,13 +85,13 @@ void testing_herkx_strided_batched_bad_arg(const Arguments& arg)
 
     device_vector<T> d_alpha(1), d_zero(1);
     device_vector<U> d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
     const U          h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
+    const Ts* alpha = &h_alpha;
     const U* beta  = &h_beta;
     const U* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -414,6 +415,7 @@ template <typename T>
 void testing_herkx_strided_batched(const Arguments& arg)
 {
     using U                              = real_t<T>;
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN                         = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasHerkxStridedBatchedFn    = arg.api == FORTRAN
                                                ? hipblasHerkxStridedBatched<T, U, true>
@@ -533,7 +535,7 @@ void testing_herkx_strided_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,

--- a/clients/include/blas3/testing_symm.hpp
+++ b/clients/include/blas3/testing_symm.hpp
@@ -41,7 +41,7 @@ inline void testname_symm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_symm_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSymmFn = arg.api == FORTRAN ? hipblasSymm<T, true> : hipblasSymm<T, false>;
     auto hipblasSymmFn_64
         = arg.api == FORTRAN_64 ? hipblasSymm_64<T, true> : hipblasSymm_64<T, false>;
@@ -64,7 +64,7 @@ void testing_symm_bad_arg(const Arguments& arg)
     device_matrix<T> dC(M, N, ldc);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -196,7 +196,7 @@ void testing_symm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symm(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSymmFn = arg.api == FORTRAN ? hipblasSymm<T, true> : hipblasSymm<T, false>;
     auto hipblasSymmFn_64
         = arg.api == FORTRAN_64 ? hipblasSymm_64<T, true> : hipblasSymm_64<T, false>;
@@ -276,7 +276,19 @@ void testing_symm(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSymmFn,
-                   (handle, side, uplo, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
+                   (handle,
+                    side,
+                    uplo,
+                    M,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dC,
+                    ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_symm.hpp
+++ b/clients/include/blas3/testing_symm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_symm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_symm_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymmFn = arg.api == FORTRAN ? hipblasSymm<T, true> : hipblasSymm<T, false>;
     auto hipblasSymmFn_64
         = arg.api == FORTRAN_64 ? hipblasSymm_64<T, true> : hipblasSymm_64<T, false>;
@@ -63,12 +64,12 @@ void testing_symm_bad_arg(const Arguments& arg)
     device_matrix<T> dC(M, N, ldc);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -195,6 +196,7 @@ void testing_symm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symm(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymmFn = arg.api == FORTRAN ? hipblasSymm<T, true> : hipblasSymm<T, false>;
     auto hipblasSymmFn_64
         = arg.api == FORTRAN_64 ? hipblasSymm_64<T, true> : hipblasSymm_64<T, false>;
@@ -274,7 +276,7 @@ void testing_symm(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSymmFn,
-                   (handle, side, uplo, M, N, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+                   (handle, side, uplo, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_symm_batched.hpp
+++ b/clients/include/blas3/testing_symm_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_symm_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_symm_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymmBatchedFn
         = arg.api == FORTRAN ? hipblasSymmBatched<T, true> : hipblasSymmBatched<T, false>;
     auto hipblasSymmBatchedFn_64
@@ -74,12 +75,12 @@ void testing_symm_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(M, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -355,6 +356,7 @@ void testing_symm_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symm_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymmBatchedFn
         = arg.api == FORTRAN ? hipblasSymmBatched<T, true> : hipblasSymmBatched<T, false>;
     auto hipblasSymmBatchedFn_64
@@ -461,12 +463,12 @@ void testing_symm_batched(const Arguments& arg)
                     uplo,
                     M,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dB.ptr_on_device(),
                     ldb,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC.ptr_on_device(),
                     ldc,
                     batch_count));

--- a/clients/include/blas3/testing_symm_batched.hpp
+++ b/clients/include/blas3/testing_symm_batched.hpp
@@ -75,7 +75,7 @@ void testing_symm_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(M, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;

--- a/clients/include/blas3/testing_symm_strided_batched.hpp
+++ b/clients/include/blas3/testing_symm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ inline void testname_symm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_symm_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymmStridedBatchedFn    = arg.api == FORTRAN ? hipblasSymmStridedBatched<T, true>
                                                              : hipblasSymmStridedBatched<T, false>;
     auto hipblasSymmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -80,12 +81,12 @@ void testing_symm_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const T          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -406,6 +407,7 @@ void testing_symm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symm_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSymmStridedBatchedFn    = arg.api == FORTRAN ? hipblasSymmStridedBatched<T, true>
                                                              : hipblasSymmStridedBatched<T, false>;
     auto hipblasSymmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -521,14 +523,14 @@ void testing_symm_strided_batched(const Arguments& arg)
                     uplo,
                     M,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dB,
                     ldb,
                     stride_B,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC,
                     ldc,
                     stride_C,

--- a/clients/include/blas3/testing_symm_strided_batched.hpp
+++ b/clients/include/blas3/testing_symm_strided_batched.hpp
@@ -51,7 +51,7 @@ inline void testname_symm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_symm_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSymmStridedBatchedFn    = arg.api == FORTRAN ? hipblasSymmStridedBatched<T, true>
                                                              : hipblasSymmStridedBatched<T, false>;
     auto hipblasSymmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -81,7 +81,7 @@ void testing_symm_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    const Ts          h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    const Ts         h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -407,7 +407,7 @@ void testing_symm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_symm_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSymmStridedBatchedFn    = arg.api == FORTRAN ? hipblasSymmStridedBatched<T, true>
                                                              : hipblasSymmStridedBatched<T, false>;
     auto hipblasSymmStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas3/testing_syr2k.hpp
+++ b/clients/include/blas3/testing_syr2k.hpp
@@ -41,7 +41,7 @@ inline void testname_syr2k(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr2k_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts            = hipblas_internal_type<T>;
     auto hipblasSyr2kFn = arg.api == FORTRAN ? hipblasSyr2k<T, true> : hipblasSyr2k<T, false>;
     auto hipblasSyr2kFn_64
         = arg.api == FORTRAN_64 ? hipblasSyr2k_64<T, true> : hipblasSyr2k_64<T, false>;
@@ -65,7 +65,7 @@ void testing_syr2k_bad_arg(const Arguments& arg)
     device_matrix<T> dC(N, N, ldc);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -203,7 +203,7 @@ void testing_syr2k_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2k(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts            = hipblas_internal_type<T>;
     auto hipblasSyr2kFn = arg.api == FORTRAN ? hipblasSyr2k<T, true> : hipblasSyr2k<T, false>;
     auto hipblasSyr2kFn_64
         = arg.api == FORTRAN_64 ? hipblasSyr2k_64<T, true> : hipblasSyr2k_64<T, false>;
@@ -298,7 +298,19 @@ void testing_syr2k(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSyr2kFn,
-                   (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
+                   (handle,
+                    uplo,
+                    transA,
+                    N,
+                    K,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dC,
+                    ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_syr2k.hpp
+++ b/clients/include/blas3/testing_syr2k.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_syr2k(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr2k_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2kFn = arg.api == FORTRAN ? hipblasSyr2k<T, true> : hipblasSyr2k<T, false>;
     auto hipblasSyr2kFn_64
         = arg.api == FORTRAN_64 ? hipblasSyr2k_64<T, true> : hipblasSyr2k_64<T, false>;
@@ -64,12 +65,12 @@ void testing_syr2k_bad_arg(const Arguments& arg)
     device_matrix<T> dC(N, N, ldc);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -202,6 +203,7 @@ void testing_syr2k_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2k(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2kFn = arg.api == FORTRAN ? hipblasSyr2k<T, true> : hipblasSyr2k<T, false>;
     auto hipblasSyr2kFn_64
         = arg.api == FORTRAN_64 ? hipblasSyr2k_64<T, true> : hipblasSyr2k_64<T, false>;
@@ -296,7 +298,7 @@ void testing_syr2k(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSyr2kFn,
-                   (handle, uplo, transA, N, K, &h_alpha, dA, lda, dB, ldb, &h_beta, dC, ldc));
+                   (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_syr2k_batched.hpp
+++ b/clients/include/blas3/testing_syr2k_batched.hpp
@@ -76,7 +76,7 @@ void testing_syr2k_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(N, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;

--- a/clients/include/blas3/testing_syr2k_batched.hpp
+++ b/clients/include/blas3/testing_syr2k_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_syr2k_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syr2k_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2kBatchedFn
         = arg.api == FORTRAN ? hipblasSyr2kBatched<T, true> : hipblasSyr2kBatched<T, false>;
     auto hipblasSyr2kBatchedFn_64 = arg.api == FORTRAN_64 ? hipblasSyr2kBatched_64<T, true>
@@ -75,12 +76,12 @@ void testing_syr2k_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(N, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -342,6 +343,7 @@ void testing_syr2k_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2k_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyr2kBatchedFn
         = arg.api == FORTRAN ? hipblasSyr2kBatched<T, true> : hipblasSyr2kBatched<T, false>;
     auto hipblasSyr2kBatchedFn_64 = arg.api == FORTRAN_64 ? hipblasSyr2kBatched_64<T, true>
@@ -450,12 +452,12 @@ void testing_syr2k_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dB.ptr_on_device(),
                     ldb,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC.ptr_on_device(),
                     ldc,
                     batch_count));

--- a/clients/include/blas3/testing_syr2k_strided_batched.hpp
+++ b/clients/include/blas3/testing_syr2k_strided_batched.hpp
@@ -51,7 +51,7 @@ inline void testname_syr2k_strided_batched(const Arguments& arg, std::string& na
 template <typename T>
 void testing_syr2k_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                             = hipblas_internal_type<T>;
     auto hipblasSyrk2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSyr2kStridedBatched<T, true>
                                                               : hipblasSyr2kStridedBatched<T, false>;
     auto hipblasSyrk2StridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -82,7 +82,7 @@ void testing_syr2k_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(N, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -391,7 +391,7 @@ void testing_syr2k_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2k_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                             = hipblas_internal_type<T>;
     auto hipblasSyrk2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSyr2kStridedBatched<T, true>
                                                               : hipblasSyr2kStridedBatched<T, false>;
     auto hipblasSyrk2StridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas3/testing_syr2k_strided_batched.hpp
+++ b/clients/include/blas3/testing_syr2k_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ inline void testname_syr2k_strided_batched(const Arguments& arg, std::string& na
 template <typename T>
 void testing_syr2k_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrk2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSyr2kStridedBatched<T, true>
                                                               : hipblasSyr2kStridedBatched<T, false>;
     auto hipblasSyrk2StridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -81,12 +82,12 @@ void testing_syr2k_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(N, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -390,6 +391,7 @@ void testing_syr2k_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syr2k_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrk2StridedBatchedFn    = arg.api == FORTRAN ? hipblasSyr2kStridedBatched<T, true>
                                                               : hipblasSyr2kStridedBatched<T, false>;
     auto hipblasSyrk2StridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -507,14 +509,14 @@ void testing_syr2k_strided_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dB,
                     ldb,
                     stride_B,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC,
                     ldc,
                     stride_C,

--- a/clients/include/blas3/testing_syrk.hpp
+++ b/clients/include/blas3/testing_syrk.hpp
@@ -41,7 +41,7 @@ inline void testname_syrk(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syrk_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSyrkFn = arg.api == FORTRAN ? hipblasSyrk<T, true> : hipblasSyrk<T, false>;
     auto hipblasSyrkFn_64
         = arg.api == FORTRAN_64 ? hipblasSyrk_64<T, true> : hipblasSyrk_64<T, false>;
@@ -63,7 +63,7 @@ void testing_syrk_bad_arg(const Arguments& arg)
     device_matrix<T> dC(N, N, ldc);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -165,7 +165,7 @@ void testing_syrk_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrk(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasSyrkFn = arg.api == FORTRAN ? hipblasSyrk<T, true> : hipblasSyrk<T, false>;
     auto hipblasSyrkFn_64
         = arg.api == FORTRAN_64 ? hipblasSyrk_64<T, true> : hipblasSyrk_64<T, false>;
@@ -241,7 +241,17 @@ void testing_syrk(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSyrkFn,
-                   (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
+                   (handle,
+                    uplo,
+                    transA,
+                    N,
+                    K,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dC,
+                    ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_syrk.hpp
+++ b/clients/include/blas3/testing_syrk.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_syrk(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syrk_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkFn = arg.api == FORTRAN ? hipblasSyrk<T, true> : hipblasSyrk<T, false>;
     auto hipblasSyrkFn_64
         = arg.api == FORTRAN_64 ? hipblasSyrk_64<T, true> : hipblasSyrk_64<T, false>;
@@ -62,12 +63,12 @@ void testing_syrk_bad_arg(const Arguments& arg)
     device_matrix<T> dC(N, N, ldc);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -164,6 +165,7 @@ void testing_syrk_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrk(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkFn = arg.api == FORTRAN ? hipblasSyrk<T, true> : hipblasSyrk<T, false>;
     auto hipblasSyrkFn_64
         = arg.api == FORTRAN_64 ? hipblasSyrk_64<T, true> : hipblasSyrk_64<T, false>;
@@ -239,7 +241,7 @@ void testing_syrk(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasSyrkFn,
-                   (handle, uplo, transA, N, K, &h_alpha, dA, lda, &h_beta, dC, ldc));
+                   (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_syrk_batched.hpp
+++ b/clients/include/blas3/testing_syrk_batched.hpp
@@ -73,7 +73,7 @@ void testing_syrk_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(N, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;

--- a/clients/include/blas3/testing_syrk_batched.hpp
+++ b/clients/include/blas3/testing_syrk_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,7 @@ inline void testname_syrk_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syrk_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkBatchedFn
         = arg.api == FORTRAN ? hipblasSyrkBatched<T, true> : hipblasSyrkBatched<T, false>;
     auto hipblasSyrkBatchedFn_64
@@ -72,12 +73,12 @@ void testing_syrk_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(N, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -266,6 +267,7 @@ void testing_syrk_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrk_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkBatchedFn
         = arg.api == FORTRAN ? hipblasSyrkBatched<T, true> : hipblasSyrkBatched<T, false>;
     auto hipblasSyrkBatchedFn_64
@@ -361,10 +363,10 @@ void testing_syrk_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC.ptr_on_device(),
                     ldc,
                     batch_count));

--- a/clients/include/blas3/testing_syrk_strided_batched.hpp
+++ b/clients/include/blas3/testing_syrk_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_syrk_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_syrk_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrkStridedBatched<T, true>
                                                              : hipblasSyrkStridedBatched<T, false>;
     auto hipblasSyrkStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -77,12 +78,12 @@ void testing_syrk_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(N, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -328,6 +329,7 @@ void testing_syrk_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrk_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrkStridedBatched<T, true>
                                                              : hipblasSyrkStridedBatched<T, false>;
     auto hipblasSyrkStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -430,11 +432,11 @@ void testing_syrk_strided_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC,
                     ldc,
                     stride_C,

--- a/clients/include/blas3/testing_syrk_strided_batched.hpp
+++ b/clients/include/blas3/testing_syrk_strided_batched.hpp
@@ -50,7 +50,7 @@ inline void testname_syrk_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_syrk_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSyrkStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrkStridedBatched<T, true>
                                                              : hipblasSyrkStridedBatched<T, false>;
     auto hipblasSyrkStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -78,7 +78,7 @@ void testing_syrk_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(N, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -329,7 +329,7 @@ void testing_syrk_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrk_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasSyrkStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrkStridedBatched<T, true>
                                                              : hipblasSyrkStridedBatched<T, false>;
     auto hipblasSyrkStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas3/testing_syrkx.hpp
+++ b/clients/include/blas3/testing_syrkx.hpp
@@ -41,7 +41,7 @@ inline void testname_syrkx(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syrkx_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts            = hipblas_internal_type<T>;
     auto hipblasSyrkxFn = arg.api == FORTRAN ? hipblasSyrkx<T, true> : hipblasSyrkx<T, false>;
     auto hipblasSyrkxFn_64
         = arg.api == FORTRAN_64 ? hipblasSyrkx_64<T, true> : hipblasSyrkx_64<T, false>;
@@ -65,7 +65,7 @@ void testing_syrkx_bad_arg(const Arguments& arg)
     device_matrix<T> dC(N, N, ldc);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -203,7 +203,7 @@ void testing_syrkx_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrkx(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts            = hipblas_internal_type<T>;
     auto hipblasSyrkxFn = arg.api == FORTRAN ? hipblasSyrkx<T, true> : hipblasSyrkx<T, false>;
     auto hipblasSyrkxFn_64
         = arg.api == FORTRAN_64 ? hipblasSyrkx_64<T, true> : hipblasSyrkx_64<T, false>;
@@ -295,9 +295,20 @@ void testing_syrkx(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(
-            hipblasSyrkxFn,
-            (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
+        DAPI_CHECK(hipblasSyrkxFn,
+                   (handle,
+                    uplo,
+                    transA,
+                    N,
+                    K,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb,
+                    reinterpret_cast<Ts*>(&h_beta),
+                    dC,
+                    ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_syrkx.hpp
+++ b/clients/include/blas3/testing_syrkx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_syrkx(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syrkx_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkxFn = arg.api == FORTRAN ? hipblasSyrkx<T, true> : hipblasSyrkx<T, false>;
     auto hipblasSyrkxFn_64
         = arg.api == FORTRAN_64 ? hipblasSyrkx_64<T, true> : hipblasSyrkx_64<T, false>;
@@ -64,12 +65,12 @@ void testing_syrkx_bad_arg(const Arguments& arg)
     device_matrix<T> dC(N, N, ldc);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -202,6 +203,7 @@ void testing_syrkx_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrkx(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkxFn = arg.api == FORTRAN ? hipblasSyrkx<T, true> : hipblasSyrkx<T, false>;
     auto hipblasSyrkxFn_64
         = arg.api == FORTRAN_64 ? hipblasSyrkx_64<T, true> : hipblasSyrkx_64<T, false>;
@@ -295,7 +297,7 @@ void testing_syrkx(const Arguments& arg)
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(
             hipblasSyrkxFn,
-            (handle, uplo, transA, N, K, (T*)&h_alpha, dA, lda, dB, ldb, (T*)&h_beta, dC, ldc));
+            (handle, uplo, transA, N, K, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, reinterpret_cast<Ts*>(&h_beta), dC, ldc));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hC_host.transfer_from(dC));

--- a/clients/include/blas3/testing_syrkx_batched.hpp
+++ b/clients/include/blas3/testing_syrkx_batched.hpp
@@ -68,7 +68,7 @@ void testing_syrkx_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(N, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;

--- a/clients/include/blas3/testing_syrkx_batched.hpp
+++ b/clients/include/blas3/testing_syrkx_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,6 +42,7 @@ inline void testname_syrkx_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_syrkx_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkxBatchedFn
         = arg.api == FORTRAN ? hipblasSyrkxBatched<T, true> : hipblasSyrkxBatched<T, false>;
     auto hipblasSyrkxBatchedFn_64 = arg.api == FORTRAN_64 ? hipblasSyrkxBatched_64<T, true>
@@ -67,12 +68,12 @@ void testing_syrkx_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dC(N, N, ldc, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -334,6 +335,7 @@ void testing_syrkx_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrkx_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkxBatchedFn
         = arg.api == FORTRAN ? hipblasSyrkxBatched<T, true> : hipblasSyrkxBatched<T, false>;
     auto hipblasSyrkxBatchedFn_64 = arg.api == FORTRAN_64 ? hipblasSyrkxBatched_64<T, true>
@@ -441,12 +443,12 @@ void testing_syrkx_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dB.ptr_on_device(),
                     ldb,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC.ptr_on_device(),
                     ldc,
                     batch_count));

--- a/clients/include/blas3/testing_syrkx_strided_batched.hpp
+++ b/clients/include/blas3/testing_syrkx_strided_batched.hpp
@@ -50,7 +50,7 @@ inline void testname_syrkx_strided_batched(const Arguments& arg, std::string& na
 template <typename T>
 void testing_syrkx_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                             = hipblas_internal_type<T>;
     auto hipblasSyrkxStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrkxStridedBatched<T, true>
                                                               : hipblasSyrkxStridedBatched<T, false>;
     auto hipblasSyrkxStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -81,7 +81,7 @@ void testing_syrkx_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(N, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts         h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
     const Ts* alpha = &h_alpha;
     const Ts* beta  = &h_beta;
@@ -390,7 +390,7 @@ void testing_syrkx_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrkx_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                             = hipblas_internal_type<T>;
     auto hipblasSyrkxStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrkxStridedBatched<T, true>
                                                               : hipblasSyrkxStridedBatched<T, false>;
     auto hipblasSyrkxStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas3/testing_syrkx_strided_batched.hpp
+++ b/clients/include/blas3/testing_syrkx_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_syrkx_strided_batched(const Arguments& arg, std::string& na
 template <typename T>
 void testing_syrkx_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkxStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrkxStridedBatched<T, true>
                                                               : hipblasSyrkxStridedBatched<T, false>;
     auto hipblasSyrkxStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -80,12 +81,12 @@ void testing_syrkx_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dC(N, N, ldc, stride_C, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1), d_beta(1), d_one(1);
-    const T          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
+    const Ts          h_alpha(1), h_zero(0), h_beta(2), h_one(1);
 
-    const T* alpha = &h_alpha;
-    const T* beta  = &h_beta;
-    const T* one   = &h_one;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -389,6 +390,7 @@ void testing_syrkx_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_syrkx_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasSyrkxStridedBatchedFn    = arg.api == FORTRAN ? hipblasSyrkxStridedBatched<T, true>
                                                               : hipblasSyrkxStridedBatched<T, false>;
     auto hipblasSyrkxStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -505,14 +507,14 @@ void testing_syrkx_strided_batched(const Arguments& arg)
                     transA,
                     N,
                     K,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,
                     dB,
                     ldb,
                     stride_B,
-                    &h_beta,
+                    reinterpret_cast<Ts*>(&h_beta),
                     dC,
                     ldc,
                     stride_C,

--- a/clients/include/blas3/testing_trmm.hpp
+++ b/clients/include/blas3/testing_trmm.hpp
@@ -429,9 +429,21 @@ void testing_trmm(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
 
-        DAPI_CHECK(
-            hipblasTrmmFn,
-            (handle, side, uplo, transA, diag, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, *dOut, ldOut));
+        DAPI_CHECK(hipblasTrmmFn,
+                   (handle,
+                    side,
+                    uplo,
+                    transA,
+                    diag,
+                    M,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb,
+                    *dOut,
+                    ldOut));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hOut_host.transfer_from(*dOut));

--- a/clients/include/blas3/testing_trmm.hpp
+++ b/clients/include/blas3/testing_trmm.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ inline void testname_trmm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_trmm_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrmmFn
         = arg.api == hipblas_client_api::FORTRAN ? hipblasTrmm<T, true> : hipblasTrmm<T, false>;
     auto hipblasTrmmFn_64 = arg.api == hipblas_client_api::FORTRAN_64 ? hipblasTrmm_64<T, true>
@@ -62,10 +63,10 @@ void testing_trmm_bad_arg(const Arguments& arg)
 
         device_vector<T> alpha_d(1), zero_d(1);
 
-        const T alpha_h(1), zero_h(0);
+        const Ts alpha_h(1), zero_h(0);
 
-        const T* alpha = &alpha_h;
-        const T* zero  = &zero_h;
+        const Ts* alpha = &alpha_h;
+        const Ts* zero  = &zero_h;
 
         hipblasLocalHandle handle(arg);
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, pointer_mode));
@@ -331,6 +332,7 @@ void testing_trmm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trmm(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrmmFn
         = arg.api == hipblas_client_api::FORTRAN ? hipblasTrmm<T, true> : hipblasTrmm<T, false>;
     auto hipblasTrmmFn_64 = arg.api == hipblas_client_api::FORTRAN_64 ? hipblasTrmm_64<T, true>
@@ -429,7 +431,7 @@ void testing_trmm(const Arguments& arg)
 
         DAPI_CHECK(
             hipblasTrmmFn,
-            (handle, side, uplo, transA, diag, M, N, &h_alpha, dA, lda, dB, ldb, *dOut, ldOut));
+            (handle, side, uplo, transA, diag, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb, *dOut, ldOut));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hOut_host.transfer_from(*dOut));

--- a/clients/include/blas3/testing_trmm_batched.hpp
+++ b/clients/include/blas3/testing_trmm_batched.hpp
@@ -50,7 +50,7 @@ inline void testname_trmm_batched(const Arguments& arg, std::string& name)
 template <typename T>
 inline void testing_trmm_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                     = hipblas_internal_type<T>;
     auto hipblasTrmmBatchedFn    = arg.api == hipblas_client_api::FORTRAN
                                        ? hipblasTrmmBatched<T, true>
                                        : hipblasTrmmBatched<T, false>;
@@ -409,7 +409,7 @@ inline void testing_trmm_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trmm_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                     = hipblas_internal_type<T>;
     auto hipblasTrmmBatchedFn    = arg.api == hipblas_client_api::FORTRAN
                                        ? hipblasTrmmBatched<T, true>
                                        : hipblasTrmmBatched<T, false>;

--- a/clients/include/blas3/testing_trmm_batched.hpp
+++ b/clients/include/blas3/testing_trmm_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_trmm_batched(const Arguments& arg, std::string& name)
 template <typename T>
 inline void testing_trmm_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrmmBatchedFn    = arg.api == hipblas_client_api::FORTRAN
                                        ? hipblasTrmmBatched<T, true>
                                        : hipblasTrmmBatched<T, false>;
@@ -75,10 +76,10 @@ inline void testing_trmm_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> alpha_d(1), zero_d(1);
 
-        const T alpha_h(1), zero_h(0);
+        const Ts alpha_h(1), zero_h(0);
 
-        const T* alpha = &alpha_h;
-        const T* zero  = &zero_h;
+        const Ts* alpha = &alpha_h;
+        const Ts* zero  = &zero_h;
 
         hipblasLocalHandle handle(arg);
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, pointer_mode));
@@ -408,6 +409,7 @@ inline void testing_trmm_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trmm_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrmmBatchedFn    = arg.api == hipblas_client_api::FORTRAN
                                        ? hipblasTrmmBatched<T, true>
                                        : hipblasTrmmBatched<T, false>;
@@ -527,7 +529,7 @@ void testing_trmm_batched(const Arguments& arg)
                     diag,
                     M,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dB.ptr_on_device(),

--- a/clients/include/blas3/testing_trmm_strided_batched.hpp
+++ b/clients/include/blas3/testing_trmm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ inline void testname_trmm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_trmm_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrmmStridedBatchedFn    = arg.api == hipblas_client_api::FORTRAN
                                               ? hipblasTrmmStridedBatched<T, true>
                                               : hipblasTrmmStridedBatched<T, false>;
@@ -76,10 +77,10 @@ void testing_trmm_strided_batched_bad_arg(const Arguments& arg)
 
         device_vector<T> alpha_d(1), zero_d(1);
 
-        const T alpha_h(1), zero_h(0);
+        const Ts alpha_h(1), zero_h(0);
 
-        const T* alpha = &alpha_h;
-        const T* zero  = &zero_h;
+        const Ts* alpha = &alpha_h;
+        const Ts* zero  = &zero_h;
 
         hipblasLocalHandle handle(arg);
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, pointer_mode));
@@ -461,6 +462,7 @@ void testing_trmm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trmm_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrmmStridedBatchedFn    = arg.api == hipblas_client_api::FORTRAN
                                               ? hipblasTrmmStridedBatched<T, true>
                                               : hipblasTrmmStridedBatched<T, false>;
@@ -591,7 +593,7 @@ void testing_trmm_strided_batched(const Arguments& arg)
                     diag,
                     M,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,

--- a/clients/include/blas3/testing_trmm_strided_batched.hpp
+++ b/clients/include/blas3/testing_trmm_strided_batched.hpp
@@ -51,7 +51,7 @@ inline void testname_trmm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_trmm_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasTrmmStridedBatchedFn    = arg.api == hipblas_client_api::FORTRAN
                                               ? hipblasTrmmStridedBatched<T, true>
                                               : hipblasTrmmStridedBatched<T, false>;
@@ -462,7 +462,7 @@ void testing_trmm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trmm_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasTrmmStridedBatchedFn    = arg.api == hipblas_client_api::FORTRAN
                                               ? hipblasTrmmStridedBatched<T, true>
                                               : hipblasTrmmStridedBatched<T, false>;

--- a/clients/include/blas3/testing_trsm.hpp
+++ b/clients/include/blas3/testing_trsm.hpp
@@ -50,6 +50,7 @@ inline void testname_trsm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_trsm_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrsmFn = arg.api == FORTRAN ? hipblasTrsm<T, true> : hipblasTrsm<T, false>;
     auto hipblasTrsmFn_64
         = arg.api == FORTRAN_64 ? hipblasTrsm_64<T, true> : hipblasTrsm_64<T, false>;
@@ -72,10 +73,10 @@ void testing_trsm_bad_arg(const Arguments& arg)
     device_matrix<T> dB(M, N, ldb);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -199,6 +200,7 @@ void testing_trsm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrsmFn = arg.api == FORTRAN ? hipblasTrsm<T, true> : hipblasTrsm<T, false>;
     auto hipblasTrsmFn_64
         = arg.api == FORTRAN_64 ? hipblasTrsm_64<T, true> : hipblasTrsm_64<T, false>;
@@ -280,7 +282,7 @@ void testing_trsm(const Arguments& arg)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasTrsmFn,
-                   (handle, side, uplo, transA, diag, M, N, &h_alpha, dA, lda, dB, ldb));
+                   (handle, side, uplo, transA, diag, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb));
 
         CHECK_HIP_ERROR(hB_host.transfer_from(dB));
         CHECK_HIP_ERROR(dB.transfer_from(hB_device));

--- a/clients/include/blas3/testing_trsm.hpp
+++ b/clients/include/blas3/testing_trsm.hpp
@@ -50,7 +50,7 @@ inline void testname_trsm(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_trsm_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasTrsmFn = arg.api == FORTRAN ? hipblasTrsm<T, true> : hipblasTrsm<T, false>;
     auto hipblasTrsmFn_64
         = arg.api == FORTRAN_64 ? hipblasTrsm_64<T, true> : hipblasTrsm_64<T, false>;
@@ -73,7 +73,7 @@ void testing_trsm_bad_arg(const Arguments& arg)
     device_matrix<T> dB(M, N, ldb);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* zero  = &h_zero;
@@ -200,7 +200,7 @@ void testing_trsm_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts           = hipblas_internal_type<T>;
     auto hipblasTrsmFn = arg.api == FORTRAN ? hipblasTrsm<T, true> : hipblasTrsm<T, false>;
     auto hipblasTrsmFn_64
         = arg.api == FORTRAN_64 ? hipblasTrsm_64<T, true> : hipblasTrsm_64<T, false>;
@@ -282,7 +282,18 @@ void testing_trsm(const Arguments& arg)
     {
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasTrsmFn,
-                   (handle, side, uplo, transA, diag, M, N, reinterpret_cast<Ts*>(&h_alpha), dA, lda, dB, ldb));
+                   (handle,
+                    side,
+                    uplo,
+                    transA,
+                    diag,
+                    M,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    dA,
+                    lda,
+                    dB,
+                    ldb));
 
         CHECK_HIP_ERROR(hB_host.transfer_from(dB));
         CHECK_HIP_ERROR(dB.transfer_from(hB_device));

--- a/clients/include/blas3/testing_trsm_batched.hpp
+++ b/clients/include/blas3/testing_trsm_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ inline void testname_trsm_batched(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_trsm_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrsmBatchedFn
         = arg.api == FORTRAN ? hipblasTrsmBatched<T, true> : hipblasTrsmBatched<T, false>;
     auto hipblasTrsmBatchedFn_64
@@ -74,10 +75,10 @@ void testing_trsm_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dB(M, N, ldb, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -315,6 +316,7 @@ void testing_trsm_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrsmBatchedFn
         = arg.api == FORTRAN ? hipblasTrsmBatched<T, true> : hipblasTrsmBatched<T, false>;
     auto hipblasTrsmBatchedFn_64
@@ -434,7 +436,7 @@ void testing_trsm_batched(const Arguments& arg)
                     diag,
                     M,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA.ptr_on_device(),
                     lda,
                     dB.ptr_on_device(),

--- a/clients/include/blas3/testing_trsm_batched.hpp
+++ b/clients/include/blas3/testing_trsm_batched.hpp
@@ -75,7 +75,7 @@ void testing_trsm_batched_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dB(M, N, ldb, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* zero  = &h_zero;

--- a/clients/include/blas3/testing_trsm_strided_batched.hpp
+++ b/clients/include/blas3/testing_trsm_strided_batched.hpp
@@ -51,7 +51,7 @@ inline void testname_trsm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_trsm_strided_batched_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasTrsmStridedBatchedFn    = arg.api == FORTRAN ? hipblasTrsmStridedBatched<T, true>
                                                              : hipblasTrsmStridedBatched<T, false>;
     auto hipblasTrsmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -80,7 +80,7 @@ void testing_trsm_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dB(M, N, ldb, stride_B, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* zero  = &h_zero;
@@ -360,7 +360,7 @@ void testing_trsm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_strided_batched(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                            = hipblas_internal_type<T>;
     auto hipblasTrsmStridedBatchedFn    = arg.api == FORTRAN ? hipblasTrsmStridedBatched<T, true>
                                                              : hipblasTrsmStridedBatched<T, false>;
     auto hipblasTrsmStridedBatchedFn_64 = arg.api == FORTRAN_64

--- a/clients/include/blas3/testing_trsm_strided_batched.hpp
+++ b/clients/include/blas3/testing_trsm_strided_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ inline void testname_trsm_strided_batched(const Arguments& arg, std::string& nam
 template <typename T>
 void testing_trsm_strided_batched_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrsmStridedBatchedFn    = arg.api == FORTRAN ? hipblasTrsmStridedBatched<T, true>
                                                              : hipblasTrsmStridedBatched<T, false>;
     auto hipblasTrsmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -79,10 +80,10 @@ void testing_trsm_strided_batched_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dB(M, N, ldb, stride_B, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -359,6 +360,7 @@ void testing_trsm_strided_batched_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_strided_batched(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     auto hipblasTrsmStridedBatchedFn    = arg.api == FORTRAN ? hipblasTrsmStridedBatched<T, true>
                                                              : hipblasTrsmStridedBatched<T, false>;
     auto hipblasTrsmStridedBatchedFn_64 = arg.api == FORTRAN_64
@@ -487,7 +489,7 @@ void testing_trsm_strided_batched(const Arguments& arg)
                     diag,
                     M,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     dA,
                     lda,
                     stride_A,

--- a/clients/include/blas_ex/testing_axpy_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_axpy_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -47,6 +47,7 @@ inline void testname_axpy_batched_ex(const Arguments& arg, std::string& name)
 template <typename Ta, typename Tx = Ta, typename Ty = Tx, typename Tex = Ty>
 void testing_axpy_batched_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasAxpyBatchedExFn
         = arg.api == FORTRAN ? hipblasAxpyBatchedExFortran : hipblasAxpyBatchedEx;
     auto hipblasAxpyBatchedExFn_64
@@ -71,9 +72,9 @@ void testing_axpy_batched_ex_bad_arg(const Arguments& arg)
         device_batch_vector<Tx> dx(N, incx, batch_count);
         device_batch_vector<Ty> dy(N, incy, batch_count);
 
-        const Ta  h_alpha(1), h_zero(0);
-        const Ta* alpha = &h_alpha;
-        const Ta* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -211,6 +212,7 @@ void testing_axpy_batched_ex_bad_arg(const Arguments& arg)
 template <typename Ta, typename Tx = Ta, typename Ty = Tx, typename Tex = Ty>
 void testing_axpy_batched_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasAxpyBatchedExFn
         = arg.api == FORTRAN ? hipblasAxpyBatchedExFortran : hipblasAxpyBatchedEx;
     auto hipblasAxpyBatchedExFn_64
@@ -287,7 +289,7 @@ void testing_axpy_batched_ex(const Arguments& arg)
     DAPI_CHECK(hipblasAxpyBatchedExFn,
                (handle,
                 N,
-                &h_alpha,
+                reinterpret_cast<Ts*>(&h_alpha),
                 alphaType,
                 dx.ptr_on_device(),
                 xType,

--- a/clients/include/blas_ex/testing_axpy_ex.hpp
+++ b/clients/include/blas_ex/testing_axpy_ex.hpp
@@ -40,7 +40,7 @@ inline void testname_axpy_ex(const Arguments& arg, std::string& name)
 template <typename Ta, typename Tx = Ta, typename Ty = Tx, typename Tex = Ty>
 void testing_axpy_ex_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<Ta>;
+    using Ts                = hipblas_internal_type<Ta>;
     auto hipblasAxpyExFn    = arg.api == FORTRAN ? hipblasAxpyExFortran : hipblasAxpyEx;
     auto hipblasAxpyExFn_64 = arg.api == FORTRAN_64 ? hipblasAxpyEx_64Fortran : hipblasAxpyEx_64;
 
@@ -167,7 +167,7 @@ void testing_axpy_ex_bad_arg(const Arguments& arg)
 template <typename Ta, typename Tx = Ta, typename Ty = Tx, typename Tex = Ty>
 void testing_axpy_ex(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<Ta>;
+    using Ts                = hipblas_internal_type<Ta>;
     auto hipblasAxpyExFn    = arg.api == FORTRAN ? hipblasAxpyExFortran : hipblasAxpyEx;
     auto hipblasAxpyExFn_64 = arg.api == FORTRAN_64 ? hipblasAxpyEx_64Fortran : hipblasAxpyEx_64;
 
@@ -238,7 +238,17 @@ void testing_axpy_ex(const Arguments& arg)
     =================================================================== */
     CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
     DAPI_CHECK(hipblasAxpyExFn,
-               (handle, N, reinterpret_cast<Ts*>(&h_alpha), alphaType, dx, xType, incx, dy, yType, incy, executionType));
+               (handle,
+                N,
+                reinterpret_cast<Ts*>(&h_alpha),
+                alphaType,
+                dx,
+                xType,
+                incx,
+                dy,
+                yType,
+                incy,
+                executionType));
 
     // copy output from device to CPU
     CHECK_HIP_ERROR(hy_host.transfer_from(dy));

--- a/clients/include/blas_ex/testing_axpy_ex.hpp
+++ b/clients/include/blas_ex/testing_axpy_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_axpy_ex(const Arguments& arg, std::string& name)
 template <typename Ta, typename Tx = Ta, typename Ty = Tx, typename Tex = Ty>
 void testing_axpy_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasAxpyExFn    = arg.api == FORTRAN ? hipblasAxpyExFortran : hipblasAxpyEx;
     auto hipblasAxpyExFn_64 = arg.api == FORTRAN_64 ? hipblasAxpyEx_64Fortran : hipblasAxpyEx_64;
 
@@ -61,9 +62,9 @@ void testing_axpy_ex_bad_arg(const Arguments& arg)
         device_vector<Tx> dx(N, incx);
         device_vector<Ty> dy(N, incy);
 
-        const Ta  h_alpha(1), h_zero(0);
-        const Ta* alpha = &h_alpha;
-        const Ta* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -166,6 +167,7 @@ void testing_axpy_ex_bad_arg(const Arguments& arg)
 template <typename Ta, typename Tx = Ta, typename Ty = Tx, typename Tex = Ty>
 void testing_axpy_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasAxpyExFn    = arg.api == FORTRAN ? hipblasAxpyExFortran : hipblasAxpyEx;
     auto hipblasAxpyExFn_64 = arg.api == FORTRAN_64 ? hipblasAxpyEx_64Fortran : hipblasAxpyEx_64;
 
@@ -236,7 +238,7 @@ void testing_axpy_ex(const Arguments& arg)
     =================================================================== */
     CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
     DAPI_CHECK(hipblasAxpyExFn,
-               (handle, N, &h_alpha, alphaType, dx, xType, incx, dy, yType, incy, executionType));
+               (handle, N, reinterpret_cast<Ts*>(&h_alpha), alphaType, dx, xType, incx, dy, yType, incy, executionType));
 
     // copy output from device to CPU
     CHECK_HIP_ERROR(hy_host.transfer_from(dy));

--- a/clients/include/blas_ex/testing_axpy_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_axpy_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,7 @@ inline void testname_axpy_strided_batched_ex(const Arguments& arg, std::string& 
 template <typename Ta, typename Tx = Ta, typename Ty = Tx, typename Tex = Ty>
 void testing_axpy_strided_batched_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasAxpyStridedBatchedExFn
         = arg.api == FORTRAN ? hipblasAxpyStridedBatchedExFortran : hipblasAxpyStridedBatchedEx;
     auto hipblasAxpyStridedBatchedExFn_64 = arg.api == FORTRAN_64
@@ -76,9 +77,9 @@ void testing_axpy_strided_batched_ex_bad_arg(const Arguments& arg)
         device_strided_batch_vector<Tx> dx(N, incx, stridex, batch_count);
         device_strided_batch_vector<Ty> dy(N, incy, stridey, batch_count);
 
-        const Ta  h_alpha(1), h_zero(0);
-        const Ta* alpha = &h_alpha;
-        const Ta* zero  = &h_zero;
+        const Ts  h_alpha(1), h_zero(0);
+        const Ts* alpha = &h_alpha;
+        const Ts* zero  = &h_zero;
 
         if(pointer_mode == HIPBLAS_POINTER_MODE_DEVICE)
         {
@@ -232,6 +233,7 @@ void testing_axpy_strided_batched_ex_bad_arg(const Arguments& arg)
 template <typename Ta, typename Tx = Ta, typename Ty = Tx, typename Tex = Ty>
 void testing_axpy_strided_batched_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasAxpyStridedBatchedExFn
         = arg.api == FORTRAN ? hipblasAxpyStridedBatchedExFortran : hipblasAxpyStridedBatchedEx;
     auto hipblasAxpyStridedBatchedExFn_64 = arg.api == FORTRAN_64
@@ -315,7 +317,7 @@ void testing_axpy_strided_batched_ex(const Arguments& arg)
     DAPI_CHECK(hipblasAxpyStridedBatchedExFn,
                (handle,
                 N,
-                &h_alpha,
+                reinterpret_cast<Ts*>(&h_alpha),
                 alphaType,
                 dx,
                 xType,

--- a/clients/include/blas_ex/testing_dot_ex.hpp
+++ b/clients/include/blas_ex/testing_dot_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -123,7 +123,7 @@ void testing_dot_ex_bad_arg(const Arguments& arg)
                          nullptr,
                          yType,
                          incy,
-                         pointer_mode == HIPBLAS_POINTER_MODE_HOST ? h_res : d_res,
+                         pointer_mode == HIPBLAS_POINTER_MODE_HOST ? h_res.internal_type() : d_res,
                          resultType,
                          executionType));
         }

--- a/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -58,6 +58,7 @@ inline void testname_gemm_batched_ex(const Arguments& arg, std::string& name)
 template <typename Ti, typename To = Ti, typename Tex = To>
 void testing_gemm_batched_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Tex>;
     // Note: hipblasGemmEx and hipblasGemmExWithFlags are essentially the exact same.
     //       Only testing WithFlags version as it has slightly more functionality.
     auto hipblasGemmBatchedExFn
@@ -100,15 +101,15 @@ void testing_gemm_batched_ex_bad_arg(const Arguments& arg)
     device_batch_matrix<To> dC(M, N, ldc, batch_count);
 
     device_vector<Tex> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Tex                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
         h_one = float_to_half(1.0f);
 
-    const Tex* alpha = &h_alpha;
-    const Tex* beta  = &h_beta;
-    const Tex* one   = &h_one;
-    const Tex* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -299,6 +300,7 @@ void testing_gemm_batched_ex_bad_arg(const Arguments& arg)
 template <typename Ti, typename To = Ti, typename Tex = To>
 void testing_gemm_batched_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Tex>;
     auto hipblasGemmBatchedExFn
         = arg.api == FORTRAN ? hipblasGemmBatchedExFortran : hipblasGemmBatchedEx;
     auto hipblasGemmBatchedExWithFlagsFn
@@ -440,14 +442,14 @@ void testing_gemm_batched_ex(const Arguments& arg)
                         M,
                         N,
                         K,
-                        &h_alpha_Tex,
+                        reinterpret_cast<Ts*>(&h_alpha_Tex),
                         (const void**)(Ti**)dA.ptr_on_device(),
                         a_type,
                         lda,
                         (const void**)(Ti**)dB.ptr_on_device(),
                         b_type,
                         ldb,
-                        &h_beta_Tex,
+                        reinterpret_cast<Ts*>(&h_beta_Tex),
                         (void**)(To**)dC.ptr_on_device(),
                         c_type,
                         ldc,

--- a/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -101,7 +101,7 @@ void testing_gemm_batched_ex_bad_arg(const Arguments& arg)
     device_batch_matrix<To> dC(M, N, ldc, batch_count);
 
     device_vector<Tex> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                 h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
         h_one = float_to_half(1.0f);

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -99,7 +99,7 @@ void testing_gemm_ex_bad_arg(const Arguments& arg)
     device_matrix<To> dC(M, N, ldc);
 
     device_vector<Tex> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                 h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
         h_one = float_to_half(1.0f);
@@ -291,7 +291,7 @@ void testing_gemm_ex_bad_arg(const Arguments& arg)
 template <typename Ti, typename To = Ti, typename Tex = To>
 void testing_gemm_ex(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<Tex>;
+    using Ts             = hipblas_internal_type<Tex>;
     auto hipblasGemmExFn = arg.api == FORTRAN ? hipblasGemmExFortran : hipblasGemmEx;
     auto hipblasGemmExWithFlagsFn
         = arg.api == FORTRAN ? hipblasGemmExWithFlagsFortran : hipblasGemmExWithFlags;

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -57,6 +57,7 @@ inline void testname_gemm_ex(const Arguments& arg, std::string& name)
 template <typename Ti, typename To = Ti, typename Tex = To>
 void testing_gemm_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Tex>;
     // Note: hipblasGemmEx and hipblasGemmExWithFlags are essentially the exact same.
     //       Only testing WithFlags version as it has slightly more functionality.
     auto hipblasGemmExFn
@@ -98,15 +99,15 @@ void testing_gemm_ex_bad_arg(const Arguments& arg)
     device_matrix<To> dC(M, N, ldc);
 
     device_vector<Tex> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Tex                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
         h_one = float_to_half(1.0f);
 
-    const Tex* alpha = &h_alpha;
-    const Tex* beta  = &h_beta;
-    const Tex* one   = &h_one;
-    const Tex* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -290,6 +291,7 @@ void testing_gemm_ex_bad_arg(const Arguments& arg)
 template <typename Ti, typename To = Ti, typename Tex = To>
 void testing_gemm_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Tex>;
     auto hipblasGemmExFn = arg.api == FORTRAN ? hipblasGemmExFortran : hipblasGemmEx;
     auto hipblasGemmExWithFlagsFn
         = arg.api == FORTRAN ? hipblasGemmExWithFlagsFortran : hipblasGemmExWithFlags;
@@ -408,14 +410,14 @@ void testing_gemm_ex(const Arguments& arg)
                         M,
                         N,
                         K,
-                        &h_alpha_Tex,
+                        reinterpret_cast<Ts*>(&h_alpha_Tex),
                         dA,
                         a_type,
                         lda,
                         dB,
                         b_type,
                         ldb,
-                        &h_beta_Tex,
+                        reinterpret_cast<Ts*>(&h_beta_Tex),
                         dC,
                         c_type,
                         ldc,

--- a/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -109,7 +109,7 @@ void testing_gemm_strided_batched_ex_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<To> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<Tex> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                 h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
         h_one = float_to_half(1.0f);

--- a/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -60,6 +60,7 @@ inline void testname_gemm_strided_batched_ex(const Arguments& arg, std::string& 
 template <typename Ti, typename To = Ti, typename Tex = To>
 void testing_gemm_strided_batched_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Tex>;
     // Note: hipblasGemmEx and hipblasGemmExWithFlags are essentially the exact same.
     //       Only testing WithFlags version as it has slightly more functionality.
     auto hipblasGemmStridedBatchedExFn    = arg.api == FORTRAN
@@ -108,15 +109,15 @@ void testing_gemm_strided_batched_ex_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<To> dC(M, N, ldc, stride_C, batch_count);
 
     device_vector<Tex> d_alpha(1), d_beta(1), d_one(1), d_zero(1);
-    Tex                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
+    Ts                h_alpha(1), h_beta(2), h_one(1), h_zero(0);
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
         h_one = float_to_half(1.0f);
 
-    const Tex* alpha = &h_alpha;
-    const Tex* beta  = &h_beta;
-    const Tex* one   = &h_one;
-    const Tex* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* beta  = &h_beta;
+    const Ts* one   = &h_one;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -312,6 +313,7 @@ void testing_gemm_strided_batched_ex_bad_arg(const Arguments& arg)
 template <typename Ti, typename To = Ti, typename Tex = To>
 void testing_gemm_strided_batched_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Tex>;
     auto hipblasGemmStridedBatchedExFn
         = arg.api == FORTRAN ? hipblasGemmStridedBatchedExFortran : hipblasGemmStridedBatchedEx;
     auto hipblasGemmStridedBatchedExWithFlagsFn = arg.api == FORTRAN
@@ -465,7 +467,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
                         M,
                         N,
                         K,
-                        &h_alpha_Tex,
+                        reinterpret_cast<Ts*>(&h_alpha_Tex),
                         dA,
                         a_type,
                         lda,
@@ -474,7 +476,7 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
                         b_type,
                         ldb,
                         stride_B,
-                        &h_beta_Tex,
+                        reinterpret_cast<Ts*>(&h_beta_Tex),
                         dC,
                         c_type,
                         ldc,

--- a/clients/include/blas_ex/testing_scal_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_scal_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ inline void testname_scal_batched_ex(const Arguments& arg, std::string& name)
 template <typename Ta, typename Tx = Ta, typename Tex = Tx>
 void testing_scal_batched_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasScalBatchedExFn
         = arg.api == FORTRAN ? hipblasScalBatchedExFortran : hipblasScalBatchedEx;
     auto hipblasScalBatchedExFn_64
@@ -52,7 +53,7 @@ void testing_scal_batched_ex_bad_arg(const Arguments& arg)
     int64_t N           = 100;
     int64_t incx        = 1;
     int64_t batch_count = 2;
-    Ta      alpha       = (Ta)0.6;
+    Ts      alpha       = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -102,6 +103,7 @@ void testing_scal_batched_ex_bad_arg(const Arguments& arg)
 template <typename Ta, typename Tx = Ta, typename Tex = Tx>
 void testing_scal_batched_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasScalBatchedExFn
         = arg.api == FORTRAN ? hipblasScalBatchedExFortran : hipblasScalBatchedEx;
     auto hipblasScalBatchedExFn_64
@@ -168,7 +170,7 @@ void testing_scal_batched_ex(const Arguments& arg)
         DAPI_CHECK(hipblasScalBatchedExFn,
                    (handle,
                     N,
-                    &h_alpha,
+                    reinterpret_cast<Ts*>(&h_alpha),
                     alphaType,
                     dx.ptr_on_device(),
                     xType,

--- a/clients/include/blas_ex/testing_scal_ex.hpp
+++ b/clients/include/blas_ex/testing_scal_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ inline void testname_scal_ex(const Arguments& arg, std::string& name)
 template <typename Ta, typename Tx = Ta, typename Tex = Tx>
 void testing_scal_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasScalExFn    = arg.api == FORTRAN ? hipblasScalExFortran : hipblasScalEx;
     auto hipblasScalExFn_64 = arg.api == FORTRAN_64 ? hipblasScalEx_64Fortran : hipblasScalEx_64;
 
@@ -48,7 +49,7 @@ void testing_scal_ex_bad_arg(const Arguments& arg)
 
     int64_t N     = 100;
     int64_t incx  = 1;
-    Ta      alpha = (Ta)0.6;
+    Ts      alpha = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -88,6 +89,7 @@ void testing_scal_ex_bad_arg(const Arguments& arg)
 template <typename Ta, typename Tx = Ta, typename Tex = Tx>
 void testing_scal_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasScalExFn    = arg.api == FORTRAN ? hipblasScalExFortran : hipblasScalEx;
     auto hipblasScalExFn_64 = arg.api == FORTRAN_64 ? hipblasScalEx_64Fortran : hipblasScalEx_64;
 
@@ -149,7 +151,7 @@ void testing_scal_ex(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasScalExFn,
-                   (handle, N, &h_alpha, alphaType, dx, xType, incx, executionType));
+                   (handle, N, reinterpret_cast<Ts*>(&h_alpha), alphaType, dx, xType, incx, executionType));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hx_host.transfer_from(dx));

--- a/clients/include/blas_ex/testing_scal_ex.hpp
+++ b/clients/include/blas_ex/testing_scal_ex.hpp
@@ -39,7 +39,7 @@ inline void testname_scal_ex(const Arguments& arg, std::string& name)
 template <typename Ta, typename Tx = Ta, typename Tex = Tx>
 void testing_scal_ex_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<Ta>;
+    using Ts                = hipblas_internal_type<Ta>;
     auto hipblasScalExFn    = arg.api == FORTRAN ? hipblasScalExFortran : hipblasScalEx;
     auto hipblasScalExFn_64 = arg.api == FORTRAN_64 ? hipblasScalEx_64Fortran : hipblasScalEx_64;
 
@@ -89,7 +89,7 @@ void testing_scal_ex_bad_arg(const Arguments& arg)
 template <typename Ta, typename Tx = Ta, typename Tex = Tx>
 void testing_scal_ex(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<Ta>;
+    using Ts                = hipblas_internal_type<Ta>;
     auto hipblasScalExFn    = arg.api == FORTRAN ? hipblasScalExFortran : hipblasScalEx;
     auto hipblasScalExFn_64 = arg.api == FORTRAN_64 ? hipblasScalEx_64Fortran : hipblasScalEx_64;
 
@@ -151,7 +151,14 @@ void testing_scal_ex(const Arguments& arg)
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(hipblasScalExFn,
-                   (handle, N, reinterpret_cast<Ts*>(&h_alpha), alphaType, dx, xType, incx, executionType));
+                   (handle,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    alphaType,
+                    dx,
+                    xType,
+                    incx,
+                    executionType));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hx_host.transfer_from(dx));

--- a/clients/include/blas_ex/testing_scal_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_scal_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,6 +46,7 @@ inline void testname_scal_strided_batched_ex(const Arguments& arg, std::string& 
 template <typename Ta, typename Tx = Ta, typename Tex = Tx>
 void testing_scal_strided_batched_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasScalStridedBatchedExFn
         = arg.api == FORTRAN ? hipblasScalStridedBatchedExFortran : hipblasScalStridedBatchedEx;
     auto hipblasScalStridedBatchedExFn_64 = arg.api == FORTRAN_64
@@ -62,7 +63,7 @@ void testing_scal_strided_batched_ex_bad_arg(const Arguments& arg)
 
     hipblasStride stridex = N * incx;
 
-    Ta alpha = (Ta)0.6;
+    Ts alpha = (Ts)0.6;
 
     hipblasLocalHandle handle(arg);
 
@@ -130,6 +131,7 @@ void testing_scal_strided_batched_ex_bad_arg(const Arguments& arg)
 template <typename Ta, typename Tx = Ta, typename Tex = Tx>
 void testing_scal_strided_batched_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<Ta>;
     auto hipblasScalStridedBatchedExFn
         = arg.api == FORTRAN ? hipblasScalStridedBatchedExFortran : hipblasScalStridedBatchedEx;
     auto hipblasScalStridedBatchedExFn_64 = arg.api == FORTRAN_64
@@ -210,7 +212,7 @@ void testing_scal_strided_batched_ex(const Arguments& arg)
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
         DAPI_CHECK(
             hipblasScalStridedBatchedExFn,
-            (handle, N, &h_alpha, alphaType, dx, xType, incx, stridex, batch_count, executionType));
+            (handle, N, reinterpret_cast<Ts*>(&h_alpha), alphaType, dx, xType, incx, stridex, batch_count, executionType));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hx_host.transfer_from(dx));

--- a/clients/include/blas_ex/testing_scal_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_scal_strided_batched_ex.hpp
@@ -210,9 +210,17 @@ void testing_scal_strided_batched_ex(const Arguments& arg)
             HIPBLAS
         =================================================================== */
         CHECK_HIPBLAS_ERROR(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
-        DAPI_CHECK(
-            hipblasScalStridedBatchedExFn,
-            (handle, N, reinterpret_cast<Ts*>(&h_alpha), alphaType, dx, xType, incx, stridex, batch_count, executionType));
+        DAPI_CHECK(hipblasScalStridedBatchedExFn,
+                   (handle,
+                    N,
+                    reinterpret_cast<Ts*>(&h_alpha),
+                    alphaType,
+                    dx,
+                    xType,
+                    incx,
+                    stridex,
+                    batch_count,
+                    executionType));
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hx_host.transfer_from(dx));

--- a/clients/include/blas_ex/testing_trsm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@ inline void testname_trsm_batched_ex(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_trsm_batched_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN                = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmBatchedExFn = FORTRAN ? hipblasTrsmBatchedExFortran : hipblasTrsmBatchedEx;
 
@@ -77,10 +78,10 @@ void testing_trsm_batched_ex_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dinvA(TRSM_BLOCK, TRSM_BLOCK, K, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -346,6 +347,7 @@ void testing_trsm_batched_ex_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_batched_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN                = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmBatchedExFn = FORTRAN ? hipblasTrsmBatchedExFortran : hipblasTrsmBatchedEx;
 
@@ -485,7 +487,7 @@ void testing_trsm_batched_ex(const Arguments& arg)
                                                    diag,
                                                    M,
                                                    N,
-                                                   &h_alpha,
+                                                   reinterpret_cast<Ts*>(&h_alpha),
                                                    dA.ptr_on_device(),
                                                    lda,
                                                    dB.ptr_on_device(),

--- a/clients/include/blas_ex/testing_trsm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_batched_ex.hpp
@@ -52,7 +52,7 @@ inline void testname_trsm_batched_ex(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_trsm_batched_ex_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                    = hipblas_internal_type<T>;
     bool FORTRAN                = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmBatchedExFn = FORTRAN ? hipblasTrsmBatchedExFortran : hipblasTrsmBatchedEx;
 
@@ -78,7 +78,7 @@ void testing_trsm_batched_ex_bad_arg(const Arguments& arg)
     device_batch_matrix<T> dinvA(TRSM_BLOCK, TRSM_BLOCK, K, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* zero  = &h_zero;
@@ -347,7 +347,7 @@ void testing_trsm_batched_ex_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_batched_ex(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts                    = hipblas_internal_type<T>;
     bool FORTRAN                = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmBatchedExFn = FORTRAN ? hipblasTrsmBatchedExFortran : hipblasTrsmBatchedEx;
 

--- a/clients/include/blas_ex/testing_trsm_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_ex.hpp
@@ -43,7 +43,7 @@ inline void testname_trsm_ex(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_trsm_ex_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts             = hipblas_internal_type<T>;
     bool FORTRAN         = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmExFn = FORTRAN ? hipblasTrsmExFortran : hipblasTrsmEx;
 
@@ -68,7 +68,7 @@ void testing_trsm_ex_bad_arg(const Arguments& arg)
     device_vector<T> dinvA(TRSM_BLOCK, TRSM_BLOCK, K);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* zero  = &h_zero;
@@ -309,7 +309,7 @@ void testing_trsm_ex_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_ex(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts             = hipblas_internal_type<T>;
     bool FORTRAN         = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmExFn = FORTRAN ? hipblasTrsmExFortran : hipblasTrsmEx;
 

--- a/clients/include/blas_ex/testing_trsm_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,7 @@ inline void testname_trsm_ex(const Arguments& arg, std::string& name)
 template <typename T>
 void testing_trsm_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN         = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmExFn = FORTRAN ? hipblasTrsmExFortran : hipblasTrsmEx;
 
@@ -67,10 +68,10 @@ void testing_trsm_ex_bad_arg(const Arguments& arg)
     device_vector<T> dinvA(TRSM_BLOCK, TRSM_BLOCK, K);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -308,6 +309,7 @@ void testing_trsm_ex_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN         = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmExFn = FORTRAN ? hipblasTrsmExFortran : hipblasTrsmEx;
 
@@ -430,7 +432,7 @@ void testing_trsm_ex(const Arguments& arg)
                                             diag,
                                             M,
                                             N,
-                                            &h_alpha,
+                                            reinterpret_cast<Ts*>(&h_alpha),
                                             dA,
                                             lda,
                                             dB,

--- a/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -53,6 +53,7 @@ inline void testname_trsm_strided_batched_ex(const Arguments& arg, std::string& 
 template <typename T>
 void testing_trsm_strided_batched_ex_bad_arg(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmStridedBatchedExFn
         = FORTRAN ? hipblasTrsmStridedBatchedEx : hipblasTrsmStridedBatchedEx;
@@ -83,10 +84,10 @@ void testing_trsm_strided_batched_ex_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dinvA(TRSM_BLOCK, TRSM_BLOCK, K, strideInvA, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const T          h_alpha(1), h_zero(0);
+    const Ts          h_alpha(1), h_zero(0);
 
-    const T* alpha = &h_alpha;
-    const T* zero  = &h_zero;
+    const Ts* alpha = &h_alpha;
+    const Ts* zero  = &h_zero;
 
     for(auto pointer_mode : {HIPBLAS_POINTER_MODE_HOST, HIPBLAS_POINTER_MODE_DEVICE})
     {
@@ -396,6 +397,7 @@ void testing_trsm_strided_batched_ex_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_strided_batched_ex(const Arguments& arg)
 {
+    using Ts = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmStridedBatchedExFn
         = FORTRAN ? hipblasTrsmStridedBatchedEx : hipblasTrsmStridedBatchedEx;
@@ -546,7 +548,7 @@ void testing_trsm_strided_batched_ex(const Arguments& arg)
                                                           diag,
                                                           M,
                                                           N,
-                                                          &h_alpha,
+                                                          reinterpret_cast<Ts*>(&h_alpha),
                                                           dA,
                                                           lda,
                                                           stride_A,

--- a/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_trsm_strided_batched_ex.hpp
@@ -53,7 +53,7 @@ inline void testname_trsm_strided_batched_ex(const Arguments& arg, std::string& 
 template <typename T>
 void testing_trsm_strided_batched_ex_bad_arg(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmStridedBatchedExFn
         = FORTRAN ? hipblasTrsmStridedBatchedEx : hipblasTrsmStridedBatchedEx;
@@ -84,7 +84,7 @@ void testing_trsm_strided_batched_ex_bad_arg(const Arguments& arg)
     device_strided_batch_matrix<T> dinvA(TRSM_BLOCK, TRSM_BLOCK, K, strideInvA, batch_count);
 
     device_vector<T> d_alpha(1), d_zero(1);
-    const Ts          h_alpha(1), h_zero(0);
+    const Ts         h_alpha(1), h_zero(0);
 
     const Ts* alpha = &h_alpha;
     const Ts* zero  = &h_zero;
@@ -397,7 +397,7 @@ void testing_trsm_strided_batched_ex_bad_arg(const Arguments& arg)
 template <typename T>
 void testing_trsm_strided_batched_ex(const Arguments& arg)
 {
-    using Ts = hipblas_internal_type<T>;
+    using Ts     = hipblas_internal_type<T>;
     bool FORTRAN = arg.api == hipblas_client_api::FORTRAN;
     auto hipblasTrsmStridedBatchedExFn
         = FORTRAN ? hipblasTrsmStridedBatchedEx : hipblasTrsmStridedBatchedEx;

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,13 +81,13 @@ inline void ref_asum(int64_t n, const double* x, int64_t incx, double* result)
 }
 
 template <>
-inline void ref_asum(int64_t n, const hipblasComplex* x, int64_t incx, float* result)
+inline void ref_asum(int64_t n, const std::complex<float>* x, int64_t incx, float* result)
 {
     *result = cblas_scasum(n, x, incx);
 }
 
 template <>
-inline void ref_asum(int64_t n, const hipblasDoubleComplex* x, int64_t incx, double* result)
+inline void ref_asum(int64_t n, const std::complex<double>* x, int64_t incx, double* result)
 {
     *result = cblas_dzasum(n, x, incx);
 }
@@ -721,16 +721,16 @@ inline void ref_trsm<double>(hipblasSideMode_t  side,
 }
 
 template <>
-inline void ref_trsm<hipblasComplex>(hipblasSideMode_t     side,
+inline void ref_trsm<std::complex<float>>(hipblasSideMode_t     side,
                                      hipblasFillMode_t     uplo,
                                      hipblasOperation_t    transA,
                                      hipblasDiagType_t     diag,
                                      int64_t               m,
                                      int64_t               n,
-                                     hipblasComplex        alpha,
-                                     const hipblasComplex* A,
+                                     std::complex<float>        alpha,
+                                     const std::complex<float>* A,
                                      int64_t               lda,
-                                     hipblasComplex*       B,
+                                     std::complex<float>*       B,
                                      int64_t               ldb)
 {
     cblas_ctrsm(CblasColMajor,
@@ -748,16 +748,16 @@ inline void ref_trsm<hipblasComplex>(hipblasSideMode_t     side,
 }
 
 template <>
-inline void ref_trsm<hipblasDoubleComplex>(hipblasSideMode_t           side,
+inline void ref_trsm<std::complex<double>>(hipblasSideMode_t           side,
                                            hipblasFillMode_t           uplo,
                                            hipblasOperation_t          transA,
                                            hipblasDiagType_t           diag,
                                            int64_t                     m,
                                            int64_t                     n,
-                                           hipblasDoubleComplex        alpha,
-                                           const hipblasDoubleComplex* A,
+                                           std::complex<double>        alpha,
+                                           const std::complex<double>* A,
                                            int64_t                     lda,
-                                           hipblasDoubleComplex*       B,
+                                           std::complex<double>*       B,
                                            int64_t                     ldb)
 {
     cblas_ztrsm(CblasColMajor,

--- a/clients/include/cblas_interface.h
+++ b/clients/include/cblas_interface.h
@@ -721,17 +721,17 @@ inline void ref_trsm<double>(hipblasSideMode_t  side,
 }
 
 template <>
-inline void ref_trsm<std::complex<float>>(hipblasSideMode_t     side,
-                                     hipblasFillMode_t     uplo,
-                                     hipblasOperation_t    transA,
-                                     hipblasDiagType_t     diag,
-                                     int64_t               m,
-                                     int64_t               n,
-                                     std::complex<float>        alpha,
-                                     const std::complex<float>* A,
-                                     int64_t               lda,
-                                     std::complex<float>*       B,
-                                     int64_t               ldb)
+inline void ref_trsm<std::complex<float>>(hipblasSideMode_t          side,
+                                          hipblasFillMode_t          uplo,
+                                          hipblasOperation_t         transA,
+                                          hipblasDiagType_t          diag,
+                                          int64_t                    m,
+                                          int64_t                    n,
+                                          std::complex<float>        alpha,
+                                          const std::complex<float>* A,
+                                          int64_t                    lda,
+                                          std::complex<float>*       B,
+                                          int64_t                    ldb)
 {
     cblas_ctrsm(CblasColMajor,
                 (CBLAS_SIDE)side,

--- a/clients/include/complex.hpp
+++ b/clients/include/complex.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,7 @@
 
 #include "hipblas.h"
 #include <complex>
-
+/*
 inline hipblasComplex& operator+=(hipblasComplex& lhs, const hipblasComplex& rhs)
 {
     reinterpret_cast<std::complex<float>&>(lhs)
@@ -206,5 +206,5 @@ namespace std
         return r;
     }
 }
-
+*/
 #endif

--- a/clients/include/d_vector.hpp
+++ b/clients/include/d_vector.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -64,14 +64,14 @@ public:
     bool use_HMM = false;
 
 public:
-    static T m_guard[MEM_MAX_GUARD_PAD];
+    static hipblas_internal_type<T> m_guard[MEM_MAX_GUARD_PAD];
 
 #ifdef GOOGLE_TEST
     d_vector(size_t s, bool HMM = false)
         : m_size(s)
         , m_pad(std::min(g_DVEC_PAD, size_t(MEM_MAX_GUARD_PAD)))
-        , m_guard_len(m_pad * sizeof(T))
-        , m_bytes((s + m_pad * 2) * sizeof(T))
+        , m_guard_len(m_pad * sizeof(hipblas_internal_type<T>))
+        , m_bytes((s + m_pad * 2) * sizeof(hipblas_internal_type<T>))
         , use_HMM(HMM)
     {
         // Initialize m_guard with random data
@@ -85,16 +85,16 @@ public:
     d_vector(size_t s, bool HMM = false)
         : m_size(s)
         , m_pad(0) // save current pad length
-        , m_guard_len(0 * sizeof(T))
-        , m_bytes(s ? s * sizeof(T) : sizeof(T))
+        , m_guard_len(0 * sizeof(hipblas_internal_type<T>))
+        , m_bytes(s ? s * sizeof(hipblas_internal_type<T>) : sizeof(hipblas_internal_type<T>))
         , use_HMM(HMM)
     {
     }
 #endif
 
-    T* device_vector_setup()
+    hipblas_internal_type<T>* device_vector_setup()
     {
-        T* d = nullptr;
+        hipblas_internal_type<T>* d = nullptr;
         if(use_HMM ? hipMallocManaged(&d, m_bytes) : (hipMalloc)(&d, m_bytes) != hipSuccess)
         {
             std::cout << "Warning: hip can't allocate " << m_bytes << " bytes (" << (m_bytes >> 30)
@@ -123,12 +123,12 @@ public:
         return d;
     }
 
-    void device_vector_check(T* d)
+    void device_vector_check(hipblas_internal_type<T>* d)
     {
 #ifdef GOOGLE_TEST
         if(m_pad > 0)
         {
-            std::vector<T> host(m_pad);
+            std::vector<hipblas_internal_type<T>> host(m_pad);
 
             // Copy device memory after allocated memory to host
             if(hipMemcpy(host.data(), d + m_size, m_guard_len, hipMemcpyDefault) != hipSuccess)
@@ -150,7 +150,7 @@ public:
 #endif
     }
 
-    void device_vector_teardown(T* d)
+    void device_vector_teardown(hipblas_internal_type<T>* d)
     {
         if(d != nullptr)
         {
@@ -166,7 +166,7 @@ public:
 };
 
 template <typename T>
-T d_vector<T>::m_guard[MEM_MAX_GUARD_PAD] = {};
+hipblas_internal_type<T> d_vector<T>::m_guard[MEM_MAX_GUARD_PAD] = {};
 
 template <typename T>
 bool d_vector<T>::m_init_guard = false;

--- a/clients/include/device_batch_matrix.hpp
+++ b/clients/include/device_batch_matrix.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -127,7 +127,7 @@ public:
     //! @brief Access to device data.
     //! @return Pointer to the device data.
     //!
-    T** ptr_on_device()
+    hipblas_internal_type<T>** ptr_on_device()
     {
         return m_device_data;
     }
@@ -136,7 +136,7 @@ public:
     //! @brief Const access to device data.
     //! @return Const pointer to the device data.
     //!
-    const T* const* ptr_on_device() const
+    const hipblas_internal_type<T>* const* ptr_on_device() const
     {
         return m_device_data;
     }
@@ -145,7 +145,7 @@ public:
     //! @brief access to device data.
     //! @return Const pointer to the device data.
     //!
-    T* const* const_batch_ptr()
+    hipblas_internal_type<T>* const* const_batch_ptr()
     {
         return m_device_data;
     }
@@ -155,7 +155,7 @@ public:
     //! @param batch_index The batch index.
     //! @return Pointer to the array on device.
     //!
-    T* operator[](int64_t batch_index)
+    hipblas_internal_type<T>* operator[](int64_t batch_index)
     {
 
         return m_data[batch_index];
@@ -166,7 +166,7 @@ public:
     //! @param batch_index The batch index.
     //! @return Constant pointer to the array on device.
     //!
-    const T* operator[](int64_t batch_index) const
+    const hipblas_internal_type<T>* operator[](int64_t batch_index) const
     {
 
         return m_data[batch_index];
@@ -175,7 +175,7 @@ public:
     //!
     //! @brief Const cast of the data on host.
     //!
-    operator const T* const *() const
+    operator const hipblas_internal_type<T>* const *() const
     {
         return m_data;
     }
@@ -184,7 +184,7 @@ public:
     //! @brief Cast of the data on host.
     //!
     // clang-format off
-    operator T**()
+    operator hipblas_internal_type<T>**()
     // clang-format on
     {
         return m_data;
@@ -213,7 +213,7 @@ public:
         {
             if(hipSuccess
                != (hip_err
-                   = hipMemcpy((*this)[0], that[0], sizeof(T) * m_nmemb * m_batch_count, kind)))
+                   = hipMemcpy((*this)[0], (hipblas_internal_type<T>*)that[0], sizeof(hipblas_internal_type<T>) * m_nmemb * m_batch_count, kind)))
             {
                 return hip_err;
             }
@@ -241,8 +241,8 @@ private:
     size_t  m_nmemb{};
     int64_t m_batch_count{};
     size_t  m_offset{};
-    T**     m_data{};
-    T**     m_device_data{};
+    hipblas_internal_type<T>**     m_data{};
+    hipblas_internal_type<T>**     m_device_data{};
 
     //!
     //! @brief Try to allocate the resources.
@@ -254,12 +254,12 @@ private:
 
         success
             = (hipSuccess
-               == (!this->use_HMM ? (hipMalloc)(&m_device_data, m_batch_count * sizeof(T*))
-                                  : hipMallocManaged(&m_device_data, m_batch_count * sizeof(T*))));
+               == (!this->use_HMM ? (hipMalloc)(&m_device_data, m_batch_count * sizeof(hipblas_internal_type<T>*))
+                                  : hipMallocManaged(&m_device_data, m_batch_count * sizeof(hipblas_internal_type<T>*))));
         if(success)
         {
             success = (nullptr
-                       != (m_data = !this->use_HMM ? (T**)calloc(m_batch_count, sizeof(T*))
+                       != (m_data = !this->use_HMM ? (hipblas_internal_type<T>**)calloc(m_batch_count, sizeof(hipblas_internal_type<T>*))
                                                    : m_device_data));
             if(success)
             {
@@ -290,7 +290,7 @@ private:
                     success = (hipSuccess
                                == hipMemcpy(m_device_data,
                                             m_data,
-                                            sizeof(T*) * m_batch_count,
+                                            sizeof(hipblas_internal_type<T>*) * m_batch_count,
                                             hipMemcpyHostToDevice));
 
                     if(m_offset)

--- a/clients/include/device_batch_matrix.hpp
+++ b/clients/include/device_batch_matrix.hpp
@@ -212,8 +212,10 @@ public:
         if(m_batch_count > 0)
         {
             if(hipSuccess
-               != (hip_err
-                   = hipMemcpy((*this)[0], (hipblas_internal_type<T>*)that[0], sizeof(hipblas_internal_type<T>) * m_nmemb * m_batch_count, kind)))
+               != (hip_err = hipMemcpy((*this)[0],
+                                       (hipblas_internal_type<T>*)that[0],
+                                       sizeof(hipblas_internal_type<T>) * m_nmemb * m_batch_count,
+                                       kind)))
             {
                 return hip_err;
             }
@@ -235,14 +237,14 @@ public:
     }
 
 private:
-    size_t  m_m{};
-    size_t  m_n{};
-    size_t  m_lda{};
-    size_t  m_nmemb{};
-    int64_t m_batch_count{};
-    size_t  m_offset{};
-    hipblas_internal_type<T>**     m_data{};
-    hipblas_internal_type<T>**     m_device_data{};
+    size_t                     m_m{};
+    size_t                     m_n{};
+    size_t                     m_lda{};
+    size_t                     m_nmemb{};
+    int64_t                    m_batch_count{};
+    size_t                     m_offset{};
+    hipblas_internal_type<T>** m_data{};
+    hipblas_internal_type<T>** m_device_data{};
 
     //!
     //! @brief Try to allocate the resources.
@@ -252,14 +254,17 @@ private:
     {
         bool success = false;
 
-        success
-            = (hipSuccess
-               == (!this->use_HMM ? (hipMalloc)(&m_device_data, m_batch_count * sizeof(hipblas_internal_type<T>*))
-                                  : hipMallocManaged(&m_device_data, m_batch_count * sizeof(hipblas_internal_type<T>*))));
+        success = (hipSuccess
+                   == (!this->use_HMM
+                           ? (hipMalloc)(&m_device_data,
+                                         m_batch_count * sizeof(hipblas_internal_type<T>*))
+                           : hipMallocManaged(&m_device_data,
+                                              m_batch_count * sizeof(hipblas_internal_type<T>*))));
         if(success)
         {
             success = (nullptr
-                       != (m_data = !this->use_HMM ? (hipblas_internal_type<T>**)calloc(m_batch_count, sizeof(hipblas_internal_type<T>*))
+                       != (m_data = !this->use_HMM ? (hipblas_internal_type<T>**)calloc(
+                                        m_batch_count, sizeof(hipblas_internal_type<T>*))
                                                    : m_device_data));
             if(success)
             {

--- a/clients/include/device_batch_vector.hpp
+++ b/clients/include/device_batch_vector.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -113,7 +113,7 @@ public:
     //! @brief Access to device data.
     //! @return Pointer to the device data.
     //!
-    T** ptr_on_device()
+    hipblas_internal_type<T>** ptr_on_device()
     {
         return m_device_data;
     }
@@ -122,7 +122,7 @@ public:
     //! @brief Const access to device data.
     //! @return Const pointer to the device data.
     //!
-    const T* const* ptr_on_device() const
+    const hipblas_internal_type<T>* const* ptr_on_device() const
     {
         return m_device_data;
     }
@@ -131,7 +131,7 @@ public:
     //! @brief access to device data.
     //! @return Const pointer to the device data.
     //!
-    T* const* const_batch_ptr()
+    hipblas_internal_type<T>* const* const_batch_ptr()
     {
         return m_device_data;
     }
@@ -141,7 +141,7 @@ public:
     //! @param batch_index The batch index.
     //! @return Pointer to the array on device.
     //!
-    T* operator[](int64_t batch_index)
+    hipblas_internal_type<T>* operator[](int64_t batch_index)
     {
 
         return m_data[batch_index];
@@ -152,7 +152,7 @@ public:
     //! @param batch_index The batch index.
     //! @return Constant pointer to the array on device.
     //!
-    const T* operator[](int64_t batch_index) const
+    const hipblas_internal_type<T>* operator[](int64_t batch_index) const
     {
 
         return m_data[batch_index];
@@ -161,7 +161,7 @@ public:
     //!
     //! @brief Const cast of the data on host.
     //!
-    operator const T* const *() const
+    operator const hipblas_internal_type<T>* const *() const
     {
         return m_data;
     }
@@ -170,7 +170,7 @@ public:
     //! @brief Cast of the data on host.
     //!
     // clang-format off
-    operator T**()
+    operator hipblas_internal_type<T>**()
     // clang-format on
     {
         return m_data;
@@ -199,7 +199,7 @@ public:
         {
             if(hipSuccess
                != (hip_err
-                   = hipMemcpy((*this)[0], that[0], sizeof(T) * m_nmemb * m_batch_count, kind)))
+                   = hipMemcpy((*this)[0], (hipblas_internal_type<T>*)that[0], sizeof(hipblas_internal_type<T>) * m_nmemb * m_batch_count, kind)))
             {
                 return hip_err;
             }
@@ -225,8 +225,8 @@ private:
     int64_t m_inc{};
     size_t  m_nmemb{}; // in one batch
     int64_t m_batch_count{};
-    T**     m_data{};
-    T**     m_device_data{};
+    hipblas_internal_type<T>**     m_data{};
+    hipblas_internal_type<T>**     m_device_data{};
 
     static size_t calculate_nmemb(size_t n, int64_t inc)
     {
@@ -244,12 +244,12 @@ private:
 
         success
             = (hipSuccess
-               == (!this->use_HMM ? (hipMalloc)(&m_device_data, m_batch_count * sizeof(T*))
-                                  : hipMallocManaged(&m_device_data, m_batch_count * sizeof(T*))));
+               == (!this->use_HMM ? (hipMalloc)(&m_device_data, m_batch_count * sizeof(hipblas_internal_type<T>*))
+                                  : hipMallocManaged(&m_device_data, m_batch_count * sizeof(hipblas_internal_type<T>*))));
         if(success)
         {
             success = (nullptr
-                       != (m_data = !this->use_HMM ? (T**)calloc(m_batch_count, sizeof(T*))
+                       != (m_data = !this->use_HMM ? (hipblas_internal_type<T>**)calloc(m_batch_count, sizeof(hipblas_internal_type<T>*))
                                                    : m_device_data));
             if(success)
             {
@@ -274,7 +274,7 @@ private:
                     success = (hipSuccess
                                == hipMemcpy(m_device_data,
                                             m_data,
-                                            sizeof(T*) * m_batch_count,
+                                            sizeof(hipblas_internal_type<T>*) * m_batch_count,
                                             hipMemcpyHostToDevice));
                 }
             }

--- a/clients/include/device_batch_vector.hpp
+++ b/clients/include/device_batch_vector.hpp
@@ -198,8 +198,10 @@ public:
         if(m_batch_count > 0)
         {
             if(hipSuccess
-               != (hip_err
-                   = hipMemcpy((*this)[0], (hipblas_internal_type<T>*)that[0], sizeof(hipblas_internal_type<T>) * m_nmemb * m_batch_count, kind)))
+               != (hip_err = hipMemcpy((*this)[0],
+                                       (hipblas_internal_type<T>*)that[0],
+                                       sizeof(hipblas_internal_type<T>) * m_nmemb * m_batch_count,
+                                       kind)))
             {
                 return hip_err;
             }
@@ -221,12 +223,12 @@ public:
     }
 
 private:
-    size_t  m_n{};
-    int64_t m_inc{};
-    size_t  m_nmemb{}; // in one batch
-    int64_t m_batch_count{};
-    hipblas_internal_type<T>**     m_data{};
-    hipblas_internal_type<T>**     m_device_data{};
+    size_t                     m_n{};
+    int64_t                    m_inc{};
+    size_t                     m_nmemb{}; // in one batch
+    int64_t                    m_batch_count{};
+    hipblas_internal_type<T>** m_data{};
+    hipblas_internal_type<T>** m_device_data{};
 
     static size_t calculate_nmemb(size_t n, int64_t inc)
     {
@@ -242,14 +244,17 @@ private:
     {
         bool success = false;
 
-        success
-            = (hipSuccess
-               == (!this->use_HMM ? (hipMalloc)(&m_device_data, m_batch_count * sizeof(hipblas_internal_type<T>*))
-                                  : hipMallocManaged(&m_device_data, m_batch_count * sizeof(hipblas_internal_type<T>*))));
+        success = (hipSuccess
+                   == (!this->use_HMM
+                           ? (hipMalloc)(&m_device_data,
+                                         m_batch_count * sizeof(hipblas_internal_type<T>*))
+                           : hipMallocManaged(&m_device_data,
+                                              m_batch_count * sizeof(hipblas_internal_type<T>*))));
         if(success)
         {
             success = (nullptr
-                       != (m_data = !this->use_HMM ? (hipblas_internal_type<T>**)calloc(m_batch_count, sizeof(hipblas_internal_type<T>*))
+                       != (m_data = !this->use_HMM ? (hipblas_internal_type<T>**)calloc(
+                                        m_batch_count, sizeof(hipblas_internal_type<T>*))
                                                    : m_device_data));
             if(success)
             {

--- a/clients/include/device_matrix.hpp
+++ b/clients/include/device_matrix.hpp
@@ -149,8 +149,8 @@ public:
     }
 
 private:
-    size_t m_m   = 0;
-    size_t m_n   = 0;
-    size_t m_lda = 0;
-    hipblas_internal_type<T>*     m_data{};
+    size_t                    m_m   = 0;
+    size_t                    m_n   = 0;
+    size_t                    m_lda = 0;
+    hipblas_internal_type<T>* m_data{};
 };

--- a/clients/include/device_matrix.hpp
+++ b/clients/include/device_matrix.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -117,7 +117,7 @@ public:
     //!
     //! @brief Decay into pointer wherever pointer is expected.
     //!
-    operator T*()
+    operator hipblas_internal_type<T>*()
     {
         return m_data;
     }
@@ -125,7 +125,7 @@ public:
     //!
     //! @brief Decay into constant pointer wherever pointer is expected.
     //!
-    operator const T*() const
+    operator const hipblas_internal_type<T>*() const
     {
         return m_data;
     }
@@ -138,7 +138,7 @@ public:
     hipError_t transfer_from(const host_matrix<T>& that)
     {
         return hipMemcpy(m_data,
-                         (const T*)that,
+                         (const hipblas_internal_type<T>*)that.data(),
                          this->nmemb() * sizeof(T),
                          this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
     }
@@ -152,5 +152,5 @@ private:
     size_t m_m   = 0;
     size_t m_n   = 0;
     size_t m_lda = 0;
-    T*     m_data{};
+    hipblas_internal_type<T>*     m_data{};
 };

--- a/clients/include/device_strided_batch_matrix.hpp
+++ b/clients/include/device_strided_batch_matrix.hpp
@@ -239,12 +239,12 @@ public:
     }
 
 private:
-    size_t        m_m{};
-    size_t        m_n{};
-    size_t        m_lda{};
-    hipblasStride m_stride{};
-    int64_t       m_batch_count{};
-    hipblas_internal_type<T>*            m_data{};
+    size_t                    m_m{};
+    size_t                    m_n{};
+    size_t                    m_lda{};
+    hipblasStride             m_stride{};
+    int64_t                   m_batch_count{};
+    hipblas_internal_type<T>* m_data{};
 
     static size_t calculate_nmemb(size_t n, size_t lda, hipblasStride stride, int64_t batch_count)
     {

--- a/clients/include/device_strided_batch_matrix.hpp
+++ b/clients/include/device_strided_batch_matrix.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -88,7 +88,7 @@ public:
     //!
     //! @brief Returns the data pointer.
     //!
-    T* data()
+    hipblas_internal_type<T>* data()
     {
         return this->m_data;
     }
@@ -96,7 +96,7 @@ public:
     //!
     //! @brief Returns the data pointer.
     //!
-    const T* data() const
+    const hipblas_internal_type<T>* data() const
     {
         return this->m_data;
     }
@@ -146,7 +146,7 @@ public:
     //! @param batch_index The batch index.
     //! @return A mutable pointer to the batch_index'th matrix.
     //!
-    T* operator[](int64_t batch_index)
+    hipblas_internal_type<T>* operator[](int64_t batch_index)
     {
         return (this->m_stride >= 0)
                    ? this->m_data + batch_index * this->m_stride
@@ -158,7 +158,7 @@ public:
     //! @param batch_index The batch index.
     //! @return A non-mutable mutable pointer to the batch_index'th matrix.
     //!
-    const T* operator[](int64_t batch_index) const
+    const hipblas_internal_type<T>* operator[](int64_t batch_index) const
     {
         return (this->m_stride >= 0)
                    ? this->m_data + batch_index * this->m_stride
@@ -169,7 +169,7 @@ public:
     //! @brief Cast operator.
     //! @remark Returns the pointer of the first matrix.
     //!
-    operator T*()
+    operator hipblas_internal_type<T>*()
     {
         return (*this)[0];
     }
@@ -178,7 +178,7 @@ public:
     //! @brief Non-mutable cast operator.
     //! @remark Returns the non-mutable pointer of the first matrix.
     //!
-    operator const T*() const
+    operator const hipblas_internal_type<T>*() const
     {
         return (*this)[0];
     }
@@ -199,8 +199,8 @@ public:
     hipError_t transfer_from(const host_strided_batch_matrix<T>& that)
     {
         return hipMemcpy(this->data(),
-                         that.data(),
-                         sizeof(T) * this->nmemb(),
+                         (hipblas_internal_type<T>*)that.data(),
+                         sizeof(hipblas_internal_type<T>) * this->nmemb(),
                          this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
     }
 
@@ -215,8 +215,8 @@ public:
         for(int64_t batch_index = 0; batch_index < m_batch_count; batch_index++)
         {
             status = hipMemcpy(this->data() + (batch_index * m_stride),
-                               that.data(),
-                               sizeof(T) * this->m_n * this->m_lda,
+                               (hipblas_internal_type<T>*)that.data(),
+                               sizeof(hipblas_internal_type<T>) * this->m_n * this->m_lda,
                                this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
             if(status != hipSuccess)
                 break;
@@ -244,7 +244,7 @@ private:
     size_t        m_lda{};
     hipblasStride m_stride{};
     int64_t       m_batch_count{};
-    T*            m_data{};
+    hipblas_internal_type<T>*            m_data{};
 
     static size_t calculate_nmemb(size_t n, size_t lda, hipblasStride stride, int64_t batch_count)
     {

--- a/clients/include/device_strided_batch_vector.hpp
+++ b/clients/include/device_strided_batch_vector.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -82,7 +82,7 @@ public:
     //!
     //! @brief Returns the data pointer.
     //!
-    T* data()
+    hipblas_internal_type<T>* data()
     {
         return m_data;
     }
@@ -90,7 +90,7 @@ public:
     //!
     //! @brief Returns the data pointer.
     //!
-    const T* data() const
+    const hipblas_internal_type<T>* data() const
     {
         return m_data;
     }
@@ -132,7 +132,7 @@ public:
     //! @param batch_index The batch index.
     //! @return A mutable pointer to the batch_index'th vector.
     //!
-    T* operator[](int64_t batch_index)
+    hipblas_internal_type<T>* operator[](int64_t batch_index)
     {
         return (m_stride >= 0) ? m_data + batch_index * m_stride
                                : m_data + (batch_index + 1 - m_batch_count) * m_stride;
@@ -143,7 +143,7 @@ public:
     //! @param batch_index The batch index.
     //! @return A non-mutable mutable pointer to the batch_index'th vector.
     //!
-    const T* operator[](int64_t batch_index) const
+    const hipblas_internal_type<T>* operator[](int64_t batch_index) const
     {
         return (m_stride >= 0) ? m_data + batch_index * m_stride
                                : m_data + (batch_index + 1 - m_batch_count) * m_stride;
@@ -153,7 +153,7 @@ public:
     //! @brief Cast operator.
     //! @remark Returns the pointer of the first vector.
     //!
-    operator T*()
+    operator hipblas_internal_type<T>*()
     {
         return (*this)[0];
     }
@@ -183,8 +183,8 @@ public:
     hipError_t transfer_from(const host_strided_batch_vector<T>& that)
     {
         return hipMemcpy(data(),
-                         that.data(),
-                         sizeof(T) * this->nmemb(),
+                         (hipblas_internal_type<T>*)that.data(),
+                         sizeof(hipblas_internal_type<T>) * this->nmemb(),
                          this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
     }
 
@@ -205,7 +205,7 @@ private:
     int64_t       m_inc{};
     hipblasStride m_stride{};
     int64_t       m_batch_count{};
-    T*            m_data{};
+    hipblas_internal_type<T>*            m_data{};
 
     static size_t calculate_nmemb(size_t n, int64_t inc, hipblasStride stride, int64_t batch_count)
     {

--- a/clients/include/device_strided_batch_vector.hpp
+++ b/clients/include/device_strided_batch_vector.hpp
@@ -201,11 +201,11 @@ public:
     }
 
 private:
-    size_t        m_n{};
-    int64_t       m_inc{};
-    hipblasStride m_stride{};
-    int64_t       m_batch_count{};
-    hipblas_internal_type<T>*            m_data{};
+    size_t                    m_n{};
+    int64_t                   m_inc{};
+    hipblasStride             m_stride{};
+    int64_t                   m_batch_count{};
+    hipblas_internal_type<T>* m_data{};
 
     static size_t calculate_nmemb(size_t n, int64_t inc, hipblasStride stride, int64_t batch_count)
     {

--- a/clients/include/device_vector.hpp
+++ b/clients/include/device_vector.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ public:
     //!
     //! @brief Decay into pointer wherever pointer is expected.
     //!
-    operator T*()
+    operator hipblas_internal_type<T>*()
     {
         return m_data;
     }
@@ -115,7 +115,7 @@ public:
     //!
     //! @brief Decay into constant pointer wherever pointer is expected.
     //!
-    operator const T*() const
+    operator const hipblas_internal_type<T>*() const
     {
         return m_data;
     }
@@ -128,8 +128,8 @@ public:
     hipError_t transfer_from(const host_vector<T>& that)
     {
         return hipMemcpy(m_data,
-                         (const T*)that,
-                         this->nmemb() * sizeof(T),
+                         (const hipblas_internal_type<T>*)that.data(),
+                         this->nmemb() * sizeof(hipblas_internal_type<T>),
                          this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
     }
 
@@ -141,7 +141,7 @@ public:
 private:
     size_t  m_n{};
     int64_t m_inc{};
-    T*      m_data{};
+    hipblas_internal_type<T>*      m_data{};
 
     static size_t calculate_nmemb(size_t n, int64_t inc)
     {

--- a/clients/include/device_vector.hpp
+++ b/clients/include/device_vector.hpp
@@ -139,9 +139,9 @@ public:
     }
 
 private:
-    size_t  m_n{};
-    int64_t m_inc{};
-    hipblas_internal_type<T>*      m_data{};
+    size_t                    m_n{};
+    int64_t                   m_inc{};
+    hipblas_internal_type<T>* m_data{};
 
     static size_t calculate_nmemb(size_t n, int64_t inc)
     {

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,12 +50,12 @@ constexpr double asum_gflop_count(int64_t n)
     return (2.0 * n) / 1e9;
 }
 template <>
-constexpr double asum_gflop_count<hipblasComplex>(int64_t n)
+constexpr double asum_gflop_count<std::complex<float>>(int64_t n)
 {
     return (4.0 * n) / 1e9;
 }
 template <>
-constexpr double asum_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double asum_gflop_count<std::complex<double>>(int64_t n)
 {
     return (4.0 * n) / 1e9;
 }
@@ -67,12 +67,12 @@ constexpr double axpy_gflop_count(int64_t n)
     return (2.0 * n) / 1e9;
 }
 template <>
-constexpr double axpy_gflop_count<hipblasComplex>(int64_t n)
+constexpr double axpy_gflop_count<std::complex<float>>(int64_t n)
 {
     return (8.0 * n) / 1e9; // 6 for complex-complex multiply, 2 for c-c add
 }
 template <>
-constexpr double axpy_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double axpy_gflop_count<std::complex<double>>(int64_t n)
 {
     return (8.0 * n) / 1e9;
 }
@@ -91,22 +91,22 @@ constexpr double dot_gflop_count(int64_t n)
     return (2.0 * n) / 1e9;
 }
 template <>
-constexpr double dot_gflop_count<false, hipblasComplex>(int64_t n)
+constexpr double dot_gflop_count<false, std::complex<float>>(int64_t n)
 {
     return (8.0 * n) / 1e9; // 6 for each c-c multiply, 2 for each c-c add
 }
 template <>
-constexpr double dot_gflop_count<false, hipblasDoubleComplex>(int64_t n)
+constexpr double dot_gflop_count<false, std::complex<double>>(int64_t n)
 {
     return (8.0 * n) / 1e9;
 }
 template <>
-constexpr double dot_gflop_count<true, hipblasComplex>(int64_t n)
+constexpr double dot_gflop_count<true, std::complex<float>>(int64_t n)
 {
     return (9.0 * n) / 1e9; // regular dot (8n) + 1n for complex conjugate
 }
 template <>
-constexpr double dot_gflop_count<true, hipblasDoubleComplex>(int64_t n)
+constexpr double dot_gflop_count<true, std::complex<double>>(int64_t n)
 {
     return (9.0 * n) / 1e9;
 }
@@ -126,15 +126,15 @@ constexpr double nrm2_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double nrm2_gflop_count<hipblasComplex>(int64_t n)
+constexpr double nrm2_gflop_count<std::complex<float>>(int64_t n)
 {
     return (6.0 * n + 2.0 * n) / 1e9;
 }
 
 template <>
-constexpr double nrm2_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double nrm2_gflop_count<std::complex<double>>(int64_t n)
 {
-    return nrm2_gflop_count<hipblasComplex>(n);
+    return nrm2_gflop_count<std::complex<float>>(n);
 }
 
 // rot
@@ -144,26 +144,26 @@ constexpr double rot_gflop_count(int64_t n)
     return (6.0 * n) / 1e9; //4 real multiplication, 1 addition , 1 subtraction
 }
 template <>
-constexpr double rot_gflop_count<hipblasComplex, hipblasComplex, float, hipblasComplex>(int64_t n)
+constexpr double rot_gflop_count<std::complex<float>, std::complex<float>, float, std::complex<float>>(int64_t n)
 {
     return (20.0 * n)
            / 1e9; // (6*2 n for c-c multiply)+(2*2 n for real-complex multiply) + 2n for c-c add + 2n for c-c sub
 }
 template <>
-constexpr double rot_gflop_count<hipblasComplex, hipblasComplex, float, float>(int64_t n)
+constexpr double rot_gflop_count<std::complex<float>, std::complex<float>, float, float>(int64_t n)
 {
     return (12.0 * n) / 1e9; // (2*4 n for real-complex multiply) + 2n for c-c add + 2n for c-c sub
 }
 template <>
 constexpr double
-    rot_gflop_count<hipblasDoubleComplex, hipblasDoubleComplex, double, hipblasDoubleComplex>(
+    rot_gflop_count<std::complex<double>, std::complex<double>, double, std::complex<double>>(
         int64_t n)
 {
     return (20.0 * n) / 1e9;
 }
 template <>
 constexpr double
-    rot_gflop_count<hipblasDoubleComplex, hipblasDoubleComplex, double, double>(int64_t n)
+    rot_gflop_count<std::complex<double>, std::complex<double>, double, double>(int64_t n)
 {
     return (12.0 * n) / 1e9;
 }
@@ -193,22 +193,22 @@ constexpr double scal_gflop_count(int64_t n)
     return (1.0 * n) / 1e9;
 }
 template <>
-constexpr double scal_gflop_count<hipblasComplex, hipblasComplex>(int64_t n)
+constexpr double scal_gflop_count<std::complex<float>, std::complex<float>>(int64_t n)
 {
     return (6.0 * n) / 1e9; // 6 for c-c multiply
 }
 template <>
-constexpr double scal_gflop_count<hipblasDoubleComplex, hipblasDoubleComplex>(int64_t n)
+constexpr double scal_gflop_count<std::complex<double>, std::complex<double>>(int64_t n)
 {
     return (6.0 * n) / 1e9;
 }
 template <>
-constexpr double scal_gflop_count<hipblasComplex, float>(int64_t n)
+constexpr double scal_gflop_count<std::complex<float>, float>(int64_t n)
 {
     return (2.0 * n) / 1e9; // 2 for real-complex multiply
 }
 template <>
-constexpr double scal_gflop_count<hipblasDoubleComplex, double>(int64_t n)
+constexpr double scal_gflop_count<std::complex<double>, double>(int64_t n)
 {
     return (2.0 * n) / 1e9;
 }
@@ -234,15 +234,15 @@ constexpr double tpmv_gflop_count(int64_t m)
 }
 
 template <>
-constexpr double tpmv_gflop_count<hipblasComplex>(int64_t m)
+constexpr double tpmv_gflop_count<std::complex<float>>(int64_t m)
 {
     return (4.0 * m * m) / 1e9;
 }
 
 template <>
-constexpr double tpmv_gflop_count<hipblasDoubleComplex>(int64_t m)
+constexpr double tpmv_gflop_count<std::complex<double>>(int64_t m)
 {
-    return tpmv_gflop_count<hipblasComplex>(m);
+    return tpmv_gflop_count<std::complex<float>>(m);
 }
 
 /* \brief floating point counts of trmv */
@@ -253,15 +253,15 @@ constexpr double trmv_gflop_count(int64_t m)
 }
 
 template <>
-constexpr double trmv_gflop_count<hipblasComplex>(int64_t m)
+constexpr double trmv_gflop_count<std::complex<float>>(int64_t m)
 {
     return (4.0 * m * m) / 1e9;
 }
 
 template <>
-constexpr double trmv_gflop_count<hipblasDoubleComplex>(int64_t m)
+constexpr double trmv_gflop_count<std::complex<double>>(int64_t m)
 {
-    return trmv_gflop_count<hipblasComplex>(m);
+    return trmv_gflop_count<std::complex<float>>(m);
 }
 
 /* \brief floating point counts of GBMV */
@@ -282,7 +282,7 @@ constexpr double
 }
 
 template <>
-constexpr double gbmv_gflop_count<hipblasComplex>(
+constexpr double gbmv_gflop_count<std::complex<float>>(
     hipblasOperation_t transA, int64_t m, int64_t n, int64_t kl, int64_t ku)
 {
     int64_t dim_x = transA == HIPBLAS_OP_N ? n : m;
@@ -296,7 +296,7 @@ constexpr double gbmv_gflop_count<hipblasComplex>(
 }
 
 template <>
-constexpr double gbmv_gflop_count<hipblasDoubleComplex>(
+constexpr double gbmv_gflop_count<std::complex<double>>(
     hipblasOperation_t transA, int64_t m, int64_t n, int64_t kl, int64_t ku)
 {
     int64_t dim_x = transA == HIPBLAS_OP_N ? n : m;
@@ -316,14 +316,14 @@ constexpr double gemv_gflop_count(hipblasOperation_t transA, int64_t m, int64_t 
     return (2.0 * m * n + 2.0 * (transA == HIPBLAS_OP_N ? m : n)) / 1e9;
 }
 template <>
-constexpr double gemv_gflop_count<hipblasComplex>(hipblasOperation_t transA, int64_t m, int64_t n)
+constexpr double gemv_gflop_count<std::complex<float>>(hipblasOperation_t transA, int64_t m, int64_t n)
 {
     return (8.0 * m * n + 6.0 * (transA == HIPBLAS_OP_N ? m : n)) / 1e9;
 }
 
 template <>
 constexpr double
-    gemv_gflop_count<hipblasDoubleComplex>(hipblasOperation_t transA, int64_t m, int64_t n)
+    gemv_gflop_count<std::complex<double>>(hipblasOperation_t transA, int64_t m, int64_t n)
 {
     return (8.0 * m * n + 6.0 * (transA == HIPBLAS_OP_N ? m : n)) / 1e9;
 }
@@ -387,16 +387,16 @@ constexpr double tbsv_gflop_count(int64_t n, int64_t k)
 }
 
 template <>
-constexpr double tbsv_gflop_count<hipblasComplex>(int64_t n, int64_t k)
+constexpr double tbsv_gflop_count<std::complex<float>>(int64_t n, int64_t k)
 {
     int64_t k1 = std::min(k, n);
     return (4.0 * (2.0 * n * k1 - k1 * (k1 + 1)) + 4.0 * n) / 1e9;
 }
 
 template <>
-constexpr double tbsv_gflop_count<hipblasDoubleComplex>(int64_t n, int64_t k)
+constexpr double tbsv_gflop_count<std::complex<double>>(int64_t n, int64_t k)
 {
-    return tbsv_gflop_count<hipblasComplex>(n, k);
+    return tbsv_gflop_count<std::complex<float>>(n, k);
 }
 
 /* \brief floating point counts of TRSV */
@@ -407,15 +407,15 @@ constexpr double trsv_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double trsv_gflop_count<hipblasComplex>(int64_t n)
+constexpr double trsv_gflop_count<std::complex<float>>(int64_t n)
 {
     return (4.0 * n * n) / 1e9;
 }
 
 template <>
-constexpr double trsv_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double trsv_gflop_count<std::complex<double>>(int64_t n)
 {
-    return trsv_gflop_count<hipblasComplex>(n);
+    return trsv_gflop_count<std::complex<float>>(n);
 }
 
 /* \brief floating point counts of TBMV */
@@ -427,14 +427,14 @@ constexpr double tbmv_gflop_count(int64_t m, int64_t k)
 }
 
 template <>
-constexpr double tbmv_gflop_count<hipblasComplex>(int64_t m, int64_t k)
+constexpr double tbmv_gflop_count<std::complex<float>>(int64_t m, int64_t k)
 {
     int64_t k1 = k < m ? k : m;
     return (4.0 * (2.0 * m * k1 - double(k1) * (k1 + 1)) + 4.0 * m) / 1e9;
 }
 
 template <>
-constexpr double tbmv_gflop_count<hipblasDoubleComplex>(int64_t m, int64_t k)
+constexpr double tbmv_gflop_count<std::complex<double>>(int64_t m, int64_t k)
 {
     int64_t k1 = k < m ? k : m;
     return (4.0 * (2.0 * m * k1 - double(k1) * (k1 + 1)) + 4.0 * m) / 1e9;
@@ -448,15 +448,15 @@ constexpr double tpsv_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double tpsv_gflop_count<hipblasComplex>(int64_t n)
+constexpr double tpsv_gflop_count<std::complex<float>>(int64_t n)
 {
     return (4.0 * n * n) / 1e9;
 }
 
 template <>
-constexpr double tpsv_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double tpsv_gflop_count<std::complex<double>>(int64_t n)
 {
-    return tpsv_gflop_count<hipblasComplex>(n);
+    return tpsv_gflop_count<std::complex<float>>(n);
 }
 
 /* \brief floating point counts of SY(HE)MV */
@@ -467,15 +467,15 @@ constexpr double symv_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double symv_gflop_count<hipblasComplex>(int64_t n)
+constexpr double symv_gflop_count<std::complex<float>>(int64_t n)
 {
     return 4.0 * symv_gflop_count<float>(n);
 }
 
 template <>
-constexpr double symv_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double symv_gflop_count<std::complex<double>>(int64_t n)
 {
-    return symv_gflop_count<hipblasComplex>(n);
+    return symv_gflop_count<std::complex<float>>(n);
 }
 
 /* \brief floating point counts of SPMV */
@@ -501,15 +501,15 @@ constexpr double spr_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double spr_gflop_count<hipblasComplex>(int64_t n)
+constexpr double spr_gflop_count<std::complex<float>>(int64_t n)
 {
     return (6.0 * n + 4.0 * n * (n + 1.0)) / 1e9;
 }
 
 template <>
-constexpr double spr_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double spr_gflop_count<std::complex<double>>(int64_t n)
 {
-    return spr_gflop_count<hipblasComplex>(n);
+    return spr_gflop_count<std::complex<float>>(n);
 }
 
 /* \brief floating point counts of SPR2 */
@@ -546,15 +546,15 @@ constexpr double syr_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double syr_gflop_count<hipblasComplex>(int64_t n)
+constexpr double syr_gflop_count<std::complex<float>>(int64_t n)
 {
     return 4.0 * syr_gflop_count<float>(n);
 }
 
 template <>
-constexpr double syr_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double syr_gflop_count<std::complex<double>>(int64_t n)
 {
-    return syr_gflop_count<hipblasComplex>(n);
+    return syr_gflop_count<std::complex<float>>(n);
 }
 
 /* \brief floating point counts of SYR2 */
@@ -565,13 +565,13 @@ constexpr double syr2_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double syr2_gflop_count<hipblasComplex>(int64_t n)
+constexpr double syr2_gflop_count<std::complex<float>>(int64_t n)
 {
     return (8.0 * (n + 1.0) * n + 12.0 * n) / 1e9;
 }
 
 template <>
-constexpr double syr2_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double syr2_gflop_count<std::complex<double>>(int64_t n)
 {
     return (8.0 * (n + 1.0) * n + 12.0 * n) / 1e9;
 }
@@ -590,13 +590,13 @@ constexpr double gemm_gflop_count(int64_t m, int64_t n, int64_t k)
 }
 
 template <>
-constexpr double gemm_gflop_count<hipblasComplex>(int64_t m, int64_t n, int64_t k)
+constexpr double gemm_gflop_count<std::complex<float>>(int64_t m, int64_t n, int64_t k)
 {
     return (8.0 * m * n * k) / 1e9;
 }
 
 template <>
-constexpr double gemm_gflop_count<hipblasDoubleComplex>(int64_t m, int64_t n, int64_t k)
+constexpr double gemm_gflop_count<std::complex<double>>(int64_t m, int64_t n, int64_t k)
 {
     return (8.0 * m * n * k) / 1e9;
 }
@@ -609,13 +609,13 @@ constexpr double geam_gflop_count(int64_t m, int64_t n)
 }
 
 template <>
-constexpr double geam_gflop_count<hipblasComplex>(int64_t m, int64_t n)
+constexpr double geam_gflop_count<std::complex<float>>(int64_t m, int64_t n)
 {
     return (14.0 * m * n) / 1e9;
 }
 
 template <>
-constexpr double geam_gflop_count<hipblasDoubleComplex>(int64_t m, int64_t n)
+constexpr double geam_gflop_count<std::complex<double>>(int64_t m, int64_t n)
 {
     return (14.0 * m * n) / 1e9;
 }
@@ -628,13 +628,13 @@ constexpr double dgmm_gflop_count(int64_t m, int64_t n)
 }
 
 template <>
-constexpr double dgmm_gflop_count<hipblasComplex>(int64_t m, int64_t n)
+constexpr double dgmm_gflop_count<std::complex<float>>(int64_t m, int64_t n)
 {
     return (6 * m * n) / 1e9;
 }
 
 template <>
-constexpr double dgmm_gflop_count<hipblasDoubleComplex>(int64_t m, int64_t n)
+constexpr double dgmm_gflop_count<std::complex<double>>(int64_t m, int64_t n)
 {
     return (6 * m * n) / 1e9;
 }
@@ -675,15 +675,15 @@ constexpr double symm_gflop_count(int64_t m, int64_t n, int64_t k)
 }
 
 template <>
-constexpr double symm_gflop_count<hipblasComplex>(int64_t m, int64_t n, int64_t k)
+constexpr double symm_gflop_count<std::complex<float>>(int64_t m, int64_t n, int64_t k)
 {
     return 4.0 * symm_gflop_count<float>(m, n, k);
 }
 
 template <>
-constexpr double symm_gflop_count<hipblasDoubleComplex>(int64_t m, int64_t n, int64_t k)
+constexpr double symm_gflop_count<std::complex<double>>(int64_t m, int64_t n, int64_t k)
 {
-    return symm_gflop_count<hipblasComplex>(m, n, k);
+    return symm_gflop_count<std::complex<float>>(m, n, k);
 }
 
 /* \brief floating point counts of SYRK */
@@ -694,15 +694,15 @@ constexpr double syrk_gflop_count(int64_t n, int64_t k)
 }
 
 template <>
-constexpr double syrk_gflop_count<hipblasComplex>(int64_t n, int64_t k)
+constexpr double syrk_gflop_count<std::complex<float>>(int64_t n, int64_t k)
 {
     return 4.0 * syrk_gflop_count<float>(n, k);
 }
 
 template <>
-constexpr double syrk_gflop_count<hipblasDoubleComplex>(int64_t n, int64_t k)
+constexpr double syrk_gflop_count<std::complex<double>>(int64_t n, int64_t k)
 {
-    return syrk_gflop_count<hipblasComplex>(n, k);
+    return syrk_gflop_count<std::complex<float>>(n, k);
 }
 
 /* \brief floating point counts of SYR2K */
@@ -713,15 +713,15 @@ constexpr double syr2k_gflop_count(int64_t n, int64_t k)
 }
 
 template <>
-constexpr double syr2k_gflop_count<hipblasComplex>(int64_t n, int64_t k)
+constexpr double syr2k_gflop_count<std::complex<float>>(int64_t n, int64_t k)
 {
     return 4.0 * syr2k_gflop_count<float>(n, k);
 }
 
 template <>
-constexpr double syr2k_gflop_count<hipblasDoubleComplex>(int64_t n, int64_t k)
+constexpr double syr2k_gflop_count<std::complex<double>>(int64_t n, int64_t k)
 {
-    return syr2k_gflop_count<hipblasComplex>(n, k);
+    return syr2k_gflop_count<std::complex<float>>(n, k);
 }
 
 /* \brief floating point counts of SYRKX */
@@ -732,15 +732,15 @@ constexpr double syrkx_gflop_count(int64_t n, int64_t k)
 }
 
 template <>
-constexpr double syrkx_gflop_count<hipblasComplex>(int64_t n, int64_t k)
+constexpr double syrkx_gflop_count<std::complex<float>>(int64_t n, int64_t k)
 {
     return 4.0 * syrkx_gflop_count<float>(n, k);
 }
 
 template <>
-constexpr double syrkx_gflop_count<hipblasDoubleComplex>(int64_t n, int64_t k)
+constexpr double syrkx_gflop_count<std::complex<double>>(int64_t n, int64_t k)
 {
-    return syrkx_gflop_count<hipblasComplex>(n, k);
+    return syrkx_gflop_count<std::complex<float>>(n, k);
 }
 
 /* \brief floating point counts of TRSM */
@@ -751,15 +751,15 @@ constexpr double trmm_gflop_count(int64_t m, int64_t n, int64_t k)
 }
 
 template <>
-constexpr double trmm_gflop_count<hipblasComplex>(int64_t m, int64_t n, int64_t k)
+constexpr double trmm_gflop_count<std::complex<float>>(int64_t m, int64_t n, int64_t k)
 {
     return 4.0 * trmm_gflop_count<float>(m, n, k);
 }
 
 template <>
-constexpr double trmm_gflop_count<hipblasDoubleComplex>(int64_t m, int64_t n, int64_t k)
+constexpr double trmm_gflop_count<std::complex<double>>(int64_t m, int64_t n, int64_t k)
 {
-    return trmm_gflop_count<hipblasComplex>(m, n, k);
+    return trmm_gflop_count<std::complex<float>>(m, n, k);
 }
 
 /* \brief floating point counts of TRSM */
@@ -770,15 +770,15 @@ constexpr double trsm_gflop_count(int64_t m, int64_t n, int64_t k)
 }
 
 template <>
-constexpr double trsm_gflop_count<hipblasComplex>(int64_t m, int64_t n, int64_t k)
+constexpr double trsm_gflop_count<std::complex<float>>(int64_t m, int64_t n, int64_t k)
 {
     return 4.0 * trsm_gflop_count<float>(m, n, k);
 }
 
 template <>
-constexpr double trsm_gflop_count<hipblasDoubleComplex>(int64_t m, int64_t n, int64_t k)
+constexpr double trsm_gflop_count<std::complex<double>>(int64_t m, int64_t n, int64_t k)
 {
-    return trsm_gflop_count<hipblasComplex>(m, n, k);
+    return trsm_gflop_count<std::complex<float>>(m, n, k);
 }
 
 /* \brief floating point counts of TRTRI */
@@ -789,13 +789,13 @@ constexpr double trtri_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double trtri_gflop_count<hipblasComplex>(int64_t n)
+constexpr double trtri_gflop_count<std::complex<float>>(int64_t n)
 {
     return (8.0 * n * n * n) / 3e9;
 }
 
 template <>
-constexpr double trtri_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double trtri_gflop_count<std::complex<double>>(int64_t n)
 {
     return (8.0 * n * n * n) / 3e9;
 }
@@ -816,13 +816,13 @@ constexpr double geqrf_gflop_count(int64_t n, int64_t m)
 }
 
 template <>
-constexpr double geqrf_gflop_count<hipblasComplex>(int64_t n, int64_t m)
+constexpr double geqrf_gflop_count<std::complex<float>>(int64_t n, int64_t m)
 {
     return 4.0 * geqrf_gflop_count<float>(n, m);
 }
 
 template <>
-constexpr double geqrf_gflop_count<hipblasDoubleComplex>(int64_t n, int64_t m)
+constexpr double geqrf_gflop_count<std::complex<double>>(int64_t n, int64_t m)
 {
     return 4.0 * geqrf_gflop_count<float>(n, m);
 }
@@ -835,13 +835,13 @@ constexpr double getrf_gflop_count(int64_t n, int64_t m)
 }
 
 template <>
-constexpr double getrf_gflop_count<hipblasComplex>(int64_t n, int64_t m)
+constexpr double getrf_gflop_count<std::complex<float>>(int64_t n, int64_t m)
 {
     return 4.0 * getrf_gflop_count<float>(n, m);
 }
 
 template <>
-constexpr double getrf_gflop_count<hipblasDoubleComplex>(int64_t n, int64_t m)
+constexpr double getrf_gflop_count<std::complex<double>>(int64_t n, int64_t m)
 {
     return 4.0 * getrf_gflop_count<float>(n, m);
 }
@@ -854,13 +854,13 @@ constexpr double getri_gflop_count(int64_t n)
 }
 
 template <>
-constexpr double getri_gflop_count<hipblasComplex>(int64_t n)
+constexpr double getri_gflop_count<std::complex<float>>(int64_t n)
 {
     return 4.0 * getri_gflop_count<float>(n);
 }
 
 template <>
-constexpr double getri_gflop_count<hipblasDoubleComplex>(int64_t n)
+constexpr double getri_gflop_count<std::complex<double>>(int64_t n)
 {
     return 4.0 * getri_gflop_count<float>(n);
 }
@@ -873,13 +873,13 @@ constexpr double getrs_gflop_count(int64_t n, int64_t nrhs)
 }
 
 template <>
-constexpr double getrs_gflop_count<hipblasComplex>(int64_t n, int64_t nrhs)
+constexpr double getrs_gflop_count<std::complex<float>>(int64_t n, int64_t nrhs)
 {
     return 4.0 * getrs_gflop_count<float>(n, nrhs);
 }
 
 template <>
-constexpr double getrs_gflop_count<hipblasDoubleComplex>(int64_t n, int64_t nrhs)
+constexpr double getrs_gflop_count<std::complex<double>>(int64_t n, int64_t nrhs)
 {
     return 4.0 * getrs_gflop_count<float>(n, nrhs);
 }
@@ -894,13 +894,13 @@ constexpr double gels_gflop_count(int64_t m, int64_t n)
 }
 
 template <>
-constexpr double gels_gflop_count<hipblasComplex>(int64_t m, int64_t n)
+constexpr double gels_gflop_count<std::complex<float>>(int64_t m, int64_t n)
 {
     return 4 * gels_gflop_count<float>(m, n);
 }
 
 template <>
-constexpr double gels_gflop_count<hipblasDoubleComplex>(int64_t m, int64_t n)
+constexpr double gels_gflop_count<std::complex<double>>(int64_t m, int64_t n)
 {
     return 4 * gels_gflop_count<float>(m, n);
 }

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -144,7 +144,8 @@ constexpr double rot_gflop_count(int64_t n)
     return (6.0 * n) / 1e9; //4 real multiplication, 1 addition , 1 subtraction
 }
 template <>
-constexpr double rot_gflop_count<std::complex<float>, std::complex<float>, float, std::complex<float>>(int64_t n)
+constexpr double
+    rot_gflop_count<std::complex<float>, std::complex<float>, float, std::complex<float>>(int64_t n)
 {
     return (20.0 * n)
            / 1e9; // (6*2 n for c-c multiply)+(2*2 n for real-complex multiply) + 2n for c-c add + 2n for c-c sub
@@ -316,7 +317,8 @@ constexpr double gemv_gflop_count(hipblasOperation_t transA, int64_t m, int64_t 
     return (2.0 * m * n + 2.0 * (transA == HIPBLAS_OP_N ? m : n)) / 1e9;
 }
 template <>
-constexpr double gemv_gflop_count<std::complex<float>>(hipblasOperation_t transA, int64_t m, int64_t n)
+constexpr double
+    gemv_gflop_count<std::complex<float>>(hipblasOperation_t transA, int64_t m, int64_t n)
 {
     return (8.0 * m * n + 6.0 * (transA == HIPBLAS_OP_N ? m : n)) / 1e9;
 }

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,7 @@
 
 /* library headers */
 #include "hipblas.h"
+#include "type_utils.h"
 
 #ifndef WIN32
 #include "hipblas_fortran.hpp"
@@ -148,7 +149,7 @@
 #define MAP2CF_V2(...) MAP2CF(__VA_ARGS__##Cast)
 #endif
 
-// Need these temporarily during transition period between hipblasComplex -> hipComplex
+// Need these temporarily during transition period between std::complex<float> -> hipComplex
 #ifdef HIPBLAS_V2
 
 // scal
@@ -7300,667 +7301,667 @@ namespace
 {
     // Scal
     template <typename T, typename U = T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasScal)(hipblasHandle_t handle, int n, const U* alpha, T* x, int incx);
+    hipblasStatus_t (*hipblasScal)(hipblasHandle_t handle, int n, const hipblas_internal_type<U>* alpha, hipblas_internal_type<T>* x, int incx);
 
     template <typename T, typename U = T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasScalBatched)(
-        hipblasHandle_t handle, int n, const U* alpha, T* const x[], int incx, int batch_count);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<U>* alpha, hipblas_internal_type<T>* const x[], int incx, int batch_count);
 
     template <typename T, typename U = T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasScalStridedBatched)(hipblasHandle_t handle,
                                                  int             n,
-                                                 const U*        alpha,
-                                                 T*              x,
+                                                 const hipblas_internal_type<U>*        alpha,
+                                                 hipblas_internal_type<T>*              x,
                                                  int             incx,
                                                  hipblasStride   stridex,
                                                  int             batch_count);
 
     template <typename T, typename U = T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasScal_64)(
-        hipblasHandle_t handle, int64_t n, const U* alpha, T* x, int64_t incx);
+        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<U>* alpha, hipblas_internal_type<T>* x, int64_t incx);
 
     template <typename T, typename U = T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasScalBatched_64)(hipblasHandle_t handle,
                                              int64_t         n,
-                                             const U*        alpha,
-                                             T* const        x[],
+                                             const hipblas_internal_type<U>*        alpha,
+                                             hipblas_internal_type<T>* const        x[],
                                              int64_t         incx,
                                              int64_t         batch_count);
 
     template <typename T, typename U = T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasScalStridedBatched_64)(hipblasHandle_t handle,
                                                     int64_t         n,
-                                                    const U*        alpha,
-                                                    T*              x,
+                                                    const hipblas_internal_type<U>*        alpha,
+                                                    hipblas_internal_type<T>*              x,
                                                     int64_t         incx,
                                                     hipblasStride   stridex,
                                                     int64_t         batch_count);
 
     MAP2CF_D64(hipblasScal, float, float, hipblasSscal);
     MAP2CF_D64(hipblasScal, double, double, hipblasDscal);
-    MAP2CF_D64_V2(hipblasScal, hipblasComplex, hipblasComplex, hipblasCscal);
-    MAP2CF_D64_V2(hipblasScal, hipblasDoubleComplex, hipblasDoubleComplex, hipblasZscal);
-    MAP2CF_D64_V2(hipblasScal, hipblasComplex, float, hipblasCsscal);
-    MAP2CF_D64_V2(hipblasScal, hipblasDoubleComplex, double, hipblasZdscal);
+    MAP2CF_D64_V2(hipblasScal, std::complex<float>, std::complex<float>, hipblasCscal);
+    MAP2CF_D64_V2(hipblasScal, std::complex<double>, std::complex<double>, hipblasZscal);
+    MAP2CF_D64_V2(hipblasScal, std::complex<float>, float, hipblasCsscal);
+    MAP2CF_D64_V2(hipblasScal, std::complex<double>, double, hipblasZdscal);
 
     MAP2CF_D64(hipblasScalBatched, float, float, hipblasSscalBatched);
     MAP2CF_D64(hipblasScalBatched, double, double, hipblasDscalBatched);
-    MAP2CF_D64_V2(hipblasScalBatched, hipblasComplex, hipblasComplex, hipblasCscalBatched);
+    MAP2CF_D64_V2(hipblasScalBatched, std::complex<float>, std::complex<float>, hipblasCscalBatched);
     MAP2CF_D64_V2(hipblasScalBatched,
-                  hipblasDoubleComplex,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
+                  std::complex<double>,
                   hipblasZscalBatched);
-    MAP2CF_D64_V2(hipblasScalBatched, hipblasComplex, float, hipblasCsscalBatched);
-    MAP2CF_D64_V2(hipblasScalBatched, hipblasDoubleComplex, double, hipblasZdscalBatched);
+    MAP2CF_D64_V2(hipblasScalBatched, std::complex<float>, float, hipblasCsscalBatched);
+    MAP2CF_D64_V2(hipblasScalBatched, std::complex<double>, double, hipblasZdscalBatched);
 
     MAP2CF_D64(hipblasScalStridedBatched, float, float, hipblasSscalStridedBatched);
     MAP2CF_D64(hipblasScalStridedBatched, double, double, hipblasDscalStridedBatched);
     MAP2CF_D64_V2(hipblasScalStridedBatched,
-                  hipblasComplex,
-                  hipblasComplex,
+                  std::complex<float>,
+                  std::complex<float>,
                   hipblasCscalStridedBatched);
     MAP2CF_D64_V2(hipblasScalStridedBatched,
-                  hipblasDoubleComplex,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
+                  std::complex<double>,
                   hipblasZscalStridedBatched);
-    MAP2CF_D64_V2(hipblasScalStridedBatched, hipblasComplex, float, hipblasCsscalStridedBatched);
+    MAP2CF_D64_V2(hipblasScalStridedBatched, std::complex<float>, float, hipblasCsscalStridedBatched);
     MAP2CF_D64_V2(hipblasScalStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasZdscalStridedBatched);
 
     // Copy
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasCopy)(
-        hipblasHandle_t handle, int n, const T* x, int incx, T* y, int incy);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, hipblas_internal_type<T>* y, int incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasCopyBatched)(hipblasHandle_t handle,
                                           int             n,
-                                          const T* const  x[],
+                                          const hipblas_internal_type<T>* const  x[],
                                           int             incx,
-                                          T* const        y[],
+                                          hipblas_internal_type<T>* const        y[],
                                           int             incy,
                                           int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasCopyStridedBatched)(hipblasHandle_t handle,
                                                  int             n,
-                                                 const T*        x,
+                                                 const hipblas_internal_type<T>*        x,
                                                  int             incx,
                                                  hipblasStride   stridex,
-                                                 T*              y,
+                                                 hipblas_internal_type<T>*              y,
                                                  int             incy,
                                                  hipblasStride   stridey,
                                                  int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasCopy_64)(
-        hipblasHandle_t handle, int64_t n, const T* x, int64_t incx, T* y, int64_t incy);
+        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T>* x, int64_t incx, hipblas_internal_type<T>* y, int64_t incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasCopyBatched_64)(hipblasHandle_t handle,
                                              int64_t         n,
-                                             const T* const  x[],
+                                             const hipblas_internal_type<T>* const  x[],
                                              int64_t         incx,
-                                             T* const        y[],
+                                             hipblas_internal_type<T>* const        y[],
                                              int64_t         incy,
                                              int64_t         batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasCopyStridedBatched_64)(hipblasHandle_t handle,
                                                     int64_t         n,
-                                                    const T*        x,
+                                                    const hipblas_internal_type<T>*        x,
                                                     int64_t         incx,
                                                     hipblasStride   stridex,
-                                                    T*              y,
+                                                    hipblas_internal_type<T>*              y,
                                                     int64_t         incy,
                                                     hipblasStride   stridey,
                                                     int64_t         batch_count);
 
     MAP2CF_D64(hipblasCopy, float, hipblasScopy);
     MAP2CF_D64(hipblasCopy, double, hipblasDcopy);
-    MAP2CF_D64_V2(hipblasCopy, hipblasComplex, hipblasCcopy);
-    MAP2CF_D64_V2(hipblasCopy, hipblasDoubleComplex, hipblasZcopy);
+    MAP2CF_D64_V2(hipblasCopy, std::complex<float>, hipblasCcopy);
+    MAP2CF_D64_V2(hipblasCopy, std::complex<double>, hipblasZcopy);
 
     MAP2CF_D64(hipblasCopyBatched, float, hipblasScopyBatched);
     MAP2CF_D64(hipblasCopyBatched, double, hipblasDcopyBatched);
-    MAP2CF_D64_V2(hipblasCopyBatched, hipblasComplex, hipblasCcopyBatched);
-    MAP2CF_D64_V2(hipblasCopyBatched, hipblasDoubleComplex, hipblasZcopyBatched);
+    MAP2CF_D64_V2(hipblasCopyBatched, std::complex<float>, hipblasCcopyBatched);
+    MAP2CF_D64_V2(hipblasCopyBatched, std::complex<double>, hipblasZcopyBatched);
 
     MAP2CF_D64(hipblasCopyStridedBatched, float, hipblasScopyStridedBatched);
     MAP2CF_D64(hipblasCopyStridedBatched, double, hipblasDcopyStridedBatched);
-    MAP2CF_D64_V2(hipblasCopyStridedBatched, hipblasComplex, hipblasCcopyStridedBatched);
-    MAP2CF_D64_V2(hipblasCopyStridedBatched, hipblasDoubleComplex, hipblasZcopyStridedBatched);
+    MAP2CF_D64_V2(hipblasCopyStridedBatched, std::complex<float>, hipblasCcopyStridedBatched);
+    MAP2CF_D64_V2(hipblasCopyStridedBatched, std::complex<double>, hipblasZcopyStridedBatched);
 
     // Swap
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSwap)(hipblasHandle_t handle, int n, T* x, int incx, T* y, int incy);
+    hipblasStatus_t (*hipblasSwap)(hipblasHandle_t handle, int n, hipblas_internal_type<T>* x, int incx, hipblas_internal_type<T>* y, int incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSwapBatched)(hipblasHandle_t handle,
                                           int             n,
-                                          T* const        x[],
+                                          hipblas_internal_type<T>* const        x[],
                                           int             incx,
-                                          T* const        y[],
+                                          hipblas_internal_type<T>* const        y[],
                                           int             incy,
                                           int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSwapStridedBatched)(hipblasHandle_t handle,
                                                  int             n,
-                                                 T*              x,
+                                                 hipblas_internal_type<T>*              x,
                                                  int             incx,
                                                  hipblasStride   stridex,
-                                                 T*              y,
+                                                 hipblas_internal_type<T>*              y,
                                                  int             incy,
                                                  hipblasStride   stridey,
                                                  int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSwap_64)(
-        hipblasHandle_t handle, int64_t n, T* x, int64_t incx, T* y, int64_t incy);
+        hipblasHandle_t handle, int64_t n, hipblas_internal_type<T>* x, int64_t incx, hipblas_internal_type<T>* y, int64_t incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSwapBatched_64)(hipblasHandle_t handle,
                                              int64_t         n,
-                                             T* const        x[],
+                                             hipblas_internal_type<T>* const        x[],
                                              int64_t         incx,
-                                             T* const        y[],
+                                             hipblas_internal_type<T>* const        y[],
                                              int64_t         incy,
                                              int64_t         batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSwapStridedBatched_64)(hipblasHandle_t handle,
                                                     int64_t         n,
-                                                    T*              x,
+                                                    hipblas_internal_type<T>*              x,
                                                     int64_t         incx,
                                                     hipblasStride   stridex,
-                                                    T*              y,
+                                                    hipblas_internal_type<T>*              y,
                                                     int64_t         incy,
                                                     hipblasStride   stridey,
                                                     int64_t         batch_count);
 
     MAP2CF_D64(hipblasSwap, float, hipblasSswap);
     MAP2CF_D64(hipblasSwap, double, hipblasDswap);
-    MAP2CF_D64_V2(hipblasSwap, hipblasComplex, hipblasCswap);
-    MAP2CF_D64_V2(hipblasSwap, hipblasDoubleComplex, hipblasZswap);
+    MAP2CF_D64_V2(hipblasSwap, std::complex<float>, hipblasCswap);
+    MAP2CF_D64_V2(hipblasSwap, std::complex<double>, hipblasZswap);
 
     MAP2CF_D64(hipblasSwapBatched, float, hipblasSswapBatched);
     MAP2CF_D64(hipblasSwapBatched, double, hipblasDswapBatched);
-    MAP2CF_D64_V2(hipblasSwapBatched, hipblasComplex, hipblasCswapBatched);
-    MAP2CF_D64_V2(hipblasSwapBatched, hipblasDoubleComplex, hipblasZswapBatched);
+    MAP2CF_D64_V2(hipblasSwapBatched, std::complex<float>, hipblasCswapBatched);
+    MAP2CF_D64_V2(hipblasSwapBatched, std::complex<double>, hipblasZswapBatched);
 
     MAP2CF_D64(hipblasSwapStridedBatched, float, hipblasSswapStridedBatched);
     MAP2CF_D64(hipblasSwapStridedBatched, double, hipblasDswapStridedBatched);
-    MAP2CF_D64_V2(hipblasSwapStridedBatched, hipblasComplex, hipblasCswapStridedBatched);
-    MAP2CF_D64_V2(hipblasSwapStridedBatched, hipblasDoubleComplex, hipblasZswapStridedBatched);
+    MAP2CF_D64_V2(hipblasSwapStridedBatched, std::complex<float>, hipblasCswapStridedBatched);
+    MAP2CF_D64_V2(hipblasSwapStridedBatched, std::complex<double>, hipblasZswapStridedBatched);
 
     // Dot
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDot)(
-        hipblasHandle_t handle, int n, const T* x, int incx, const T* y, int incy, T* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, const hipblas_internal_type<T>* y, int incy, hipblas_internal_type<T>* result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotc)(
-        hipblasHandle_t handle, int n, const T* x, int incx, const T* y, int incy, T* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, const hipblas_internal_type<T>* y, int incy, hipblas_internal_type<T>* result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotBatched)(hipblasHandle_t handle,
                                          int             n,
-                                         const T* const  x[],
+                                         const hipblas_internal_type<T>* const  x[],
                                          int             incx,
-                                         const T* const  y[],
+                                         const hipblas_internal_type<T>* const  y[],
                                          int             incy,
                                          int             batch_count,
-                                         T*              result);
+                                         hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotcBatched)(hipblasHandle_t handle,
                                           int             n,
-                                          const T* const  x[],
+                                          const hipblas_internal_type<T>* const  x[],
                                           int             incx,
-                                          const T* const  y[],
+                                          const hipblas_internal_type<T>* const  y[],
                                           int             incy,
                                           int             batch_count,
-                                          T*              result);
+                                          hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotStridedBatched)(hipblasHandle_t handle,
                                                 int             n,
-                                                const T*        x,
+                                                const hipblas_internal_type<T>*        x,
                                                 int             incx,
                                                 hipblasStride   stridex,
-                                                const T*        y,
+                                                const hipblas_internal_type<T>*        y,
                                                 int             incy,
                                                 hipblasStride   stridey,
                                                 int             batch_count,
-                                                T*              result);
+                                                hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotcStridedBatched)(hipblasHandle_t handle,
                                                  int             n,
-                                                 const T*        x,
+                                                 const hipblas_internal_type<T>*        x,
                                                  int             incx,
                                                  hipblasStride   stridex,
-                                                 const T*        y,
+                                                 const hipblas_internal_type<T>*        y,
                                                  int             incy,
                                                  hipblasStride   stridey,
                                                  int             batch_count,
-                                                 T*              result);
+                                                 hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDot_64)(hipblasHandle_t handle,
                                      int64_t         n,
-                                     const T*        x,
+                                     const hipblas_internal_type<T>*        x,
                                      int64_t         incx,
-                                     const T*        y,
+                                     const hipblas_internal_type<T>*        y,
                                      int64_t         incy,
-                                     T*              result);
+                                     hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotc_64)(hipblasHandle_t handle,
                                       int64_t         n,
-                                      const T*        x,
+                                      const hipblas_internal_type<T>*        x,
                                       int64_t         incx,
-                                      const T*        y,
+                                      const hipblas_internal_type<T>*        y,
                                       int64_t         incy,
-                                      T*              result);
+                                      hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotBatched_64)(hipblasHandle_t handle,
                                             int64_t         n,
-                                            const T* const  x[],
+                                            const hipblas_internal_type<T>* const  x[],
                                             int64_t         incx,
-                                            const T* const  y[],
+                                            const hipblas_internal_type<T>* const  y[],
                                             int64_t         incy,
                                             int64_t         batch_count,
-                                            T*              result);
+                                            hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotcBatched_64)(hipblasHandle_t handle,
                                              int64_t         n,
-                                             const T* const  x[],
+                                             const hipblas_internal_type<T>* const  x[],
                                              int64_t         incx,
-                                             const T* const  y[],
+                                             const hipblas_internal_type<T>* const  y[],
                                              int64_t         incy,
                                              int64_t         batch_count,
-                                             T*              result);
+                                             hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotStridedBatched_64)(hipblasHandle_t handle,
                                                    int64_t         n,
-                                                   const T*        x,
+                                                   const hipblas_internal_type<T>*        x,
                                                    int64_t         incx,
                                                    hipblasStride   stridex,
-                                                   const T*        y,
+                                                   const hipblas_internal_type<T>*        y,
                                                    int64_t         incy,
                                                    hipblasStride   stridey,
                                                    int64_t         batch_count,
-                                                   T*              result);
+                                                   hipblas_internal_type<T>*              result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasDotcStridedBatched_64)(hipblasHandle_t handle,
                                                     int64_t         n,
-                                                    const T*        x,
+                                                    const hipblas_internal_type<T>*        x,
                                                     int64_t         incx,
                                                     hipblasStride   stridex,
-                                                    const T*        y,
+                                                    const hipblas_internal_type<T>*        y,
                                                     int64_t         incy,
                                                     hipblasStride   stridey,
-                                                    int64_t         batch_count,
-                                                    T*              result);
+                                            hipblas_internal_type<        int64_t>         batch_count,
+                                                    hipblas_internal_type<T>*              result);
 
     MAP2CF_D64(hipblasDot, hipblasHalf, hipblasHdot);
     MAP2CF_D64(hipblasDot, hipblasBfloat16, hipblasBfdot);
     MAP2CF_D64(hipblasDot, float, hipblasSdot);
     MAP2CF_D64(hipblasDot, double, hipblasDdot);
-    MAP2CF_D64_V2(hipblasDot, hipblasComplex, hipblasCdotu);
-    MAP2CF_D64_V2(hipblasDot, hipblasDoubleComplex, hipblasZdotu);
-    MAP2CF_D64_V2(hipblasDotc, hipblasComplex, hipblasCdotc);
-    MAP2CF_D64_V2(hipblasDotc, hipblasDoubleComplex, hipblasZdotc);
+    MAP2CF_D64_V2(hipblasDot, std::complex<float>, hipblasCdotu);
+    MAP2CF_D64_V2(hipblasDot, std::complex<double>, hipblasZdotu);
+    MAP2CF_D64_V2(hipblasDotc, std::complex<float>, hipblasCdotc);
+    MAP2CF_D64_V2(hipblasDotc, std::complex<double>, hipblasZdotc);
 
     MAP2CF_D64(hipblasDotBatched, hipblasHalf, hipblasHdotBatched);
     MAP2CF_D64(hipblasDotBatched, hipblasBfloat16, hipblasBfdotBatched);
     MAP2CF_D64(hipblasDotBatched, float, hipblasSdotBatched);
     MAP2CF_D64(hipblasDotBatched, double, hipblasDdotBatched);
-    MAP2CF_D64_V2(hipblasDotBatched, hipblasComplex, hipblasCdotuBatched);
-    MAP2CF_D64_V2(hipblasDotBatched, hipblasDoubleComplex, hipblasZdotuBatched);
-    MAP2CF_D64_V2(hipblasDotcBatched, hipblasComplex, hipblasCdotcBatched);
-    MAP2CF_D64_V2(hipblasDotcBatched, hipblasDoubleComplex, hipblasZdotcBatched);
+    MAP2CF_D64_V2(hipblasDotBatched, std::complex<float>, hipblasCdotuBatched);
+    MAP2CF_D64_V2(hipblasDotBatched, std::complex<double>, hipblasZdotuBatched);
+    MAP2CF_D64_V2(hipblasDotcBatched, std::complex<float>, hipblasCdotcBatched);
+    MAP2CF_D64_V2(hipblasDotcBatched, std::complex<double>, hipblasZdotcBatched);
 
     MAP2CF_D64(hipblasDotStridedBatched, hipblasHalf, hipblasHdotStridedBatched);
     MAP2CF_D64(hipblasDotStridedBatched, hipblasBfloat16, hipblasBfdotStridedBatched);
     MAP2CF_D64(hipblasDotStridedBatched, float, hipblasSdotStridedBatched);
     MAP2CF_D64(hipblasDotStridedBatched, double, hipblasDdotStridedBatched);
-    MAP2CF_D64_V2(hipblasDotStridedBatched, hipblasComplex, hipblasCdotuStridedBatched);
-    MAP2CF_D64_V2(hipblasDotStridedBatched, hipblasDoubleComplex, hipblasZdotuStridedBatched);
-    MAP2CF_D64_V2(hipblasDotcStridedBatched, hipblasComplex, hipblasCdotcStridedBatched);
-    MAP2CF_D64_V2(hipblasDotcStridedBatched, hipblasDoubleComplex, hipblasZdotcStridedBatched);
+    MAP2CF_D64_V2(hipblasDotStridedBatched, std::complex<float>, hipblasCdotuStridedBatched);
+    MAP2CF_D64_V2(hipblasDotStridedBatched, std::complex<double>, hipblasZdotuStridedBatched);
+    MAP2CF_D64_V2(hipblasDotcStridedBatched, std::complex<float>, hipblasCdotcStridedBatched);
+    MAP2CF_D64_V2(hipblasDotcStridedBatched, std::complex<double>, hipblasZdotcStridedBatched);
 
     // Asum
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAsum)(
-        hipblasHandle_t handle, int n, const T1* x, int incx, T2* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T1>* x, int incx, hipblas_internal_type<T2>* result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAsumBatched)(
-        hipblasHandle_t handle, int n, const T1* const x[], int incx, int batch_count, T2* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T1>* const x[], int incx, int batch_count, hipblas_internal_type<T2>* result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAsumStridedBatched)(hipblasHandle_t handle,
                                                  int             n,
-                                                 const T1*       x,
+                                                 const hipblas_internal_type<T1>*       x,
                                                  int             incx,
                                                  hipblasStride   stridex,
                                                  int             batch_count,
-                                                 T2*             result);
+                                                 hipblas_internal_type<T2>*             result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAsum_64)(
-        hipblasHandle_t handle, int64_t n, const T1* x, int64_t incx, T2* result);
+        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T1>* x, int64_t incx, hipblas_internal_type<T2>* result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAsumBatched_64)(hipblasHandle_t handle,
                                              int64_t         n,
-                                             const T1* const x[],
+                                             const hipblas_internal_type<T1>* const x[],
                                              int64_t         incx,
                                              int64_t         batch_count,
-                                             T2*             result);
+                                             hipblas_internal_type<T2>*             result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAsumStridedBatched_64)(hipblasHandle_t handle,
                                                     int64_t         n,
-                                                    const T1*       x,
+                                                    const hipblas_internal_type<T1>*       x,
                                                     int64_t         incx,
                                                     hipblasStride   stridex,
                                                     int64_t         batch_count,
-                                                    T2*             result);
+                                                    hipblas_internal_type<T2>*             result);
 
     MAP2CF_D64(hipblasAsum, float, float, hipblasSasum);
     MAP2CF_D64(hipblasAsum, double, double, hipblasDasum);
-    MAP2CF_D64_V2(hipblasAsum, hipblasComplex, float, hipblasScasum);
-    MAP2CF_D64_V2(hipblasAsum, hipblasDoubleComplex, double, hipblasDzasum);
+    MAP2CF_D64_V2(hipblasAsum, std::complex<float>, float, hipblasScasum);
+    MAP2CF_D64_V2(hipblasAsum, std::complex<double>, double, hipblasDzasum);
 
     MAP2CF_D64(hipblasAsumBatched, float, float, hipblasSasumBatched);
     MAP2CF_D64(hipblasAsumBatched, double, double, hipblasDasumBatched);
-    MAP2CF_D64_V2(hipblasAsumBatched, hipblasComplex, float, hipblasScasumBatched);
-    MAP2CF_D64_V2(hipblasAsumBatched, hipblasDoubleComplex, double, hipblasDzasumBatched);
+    MAP2CF_D64_V2(hipblasAsumBatched, std::complex<float>, float, hipblasScasumBatched);
+    MAP2CF_D64_V2(hipblasAsumBatched, std::complex<double>, double, hipblasDzasumBatched);
 
     MAP2CF_D64(hipblasAsumStridedBatched, float, float, hipblasSasumStridedBatched);
     MAP2CF_D64(hipblasAsumStridedBatched, double, double, hipblasDasumStridedBatched);
-    MAP2CF_D64_V2(hipblasAsumStridedBatched, hipblasComplex, float, hipblasScasumStridedBatched);
+    MAP2CF_D64_V2(hipblasAsumStridedBatched, std::complex<float>, float, hipblasScasumStridedBatched);
     MAP2CF_D64_V2(hipblasAsumStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasDzasumStridedBatched);
 
     // nrm2
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasNrm2)(
-        hipblasHandle_t handle, int n, const T1* x, int incx, T2* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T1>* x, int incx, hipblas_internal_type<T2>* result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasNrm2Batched)(
-        hipblasHandle_t handle, int n, const T1* const x[], int incx, int batch_count, T2* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T1>* const x[], int incx, int batch_count, hipblas_internal_type<T2>* result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasNrm2StridedBatched)(hipblasHandle_t handle,
                                                  int             n,
-                                                 const T1*       x,
+                                                 const hipblas_internal_type<T1>*       x,
                                                  int             incx,
                                                  hipblasStride   stridex,
                                                  int             batch_count,
-                                                 T2*             result);
+                                                 hipblas_internal_type<T2>*             result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasNrm2_64)(
-        hipblasHandle_t handle, int64_t n, const T1* x, int64_t incx, T2* result);
+        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T1>* x, int64_t incx, hipblas_internal_type<T2>* result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasNrm2Batched_64)(hipblasHandle_t handle,
                                              int64_t         n,
-                                             const T1* const x[],
+                                             const hipblas_internal_type<T1>* const x[],
                                              int64_t         incx,
                                              int64_t         batch_count,
-                                             T2*             result);
+                                             hipblas_internal_type<T2>*             result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
     hipblasStatus_t (*hipblasNrm2StridedBatched_64)(hipblasHandle_t handle,
                                                     int64_t         n,
-                                                    const T1*       x,
+                                                    const hipblas_internal_type<T1>*       x,
                                                     int64_t         incx,
                                                     hipblasStride   stridex,
                                                     int64_t         batch_count,
-                                                    T2*             result);
+                                                    hipblas_internal_type<T2>*             result);
 
     MAP2CF_D64(hipblasNrm2, float, float, hipblasSnrm2);
     MAP2CF_D64(hipblasNrm2, double, double, hipblasDnrm2);
-    MAP2CF_D64_V2(hipblasNrm2, hipblasComplex, float, hipblasScnrm2);
-    MAP2CF_D64_V2(hipblasNrm2, hipblasDoubleComplex, double, hipblasDznrm2);
+    MAP2CF_D64_V2(hipblasNrm2, std::complex<float>, float, hipblasScnrm2);
+    MAP2CF_D64_V2(hipblasNrm2, std::complex<double>, double, hipblasDznrm2);
 
     MAP2CF_D64(hipblasNrm2Batched, float, float, hipblasSnrm2Batched);
     MAP2CF_D64(hipblasNrm2Batched, double, double, hipblasDnrm2Batched);
-    MAP2CF_D64_V2(hipblasNrm2Batched, hipblasComplex, float, hipblasScnrm2Batched);
-    MAP2CF_D64_V2(hipblasNrm2Batched, hipblasDoubleComplex, double, hipblasDznrm2Batched);
+    MAP2CF_D64_V2(hipblasNrm2Batched, std::complex<float>, float, hipblasScnrm2Batched);
+    MAP2CF_D64_V2(hipblasNrm2Batched, std::complex<double>, double, hipblasDznrm2Batched);
 
     MAP2CF_D64(hipblasNrm2StridedBatched, float, float, hipblasSnrm2StridedBatched);
     MAP2CF_D64(hipblasNrm2StridedBatched, double, double, hipblasDnrm2StridedBatched);
-    MAP2CF_D64_V2(hipblasNrm2StridedBatched, hipblasComplex, float, hipblasScnrm2StridedBatched);
+    MAP2CF_D64_V2(hipblasNrm2StridedBatched, std::complex<float>, float, hipblasScnrm2StridedBatched);
     MAP2CF_D64_V2(hipblasNrm2StridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasDznrm2StridedBatched);
 
     // Rot
     template <typename T1, typename T2, typename T3 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRot)(
-        hipblasHandle_t handle, int n, T1* x, int incx, T1* y, int incy, const T2* c, const T3* s);
+        hipblasHandle_t handle, int n, hipblas_internal_type<T1>* x, int incx, hipblas_internal_type<T1>* y, int incy, const hipblas_internal_type<T2>* c, const hipblas_internal_type<T3>* s);
 
     template <typename T1, typename T2 = T1, typename T3 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotBatched)(hipblasHandle_t handle,
                                          int             n,
-                                         T1* const       x[],
+                                         hipblas_internal_type<T1>* const       x[],
                                          int             incx,
-                                         T1* const       y[],
+                                         hipblas_internal_type<T1>* const       y[],
                                          int             incy,
-                                         const T2*       c,
-                                         const T3*       s,
+                                         const hipblas_internal_type<T2>*       c,
+                                         const hipblas_internal_type<T3>*       s,
                                          int             batch_count);
 
     template <typename T1, typename T2 = T1, typename T3 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotStridedBatched)(hipblasHandle_t handle,
                                                 int             n,
-                                                T1*             x,
+                                                hipblas_internal_type<T1>*             x,
                                                 int             incx,
                                                 hipblasStride   stridex,
-                                                T1*             y,
+                                                hipblas_internal_type<T1>*             y,
                                                 int             incy,
                                                 hipblasStride   stridey,
-                                                const T2*       c,
-                                                const T3*       s,
+                                                const hipblas_internal_type<T2>*       c,
+                                                const hipblas_internal_type<T3>*       s,
                                                 int             batch_count);
 
     template <typename T1, typename T2, typename T3 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRot_64)(hipblasHandle_t handle,
                                      int64_t         n,
-                                     T1*             x,
+                                     hipblas_internal_type<T1>*             x,
                                      int64_t         incx,
-                                     T1*             y,
+                                     hipblas_internal_type<T1>*             y,
                                      int64_t         incy,
-                                     const T2*       c,
-                                     const T3*       s);
+                                     const hipblas_internal_type<T2>*       c,
+                                     const hipblas_internal_type<T3>*       s);
 
     template <typename T1, typename T2 = T1, typename T3 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotBatched_64)(hipblasHandle_t handle,
                                             int64_t         n,
-                                            T1* const       x[],
+                                            hipblas_internal_type<T1>* const       x[],
                                             int64_t         incx,
-                                            T1* const       y[],
+                                            hipblas_internal_type<T1>* const       y[],
                                             int64_t         incy,
-                                            const T2*       c,
-                                            const T3*       s,
+                                            const hipblas_internal_type<T2>*       c,
+                                            const hipblas_internal_type<T3>*       s,
                                             int64_t         batch_count);
 
     template <typename T1, typename T2 = T1, typename T3 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotStridedBatched_64)(hipblasHandle_t handle,
                                                    int64_t         n,
-                                                   T1*             x,
+                                                   hipblas_internal_type<T1>*             x,
                                                    int64_t         incx,
                                                    hipblasStride   stridex,
-                                                   T1*             y,
+                                                   hipblas_internal_type<T1>*             y,
                                                    int64_t         incy,
                                                    hipblasStride   stridey,
-                                                   const T2*       c,
-                                                   const T3*       s,
+                                                   const hipblas_internal_type<T2>*       c,
+                                                   const hipblas_internal_type<T3>*       s,
                                                    int64_t         batch_count);
 
     MAP2CF_D64(hipblasRot, float, float, float, hipblasSrot);
     MAP2CF_D64(hipblasRot, double, double, double, hipblasDrot);
-    MAP2CF_D64_V2(hipblasRot, hipblasComplex, float, hipblasComplex, hipblasCrot);
-    MAP2CF_D64_V2(hipblasRot, hipblasDoubleComplex, double, hipblasDoubleComplex, hipblasZrot);
-    MAP2CF_D64_V2(hipblasRot, hipblasComplex, float, float, hipblasCsrot);
-    MAP2CF_D64_V2(hipblasRot, hipblasDoubleComplex, double, double, hipblasZdrot);
+    MAP2CF_D64_V2(hipblasRot, std::complex<float>, float, std::complex<float>, hipblasCrot);
+    MAP2CF_D64_V2(hipblasRot, std::complex<double>, double, std::complex<double>, hipblasZrot);
+    MAP2CF_D64_V2(hipblasRot, std::complex<float>, float, float, hipblasCsrot);
+    MAP2CF_D64_V2(hipblasRot, std::complex<double>, double, double, hipblasZdrot);
 
     MAP2CF_D64(hipblasRotBatched, float, float, float, hipblasSrotBatched);
     MAP2CF_D64(hipblasRotBatched, double, double, double, hipblasDrotBatched);
-    MAP2CF_D64_V2(hipblasRotBatched, hipblasComplex, float, hipblasComplex, hipblasCrotBatched);
+    MAP2CF_D64_V2(hipblasRotBatched, std::complex<float>, float, std::complex<float>, hipblasCrotBatched);
     MAP2CF_D64_V2(
-        hipblasRotBatched, hipblasDoubleComplex, double, hipblasDoubleComplex, hipblasZrotBatched);
-    MAP2CF_D64_V2(hipblasRotBatched, hipblasComplex, float, float, hipblasCsrotBatched);
-    MAP2CF_D64_V2(hipblasRotBatched, hipblasDoubleComplex, double, double, hipblasZdrotBatched);
+        hipblasRotBatched, std::complex<double>, double, std::complex<double>, hipblasZrotBatched);
+    MAP2CF_D64_V2(hipblasRotBatched, std::complex<float>, float, float, hipblasCsrotBatched);
+    MAP2CF_D64_V2(hipblasRotBatched, std::complex<double>, double, double, hipblasZdrotBatched);
 
     MAP2CF_D64(hipblasRotStridedBatched, float, float, float, hipblasSrotStridedBatched);
     MAP2CF_D64(hipblasRotStridedBatched, double, double, double, hipblasDrotStridedBatched);
     MAP2CF_D64_V2(
-        hipblasRotStridedBatched, hipblasComplex, float, hipblasComplex, hipblasCrotStridedBatched);
+        hipblasRotStridedBatched, std::complex<float>, float, std::complex<float>, hipblasCrotStridedBatched);
     MAP2CF_D64_V2(hipblasRotStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   hipblasZrotStridedBatched);
     MAP2CF_D64_V2(
-        hipblasRotStridedBatched, hipblasComplex, float, float, hipblasCsrotStridedBatched);
+        hipblasRotStridedBatched, std::complex<float>, float, float, hipblasCsrotStridedBatched);
     MAP2CF_D64_V2(
-        hipblasRotStridedBatched, hipblasDoubleComplex, double, double, hipblasZdrotStridedBatched);
+        hipblasRotStridedBatched, std::complex<double>, double, double, hipblasZdrotStridedBatched);
 
     // Rotg
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotg)(hipblasHandle_t handle, T1* a, T1* b, T2* c, T1* s);
+    hipblasStatus_t (*hipblasRotg)(hipblasHandle_t handle, hipblas_internal_type<T1>* a, hipblas_internal_type<T1>* b, T2* c, hipblas_internal_type<T1>* s);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotgBatched)(hipblasHandle_t handle,
-                                          T1* const       a[],
-                                          T1* const       b[],
-                                          T2* const       c[],
-                                          T1* const       s[],
+                                          hipblas_internal_type<T1>* const       a[],
+                                          hipblas_internal_type<T1>* const       b[],
+                                          hipblas_internal_type<T2>* const       c[],
+                                          hipblas_internal_type<T1>* const       s[],
                                           int             batch_count);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotgStridedBatched)(hipblasHandle_t handle,
-                                                 T1*             a,
+                                                 hipblas_internal_type<T1>*             a,
                                                  hipblasStride   stridea,
-                                                 T1*             b,
+                                                 hipblas_internal_type<T1>*             b,
                                                  hipblasStride   strideb,
-                                                 T2*             c,
+                                                 hipblas_internal_type<T2>*             c,
                                                  hipblasStride   stridec,
-                                                 T1*             s,
+                                                 hipblas_internal_type<T1>*             s,
                                                  hipblasStride   strides,
                                                  int             batch_count);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotg_64)(hipblasHandle_t handle, T1* a, T1* b, T2* c, T1* s);
+    hipblasStatus_t (*hipblasRotg_64)(hipblasHandle_t handle, hipblas_internal_type<T1>* a, hipblas_internal_type<T1>* b, hipblas_internal_type<T2>* c, hipblas_internal_type<T1>* s);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotgBatched_64)(hipblasHandle_t handle,
-                                             T1* const       a[],
-                                             T1* const       b[],
-                                             T2* const       c[],
-                                             T1* const       s[],
+                                             hipblas_internal_type<T1>* const       a[],
+                                             hipblas_internal_type<T1>* const       b[],
+                                             hipblas_internal_type<T2>* const       c[],
+                                             hipblas_internal_type<T1>* const       s[],
                                              int64_t         batch_count);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotgStridedBatched_64)(hipblasHandle_t handle,
-                                                    T1*             a,
+                                                    hipblas_internal_type<T1>*             a,
                                                     hipblasStride   stridea,
-                                                    T1*             b,
+                                                    hipblas_internal_type<T1>*             b,
                                                     hipblasStride   strideb,
-                                                    T2*             c,
+                                                    hipblas_internal_type<T2>*             c,
                                                     hipblasStride   stridec,
-                                                    T1*             s,
+                                                    hipblas_internal_type<T1>*             s,
                                                     hipblasStride   strides,
                                                     int64_t         batch_count);
 
     MAP2CF_D64(hipblasRotg, float, float, hipblasSrotg);
     MAP2CF_D64(hipblasRotg, double, double, hipblasDrotg);
-    MAP2CF_D64_V2(hipblasRotg, hipblasComplex, float, hipblasCrotg);
-    MAP2CF_D64_V2(hipblasRotg, hipblasDoubleComplex, double, hipblasZrotg);
+    MAP2CF_D64_V2(hipblasRotg, std::complex<float>, float, hipblasCrotg);
+    MAP2CF_D64_V2(hipblasRotg, std::complex<double>, double, hipblasZrotg);
 
     MAP2CF_D64(hipblasRotgBatched, float, float, hipblasSrotgBatched);
     MAP2CF_D64(hipblasRotgBatched, double, double, hipblasDrotgBatched);
-    MAP2CF_D64_V2(hipblasRotgBatched, hipblasComplex, float, hipblasCrotgBatched);
-    MAP2CF_D64_V2(hipblasRotgBatched, hipblasDoubleComplex, double, hipblasZrotgBatched);
+    MAP2CF_D64_V2(hipblasRotgBatched, std::complex<float>, float, hipblasCrotgBatched);
+    MAP2CF_D64_V2(hipblasRotgBatched, std::complex<double>, double, hipblasZrotgBatched);
 
     MAP2CF_D64(hipblasRotgStridedBatched, float, float, hipblasSrotgStridedBatched);
     MAP2CF_D64(hipblasRotgStridedBatched, double, double, hipblasDrotgStridedBatched);
-    MAP2CF_D64_V2(hipblasRotgStridedBatched, hipblasComplex, float, hipblasCrotgStridedBatched);
+    MAP2CF_D64_V2(hipblasRotgStridedBatched, std::complex<float>, float, hipblasCrotgStridedBatched);
     MAP2CF_D64_V2(hipblasRotgStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasZrotgStridedBatched);
 
     // rotm
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotm)(
-        hipblasHandle_t handle, int n, T* x, int incx, T* y, int incy, const T* param);
+        hipblasHandle_t handle, int n, hipblas_internal_type<T>* x, int incx, hipblas_internal_type<T>* y, int incy, const hipblas_internal_type<T>* param);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmBatched)(hipblasHandle_t handle,
                                           int             n,
-                                          T* const        x[],
+                                          hipblas_internal_type<T>* const        x[],
                                           int             incx,
-                                          T* const        y[],
+                                          hipblas_internal_type<T>* const        y[],
                                           int             incy,
-                                          const T* const  param[],
+                                          const hipblas_internal_type<T>* const  param[],
                                           int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmStridedBatched)(hipblasHandle_t handle,
                                                  int             n,
-                                                 T*              x,
+                                                 hipblas_internal_type<T>*              x,
                                                  int             incx,
                                                  hipblasStride   stridex,
-                                                 T*              y,
+                                                 hipblas_internal_type<T>*              y,
                                                  int             incy,
                                                  hipblasStride   stridey,
-                                                 const T*        param,
+                                                 const hipblas_internal_type<T>*        param,
                                                  hipblasStride   strideparam,
                                                  int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotm_64)(
-        hipblasHandle_t handle, int64_t n, T* x, int64_t incx, T* y, int64_t incy, const T* param);
+        hipblasHandle_t handle, int64_t n, hipblas_internal_type<T>* x, int64_t incx, hipblas_internal_type<T>* y, int64_t incy, const hipblas_internal_type<T>* param);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmBatched_64)(hipblasHandle_t handle,
                                              int64_t         n,
-                                             T* const        x[],
+                                             hipblas_internal_type<T>* const        x[],
                                              int64_t         incx,
-                                             T* const        y[],
+                                             hipblas_internal_type<T>* const        y[],
                                              int64_t         incy,
-                                             const T* const  param[],
+                                             const hipblas_internal_type<T>* const  param[],
                                              int64_t         batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmStridedBatched_64)(hipblasHandle_t handle,
                                                     int64_t         n,
-                                                    T*              x,
+                                                    hipblas_internal_type<T>*              x,
                                                     int64_t         incx,
                                                     hipblasStride   stridex,
-                                                    T*              y,
+                                                    hipblas_internal_type<T>*              y,
                                                     int64_t         incy,
                                                     hipblasStride   stridey,
-                                                    const T*        param,
+                                                    const hipblas_internal_type<T>*        param,
                                                     hipblasStride   strideparam,
                                                     int64_t         batch_count);
 
@@ -7976,55 +7977,55 @@ namespace
     // rotmg
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmg)(
-        hipblasHandle_t handle, T* d1, T* d2, T* x1, const T* y1, T* param);
+        hipblasHandle_t handle, hipblas_internal_type<T>* d1, hipblas_internal_type<T>* d2, hipblas_internal_type<T>* x1, const hipblas_internal_type<T>* y1, hipblas_internal_type<T>* param);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmgBatched)(hipblasHandle_t handle,
-                                           T* const        d1[],
-                                           T* const        d2[],
-                                           T* const        x1[],
-                                           const T* const  y1[],
-                                           T* const        param[],
+                                           hipblas_internal_type<T>* const        d1[],
+                                           hipblas_internal_type<T>* const        d2[],
+                                           hipblas_internal_type<T>* const        x1[],
+                                           const hipblas_internal_type<T>* const  y1[],
+                                           hipblas_internal_type<T>* const        param[],
                                            int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmgStridedBatched)(hipblasHandle_t handle,
-                                                  T*              d1,
+                                                  hipblas_internal_type<T>*              d1,
                                                   hipblasStride   stride_d1,
-                                                  T*              d2,
+                                                  hipblas_internal_type<T>*              d2,
                                                   hipblasStride   stride_d2,
-                                                  T*              x1,
+                                                  hipblas_internal_type<T>*              x1,
                                                   hipblasStride   stride_x1,
-                                                  const T*        y1,
+                                                  const hipblas_internal_type<T>*        y1,
                                                   hipblasStride   stride_y1,
-                                                  T*              param,
+                                                  hipblas_internal_type<T>*              param,
                                                   hipblasStride   strideparam,
                                                   int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmg_64)(
-        hipblasHandle_t handle, T* d1, T* d2, T* x1, const T* y1, T* param);
+        hipblasHandle_t handle, hipblas_internal_type<T>* d1, hipblas_internal_type<T>* d2, hipblas_internal_type<T>* x1, const hipblas_internal_type<T>* y1, hipblas_internal_type<T>* param);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmgBatched_64)(hipblasHandle_t handle,
-                                              T* const        d1[],
-                                              T* const        d2[],
-                                              T* const        x1[],
-                                              const T* const  y1[],
-                                              T* const        param[],
+                                              hipblas_internal_type<T>* const        d1[],
+                                              hipblas_internal_type<T>* const        d2[],
+                                              hipblas_internal_type<T>* const        x1[],
+                                              const hipblas_internal_type<T>* const  y1[],
+                                              hipblas_internal_type<T>* const        param[],
                                               int64_t         batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasRotmgStridedBatched_64)(hipblasHandle_t handle,
-                                                     T*              d1,
+                                                     hipblas_internal_type<T>*              d1,
                                                      hipblasStride   stride_d1,
-                                                     T*              d2,
+                                                     hipblas_internal_type<T>*              d2,
                                                      hipblasStride   stride_d2,
-                                                     T*              x1,
+                                                     hipblas_internal_type<T>*              x1,
                                                      hipblasStride   stride_x1,
-                                                     const T*        y1,
+                                                     const hipblas_internal_type<T>*        y1,
                                                      hipblasStride   stride_y1,
-                                                     T*              param,
+                                                     hipblas_internal_type<T>*              param,
                                                      hipblasStride   strideparam,
                                                      int64_t         batch_count);
 
@@ -8040,16 +8041,16 @@ namespace
     // amax
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIamax)(
-        hipblasHandle_t handle, int n, const T* x, int incx, int* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, int* result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIamaxBatched)(
-        hipblasHandle_t handle, int n, const T* const x[], int incx, int batch_count, int* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* const x[], int incx, int batch_count, int* result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIamaxStridedBatched)(hipblasHandle_t handle,
                                                   int             n,
-                                                  const T*        x,
+                                                  const hipblas_internal_type<T>*        x,
                                                   int             incx,
                                                   hipblasStride   stridex,
                                                   int             batch_count,
@@ -8057,12 +8058,12 @@ namespace
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIamax_64)(
-        hipblasHandle_t handle, int64_t n, const T* x, int64_t incx, int64_t* result);
+        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T>* x, int64_t incx, int64_t* result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIamaxBatched_64)(hipblasHandle_t handle,
                                               int64_t         n,
-                                              const T* const  x[],
+                                              const hipblas_internal_type<T>* const  x[],
                                               int64_t         incx,
                                               int64_t         batch_count,
                                               int64_t*        result);
@@ -8070,7 +8071,7 @@ namespace
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIamaxStridedBatched_64)(hipblasHandle_t handle,
                                                      int64_t         n,
-                                                     const T*        x,
+                                                     const hipblas_internal_type<T>*        x,
                                                      int64_t         incx,
                                                      hipblasStride   stridex,
                                                      int64_t         batch_count,
@@ -8078,32 +8079,32 @@ namespace
 
     MAP2CF_D64(hipblasIamax, float, hipblasIsamax);
     MAP2CF_D64(hipblasIamax, double, hipblasIdamax);
-    MAP2CF_D64_V2(hipblasIamax, hipblasComplex, hipblasIcamax);
-    MAP2CF_D64_V2(hipblasIamax, hipblasDoubleComplex, hipblasIzamax);
+    MAP2CF_D64_V2(hipblasIamax, std::complex<float>, hipblasIcamax);
+    MAP2CF_D64_V2(hipblasIamax, std::complex<double>, hipblasIzamax);
 
     MAP2CF_D64(hipblasIamaxBatched, float, hipblasIsamaxBatched);
     MAP2CF_D64(hipblasIamaxBatched, double, hipblasIdamaxBatched);
-    MAP2CF_D64_V2(hipblasIamaxBatched, hipblasComplex, hipblasIcamaxBatched);
-    MAP2CF_D64_V2(hipblasIamaxBatched, hipblasDoubleComplex, hipblasIzamaxBatched);
+    MAP2CF_D64_V2(hipblasIamaxBatched, std::complex<float>, hipblasIcamaxBatched);
+    MAP2CF_D64_V2(hipblasIamaxBatched, std::complex<double>, hipblasIzamaxBatched);
 
     MAP2CF_D64(hipblasIamaxStridedBatched, float, hipblasIsamaxStridedBatched);
     MAP2CF_D64(hipblasIamaxStridedBatched, double, hipblasIdamaxStridedBatched);
-    MAP2CF_D64_V2(hipblasIamaxStridedBatched, hipblasComplex, hipblasIcamaxStridedBatched);
-    MAP2CF_D64_V2(hipblasIamaxStridedBatched, hipblasDoubleComplex, hipblasIzamaxStridedBatched);
+    MAP2CF_D64_V2(hipblasIamaxStridedBatched, std::complex<float>, hipblasIcamaxStridedBatched);
+    MAP2CF_D64_V2(hipblasIamaxStridedBatched, std::complex<double>, hipblasIzamaxStridedBatched);
 
     // amin
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIamin)(
-        hipblasHandle_t handle, int n, const T* x, int incx, int* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, int* result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIaminBatched)(
-        hipblasHandle_t handle, int n, const T* const x[], int incx, int batch_count, int* result);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* const x[], int incx, int batch_count, int* result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIaminStridedBatched)(hipblasHandle_t handle,
                                                   int             n,
-                                                  const T*        x,
+                                                  const hipblas_internal_type<T>*        x,
                                                   int             incx,
                                                   hipblasStride   stridex,
                                                   int             batch_count,
@@ -8111,12 +8112,12 @@ namespace
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIamin_64)(
-        hipblasHandle_t handle, int64_t n, const T* x, int64_t incx, int64_t* result);
+        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T>* x, int64_t incx, int64_t* result);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIaminBatched_64)(hipblasHandle_t handle,
                                               int64_t         n,
-                                              const T* const  x[],
+                                              const hipblas_internal_type<T>* const  x[],
                                               int64_t         incx,
                                               int64_t         batch_count,
                                               int64_t*        result);
@@ -8124,7 +8125,7 @@ namespace
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasIaminStridedBatched_64)(hipblasHandle_t handle,
                                                      int64_t         n,
-                                                     const T*        x,
+                                                     const hipblas_internal_type<T>*        x,
                                                      int64_t         incx,
                                                      hipblasStride   stridex,
                                                      int64_t         batch_count,
@@ -8132,42 +8133,42 @@ namespace
 
     MAP2CF_D64(hipblasIamin, float, hipblasIsamin);
     MAP2CF_D64(hipblasIamin, double, hipblasIdamin);
-    MAP2CF_D64_V2(hipblasIamin, hipblasComplex, hipblasIcamin);
-    MAP2CF_D64_V2(hipblasIamin, hipblasDoubleComplex, hipblasIzamin);
+    MAP2CF_D64_V2(hipblasIamin, std::complex<float>, hipblasIcamin);
+    MAP2CF_D64_V2(hipblasIamin, std::complex<double>, hipblasIzamin);
 
     MAP2CF_D64(hipblasIaminBatched, float, hipblasIsaminBatched);
     MAP2CF_D64(hipblasIaminBatched, double, hipblasIdaminBatched);
-    MAP2CF_D64_V2(hipblasIaminBatched, hipblasComplex, hipblasIcaminBatched);
-    MAP2CF_D64_V2(hipblasIaminBatched, hipblasDoubleComplex, hipblasIzaminBatched);
+    MAP2CF_D64_V2(hipblasIaminBatched, std::complex<float>, hipblasIcaminBatched);
+    MAP2CF_D64_V2(hipblasIaminBatched, std::complex<double>, hipblasIzaminBatched);
 
     MAP2CF_D64(hipblasIaminStridedBatched, float, hipblasIsaminStridedBatched);
     MAP2CF_D64(hipblasIaminStridedBatched, double, hipblasIdaminStridedBatched);
-    MAP2CF_D64_V2(hipblasIaminStridedBatched, hipblasComplex, hipblasIcaminStridedBatched);
-    MAP2CF_D64_V2(hipblasIaminStridedBatched, hipblasDoubleComplex, hipblasIzaminStridedBatched);
+    MAP2CF_D64_V2(hipblasIaminStridedBatched, std::complex<float>, hipblasIcaminStridedBatched);
+    MAP2CF_D64_V2(hipblasIaminStridedBatched, std::complex<double>, hipblasIzaminStridedBatched);
 
     // axpy
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAxpy)(
-        hipblasHandle_t handle, int n, const T* alpha, const T* x, int incx, T* y, int incy);
+        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* alpha, const hipblas_internal_type<T>* x, int incx, hipblas_internal_type<T>* y, int incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAxpyBatched)(hipblasHandle_t handle,
                                           int             n,
-                                          const T*        alpha,
-                                          const T* const  x[],
+                                          const hipblas_internal_type<T>*        alpha,
+                                          const hipblas_internal_type<T>* const  x[],
                                           int             incx,
-                                          T* const        y[],
+                                          hipblas_internal_type<T>* const        y[],
                                           int             incy,
                                           int             batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAxpyStridedBatched)(hipblasHandle_t handle,
                                                  int             n,
-                                                 const T*        alpha,
-                                                 const T*        x,
+                                                 const hipblas_internal_type<T>*        alpha,
+                                                 const hipblas_internal_type<T>*        x,
                                                  int             incx,
                                                  hipblasStride   stridex,
-                                                 T*              y,
+                                                 hipblas_internal_type<T>*              y,
                                                  int             incy,
                                                  hipblasStride   stridey,
                                                  int             batch_count);
@@ -8175,30 +8176,30 @@ namespace
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAxpy_64)(hipblasHandle_t handle,
                                       int64_t         n,
-                                      const T*        alpha,
-                                      const T*        x,
+                                      const hipblas_internal_type<T>*        alpha,
+                                      const hipblas_internal_type<T>*        x,
                                       int64_t         incx,
-                                      T*              y,
+                                      hipblas_internal_type<T>*              y,
                                       int64_t         incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAxpyBatched_64)(hipblasHandle_t handle,
                                              int64_t         n,
-                                             const T*        alpha,
-                                             const T* const  x[],
+                                             const hipblas_internal_type<T>*        alpha,
+                                             const hipblas_internal_type<T>* const  x[],
                                              int64_t         incx,
-                                             T* const        y[],
+                                             hipblas_internal_type<T>* const        y[],
                                              int64_t         incy,
                                              int64_t         batch_count);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasAxpyStridedBatched_64)(hipblasHandle_t handle,
                                                     int64_t         n,
-                                                    const T*        alpha,
-                                                    const T*        x,
+                                                    const hipblas_internal_type<T>*        alpha,
+                                                    const hipblas_internal_type<T>*        x,
                                                     int64_t         incx,
                                                     hipblasStride   stridex,
-                                                    T*              y,
+                                                    hipblas_internal_type<T>*              y,
                                                     int64_t         incy,
                                                     hipblasStride   stridey,
                                                     int64_t         batch_count);
@@ -8206,44 +8207,44 @@ namespace
     MAP2CF_D64(hipblasAxpy, hipblasHalf, hipblasHaxpy);
     MAP2CF_D64(hipblasAxpy, float, hipblasSaxpy);
     MAP2CF_D64(hipblasAxpy, double, hipblasDaxpy);
-    MAP2CF_D64_V2(hipblasAxpy, hipblasComplex, hipblasCaxpy);
-    MAP2CF_D64_V2(hipblasAxpy, hipblasDoubleComplex, hipblasZaxpy);
+    MAP2CF_D64_V2(hipblasAxpy, std::complex<float>, hipblasCaxpy);
+    MAP2CF_D64_V2(hipblasAxpy, std::complex<double>, hipblasZaxpy);
 
     MAP2CF_D64(hipblasAxpyBatched, hipblasHalf, hipblasHaxpyBatched);
     MAP2CF_D64(hipblasAxpyBatched, float, hipblasSaxpyBatched);
     MAP2CF_D64(hipblasAxpyBatched, double, hipblasDaxpyBatched);
-    MAP2CF_D64_V2(hipblasAxpyBatched, hipblasComplex, hipblasCaxpyBatched);
-    MAP2CF_D64_V2(hipblasAxpyBatched, hipblasDoubleComplex, hipblasZaxpyBatched);
+    MAP2CF_D64_V2(hipblasAxpyBatched, std::complex<float>, hipblasCaxpyBatched);
+    MAP2CF_D64_V2(hipblasAxpyBatched, std::complex<double>, hipblasZaxpyBatched);
 
     MAP2CF_D64(hipblasAxpyStridedBatched, hipblasHalf, hipblasHaxpyStridedBatched);
     MAP2CF_D64(hipblasAxpyStridedBatched, float, hipblasSaxpyStridedBatched);
     MAP2CF_D64(hipblasAxpyStridedBatched, double, hipblasDaxpyStridedBatched);
-    MAP2CF_D64_V2(hipblasAxpyStridedBatched, hipblasComplex, hipblasCaxpyStridedBatched);
-    MAP2CF_D64_V2(hipblasAxpyStridedBatched, hipblasDoubleComplex, hipblasZaxpyStridedBatched);
+    MAP2CF_D64_V2(hipblasAxpyStridedBatched, std::complex<float>, hipblasCaxpyStridedBatched);
+    MAP2CF_D64_V2(hipblasAxpyStridedBatched, std::complex<double>, hipblasZaxpyStridedBatched);
 
     // ger
     template <typename T, bool CONJ, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGer)(hipblasHandle_t handle,
                                   int             m,
                                   int             n,
-                                  const T*        alpha,
-                                  const T*        x,
+                                  const hipblas_internal_type<T>*        alpha,
+                                  const hipblas_internal_type<T>*        x,
                                   int             incx,
-                                  const T*        y,
+                                  const hipblas_internal_type<T>*        y,
                                   int             incy,
-                                  T*              A,
+                                  hipblas_internal_type<T>*              A,
                                   int             lda);
 
     template <typename T, bool CONJ, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGerBatched)(hipblasHandle_t handle,
                                          int             m,
                                          int             n,
-                                         const T*        alpha,
-                                         const T* const  x[],
+                                         const hipblas_internal_type<T>*        alpha,
+                                         const hipblas_internal_type<T>* const  x[],
                                          int             incx,
-                                         const T* const  y[],
+                                         const hipblas_internal_type<T>* const  y[],
                                          int             incy,
-                                         T* const        A[],
+                                         hipblas_internal_type<T>* const        A[],
                                          int             lda,
                                          int             batch_count);
 
@@ -8251,14 +8252,14 @@ namespace
     hipblasStatus_t (*hipblasGerStridedBatched)(hipblasHandle_t handle,
                                                 int             m,
                                                 int             n,
-                                                const T*        alpha,
-                                                const T*        x,
+                                                const hipblas_internal_type<T>*        alpha,
+                                                const hipblas_internal_type<T>*        x,
                                                 int             incx,
                                                 hipblasStride   stridex,
-                                                const T*        y,
+                                                const hipblas_internal_type<T>*        y,
                                                 int             incy,
                                                 hipblasStride   stridey,
-                                                T*              A,
+                                                hipblas_internal_type<T>*              A,
                                                 int             lda,
                                                 hipblasStride   strideA,
                                                 int             batch_count);
@@ -8268,24 +8269,24 @@ namespace
     hipblasStatus_t (*hipblasGer_64)(hipblasHandle_t handle,
                                      int64_t         m,
                                      int64_t         n,
-                                     const T*        alpha,
-                                     const T*        x,
+                                     const hipblas_internal_type<T>*        alpha,
+                                     const hipblas_internal_type<T>*        x,
                                      int64_t         incx,
-                                     const T*        y,
+                                     const hipblas_internal_type<T>*        y,
                                      int64_t         incy,
-                                     T*              A,
+                                     hipblas_internal_type<T>*              A,
                                      int64_t         lda);
 
     template <typename T, bool CONJ, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGerBatched_64)(hipblasHandle_t handle,
                                             int64_t         m,
                                             int64_t         n,
-                                            const T*        alpha,
-                                            const T* const  x[],
+                                            const hipblas_internal_type<T>*        alpha,
+                                            const hipblas_internal_type<T>* const  x[],
                                             int64_t         incx,
-                                            const T* const  y[],
+                                            const hipblas_internal_type<T>* const  y[],
                                             int64_t         incy,
-                                            T* const        A[],
+                                            hipblas_internal_type<T>* const        A[],
                                             int64_t         lda,
                                             int64_t         batch_count);
 
@@ -8293,41 +8294,41 @@ namespace
     hipblasStatus_t (*hipblasGerStridedBatched_64)(hipblasHandle_t handle,
                                                    int64_t         m,
                                                    int64_t         n,
-                                                   const T*        alpha,
-                                                   const T*        x,
+                                                   const hipblas_internal_type<T>*        alpha,
+                                                   const hipblas_internal_type<T>*        x,
                                                    int64_t         incx,
                                                    hipblasStride   stridex,
-                                                   const T*        y,
+                                                   const hipblas_internal_type<T>*        y,
                                                    int64_t         incy,
                                                    hipblasStride   stridey,
-                                                   T*              A,
+                                                   hipblas_internal_type<T>*              A,
                                                    int64_t         lda,
                                                    hipblasStride   strideA,
                                                    int64_t         batch_count);
 
     MAP2CF_D64(hipblasGer, float, false, hipblasSger);
     MAP2CF_D64(hipblasGer, double, false, hipblasDger);
-    MAP2CF_D64_V2(hipblasGer, hipblasComplex, false, hipblasCgeru);
-    MAP2CF_D64_V2(hipblasGer, hipblasDoubleComplex, false, hipblasZgeru);
-    MAP2CF_D64_V2(hipblasGer, hipblasComplex, true, hipblasCgerc);
-    MAP2CF_D64_V2(hipblasGer, hipblasDoubleComplex, true, hipblasZgerc);
+    MAP2CF_D64_V2(hipblasGer, std::complex<float>, false, hipblasCgeru);
+    MAP2CF_D64_V2(hipblasGer, std::complex<double>, false, hipblasZgeru);
+    MAP2CF_D64_V2(hipblasGer, std::complex<float>, true, hipblasCgerc);
+    MAP2CF_D64_V2(hipblasGer, std::complex<double>, true, hipblasZgerc);
 
     MAP2CF_D64(hipblasGerBatched, float, false, hipblasSgerBatched);
     MAP2CF_D64(hipblasGerBatched, double, false, hipblasDgerBatched);
-    MAP2CF_D64_V2(hipblasGerBatched, hipblasComplex, false, hipblasCgeruBatched);
-    MAP2CF_D64_V2(hipblasGerBatched, hipblasDoubleComplex, false, hipblasZgeruBatched);
-    MAP2CF_D64_V2(hipblasGerBatched, hipblasComplex, true, hipblasCgercBatched);
-    MAP2CF_D64_V2(hipblasGerBatched, hipblasDoubleComplex, true, hipblasZgercBatched);
+    MAP2CF_D64_V2(hipblasGerBatched, std::complex<float>, false, hipblasCgeruBatched);
+    MAP2CF_D64_V2(hipblasGerBatched, std::complex<double>, false, hipblasZgeruBatched);
+    MAP2CF_D64_V2(hipblasGerBatched, std::complex<float>, true, hipblasCgercBatched);
+    MAP2CF_D64_V2(hipblasGerBatched, std::complex<double>, true, hipblasZgercBatched);
 
     MAP2CF_D64(hipblasGerStridedBatched, float, false, hipblasSgerStridedBatched);
     MAP2CF_D64(hipblasGerStridedBatched, double, false, hipblasDgerStridedBatched);
-    MAP2CF_D64_V2(hipblasGerStridedBatched, hipblasComplex, false, hipblasCgeruStridedBatched);
+    MAP2CF_D64_V2(hipblasGerStridedBatched, std::complex<float>, false, hipblasCgeruStridedBatched);
     MAP2CF_D64_V2(hipblasGerStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   false,
                   hipblasZgeruStridedBatched);
-    MAP2CF_D64_V2(hipblasGerStridedBatched, hipblasComplex, true, hipblasCgercStridedBatched);
-    MAP2CF_D64_V2(hipblasGerStridedBatched, hipblasDoubleComplex, true, hipblasZgercStridedBatched);
+    MAP2CF_D64_V2(hipblasGerStridedBatched, std::complex<float>, true, hipblasCgercStridedBatched);
+    MAP2CF_D64_V2(hipblasGerStridedBatched, std::complex<double>, true, hipblasZgercStridedBatched);
 
     // hbmv
     template <typename T, bool FORTRAN = false>
@@ -8335,13 +8336,13 @@ namespace
                                    hipblasFillMode_t uplo,
                                    int               n,
                                    int               k,
-                                   const T*          alpha,
-                                   const T*          A,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          A,
                                    int               lda,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          beta,
-                                   T*                y,
+                                   const hipblas_internal_type<T>*          beta,
+                                   hipblas_internal_type<T>*                y,
                                    int               incy);
 
     template <typename T, bool FORTRAN = false>
@@ -8349,30 +8350,30 @@ namespace
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
                                       int64_t           k,
-                                      const T*          alpha,
-                                      const T*          A,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          A,
                                       int64_t           lda,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          beta,
-                                      T*                y,
+                                      const hipblas_internal_type<T>*          beta,
+                                      hipblas_internal_type<T>*                y,
                                       int64_t           incy);
 
-    MAP2CF_D64_V2(hipblasHbmv, hipblasComplex, hipblasChbmv);
-    MAP2CF_D64_V2(hipblasHbmv, hipblasDoubleComplex, hipblasZhbmv);
+    MAP2CF_D64_V2(hipblasHbmv, std::complex<float>, hipblasChbmv);
+    MAP2CF_D64_V2(hipblasHbmv, std::complex<double>, hipblasZhbmv);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHbmvBatched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
                                           int               k,
-                                          const T*          alpha,
-                                          const T* const    A[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    A[],
                                           int               lda,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T*          beta,
-                                          T* const          y[],
+                                          const hipblas_internal_type<T>*          beta,
+                                          hipblas_internal_type<T>* const          y[],
                                           int               incy,
                                           int               batchCount);
 
@@ -8381,33 +8382,33 @@ namespace
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
                                              int64_t           k,
-                                             const T*          alpha,
-                                             const T* const    A[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    A[],
                                              int64_t           lda,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T*          beta,
-                                             T* const          y[],
+                                             const hipblas_internal_type<T>*          beta,
+                                             hipblas_internal_type<T>* const          y[],
                                              int64_t           incy,
                                              int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHbmvBatched, hipblasComplex, hipblasChbmvBatched);
-    MAP2CF_D64_V2(hipblasHbmvBatched, hipblasDoubleComplex, hipblasZhbmvBatched);
+    MAP2CF_D64_V2(hipblasHbmvBatched, std::complex<float>, hipblasChbmvBatched);
+    MAP2CF_D64_V2(hipblasHbmvBatched, std::complex<double>, hipblasZhbmvBatched);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHbmvStridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
                                                  int               k,
-                                                 const T*          alpha,
-                                                 const T*          A,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          A,
                                                  int               lda,
                                                  hipblasStride     strideA,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          beta,
-                                                 T*                y,
+                                                 const hipblas_internal_type<T>*          beta,
+                                                 hipblas_internal_type<T>*                y,
                                                  int               incy,
                                                  hipblasStride     stridey,
                                                  int               batchCount);
@@ -8417,63 +8418,63 @@ namespace
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
                                                     int64_t           k,
-                                                    const T*          alpha,
-                                                    const T*          A,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          A,
                                                     int64_t           lda,
                                                     hipblasStride     strideA,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          beta,
-                                                    T*                y,
+                                                    const hipblas_internal_type<T>*          beta,
+                                                    hipblas_internal_type<T>*                y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
                                                     int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHbmvStridedBatched, hipblasComplex, hipblasChbmvStridedBatched);
-    MAP2CF_D64_V2(hipblasHbmvStridedBatched, hipblasDoubleComplex, hipblasZhbmvStridedBatched);
+    MAP2CF_D64_V2(hipblasHbmvStridedBatched, std::complex<float>, hipblasChbmvStridedBatched);
+    MAP2CF_D64_V2(hipblasHbmvStridedBatched, std::complex<double>, hipblasZhbmvStridedBatched);
 
     // hemv
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHemv)(hipblasHandle_t   handle,
                                    hipblasFillMode_t uplo,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          A,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          A,
                                    int               lda,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          beta,
-                                   T*                y,
+                                   const hipblas_internal_type<T>*          beta,
+                                   hipblas_internal_type<T>*                y,
                                    int               incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHemv_64)(hipblasHandle_t   handle,
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          A,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          A,
                                       int64_t           lda,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          beta,
-                                      T*                y,
+                                      const hipblas_internal_type<T>*          beta,
+                                      hipblas_internal_type<T>*                y,
                                       int64_t           incy);
 
-    MAP2CF_D64_V2(hipblasHemv, hipblasComplex, hipblasChemv);
-    MAP2CF_D64_V2(hipblasHemv, hipblasDoubleComplex, hipblasZhemv);
+    MAP2CF_D64_V2(hipblasHemv, std::complex<float>, hipblasChemv);
+    MAP2CF_D64_V2(hipblasHemv, std::complex<double>, hipblasZhemv);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHemvBatched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    A[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    A[],
                                           int               lda,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T*          beta,
-                                          T* const          y[],
+                                          const hipblas_internal_type<T>*          beta,
+                                          hipblas_internal_type<T>* const          y[],
                                           int               incy,
                                           int               batch_count);
 
@@ -8481,32 +8482,32 @@ namespace
     hipblasStatus_t (*hipblasHemvBatched_64)(hipblasHandle_t   handle,
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    A[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    A[],
                                              int64_t           lda,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T*          beta,
-                                             T* const          y[],
+                                             const hipblas_internal_type<T>*          beta,
+                                             hipblas_internal_type<T>* const          y[],
                                              int64_t           incy,
                                              int64_t           batch_count);
 
-    MAP2CF_D64_V2(hipblasHemvBatched, hipblasComplex, hipblasChemvBatched);
-    MAP2CF_D64_V2(hipblasHemvBatched, hipblasDoubleComplex, hipblasZhemvBatched);
+    MAP2CF_D64_V2(hipblasHemvBatched, std::complex<float>, hipblasChemvBatched);
+    MAP2CF_D64_V2(hipblasHemvBatched, std::complex<double>, hipblasZhemvBatched);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHemvStridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          A,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          A,
                                                  int               lda,
                                                  hipblasStride     stride_a,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stride_x,
-                                                 const T*          beta,
-                                                 T*                y,
+                                                 const hipblas_internal_type<T>*          beta,
+                                                 hipblas_internal_type<T>*                y,
                                                  int               incy,
                                                  hipblasStride     stride_y,
                                                  int               batch_count);
@@ -8515,54 +8516,54 @@ namespace
     hipblasStatus_t (*hipblasHemvStridedBatched_64)(hipblasHandle_t   handle,
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          A,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          A,
                                                     int64_t           lda,
                                                     hipblasStride     stride_a,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stride_x,
-                                                    const T*          beta,
-                                                    T*                y,
+                                                    const hipblas_internal_type<T>*          beta,
+                                                    hipblas_internal_type<T>*                y,
                                                     int64_t           incy,
                                                     hipblasStride     stride_y,
                                                     int64_t           batch_count);
 
-    MAP2CF_D64_V2(hipblasHemvStridedBatched, hipblasComplex, hipblasChemvStridedBatched);
-    MAP2CF_D64_V2(hipblasHemvStridedBatched, hipblasDoubleComplex, hipblasZhemvStridedBatched);
+    MAP2CF_D64_V2(hipblasHemvStridedBatched, std::complex<float>, hipblasChemvStridedBatched);
+    MAP2CF_D64_V2(hipblasHemvStridedBatched, std::complex<double>, hipblasZhemvStridedBatched);
 
     // her
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHer)(hipblasHandle_t   handle,
                                   hipblasFillMode_t uplo,
                                   int               n,
-                                  const U*          alpha,
-                                  const T*          x,
+                                  const hipblas_internal_type<U>*          alpha,
+                                  const hipblas_internal_type<T>*          x,
                                   int               incx,
-                                  T*                A,
+                                  hipblas_internal_type<T>*                A,
                                   int               lda);
 
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHer_64)(hipblasHandle_t   handle,
                                      hipblasFillMode_t uplo,
                                      int64_t           n,
-                                     const U*          alpha,
-                                     const T*          x,
+                                     const hipblas_internal_type<U>*          alpha,
+                                     const hipblas_internal_type<T>*          x,
                                      int64_t           incx,
-                                     T*                A,
+                                     hipblas_internal_type<T>*                A,
                                      int64_t           lda);
 
-    MAP2CF_D64_V2(hipblasHer, hipblasComplex, float, hipblasCher);
-    MAP2CF_D64_V2(hipblasHer, hipblasDoubleComplex, double, hipblasZher);
+    MAP2CF_D64_V2(hipblasHer, std::complex<float>, float, hipblasCher);
+    MAP2CF_D64_V2(hipblasHer, std::complex<double>, double, hipblasZher);
 
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHerBatched)(hipblasHandle_t   handle,
                                          hipblasFillMode_t uplo,
                                          int               n,
-                                         const U*          alpha,
-                                         const T* const    x[],
+                                         const hipblas_internal_type<U>*          alpha,
+                                         const hipblas_internal_type<T>* const    x[],
                                          int               incx,
-                                         T* const          A[],
+                                         hipblas_internal_type<T>* const          A[],
                                          int               lda,
                                          int               batchCount);
 
@@ -8570,25 +8571,25 @@ namespace
     hipblasStatus_t (*hipblasHerBatched_64)(hipblasHandle_t   handle,
                                             hipblasFillMode_t uplo,
                                             int64_t           n,
-                                            const U*          alpha,
-                                            const T* const    x[],
+                                            const hipblas_internal_type<U>*          alpha,
+                                            const hipblas_internal_type<T>* const    x[],
                                             int64_t           incx,
-                                            T* const          A[],
+                                            hipblas_internal_type<T>* const          A[],
                                             int64_t           lda,
                                             int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHerBatched, hipblasComplex, float, hipblasCherBatched);
-    MAP2CF_D64_V2(hipblasHerBatched, hipblasDoubleComplex, double, hipblasZherBatched);
+    MAP2CF_D64_V2(hipblasHerBatched, std::complex<float>, float, hipblasCherBatched);
+    MAP2CF_D64_V2(hipblasHerBatched, std::complex<double>, double, hipblasZherBatched);
 
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHerStridedBatched)(hipblasHandle_t   handle,
                                                 hipblasFillMode_t uplo,
                                                 int               n,
-                                                const U*          alpha,
-                                                const T*          x,
+                                                const hipblas_internal_type<U>*          alpha,
+                                                const hipblas_internal_type<T>*          x,
                                                 int               incx,
                                                 hipblasStride     stridex,
-                                                T*                A,
+                                                hipblas_internal_type<T>*                A,
                                                 int               lda,
                                                 hipblasStride     strideA,
                                                 int               batchCount);
@@ -8597,18 +8598,18 @@ namespace
     hipblasStatus_t (*hipblasHerStridedBatched_64)(hipblasHandle_t   handle,
                                                    hipblasFillMode_t uplo,
                                                    int64_t           n,
-                                                   const U*          alpha,
-                                                   const T*          x,
+                                                   const hipblas_internal_type<U>*          alpha,
+                                                   const hipblas_internal_type<T>*          x,
                                                    int64_t           incx,
                                                    hipblasStride     stridex,
-                                                   T*                A,
+                                                   hipblas_internal_type<T>*                A,
                                                    int64_t           lda,
                                                    hipblasStride     strideA,
                                                    int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHerStridedBatched, hipblasComplex, float, hipblasCherStridedBatched);
+    MAP2CF_D64_V2(hipblasHerStridedBatched, std::complex<float>, float, hipblasCherStridedBatched);
     MAP2CF_D64_V2(hipblasHerStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasZherStridedBatched);
 
@@ -8617,39 +8618,39 @@ namespace
     hipblasStatus_t (*hipblasHer2)(hipblasHandle_t   handle,
                                    hipblasFillMode_t uplo,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          y,
+                                   const hipblas_internal_type<T>*          y,
                                    int               incy,
-                                   T*                A,
+                                   hipblas_internal_type<T>*                A,
                                    int               lda);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHer2_64)(hipblasHandle_t   handle,
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          y,
+                                      const hipblas_internal_type<T>*          y,
                                       int64_t           incy,
-                                      T*                A,
+                                      hipblas_internal_type<T>*                A,
                                       int64_t           lda);
 
-    MAP2CF_D64_V2(hipblasHer2, hipblasComplex, hipblasCher2);
-    MAP2CF_D64_V2(hipblasHer2, hipblasDoubleComplex, hipblasZher2);
+    MAP2CF_D64_V2(hipblasHer2, std::complex<float>, hipblasCher2);
+    MAP2CF_D64_V2(hipblasHer2, std::complex<double>, hipblasZher2);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHer2Batched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T* const    y[],
+                                          const hipblas_internal_type<T>* const    y[],
                                           int               incy,
-                                          T* const          A[],
+                                          hipblas_internal_type<T>* const          A[],
                                           int               lda,
                                           int               batchCount);
 
@@ -8657,30 +8658,30 @@ namespace
     hipblasStatus_t (*hipblasHer2Batched_64)(hipblasHandle_t   handle,
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T* const    y[],
+                                             const hipblas_internal_type<T>* const    y[],
                                              int64_t           incy,
-                                             T* const          A[],
+                                             hipblas_internal_type<T>* const          A[],
                                              int64_t           lda,
                                              int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHer2Batched, hipblasComplex, hipblasCher2Batched);
-    MAP2CF_D64_V2(hipblasHer2Batched, hipblasDoubleComplex, hipblasZher2Batched);
+    MAP2CF_D64_V2(hipblasHer2Batched, std::complex<float>, hipblasCher2Batched);
+    MAP2CF_D64_V2(hipblasHer2Batched, std::complex<double>, hipblasZher2Batched);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHer2StridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          y,
+                                                 const hipblas_internal_type<T>*          y,
                                                  int               incy,
                                                  hipblasStride     stridey,
-                                                 T*                A,
+                                                 hipblas_internal_type<T>*                A,
                                                  int               lda,
                                                  hipblasStride     strideA,
                                                  int               batchCount);
@@ -8689,59 +8690,59 @@ namespace
     hipblasStatus_t (*hipblasHer2StridedBatched_64)(hipblasHandle_t   handle,
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          y,
+                                                    const hipblas_internal_type<T>*          y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
-                                                    T*                A,
+                                                    hipblas_internal_type<T>*                A,
                                                     int64_t           lda,
                                                     hipblasStride     strideA,
                                                     int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHer2StridedBatched, hipblasComplex, hipblasCher2StridedBatched);
-    MAP2CF_D64_V2(hipblasHer2StridedBatched, hipblasDoubleComplex, hipblasZher2StridedBatched);
+    MAP2CF_D64_V2(hipblasHer2StridedBatched, std::complex<float>, hipblasCher2StridedBatched);
+    MAP2CF_D64_V2(hipblasHer2StridedBatched, std::complex<double>, hipblasZher2StridedBatched);
 
     // hpmv
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpmv)(hipblasHandle_t   handle,
                                    hipblasFillMode_t uplo,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          AP,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          AP,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          beta,
-                                   T*                y,
+                                   const hipblas_internal_type<T>*          beta,
+                                   hipblas_internal_type<T>*                y,
                                    int               incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpmv_64)(hipblasHandle_t   handle,
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          AP,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          AP,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          beta,
-                                      T*                y,
+                                      const hipblas_internal_type<T>*          beta,
+                                      hipblas_internal_type<T>*                y,
                                       int64_t           incy);
 
-    MAP2CF_D64_V2(hipblasHpmv, hipblasComplex, hipblasChpmv);
-    MAP2CF_D64_V2(hipblasHpmv, hipblasDoubleComplex, hipblasZhpmv);
+    MAP2CF_D64_V2(hipblasHpmv, std::complex<float>, hipblasChpmv);
+    MAP2CF_D64_V2(hipblasHpmv, std::complex<double>, hipblasZhpmv);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpmvBatched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    AP[],
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    AP[],
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T*          beta,
-                                          T* const          y[],
+                                          const hipblas_internal_type<T>*          beta,
+                                          hipblas_internal_type<T>* const          y[],
                                           int               incy,
                                           int               batchCount);
 
@@ -8749,30 +8750,30 @@ namespace
     hipblasStatus_t (*hipblasHpmvBatched_64)(hipblasHandle_t   handle,
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    AP[],
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    AP[],
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T*          beta,
-                                             T* const          y[],
+                                             const hipblas_internal_type<T>*          beta,
+                                             hipblas_internal_type<T>* const          y[],
                                              int64_t           incy,
                                              int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHpmvBatched, hipblasComplex, hipblasChpmvBatched);
-    MAP2CF_D64_V2(hipblasHpmvBatched, hipblasDoubleComplex, hipblasZhpmvBatched);
+    MAP2CF_D64_V2(hipblasHpmvBatched, std::complex<float>, hipblasChpmvBatched);
+    MAP2CF_D64_V2(hipblasHpmvBatched, std::complex<double>, hipblasZhpmvBatched);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpmvStridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          AP,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          AP,
                                                  hipblasStride     strideAP,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          beta,
-                                                 T*                y,
+                                                 const hipblas_internal_type<T>*          beta,
+                                                 hipblas_internal_type<T>*                y,
                                                  int               incy,
                                                  hipblasStride     stridey,
                                                  int               batchCount);
@@ -8781,75 +8782,75 @@ namespace
     hipblasStatus_t (*hipblasHpmvStridedBatched_64)(hipblasHandle_t   handle,
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          AP,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          AP,
                                                     hipblasStride     strideAP,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          beta,
-                                                    T*                y,
+                                                    const hipblas_internal_type<T>*          beta,
+                                                    hipblas_internal_type<T>*                y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
                                                     int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHpmvStridedBatched, hipblasComplex, hipblasChpmvStridedBatched);
-    MAP2CF_D64_V2(hipblasHpmvStridedBatched, hipblasDoubleComplex, hipblasZhpmvStridedBatched);
+    MAP2CF_D64_V2(hipblasHpmvStridedBatched, std::complex<float>, hipblasChpmvStridedBatched);
+    MAP2CF_D64_V2(hipblasHpmvStridedBatched, std::complex<double>, hipblasZhpmvStridedBatched);
 
     // hpr
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpr)(hipblasHandle_t   handle,
                                   hipblasFillMode_t uplo,
                                   int               n,
-                                  const U*          alpha,
-                                  const T*          x,
+                                  const hipblas_internal_type<U>*          alpha,
+                                  const hipblas_internal_type<T>*          x,
                                   int               incx,
-                                  T*                AP);
+                                  hipblas_internal_type<T>*                AP);
 
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpr_64)(hipblasHandle_t   handle,
                                      hipblasFillMode_t uplo,
                                      int64_t           n,
-                                     const U*          alpha,
-                                     const T*          x,
+                                     const hipblas_internal_type<U>*          alpha,
+                                     const hipblas_internal_type<T>*          x,
                                      int64_t           incx,
-                                     T*                AP);
+                                     hipblas_internal_type<T>*                AP);
 
-    MAP2CF_D64_V2(hipblasHpr, hipblasComplex, float, hipblasChpr);
-    MAP2CF_D64_V2(hipblasHpr, hipblasDoubleComplex, double, hipblasZhpr);
+    MAP2CF_D64_V2(hipblasHpr, std::complex<float>, float, hipblasChpr);
+    MAP2CF_D64_V2(hipblasHpr, std::complex<double>, double, hipblasZhpr);
 
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHprBatched)(hipblasHandle_t   handle,
                                          hipblasFillMode_t uplo,
                                          int               n,
-                                         const U*          alpha,
-                                         const T* const    x[],
+                                         const hipblas_internal_type<U>*          alpha,
+                                         const hipblas_internal_type<T>* const    x[],
                                          int               incx,
-                                         T* const          AP[],
+                                         hipblas_internal_type<T>* const          AP[],
                                          int               batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHprBatched_64)(hipblasHandle_t   handle,
                                             hipblasFillMode_t uplo,
                                             int64_t           n,
-                                            const U*          alpha,
-                                            const T* const    x[],
+                                            const hipblas_internal_type<U>*          alpha,
+                                            const hipblas_internal_type<T>* const    x[],
                                             int64_t           incx,
-                                            T* const          AP[],
+                                            hipblas_internal_type<T>* const          AP[],
                                             int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHprBatched, hipblasComplex, float, hipblasChprBatched);
-    MAP2CF_D64_V2(hipblasHprBatched, hipblasDoubleComplex, double, hipblasZhprBatched);
+    MAP2CF_D64_V2(hipblasHprBatched, std::complex<float>, float, hipblasChprBatched);
+    MAP2CF_D64_V2(hipblasHprBatched, std::complex<double>, double, hipblasZhprBatched);
 
     template <typename T, typename U, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHprStridedBatched)(hipblasHandle_t   handle,
                                                 hipblasFillMode_t uplo,
                                                 int               n,
-                                                const U*          alpha,
-                                                const T*          x,
+                                                const hipblas_internal_type<U>*          alpha,
+                                                const hipblas_internal_type<T>*          x,
                                                 int               incx,
                                                 hipblasStride     stridex,
-                                                T*                AP,
+                                                hipblas_internal_type<T>*                AP,
                                                 hipblasStride     strideAP,
                                                 int               batchCount);
 
@@ -8857,17 +8858,17 @@ namespace
     hipblasStatus_t (*hipblasHprStridedBatched_64)(hipblasHandle_t   handle,
                                                    hipblasFillMode_t uplo,
                                                    int64_t           n,
-                                                   const U*          alpha,
-                                                   const T*          x,
+                                                   const hipblas_internal_type<U>*          alpha,
+                                                   const hipblas_internal_type<T>*          x,
                                                    int64_t           incx,
                                                    hipblasStride     stridex,
-                                                   T*                AP,
+                                                   hipblas_internal_type<T>*                AP,
                                                    hipblasStride     strideAP,
                                                    int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHprStridedBatched, hipblasComplex, float, hipblasChprStridedBatched);
+    MAP2CF_D64_V2(hipblasHprStridedBatched, std::complex<float>, float, hipblasChprStridedBatched);
     MAP2CF_D64_V2(hipblasHprStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasZhprStridedBatched);
 
@@ -8876,65 +8877,65 @@ namespace
     hipblasStatus_t (*hipblasHpr2)(hipblasHandle_t   handle,
                                    hipblasFillMode_t uplo,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          y,
+                                   const hipblas_internal_type<T>*          y,
                                    int               incy,
-                                   T*                AP);
+                                   hipblas_internal_type<T>*                AP);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpr2_64)(hipblasHandle_t   handle,
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          y,
+                                      const hipblas_internal_type<T>*          y,
                                       int64_t           incy,
-                                      T*                AP);
+                                      hipblas_internal_type<T>*                AP);
 
-    MAP2CF_D64_V2(hipblasHpr2, hipblasComplex, hipblasChpr2);
-    MAP2CF_D64_V2(hipblasHpr2, hipblasDoubleComplex, hipblasZhpr2);
+    MAP2CF_D64_V2(hipblasHpr2, std::complex<float>, hipblasChpr2);
+    MAP2CF_D64_V2(hipblasHpr2, std::complex<double>, hipblasZhpr2);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpr2Batched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T* const    y[],
+                                          const hipblas_internal_type<T>* const    y[],
                                           int               incy,
-                                          T* const          AP[],
+                                          hipblas_internal_type<T>* const          AP[],
                                           int               batchCount);
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpr2Batched_64)(hipblasHandle_t   handle,
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T* const    y[],
+                                             const hipblas_internal_type<T>* const    y[],
                                              int64_t           incy,
-                                             T* const          AP[],
+                                             hipblas_internal_type<T>* const          AP[],
                                              int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHpr2Batched, hipblasComplex, hipblasChpr2Batched);
-    MAP2CF_D64_V2(hipblasHpr2Batched, hipblasDoubleComplex, hipblasZhpr2Batched);
+    MAP2CF_D64_V2(hipblasHpr2Batched, std::complex<float>, hipblasChpr2Batched);
+    MAP2CF_D64_V2(hipblasHpr2Batched, std::complex<double>, hipblasZhpr2Batched);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasHpr2StridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          y,
+                                                 const hipblas_internal_type<T>*          y,
                                                  int               incy,
                                                  hipblasStride     stridey,
-                                                 T*                AP,
+                                                 hipblas_internal_type<T>*                AP,
                                                  hipblasStride     strideAP,
                                                  int               batchCount);
 
@@ -8942,19 +8943,19 @@ namespace
     hipblasStatus_t (*hipblasHpr2StridedBatched_64)(hipblasHandle_t   handle,
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          y,
+                                                    const hipblas_internal_type<T>*          y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
-                                                    T*                AP,
+                                                    hipblas_internal_type<T>*                AP,
                                                     hipblasStride     strideAP,
                                                     int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHpr2StridedBatched, hipblasComplex, hipblasChpr2StridedBatched);
-    MAP2CF_D64_V2(hipblasHpr2StridedBatched, hipblasDoubleComplex, hipblasZhpr2StridedBatched);
+    MAP2CF_D64_V2(hipblasHpr2StridedBatched, std::complex<float>, hipblasChpr2StridedBatched);
+    MAP2CF_D64_V2(hipblasHpr2StridedBatched, std::complex<double>, hipblasZhpr2StridedBatched);
 
     // sbmv
     template <typename T, bool FORTRAN = false>
@@ -8962,13 +8963,13 @@ namespace
                                    hipblasFillMode_t uplo,
                                    int               n,
                                    int               k,
-                                   const T*          alpha,
-                                   const T*          A,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          A,
                                    int               lda,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          beta,
-                                   T*                y,
+                                   const hipblas_internal_type<T>*          beta,
+                                   hipblas_internal_type<T>*                y,
                                    int               incy);
 
     template <typename T, bool FORTRAN = false>
@@ -8976,13 +8977,13 @@ namespace
                                           hipblasFillMode_t uplo,
                                           int               n,
                                           int               k,
-                                          const T*          alpha,
-                                          const T* const    A[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    A[],
                                           int               lda,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T*          beta,
-                                          T* const          y[],
+                                          const hipblas_internal_type<T>*          beta,
+                                          hipblas_internal_type<T>* const          y[],
                                           int               incy,
                                           int               batchCount);
 
@@ -8991,15 +8992,15 @@ namespace
                                                  hipblasFillMode_t uplo,
                                                  int               n,
                                                  int               k,
-                                                 const T*          alpha,
-                                                 const T*          A,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          A,
                                                  int               lda,
                                                  hipblasStride     strideA,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          beta,
-                                                 T*                y,
+                                                 const hipblas_internal_type<T>*          beta,
+                                                 hipblas_internal_type<T>*                y,
                                                  int               incy,
                                                  hipblasStride     stridey,
                                                  int               batchCount);
@@ -9009,13 +9010,13 @@ namespace
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
                                       int64_t           k,
-                                      const T*          alpha,
-                                      const T*          A,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          A,
                                       int64_t           lda,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          beta,
-                                      T*                y,
+                                      const hipblas_internal_type<T>*          beta,
+                                      hipblas_internal_type<T>*                y,
                                       int64_t           incy);
 
     template <typename T, bool FORTRAN = false>
@@ -9023,13 +9024,13 @@ namespace
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
                                              int64_t           k,
-                                             const T*          alpha,
-                                             const T* const    A[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    A[],
                                              int64_t           lda,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T*          beta,
-                                             T* const          y[],
+                                             const hipblas_internal_type<T>*          beta,
+                                             hipblas_internal_type<T>* const          y[],
                                              int64_t           incy,
                                              int64_t           batchCount);
 
@@ -9038,15 +9039,15 @@ namespace
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
                                                     int64_t           k,
-                                                    const T*          alpha,
-                                                    const T*          A,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          A,
                                                     int64_t           lda,
                                                     hipblasStride     strideA,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          beta,
-                                                    T*                y,
+                                                    const hipblas_internal_type<T>*          beta,
+                                                    hipblas_internal_type<T>*                y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
                                                     int64_t           batchCount);
@@ -9065,24 +9066,24 @@ namespace
     hipblasStatus_t (*hipblasSpmv)(hipblasHandle_t   handle,
                                    hipblasFillMode_t uplo,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          AP,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          AP,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          beta,
-                                   T*                y,
+                                   const hipblas_internal_type<T>*          beta,
+                                   hipblas_internal_type<T>*                y,
                                    int               incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSpmvBatched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    AP[],
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    AP[],
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T*          beta,
-                                          T* const          y[],
+                                          const hipblas_internal_type<T>*          beta,
+                                          hipblas_internal_type<T>* const          y[],
                                           int               incy,
                                           int               batchCount);
 
@@ -9090,14 +9091,14 @@ namespace
     hipblasStatus_t (*hipblasSpmvStridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          AP,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          AP,
                                                  hipblasStride     strideAP,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          beta,
-                                                 T*                y,
+                                                 const hipblas_internal_type<T>*          beta,
+                                                 hipblas_internal_type<T>*                y,
                                                  int               incy,
                                                  hipblasStride     stridey,
                                                  int               batchCount);
@@ -9106,24 +9107,24 @@ namespace
     hipblasStatus_t (*hipblasSpmv_64)(hipblasHandle_t   handle,
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          AP,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          AP,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          beta,
-                                      T*                y,
+                                      const hipblas_internal_type<T>*          beta,
+                                      hipblas_internal_type<T>*                y,
                                       int64_t           incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSpmvBatched_64)(hipblasHandle_t   handle,
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    AP[],
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    AP[],
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T*          beta,
-                                             T* const          y[],
+                                             const hipblas_internal_type<T>*          beta,
+                                             hipblas_internal_type<T>* const          y[],
                                              int64_t           incy,
                                              int64_t           batchCount);
 
@@ -9131,14 +9132,14 @@ namespace
     hipblasStatus_t (*hipblasSpmvStridedBatched_64)(hipblasHandle_t   handle,
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          AP,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          AP,
                                                     hipblasStride     strideAP,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          beta,
-                                                    T*                y,
+                                                    const hipblas_internal_type<T>*          beta,
+                                                    hipblas_internal_type<T>*                y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
                                                     int64_t           batchCount);
@@ -9157,30 +9158,30 @@ namespace
     hipblasStatus_t (*hipblasSpr)(hipblasHandle_t   handle,
                                   hipblasFillMode_t uplo,
                                   int               n,
-                                  const T*          alpha,
-                                  const T*          x,
+                                  const hipblas_internal_type<T>*          alpha,
+                                  const hipblas_internal_type<T>*          x,
                                   int               incx,
-                                  T*                AP);
+                                  hipblas_internal_type<T>*                AP);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSprBatched)(hipblasHandle_t   handle,
                                          hipblasFillMode_t uplo,
                                          int               n,
-                                         const T*          alpha,
-                                         const T* const    x[],
+                                         const hipblas_internal_type<T>*          alpha,
+                                         const hipblas_internal_type<T>* const    x[],
                                          int               incx,
-                                         T* const          AP[],
+                                         hipblas_internal_type<T>* const          AP[],
                                          int               batchCount);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSprStridedBatched)(hipblasHandle_t   handle,
                                                 hipblasFillMode_t uplo,
                                                 int               n,
-                                                const T*          alpha,
-                                                const T*          x,
+                                                const hipblas_internal_type<T>*          alpha,
+                                                const hipblas_internal_type<T>*          x,
                                                 int               incx,
                                                 hipblasStride     stridex,
-                                                T*                AP,
+                                                hipblas_internal_type<T>*                AP,
                                                 hipblasStride     strideAP,
                                                 int               batchCount);
 
@@ -9188,84 +9189,84 @@ namespace
     hipblasStatus_t (*hipblasSpr_64)(hipblasHandle_t   handle,
                                      hipblasFillMode_t uplo,
                                      int64_t           n,
-                                     const T*          alpha,
-                                     const T*          x,
+                                     const hipblas_internal_type<T>*          alpha,
+                                     const hipblas_internal_type<T>*          x,
                                      int64_t           incx,
-                                     T*                AP);
+                                     hipblas_internal_type<T>*                AP);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSprBatched_64)(hipblasHandle_t   handle,
                                             hipblasFillMode_t uplo,
                                             int64_t           n,
-                                            const T*          alpha,
-                                            const T* const    x[],
+                                            const hipblas_internal_type<T>*          alpha,
+                                            const hipblas_internal_type<T>* const    x[],
                                             int64_t           incx,
-                                            T* const          AP[],
+                                            hipblas_internal_type<T>* const          AP[],
                                             int64_t           batchCount);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSprStridedBatched_64)(hipblasHandle_t   handle,
                                                    hipblasFillMode_t uplo,
                                                    int64_t           n,
-                                                   const T*          alpha,
-                                                   const T*          x,
+                                                   const hipblas_internal_type<T>*          alpha,
+                                                   const hipblas_internal_type<T>*          x,
                                                    int64_t           incx,
                                                    hipblasStride     stridex,
-                                                   T*                AP,
+                                                   hipblas_internal_type<T>*                AP,
                                                    hipblasStride     strideAP,
                                                    int64_t           batchCount);
 
     MAP2CF_D64(hipblasSpr, float, hipblasSspr);
     MAP2CF_D64(hipblasSpr, double, hipblasDspr);
-    MAP2CF_D64_V2(hipblasSpr, hipblasComplex, hipblasCspr);
-    MAP2CF_D64_V2(hipblasSpr, hipblasDoubleComplex, hipblasZspr);
+    MAP2CF_D64_V2(hipblasSpr, std::complex<float>, hipblasCspr);
+    MAP2CF_D64_V2(hipblasSpr, std::complex<double>, hipblasZspr);
 
     MAP2CF_D64(hipblasSprBatched, float, hipblasSsprBatched);
     MAP2CF_D64(hipblasSprBatched, double, hipblasDsprBatched);
-    MAP2CF_D64_V2(hipblasSprBatched, hipblasComplex, hipblasCsprBatched);
-    MAP2CF_D64_V2(hipblasSprBatched, hipblasDoubleComplex, hipblasZsprBatched);
+    MAP2CF_D64_V2(hipblasSprBatched, std::complex<float>, hipblasCsprBatched);
+    MAP2CF_D64_V2(hipblasSprBatched, std::complex<double>, hipblasZsprBatched);
 
     MAP2CF_D64(hipblasSprStridedBatched, float, hipblasSsprStridedBatched);
     MAP2CF_D64(hipblasSprStridedBatched, double, hipblasDsprStridedBatched);
-    MAP2CF_D64_V2(hipblasSprStridedBatched, hipblasComplex, hipblasCsprStridedBatched);
-    MAP2CF_D64_V2(hipblasSprStridedBatched, hipblasDoubleComplex, hipblasZsprStridedBatched);
+    MAP2CF_D64_V2(hipblasSprStridedBatched, std::complex<float>, hipblasCsprStridedBatched);
+    MAP2CF_D64_V2(hipblasSprStridedBatched, std::complex<double>, hipblasZsprStridedBatched);
 
     // spr2
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSpr2)(hipblasHandle_t   handle,
                                    hipblasFillMode_t uplo,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          y,
+                                   const hipblas_internal_type<T>*          y,
                                    int               incy,
-                                   T*                AP);
+                                   hipblas_internal_type<T>*                AP);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSpr2Batched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T* const    y[],
+                                          const hipblas_internal_type<T>* const    y[],
                                           int               incy,
-                                          T* const          AP[],
+                                          hipblas_internal_type<T>* const          AP[],
                                           int               batchCount);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSpr2StridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          y,
+                                                 const hipblas_internal_type<T>*          y,
                                                  int               incy,
                                                  hipblasStride     stridey,
-                                                 T*                AP,
+                                                 hipblas_internal_type<T>*                AP,
                                                  hipblasStride     strideAP,
                                                  int               batchCount);
 
@@ -9273,37 +9274,37 @@ namespace
     hipblasStatus_t (*hipblasSpr2_64)(hipblasHandle_t   handle,
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          y,
+                                      const hipblas_internal_type<T>*          y,
                                       int64_t           incy,
-                                      T*                AP);
+                                      hipblas_internal_type<T>*                AP);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSpr2Batched_64)(hipblasHandle_t   handle,
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T* const    y[],
+                                             const hipblas_internal_type<T>* const    y[],
                                              int64_t           incy,
-                                             T* const          AP[],
+                                             hipblas_internal_type<T>* const          AP[],
                                              int64_t           batchCount);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSpr2StridedBatched_64)(hipblasHandle_t   handle,
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          y,
+                                                    const hipblas_internal_type<T>*          y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
-                                                    T*                AP,
+                                                    hipblas_internal_type<T>*                AP,
                                                     hipblasStride     strideAP,
                                                     int64_t           batchCount);
 
@@ -9321,26 +9322,26 @@ namespace
     hipblasStatus_t (*hipblasSymv)(hipblasHandle_t   handle,
                                    hipblasFillMode_t uplo,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          A,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          A,
                                    int               lda,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          beta,
-                                   T*                y,
+                                   const hipblas_internal_type<T>*          beta,
+                                   hipblas_internal_type<T>*                y,
                                    int               incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSymvBatched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    A[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    A[],
                                           int               lda,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T*          beta,
-                                          T* const          y[],
+                                          const hipblas_internal_type<T>*          beta,
+                                          hipblas_internal_type<T>* const          y[],
                                           int               incy,
                                           int               batchCount);
 
@@ -9348,15 +9349,15 @@ namespace
     hipblasStatus_t (*hipblasSymvStridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          A,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          A,
                                                  int               lda,
                                                  hipblasStride     strideA,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          beta,
-                                                 T*                y,
+                                                 const hipblas_internal_type<T>*          beta,
+                                                 hipblas_internal_type<T>*                y,
                                                  int               incy,
                                                  hipblasStride     stridey,
                                                  int               batchCount);
@@ -9365,26 +9366,26 @@ namespace
     hipblasStatus_t (*hipblasSymv_64)(hipblasHandle_t   handle,
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          A,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          A,
                                       int64_t           lda,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          beta,
-                                      T*                y,
+                                      const hipblas_internal_type<T>*          beta,
+                                      hipblas_internal_type<T>*                y,
                                       int64_t           incy);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSymvBatched_64)(hipblasHandle_t   handle,
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    A[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    A[],
                                              int64_t           lda,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T*          beta,
-                                             T* const          y[],
+                                             const hipblas_internal_type<T>*          beta,
+                                             hipblas_internal_type<T>* const          y[],
                                              int64_t           incy,
                                              int64_t           batchCount);
 
@@ -9392,53 +9393,53 @@ namespace
     hipblasStatus_t (*hipblasSymvStridedBatched_64)(hipblasHandle_t   handle,
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          A,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          A,
                                                     int64_t           lda,
                                                     hipblasStride     strideA,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          beta,
-                                                    T*                y,
+                                                    const hipblas_internal_type<T>*          beta,
+                                                    hipblas_internal_type<T>*                y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
                                                     int64_t           batchCount);
 
     MAP2CF_D64(hipblasSymv, float, hipblasSsymv);
     MAP2CF_D64(hipblasSymv, double, hipblasDsymv);
-    MAP2CF_D64_V2(hipblasSymv, hipblasComplex, hipblasCsymv);
-    MAP2CF_D64_V2(hipblasSymv, hipblasDoubleComplex, hipblasZsymv);
+    MAP2CF_D64_V2(hipblasSymv, std::complex<float>, hipblasCsymv);
+    MAP2CF_D64_V2(hipblasSymv, std::complex<double>, hipblasZsymv);
 
     MAP2CF_D64(hipblasSymvBatched, float, hipblasSsymvBatched);
     MAP2CF_D64(hipblasSymvBatched, double, hipblasDsymvBatched);
-    MAP2CF_D64_V2(hipblasSymvBatched, hipblasComplex, hipblasCsymvBatched);
-    MAP2CF_D64_V2(hipblasSymvBatched, hipblasDoubleComplex, hipblasZsymvBatched);
+    MAP2CF_D64_V2(hipblasSymvBatched, std::complex<float>, hipblasCsymvBatched);
+    MAP2CF_D64_V2(hipblasSymvBatched, std::complex<double>, hipblasZsymvBatched);
 
     MAP2CF_D64(hipblasSymvStridedBatched, float, hipblasSsymvStridedBatched);
     MAP2CF_D64(hipblasSymvStridedBatched, double, hipblasDsymvStridedBatched);
-    MAP2CF_D64_V2(hipblasSymvStridedBatched, hipblasComplex, hipblasCsymvStridedBatched);
-    MAP2CF_D64_V2(hipblasSymvStridedBatched, hipblasDoubleComplex, hipblasZsymvStridedBatched);
+    MAP2CF_D64_V2(hipblasSymvStridedBatched, std::complex<float>, hipblasCsymvStridedBatched);
+    MAP2CF_D64_V2(hipblasSymvStridedBatched, std::complex<double>, hipblasZsymvStridedBatched);
 
     // syr
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSyr)(hipblasHandle_t   handle,
                                   hipblasFillMode_t uplo,
                                   int               n,
-                                  const T*          alpha,
-                                  const T*          x,
+                                  const hipblas_internal_type<T>*          alpha,
+                                  const hipblas_internal_type<T>*          x,
                                   int               incx,
-                                  T*                A,
+                                  hipblas_internal_type<T>*                A,
                                   int               lda);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSyrBatched)(hipblasHandle_t   handle,
                                          hipblasFillMode_t uplo,
                                          int               n,
-                                         const T*          alpha,
-                                         const T* const    x[],
+                                         const hipblas_internal_type<T>*          alpha,
+                                         const hipblas_internal_type<T>* const    x[],
                                          int               incx,
-                                         T* const          A[],
+                                         hipblas_internal_type<T>* const          A[],
                                          int               lda,
                                          int               batch_count);
 
@@ -9446,11 +9447,11 @@ namespace
     hipblasStatus_t (*hipblasSyrStridedBatched)(hipblasHandle_t   handle,
                                                 hipblasFillMode_t uplo,
                                                 int               n,
-                                                const T*          alpha,
-                                                const T*          x,
+                                                const hipblas_internal_type<T>*          alpha,
+                                                const hipblas_internal_type<T>*          x,
                                                 int               incx,
                                                 hipblasStride     stridex,
-                                                T*                A,
+                                                hipblas_internal_type<T>*                A,
                                                 int               lda,
                                                 hipblasStride     strideA,
                                                 int               batch_count);
@@ -9459,20 +9460,20 @@ namespace
     hipblasStatus_t (*hipblasSyr_64)(hipblasHandle_t   handle,
                                      hipblasFillMode_t uplo,
                                      int64_t           n,
-                                     const T*          alpha,
-                                     const T*          x,
+                                     const hipblas_internal_type<T>*          alpha,
+                                     const hipblas_internal_type<T>*          x,
                                      int64_t           incx,
-                                     T*                A,
+                                     hipblas_internal_type<T>*                A,
                                      int64_t           lda);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSyrBatched_64)(hipblasHandle_t   handle,
                                             hipblasFillMode_t uplo,
                                             int64_t           n,
-                                            const T*          alpha,
-                                            const T* const    x[],
+                                            const hipblas_internal_type<T>*          alpha,
+                                            const hipblas_internal_type<T>* const    x[],
                                             int64_t           incx,
-                                            T* const          A[],
+                                            hipblas_internal_type<T>* const          A[],
                                             int64_t           lda,
                                             int64_t           batch_count);
 
@@ -9480,53 +9481,53 @@ namespace
     hipblasStatus_t (*hipblasSyrStridedBatched_64)(hipblasHandle_t   handle,
                                                    hipblasFillMode_t uplo,
                                                    int64_t           n,
-                                                   const T*          alpha,
-                                                   const T*          x,
+                                                   const hipblas_internal_type<T>*          alpha,
+                                                   const hipblas_internal_type<T>*          x,
                                                    int64_t           incx,
                                                    hipblasStride     stridex,
-                                                   T*                A,
+                                                   hipblas_internal_type<T>*                A,
                                                    int64_t           lda,
                                                    hipblasStride     strideA,
                                                    int64_t           batch_count);
 
     MAP2CF_D64(hipblasSyr, float, hipblasSsyr);
     MAP2CF_D64(hipblasSyr, double, hipblasDsyr);
-    MAP2CF_D64_V2(hipblasSyr, hipblasComplex, hipblasCsyr);
-    MAP2CF_D64_V2(hipblasSyr, hipblasDoubleComplex, hipblasZsyr);
+    MAP2CF_D64_V2(hipblasSyr, std::complex<float>, hipblasCsyr);
+    MAP2CF_D64_V2(hipblasSyr, std::complex<double>, hipblasZsyr);
 
     MAP2CF_D64(hipblasSyrBatched, float, hipblasSsyrBatched);
     MAP2CF_D64(hipblasSyrBatched, double, hipblasDsyrBatched);
-    MAP2CF_D64_V2(hipblasSyrBatched, hipblasComplex, hipblasCsyrBatched);
-    MAP2CF_D64_V2(hipblasSyrBatched, hipblasDoubleComplex, hipblasZsyrBatched);
+    MAP2CF_D64_V2(hipblasSyrBatched, std::complex<float>, hipblasCsyrBatched);
+    MAP2CF_D64_V2(hipblasSyrBatched, std::complex<double>, hipblasZsyrBatched);
 
     MAP2CF_D64(hipblasSyrStridedBatched, float, hipblasSsyrStridedBatched);
     MAP2CF_D64(hipblasSyrStridedBatched, double, hipblasDsyrStridedBatched);
-    MAP2CF_D64_V2(hipblasSyrStridedBatched, hipblasComplex, hipblasCsyrStridedBatched);
-    MAP2CF_D64_V2(hipblasSyrStridedBatched, hipblasDoubleComplex, hipblasZsyrStridedBatched);
+    MAP2CF_D64_V2(hipblasSyrStridedBatched, std::complex<float>, hipblasCsyrStridedBatched);
+    MAP2CF_D64_V2(hipblasSyrStridedBatched, std::complex<double>, hipblasZsyrStridedBatched);
 
     // syr2
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSyr2)(hipblasHandle_t   handle,
                                    hipblasFillMode_t uplo,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   const T*          y,
+                                   const hipblas_internal_type<T>*          y,
                                    int               incy,
-                                   T*                A,
+                                   hipblas_internal_type<T>*                A,
                                    int               lda);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSyr2Batched)(hipblasHandle_t   handle,
                                           hipblasFillMode_t uplo,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          const T* const    y[],
+                                          const hipblas_internal_type<T>* const    y[],
                                           int               incy,
-                                          T* const          A[],
+                                          hipblas_internal_type<T>* const          A[],
                                           int               lda,
                                           int               batchCount);
 
@@ -9534,14 +9535,14 @@ namespace
     hipblasStatus_t (*hipblasSyr2StridedBatched)(hipblasHandle_t   handle,
                                                  hipblasFillMode_t uplo,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stridex,
-                                                 const T*          y,
+                                                 const hipblas_internal_type<T>*          y,
                                                  int               incy,
                                                  hipblasStride     stridey,
-                                                 T*                A,
+                                                 hipblas_internal_type<T>*                A,
                                                  int               lda,
                                                  hipblasStride     strideA,
                                                  int               batchCount);
@@ -9550,24 +9551,24 @@ namespace
     hipblasStatus_t (*hipblasSyr2_64)(hipblasHandle_t   handle,
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      const T*          y,
+                                      const hipblas_internal_type<T>*          y,
                                       int64_t           incy,
-                                      T*                A,
+                                      hipblas_internal_type<T>*                A,
                                       int64_t           lda);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasSyr2Batched_64)(hipblasHandle_t   handle,
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             const T* const    y[],
+                                             const hipblas_internal_type<T>* const    y[],
                                              int64_t           incy,
-                                             T* const          A[],
+                                             hipblas_internal_type<T>* const          A[],
                                              int64_t           lda,
                                              int64_t           batchCount);
 
@@ -9575,32 +9576,32 @@ namespace
     hipblasStatus_t (*hipblasSyr2StridedBatched_64)(hipblasHandle_t   handle,
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stridex,
-                                                    const T*          y,
+                                                    const hipblas_internal_type<T>*          y,
                                                     int64_t           incy,
                                                     hipblasStride     stridey,
-                                                    T*                A,
+                                                    hipblas_internal_type<T>*                A,
                                                     int64_t           lda,
                                                     hipblasStride     strideA,
                                                     int64_t           batchCount);
 
     MAP2CF_D64(hipblasSyr2, float, hipblasSsyr2);
     MAP2CF_D64(hipblasSyr2, double, hipblasDsyr2);
-    MAP2CF_D64_V2(hipblasSyr2, hipblasComplex, hipblasCsyr2);
-    MAP2CF_D64_V2(hipblasSyr2, hipblasDoubleComplex, hipblasZsyr2);
+    MAP2CF_D64_V2(hipblasSyr2, std::complex<float>, hipblasCsyr2);
+    MAP2CF_D64_V2(hipblasSyr2, std::complex<double>, hipblasZsyr2);
 
     MAP2CF_D64(hipblasSyr2Batched, float, hipblasSsyr2Batched);
     MAP2CF_D64(hipblasSyr2Batched, double, hipblasDsyr2Batched);
-    MAP2CF_D64_V2(hipblasSyr2Batched, hipblasComplex, hipblasCsyr2Batched);
-    MAP2CF_D64_V2(hipblasSyr2Batched, hipblasDoubleComplex, hipblasZsyr2Batched);
+    MAP2CF_D64_V2(hipblasSyr2Batched, std::complex<float>, hipblasCsyr2Batched);
+    MAP2CF_D64_V2(hipblasSyr2Batched, std::complex<double>, hipblasZsyr2Batched);
 
     MAP2CF_D64(hipblasSyr2StridedBatched, float, hipblasSsyr2StridedBatched);
     MAP2CF_D64(hipblasSyr2StridedBatched, double, hipblasDsyr2StridedBatched);
-    MAP2CF_D64_V2(hipblasSyr2StridedBatched, hipblasComplex, hipblasCsyr2StridedBatched);
-    MAP2CF_D64_V2(hipblasSyr2StridedBatched, hipblasDoubleComplex, hipblasZsyr2StridedBatched);
+    MAP2CF_D64_V2(hipblasSyr2StridedBatched, std::complex<float>, hipblasCsyr2StridedBatched);
+    MAP2CF_D64_V2(hipblasSyr2StridedBatched, std::complex<double>, hipblasZsyr2StridedBatched);
 
     // tbmv
     template <typename T, bool FORTRAN = false>
@@ -9610,9 +9611,9 @@ namespace
                                    hipblasDiagType_t  diag,
                                    int                m,
                                    int                k,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   T*                 x,
+                                   hipblas_internal_type<T>*                 x,
                                    int                incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9622,9 +9623,9 @@ namespace
                                           hipblasDiagType_t  diag,
                                           int                m,
                                           int                k,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          T* const           x[],
+                                          hipblas_internal_type<T>* const           x[],
                                           int                incx,
                                           int                batch_count);
 
@@ -9635,10 +9636,10 @@ namespace
                                                  hipblasDiagType_t  diag,
                                                  int                m,
                                                  int                k,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      stride_a,
-                                                 T*                 x,
+                                                 hipblas_internal_type<T>*                 x,
                                                  int                incx,
                                                  hipblasStride      stride_x,
                                                  int                batch_count);
@@ -9650,9 +9651,9 @@ namespace
                                       hipblasDiagType_t  diag,
                                       int64_t            m,
                                       int64_t            k,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      T*                 x,
+                                      hipblas_internal_type<T>*                 x,
                                       int64_t            incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9662,9 +9663,9 @@ namespace
                                              hipblasDiagType_t  diag,
                                              int64_t            m,
                                              int64_t            k,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             T* const           x[],
+                                             hipblas_internal_type<T>* const           x[],
                                              int64_t            incx,
                                              int64_t            batch_count);
 
@@ -9675,28 +9676,28 @@ namespace
                                                     hipblasDiagType_t  diag,
                                                     int64_t            m,
                                                     int64_t            k,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      stride_a,
-                                                    T*                 x,
+                                                    hipblas_internal_type<T>*                 x,
                                                     int64_t            incx,
                                                     hipblasStride      stride_x,
                                                     int64_t            batch_count);
 
     MAP2CF_D64(hipblasTbmv, float, hipblasStbmv);
     MAP2CF_D64(hipblasTbmv, double, hipblasDtbmv);
-    MAP2CF_D64_V2(hipblasTbmv, hipblasComplex, hipblasCtbmv);
-    MAP2CF_D64_V2(hipblasTbmv, hipblasDoubleComplex, hipblasZtbmv);
+    MAP2CF_D64_V2(hipblasTbmv, std::complex<float>, hipblasCtbmv);
+    MAP2CF_D64_V2(hipblasTbmv, std::complex<double>, hipblasZtbmv);
 
     MAP2CF_D64(hipblasTbmvBatched, float, hipblasStbmvBatched);
     MAP2CF_D64(hipblasTbmvBatched, double, hipblasDtbmvBatched);
-    MAP2CF_D64_V2(hipblasTbmvBatched, hipblasComplex, hipblasCtbmvBatched);
-    MAP2CF_D64_V2(hipblasTbmvBatched, hipblasDoubleComplex, hipblasZtbmvBatched);
+    MAP2CF_D64_V2(hipblasTbmvBatched, std::complex<float>, hipblasCtbmvBatched);
+    MAP2CF_D64_V2(hipblasTbmvBatched, std::complex<double>, hipblasZtbmvBatched);
 
     MAP2CF_D64(hipblasTbmvStridedBatched, float, hipblasStbmvStridedBatched);
     MAP2CF_D64(hipblasTbmvStridedBatched, double, hipblasDtbmvStridedBatched);
-    MAP2CF_D64_V2(hipblasTbmvStridedBatched, hipblasComplex, hipblasCtbmvStridedBatched);
-    MAP2CF_D64_V2(hipblasTbmvStridedBatched, hipblasDoubleComplex, hipblasZtbmvStridedBatched);
+    MAP2CF_D64_V2(hipblasTbmvStridedBatched, std::complex<float>, hipblasCtbmvStridedBatched);
+    MAP2CF_D64_V2(hipblasTbmvStridedBatched, std::complex<double>, hipblasZtbmvStridedBatched);
 
     // tbsv
     template <typename T, bool FORTRAN = false>
@@ -9706,9 +9707,9 @@ namespace
                                    hipblasDiagType_t  diag,
                                    int                m,
                                    int                k,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   T*                 x,
+                                   hipblas_internal_type<T>*                 x,
                                    int                incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9718,9 +9719,9 @@ namespace
                                           hipblasDiagType_t  diag,
                                           int                m,
                                           int                k,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          T* const           x[],
+                                          hipblas_internal_type<T>* const           x[],
                                           int                incx,
                                           int                batchCount);
 
@@ -9731,10 +9732,10 @@ namespace
                                                  hipblasDiagType_t  diag,
                                                  int                m,
                                                  int                k,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      strideA,
-                                                 T*                 x,
+                                                 hipblas_internal_type<T>*                 x,
                                                  int                incx,
                                                  hipblasStride      stridex,
                                                  int                batchCount);
@@ -9747,9 +9748,9 @@ namespace
                                       hipblasDiagType_t  diag,
                                       int64_t            m,
                                       int64_t            k,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      T*                 x,
+                                      hipblas_internal_type<T>*                 x,
                                       int64_t            incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9759,9 +9760,9 @@ namespace
                                              hipblasDiagType_t  diag,
                                              int64_t            m,
                                              int64_t            k,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             T* const           x[],
+                                             hipblas_internal_type<T>* const           x[],
                                              int64_t            incx,
                                              int64_t            batchCount);
 
@@ -9772,28 +9773,28 @@ namespace
                                                     hipblasDiagType_t  diag,
                                                     int64_t            m,
                                                     int64_t            k,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      strideA,
-                                                    T*                 x,
+                                                    hipblas_internal_type<T>*                 x,
                                                     int64_t            incx,
                                                     hipblasStride      stridex,
                                                     int64_t            batchCount);
 
     MAP2CF_D64(hipblasTbsv, float, hipblasStbsv);
     MAP2CF_D64(hipblasTbsv, double, hipblasDtbsv);
-    MAP2CF_D64_V2(hipblasTbsv, hipblasComplex, hipblasCtbsv);
-    MAP2CF_D64_V2(hipblasTbsv, hipblasDoubleComplex, hipblasZtbsv);
+    MAP2CF_D64_V2(hipblasTbsv, std::complex<float>, hipblasCtbsv);
+    MAP2CF_D64_V2(hipblasTbsv, std::complex<double>, hipblasZtbsv);
 
     MAP2CF_D64(hipblasTbsvBatched, float, hipblasStbsvBatched);
     MAP2CF_D64(hipblasTbsvBatched, double, hipblasDtbsvBatched);
-    MAP2CF_D64_V2(hipblasTbsvBatched, hipblasComplex, hipblasCtbsvBatched);
-    MAP2CF_D64_V2(hipblasTbsvBatched, hipblasDoubleComplex, hipblasZtbsvBatched);
+    MAP2CF_D64_V2(hipblasTbsvBatched, std::complex<float>, hipblasCtbsvBatched);
+    MAP2CF_D64_V2(hipblasTbsvBatched, std::complex<double>, hipblasZtbsvBatched);
 
     MAP2CF_D64(hipblasTbsvStridedBatched, float, hipblasStbsvStridedBatched);
     MAP2CF_D64(hipblasTbsvStridedBatched, double, hipblasDtbsvStridedBatched);
-    MAP2CF_D64_V2(hipblasTbsvStridedBatched, hipblasComplex, hipblasCtbsvStridedBatched);
-    MAP2CF_D64_V2(hipblasTbsvStridedBatched, hipblasDoubleComplex, hipblasZtbsvStridedBatched);
+    MAP2CF_D64_V2(hipblasTbsvStridedBatched, std::complex<float>, hipblasCtbsvStridedBatched);
+    MAP2CF_D64_V2(hipblasTbsvStridedBatched, std::complex<double>, hipblasZtbsvStridedBatched);
 
     // tpmv
     template <typename T, bool FORTRAN = false>
@@ -9802,8 +9803,8 @@ namespace
                                    hipblasOperation_t transA,
                                    hipblasDiagType_t  diag,
                                    int                m,
-                                   const T*           AP,
-                                   T*                 x,
+                                   const hipblas_internal_type<T>*           AP,
+                                   hipblas_internal_type<T>*                 x,
                                    int                incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9812,8 +9813,8 @@ namespace
                                           hipblasOperation_t transA,
                                           hipblasDiagType_t  diag,
                                           int                m,
-                                          const T* const     AP[],
-                                          T* const           x[],
+                                          const hipblas_internal_type<T>* const     AP[],
+                                          hipblas_internal_type<T>* const           x[],
                                           int                incx,
                                           int                batchCount);
 
@@ -9823,9 +9824,9 @@ namespace
                                                  hipblasOperation_t transA,
                                                  hipblasDiagType_t  diag,
                                                  int                m,
-                                                 const T*           AP,
+                                                 const hipblas_internal_type<T>*           AP,
                                                  hipblasStride      strideAP,
-                                                 T*                 x,
+                                                 hipblas_internal_type<T>*                 x,
                                                  int                incx,
                                                  hipblasStride      stridex,
                                                  int                batchCount);
@@ -9837,8 +9838,8 @@ namespace
                                       hipblasOperation_t transA,
                                       hipblasDiagType_t  diag,
                                       int64_t            m,
-                                      const T*           AP,
-                                      T*                 x,
+                                      const hipblas_internal_type<T>*           AP,
+                                      hipblas_internal_type<T>*                 x,
                                       int64_t            incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9847,8 +9848,8 @@ namespace
                                              hipblasOperation_t transA,
                                              hipblasDiagType_t  diag,
                                              int64_t            m,
-                                             const T* const     AP[],
-                                             T* const           x[],
+                                             const hipblas_internal_type<T>* const     AP[],
+                                             hipblas_internal_type<T>* const           x[],
                                              int64_t            incx,
                                              int64_t            batchCount);
 
@@ -9858,27 +9859,27 @@ namespace
                                                     hipblasOperation_t transA,
                                                     hipblasDiagType_t  diag,
                                                     int64_t            m,
-                                                    const T*           AP,
+                                                    const hipblas_internal_type<T>*           AP,
                                                     hipblasStride      strideAP,
-                                                    T*                 x,
+                                                    hipblas_internal_type<T>*                 x,
                                                     int64_t            incx,
                                                     hipblasStride      stridex,
                                                     int64_t            batchCount);
 
     MAP2CF_D64(hipblasTpmv, float, hipblasStpmv);
     MAP2CF_D64(hipblasTpmv, double, hipblasDtpmv);
-    MAP2CF_D64_V2(hipblasTpmv, hipblasComplex, hipblasCtpmv);
-    MAP2CF_D64_V2(hipblasTpmv, hipblasDoubleComplex, hipblasZtpmv);
+    MAP2CF_D64_V2(hipblasTpmv, std::complex<float>, hipblasCtpmv);
+    MAP2CF_D64_V2(hipblasTpmv, std::complex<double>, hipblasZtpmv);
 
     MAP2CF_D64(hipblasTpmvBatched, float, hipblasStpmvBatched);
     MAP2CF_D64(hipblasTpmvBatched, double, hipblasDtpmvBatched);
-    MAP2CF_D64_V2(hipblasTpmvBatched, hipblasComplex, hipblasCtpmvBatched);
-    MAP2CF_D64_V2(hipblasTpmvBatched, hipblasDoubleComplex, hipblasZtpmvBatched);
+    MAP2CF_D64_V2(hipblasTpmvBatched, std::complex<float>, hipblasCtpmvBatched);
+    MAP2CF_D64_V2(hipblasTpmvBatched, std::complex<double>, hipblasZtpmvBatched);
 
     MAP2CF_D64(hipblasTpmvStridedBatched, float, hipblasStpmvStridedBatched);
     MAP2CF_D64(hipblasTpmvStridedBatched, double, hipblasDtpmvStridedBatched);
-    MAP2CF_D64_V2(hipblasTpmvStridedBatched, hipblasComplex, hipblasCtpmvStridedBatched);
-    MAP2CF_D64_V2(hipblasTpmvStridedBatched, hipblasDoubleComplex, hipblasZtpmvStridedBatched);
+    MAP2CF_D64_V2(hipblasTpmvStridedBatched, std::complex<float>, hipblasCtpmvStridedBatched);
+    MAP2CF_D64_V2(hipblasTpmvStridedBatched, std::complex<double>, hipblasZtpmvStridedBatched);
 
     // tpsv
     template <typename T, bool FORTRAN = false>
@@ -9887,8 +9888,8 @@ namespace
                                    hipblasOperation_t transA,
                                    hipblasDiagType_t  diag,
                                    int                m,
-                                   const T*           AP,
-                                   T*                 x,
+                                   const hipblas_internal_type<T>*           AP,
+                                   hipblas_internal_type<T>*                 x,
                                    int                incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9897,8 +9898,8 @@ namespace
                                           hipblasOperation_t transA,
                                           hipblasDiagType_t  diag,
                                           int                m,
-                                          const T* const     AP[],
-                                          T* const           x[],
+                                          const hipblas_internal_type<T>* const     AP[],
+                                          hipblas_internal_type<T>* const           x[],
                                           int                incx,
                                           int                batchCount);
 
@@ -9908,9 +9909,9 @@ namespace
                                                  hipblasOperation_t transA,
                                                  hipblasDiagType_t  diag,
                                                  int                m,
-                                                 const T*           AP,
+                                                 const hipblas_internal_type<T>*           AP,
                                                  hipblasStride      strideAP,
-                                                 T*                 x,
+                                                 hipblas_internal_type<T>*                 x,
                                                  int                incx,
                                                  hipblasStride      stridex,
                                                  int                batchCount);
@@ -9922,8 +9923,8 @@ namespace
                                       hipblasOperation_t transA,
                                       hipblasDiagType_t  diag,
                                       int64_t            m,
-                                      const T*           AP,
-                                      T*                 x,
+                                      const hipblas_internal_type<T>*           AP,
+                                      hipblas_internal_type<T>*                 x,
                                       int64_t            incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9932,8 +9933,8 @@ namespace
                                              hipblasOperation_t transA,
                                              hipblasDiagType_t  diag,
                                              int64_t            m,
-                                             const T* const     AP[],
-                                             T* const           x[],
+                                             const hipblas_internal_type<T>* const     AP[],
+                                             hipblas_internal_type<T>* const           x[],
                                              int64_t            incx,
                                              int64_t            batchCount);
 
@@ -9943,27 +9944,27 @@ namespace
                                                     hipblasOperation_t transA,
                                                     hipblasDiagType_t  diag,
                                                     int64_t            m,
-                                                    const T*           AP,
+                                                    const hipblas_internal_type<T>*           AP,
                                                     hipblasStride      strideAP,
-                                                    T*                 x,
+                                                    hipblas_internal_type<T>*                 x,
                                                     int64_t            incx,
                                                     hipblasStride      stridex,
                                                     int64_t            batchCount);
 
     MAP2CF_D64(hipblasTpsv, float, hipblasStpsv);
     MAP2CF_D64(hipblasTpsv, double, hipblasDtpsv);
-    MAP2CF_D64_V2(hipblasTpsv, hipblasComplex, hipblasCtpsv);
-    MAP2CF_D64_V2(hipblasTpsv, hipblasDoubleComplex, hipblasZtpsv);
+    MAP2CF_D64_V2(hipblasTpsv, std::complex<float>, hipblasCtpsv);
+    MAP2CF_D64_V2(hipblasTpsv, std::complex<double>, hipblasZtpsv);
 
     MAP2CF_D64(hipblasTpsvBatched, float, hipblasStpsvBatched);
     MAP2CF_D64(hipblasTpsvBatched, double, hipblasDtpsvBatched);
-    MAP2CF_D64_V2(hipblasTpsvBatched, hipblasComplex, hipblasCtpsvBatched);
-    MAP2CF_D64_V2(hipblasTpsvBatched, hipblasDoubleComplex, hipblasZtpsvBatched);
+    MAP2CF_D64_V2(hipblasTpsvBatched, std::complex<float>, hipblasCtpsvBatched);
+    MAP2CF_D64_V2(hipblasTpsvBatched, std::complex<double>, hipblasZtpsvBatched);
 
     MAP2CF_D64(hipblasTpsvStridedBatched, float, hipblasStpsvStridedBatched);
     MAP2CF_D64(hipblasTpsvStridedBatched, double, hipblasDtpsvStridedBatched);
-    MAP2CF_D64_V2(hipblasTpsvStridedBatched, hipblasComplex, hipblasCtpsvStridedBatched);
-    MAP2CF_D64_V2(hipblasTpsvStridedBatched, hipblasDoubleComplex, hipblasZtpsvStridedBatched);
+    MAP2CF_D64_V2(hipblasTpsvStridedBatched, std::complex<float>, hipblasCtpsvStridedBatched);
+    MAP2CF_D64_V2(hipblasTpsvStridedBatched, std::complex<double>, hipblasZtpsvStridedBatched);
 
     // trmv
     template <typename T, bool FORTRAN = false>
@@ -9972,9 +9973,9 @@ namespace
                                    hipblasOperation_t transA,
                                    hipblasDiagType_t  diag,
                                    int                m,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   T*                 x,
+                                   hipblas_internal_type<T>*                 x,
                                    int                incx);
 
     template <typename T, bool FORTRAN = false>
@@ -9983,9 +9984,9 @@ namespace
                                           hipblasOperation_t transA,
                                           hipblasDiagType_t  diag,
                                           int                m,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          T* const           x[],
+                                          hipblas_internal_type<T>* const           x[],
                                           int                incx,
                                           int                batch_count);
 
@@ -9995,10 +9996,10 @@ namespace
                                                  hipblasOperation_t transA,
                                                  hipblasDiagType_t  diag,
                                                  int                m,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      stride_a,
-                                                 T*                 x,
+                                                 hipblas_internal_type<T>*                 x,
                                                  int                incx,
                                                  hipblasStride      stride_x,
                                                  int                batch_count);
@@ -10010,9 +10011,9 @@ namespace
                                       hipblasOperation_t transA,
                                       hipblasDiagType_t  diag,
                                       int64_t            m,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      T*                 x,
+                                      hipblas_internal_type<T>*                 x,
                                       int64_t            incx);
 
     template <typename T, bool FORTRAN = false>
@@ -10021,9 +10022,9 @@ namespace
                                              hipblasOperation_t transA,
                                              hipblasDiagType_t  diag,
                                              int64_t            m,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             T* const           x[],
+                                             hipblas_internal_type<T>* const           x[],
                                              int64_t            incx,
                                              int64_t            batch_count);
 
@@ -10033,28 +10034,28 @@ namespace
                                                     hipblasOperation_t transA,
                                                     hipblasDiagType_t  diag,
                                                     int64_t            m,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      stride_a,
-                                                    T*                 x,
+                                                    hipblas_internal_type<T>*                 x,
                                                     int64_t            incx,
                                                     hipblasStride      stride_x,
                                                     int64_t            batch_count);
 
     MAP2CF_D64(hipblasTrmv, float, hipblasStrmv);
     MAP2CF_D64(hipblasTrmv, double, hipblasDtrmv);
-    MAP2CF_D64_V2(hipblasTrmv, hipblasComplex, hipblasCtrmv);
-    MAP2CF_D64_V2(hipblasTrmv, hipblasDoubleComplex, hipblasZtrmv);
+    MAP2CF_D64_V2(hipblasTrmv, std::complex<float>, hipblasCtrmv);
+    MAP2CF_D64_V2(hipblasTrmv, std::complex<double>, hipblasZtrmv);
 
     MAP2CF_D64(hipblasTrmvBatched, float, hipblasStrmvBatched);
     MAP2CF_D64(hipblasTrmvBatched, double, hipblasDtrmvBatched);
-    MAP2CF_D64_V2(hipblasTrmvBatched, hipblasComplex, hipblasCtrmvBatched);
-    MAP2CF_D64_V2(hipblasTrmvBatched, hipblasDoubleComplex, hipblasZtrmvBatched);
+    MAP2CF_D64_V2(hipblasTrmvBatched, std::complex<float>, hipblasCtrmvBatched);
+    MAP2CF_D64_V2(hipblasTrmvBatched, std::complex<double>, hipblasZtrmvBatched);
 
     MAP2CF_D64(hipblasTrmvStridedBatched, float, hipblasStrmvStridedBatched);
     MAP2CF_D64(hipblasTrmvStridedBatched, double, hipblasDtrmvStridedBatched);
-    MAP2CF_D64_V2(hipblasTrmvStridedBatched, hipblasComplex, hipblasCtrmvStridedBatched);
-    MAP2CF_D64_V2(hipblasTrmvStridedBatched, hipblasDoubleComplex, hipblasZtrmvStridedBatched);
+    MAP2CF_D64_V2(hipblasTrmvStridedBatched, std::complex<float>, hipblasCtrmvStridedBatched);
+    MAP2CF_D64_V2(hipblasTrmvStridedBatched, std::complex<double>, hipblasZtrmvStridedBatched);
 
     // trsv
     template <typename T, bool FORTRAN = false>
@@ -10063,9 +10064,9 @@ namespace
                                    hipblasOperation_t transA,
                                    hipblasDiagType_t  diag,
                                    int                m,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   T*                 x,
+                                   hipblas_internal_type<T>*                 x,
                                    int                incx);
 
     template <typename T, bool FORTRAN = false>
@@ -10074,9 +10075,9 @@ namespace
                                           hipblasOperation_t transA,
                                           hipblasDiagType_t  diag,
                                           int                m,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          T* const           x[],
+                                          hipblas_internal_type<T>* const           x[],
                                           int                incx,
                                           int                batch_count);
 
@@ -10086,10 +10087,10 @@ namespace
                                                  hipblasOperation_t transA,
                                                  hipblasDiagType_t  diag,
                                                  int                m,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      strideA,
-                                                 T*                 x,
+                                                 hipblas_internal_type<T>*                 x,
                                                  int                incx,
                                                  hipblasStride      stridex,
                                                  int                batch_count);
@@ -10101,9 +10102,9 @@ namespace
                                       hipblasOperation_t transA,
                                       hipblasDiagType_t  diag,
                                       int64_t            m,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      T*                 x,
+                                      hipblas_internal_type<T>*                 x,
                                       int64_t            incx);
 
     template <typename T, bool FORTRAN = false>
@@ -10112,9 +10113,9 @@ namespace
                                              hipblasOperation_t transA,
                                              hipblasDiagType_t  diag,
                                              int64_t            m,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             T* const           x[],
+                                             hipblas_internal_type<T>* const           x[],
                                              int64_t            incx,
                                              int64_t            batch_count);
 
@@ -10124,28 +10125,28 @@ namespace
                                                     hipblasOperation_t transA,
                                                     hipblasDiagType_t  diag,
                                                     int64_t            m,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      strideA,
-                                                    T*                 x,
+                                                    hipblas_internal_type<T>*                 x,
                                                     int64_t            incx,
                                                     hipblasStride      stridex,
                                                     int64_t            batch_count);
 
     MAP2CF_D64(hipblasTrsv, float, hipblasStrsv);
     MAP2CF_D64(hipblasTrsv, double, hipblasDtrsv);
-    MAP2CF_D64_V2(hipblasTrsv, hipblasComplex, hipblasCtrsv);
-    MAP2CF_D64_V2(hipblasTrsv, hipblasDoubleComplex, hipblasZtrsv);
+    MAP2CF_D64_V2(hipblasTrsv, std::complex<float>, hipblasCtrsv);
+    MAP2CF_D64_V2(hipblasTrsv, std::complex<double>, hipblasZtrsv);
 
     MAP2CF_D64(hipblasTrsvBatched, float, hipblasStrsvBatched);
     MAP2CF_D64(hipblasTrsvBatched, double, hipblasDtrsvBatched);
-    MAP2CF_D64_V2(hipblasTrsvBatched, hipblasComplex, hipblasCtrsvBatched);
-    MAP2CF_D64_V2(hipblasTrsvBatched, hipblasDoubleComplex, hipblasZtrsvBatched);
+    MAP2CF_D64_V2(hipblasTrsvBatched, std::complex<float>, hipblasCtrsvBatched);
+    MAP2CF_D64_V2(hipblasTrsvBatched, std::complex<double>, hipblasZtrsvBatched);
 
     MAP2CF_D64(hipblasTrsvStridedBatched, float, hipblasStrsvStridedBatched);
     MAP2CF_D64(hipblasTrsvStridedBatched, double, hipblasDtrsvStridedBatched);
-    MAP2CF_D64_V2(hipblasTrsvStridedBatched, hipblasComplex, hipblasCtrsvStridedBatched);
-    MAP2CF_D64_V2(hipblasTrsvStridedBatched, hipblasDoubleComplex, hipblasZtrsvStridedBatched);
+    MAP2CF_D64_V2(hipblasTrsvStridedBatched, std::complex<float>, hipblasCtrsvStridedBatched);
+    MAP2CF_D64_V2(hipblasTrsvStridedBatched, std::complex<double>, hipblasZtrsvStridedBatched);
 
     // gbmv
     template <typename T, bool FORTRAN = false>
@@ -10155,13 +10156,13 @@ namespace
                                    int                n,
                                    int                kl,
                                    int                ku,
-                                   const T*           alpha,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           alpha,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   const T*           x,
+                                   const hipblas_internal_type<T>*           x,
                                    int                incx,
-                                   const T*           beta,
-                                   T*                 y,
+                                   const hipblas_internal_type<T>*           beta,
+                                   hipblas_internal_type<T>*                 y,
                                    int                incy);
 
     template <typename T, bool FORTRAN = false>
@@ -10171,13 +10172,13 @@ namespace
                                           int                n,
                                           int                kl,
                                           int                ku,
-                                          const T*           alpha,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>*           alpha,
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          const T* const     x[],
+                                          const hipblas_internal_type<T>* const     x[],
                                           int                incx,
-                                          const T*           beta,
-                                          T* const           y[],
+                                          const hipblas_internal_type<T>*           beta,
+                                          hipblas_internal_type<T>* const           y[],
                                           int                incy,
                                           int                batch_count);
 
@@ -10188,15 +10189,15 @@ namespace
                                                  int                n,
                                                  int                kl,
                                                  int                ku,
-                                                 const T*           alpha,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           alpha,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      stride_a,
-                                                 const T*           x,
+                                                 const hipblas_internal_type<T>*           x,
                                                  int                incx,
                                                  hipblasStride      stride_x,
-                                                 const T*           beta,
-                                                 T*                 y,
+                                                 const hipblas_internal_type<T>*           beta,
+                                                 hipblas_internal_type<T>*                 y,
                                                  int                incy,
                                                  hipblasStride      stride_y,
                                                  int                batch_count);
@@ -10209,13 +10210,13 @@ namespace
                                       int64_t            n,
                                       int64_t            kl,
                                       int64_t            ku,
-                                      const T*           alpha,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           alpha,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      const T*           x,
+                                      const hipblas_internal_type<T>*           x,
                                       int64_t            incx,
-                                      const T*           beta,
-                                      T*                 y,
+                                      const hipblas_internal_type<T>*           beta,
+                                      hipblas_internal_type<T>*                 y,
                                       int64_t            incy);
 
     template <typename T, bool FORTRAN = false>
@@ -10225,13 +10226,13 @@ namespace
                                              int64_t            n,
                                              int64_t            kl,
                                              int64_t            ku,
-                                             const T*           alpha,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>*           alpha,
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             const T* const     x[],
+                                             const hipblas_internal_type<T>* const     x[],
                                              int64_t            incx,
-                                             const T*           beta,
-                                             T* const           y[],
+                                             const hipblas_internal_type<T>*           beta,
+                                             hipblas_internal_type<T>* const           y[],
                                              int64_t            incy,
                                              int64_t            batch_count);
 
@@ -10242,33 +10243,33 @@ namespace
                                                     int64_t            n,
                                                     int64_t            kl,
                                                     int64_t            ku,
-                                                    const T*           alpha,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           alpha,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      stride_a,
-                                                    const T*           x,
+                                                    const hipblas_internal_type<T>*           x,
                                                     int64_t            incx,
                                                     hipblasStride      stride_x,
-                                                    const T*           beta,
-                                                    T*                 y,
+                                                    const hipblas_internal_type<T>*           beta,
+                                                    hipblas_internal_type<T>*                 y,
                                                     int64_t            incy,
                                                     hipblasStride      stride_y,
                                                     int64_t            batch_count);
 
     MAP2CF_D64(hipblasGbmv, float, hipblasSgbmv);
     MAP2CF_D64(hipblasGbmv, double, hipblasDgbmv);
-    MAP2CF_D64_V2(hipblasGbmv, hipblasComplex, hipblasCgbmv);
-    MAP2CF_D64_V2(hipblasGbmv, hipblasDoubleComplex, hipblasZgbmv);
+    MAP2CF_D64_V2(hipblasGbmv, std::complex<float>, hipblasCgbmv);
+    MAP2CF_D64_V2(hipblasGbmv, std::complex<double>, hipblasZgbmv);
 
     MAP2CF_D64(hipblasGbmvBatched, float, hipblasSgbmvBatched);
     MAP2CF_D64(hipblasGbmvBatched, double, hipblasDgbmvBatched);
-    MAP2CF_D64_V2(hipblasGbmvBatched, hipblasComplex, hipblasCgbmvBatched);
-    MAP2CF_D64_V2(hipblasGbmvBatched, hipblasDoubleComplex, hipblasZgbmvBatched);
+    MAP2CF_D64_V2(hipblasGbmvBatched, std::complex<float>, hipblasCgbmvBatched);
+    MAP2CF_D64_V2(hipblasGbmvBatched, std::complex<double>, hipblasZgbmvBatched);
 
     MAP2CF_D64(hipblasGbmvStridedBatched, float, hipblasSgbmvStridedBatched);
     MAP2CF_D64(hipblasGbmvStridedBatched, double, hipblasDgbmvStridedBatched);
-    MAP2CF_D64_V2(hipblasGbmvStridedBatched, hipblasComplex, hipblasCgbmvStridedBatched);
-    MAP2CF_D64_V2(hipblasGbmvStridedBatched, hipblasDoubleComplex, hipblasZgbmvStridedBatched);
+    MAP2CF_D64_V2(hipblasGbmvStridedBatched, std::complex<float>, hipblasCgbmvStridedBatched);
+    MAP2CF_D64_V2(hipblasGbmvStridedBatched, std::complex<double>, hipblasZgbmvStridedBatched);
 
     // gemv
     template <typename T, bool FORTRAN = false>
@@ -10276,13 +10277,13 @@ namespace
                                    hipblasOperation_t transA,
                                    int                m,
                                    int                n,
-                                   const T*           alpha,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           alpha,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   const T*           x,
+                                   const hipblas_internal_type<T>*           x,
                                    int                incx,
-                                   const T*           beta,
-                                   T*                 y,
+                                   const hipblas_internal_type<T>*           beta,
+                                   hipblas_internal_type<T>*                 y,
                                    int                incy);
 
     template <typename T, bool FORTRAN = false>
@@ -10290,13 +10291,13 @@ namespace
                                           hipblasOperation_t transA,
                                           int                m,
                                           int                n,
-                                          const T*           alpha,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>*           alpha,
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          const T* const     x[],
+                                          const hipblas_internal_type<T>* const     x[],
                                           int                incx,
-                                          const T*           beta,
-                                          T* const           y[],
+                                          const hipblas_internal_type<T>*           beta,
+                                          hipblas_internal_type<T>* const           y[],
                                           int                incy,
                                           int                batch_count);
 
@@ -10305,15 +10306,15 @@ namespace
                                                  hipblasOperation_t transA,
                                                  int                m,
                                                  int                n,
-                                                 const T*           alpha,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           alpha,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      stride_a,
-                                                 const T*           x,
+                                                 const hipblas_internal_type<T>*           x,
                                                  int                incx,
                                                  hipblasStride      stride_x,
-                                                 const T*           beta,
-                                                 T*                 y,
+                                                 const hipblas_internal_type<T>*           beta,
+                                                 hipblas_internal_type<T>*                 y,
                                                  int                incy,
                                                  hipblasStride      stride_y,
                                                  int                batch_count);
@@ -10324,13 +10325,13 @@ namespace
                                       hipblasOperation_t transA,
                                       int64_t            m,
                                       int64_t            n,
-                                      const T*           alpha,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           alpha,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      const T*           x,
+                                      const hipblas_internal_type<T>*           x,
                                       int64_t            incx,
-                                      const T*           beta,
-                                      T*                 y,
+                                      const hipblas_internal_type<T>*           beta,
+                                      hipblas_internal_type<T>*                 y,
                                       int64_t            incy);
 
     template <typename T, bool FORTRAN = false>
@@ -10338,13 +10339,13 @@ namespace
                                              hipblasOperation_t transA,
                                              int64_t            m,
                                              int64_t            n,
-                                             const T*           alpha,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>*           alpha,
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             const T* const     x[],
+                                             const hipblas_internal_type<T>* const     x[],
                                              int64_t            incx,
-                                             const T*           beta,
-                                             T* const           y[],
+                                             const hipblas_internal_type<T>*           beta,
+                                             hipblas_internal_type<T>* const           y[],
                                              int64_t            incy,
                                              int64_t            batch_count);
 
@@ -10353,33 +10354,33 @@ namespace
                                                     hipblasOperation_t transA,
                                                     int64_t            m,
                                                     int64_t            n,
-                                                    const T*           alpha,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           alpha,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      stride_a,
-                                                    const T*           x,
+                                                    const hipblas_internal_type<T>*           x,
                                                     int64_t            incx,
                                                     hipblasStride      stride_x,
-                                                    const T*           beta,
-                                                    T*                 y,
+                                                    const hipblas_internal_type<T>*           beta,
+                                                    hipblas_internal_type<T>*                 y,
                                                     int64_t            incy,
                                                     hipblasStride      stride_y,
                                                     int64_t            batch_count);
 
     MAP2CF_D64(hipblasGemv, float, hipblasSgemv);
     MAP2CF_D64(hipblasGemv, double, hipblasDgemv);
-    MAP2CF_D64_V2(hipblasGemv, hipblasComplex, hipblasCgemv);
-    MAP2CF_D64_V2(hipblasGemv, hipblasDoubleComplex, hipblasZgemv);
+    MAP2CF_D64_V2(hipblasGemv, std::complex<float>, hipblasCgemv);
+    MAP2CF_D64_V2(hipblasGemv, std::complex<double>, hipblasZgemv);
 
     MAP2CF_D64(hipblasGemvBatched, float, hipblasSgemvBatched);
     MAP2CF_D64(hipblasGemvBatched, double, hipblasDgemvBatched);
-    MAP2CF_D64_V2(hipblasGemvBatched, hipblasComplex, hipblasCgemvBatched);
-    MAP2CF_D64_V2(hipblasGemvBatched, hipblasDoubleComplex, hipblasZgemvBatched);
+    MAP2CF_D64_V2(hipblasGemvBatched, std::complex<float>, hipblasCgemvBatched);
+    MAP2CF_D64_V2(hipblasGemvBatched, std::complex<double>, hipblasZgemvBatched);
 
     MAP2CF_D64(hipblasGemvStridedBatched, float, hipblasSgemvStridedBatched);
     MAP2CF_D64(hipblasGemvStridedBatched, double, hipblasDgemvStridedBatched);
-    MAP2CF_D64_V2(hipblasGemvStridedBatched, hipblasComplex, hipblasCgemvStridedBatched);
-    MAP2CF_D64_V2(hipblasGemvStridedBatched, hipblasDoubleComplex, hipblasZgemvStridedBatched);
+    MAP2CF_D64_V2(hipblasGemvStridedBatched, std::complex<float>, hipblasCgemvStridedBatched);
+    MAP2CF_D64_V2(hipblasGemvStridedBatched, std::complex<double>, hipblasZgemvStridedBatched);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGemm)(hipblasHandle_t    handle,
@@ -10388,13 +10389,13 @@ namespace
                                    int                m,
                                    int                n,
                                    int                k,
-                                   const T*           alpha,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           alpha,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   const T*           B,
+                                   const hipblas_internal_type<T>*           B,
                                    int                ldb,
-                                   const T*           beta,
-                                   T*                 C,
+                                   const hipblas_internal_type<T>*           beta,
+                                   hipblas_internal_type<T>*                 C,
                                    int                ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -10404,15 +10405,15 @@ namespace
                                                  int                m,
                                                  int                n,
                                                  int                k,
-                                                 const T*           alpha,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           alpha,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  int                bsa,
-                                                 const T*           B,
+                                                 const hipblas_internal_type<T>*           B,
                                                  int                ldb,
                                                  int                bsb,
-                                                 const T*           beta,
-                                                 T*                 C,
+                                                 const hipblas_internal_type<T>*           beta,
+                                                 hipblas_internal_type<T>*                 C,
                                                  int                ldc,
                                                  int                bsc,
                                                  int                batch_count);
@@ -10424,13 +10425,13 @@ namespace
                                           int                m,
                                           int                n,
                                           int                k,
-                                          const T*           alpha,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>*           alpha,
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          const T* const     B[],
+                                          const hipblas_internal_type<T>* const     B[],
                                           int                ldb,
-                                          const T*           beta,
-                                          T* const           C[],
+                                          const hipblas_internal_type<T>*           beta,
+                                          hipblas_internal_type<T>* const           C[],
                                           int                ldc,
                                           int                batch_count);
 
@@ -10441,13 +10442,13 @@ namespace
                                       int64_t            m,
                                       int64_t            n,
                                       int64_t            k,
-                                      const T*           alpha,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           alpha,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      const T*           B,
+                                      const hipblas_internal_type<T>*           B,
                                       int64_t            ldb,
-                                      const T*           beta,
-                                      T*                 C,
+                                      const hipblas_internal_type<T>*           beta,
+                                      hipblas_internal_type<T>*                 C,
                                       int64_t            ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -10457,15 +10458,15 @@ namespace
                                                     int64_t            m,
                                                     int64_t            n,
                                                     int64_t            k,
-                                                    const T*           alpha,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           alpha,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     int64_t            bsa,
-                                                    const T*           B,
+                                                    const hipblas_internal_type<T>*           B,
                                                     int64_t            ldb,
                                                     int64_t            bsb,
-                                                    const T*           beta,
-                                                    T*                 C,
+                                                    const hipblas_internal_type<T>*           beta,
+                                                    hipblas_internal_type<T>*                 C,
                                                     int64_t            ldc,
                                                     int64_t            bsc,
                                                     int64_t            batch_count);
@@ -10477,33 +10478,33 @@ namespace
                                              int64_t            m,
                                              int64_t            n,
                                              int64_t            k,
-                                             const T*           alpha,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>*           alpha,
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             const T* const     B[],
+                                             const hipblas_internal_type<T>* const     B[],
                                              int64_t            ldb,
-                                             const T*           beta,
-                                             T* const           C[],
+                                             const hipblas_internal_type<T>*           beta,
+                                             hipblas_internal_type<T>* const           C[],
                                              int64_t            ldc,
                                              int64_t            batch_count);
 
     MAP2CF_D64(hipblasGemm, hipblasHalf, hipblasHgemm);
     MAP2CF_D64(hipblasGemm, float, hipblasSgemm);
     MAP2CF_D64(hipblasGemm, double, hipblasDgemm);
-    MAP2CF_D64_V2(hipblasGemm, hipblasComplex, hipblasCgemm);
-    MAP2CF_D64_V2(hipblasGemm, hipblasDoubleComplex, hipblasZgemm);
+    MAP2CF_D64_V2(hipblasGemm, std::complex<float>, hipblasCgemm);
+    MAP2CF_D64_V2(hipblasGemm, std::complex<double>, hipblasZgemm);
 
     MAP2CF_D64(hipblasGemmBatched, hipblasHalf, hipblasHgemmBatched);
     MAP2CF_D64(hipblasGemmBatched, float, hipblasSgemmBatched);
     MAP2CF_D64(hipblasGemmBatched, double, hipblasDgemmBatched);
-    MAP2CF_D64_V2(hipblasGemmBatched, hipblasComplex, hipblasCgemmBatched);
-    MAP2CF_D64_V2(hipblasGemmBatched, hipblasDoubleComplex, hipblasZgemmBatched);
+    MAP2CF_D64_V2(hipblasGemmBatched, std::complex<float>, hipblasCgemmBatched);
+    MAP2CF_D64_V2(hipblasGemmBatched, std::complex<double>, hipblasZgemmBatched);
 
     MAP2CF_D64(hipblasGemmStridedBatched, hipblasHalf, hipblasHgemmStridedBatched);
     MAP2CF_D64(hipblasGemmStridedBatched, float, hipblasSgemmStridedBatched);
     MAP2CF_D64(hipblasGemmStridedBatched, double, hipblasDgemmStridedBatched);
-    MAP2CF_D64_V2(hipblasGemmStridedBatched, hipblasComplex, hipblasCgemmStridedBatched);
-    MAP2CF_D64_V2(hipblasGemmStridedBatched, hipblasDoubleComplex, hipblasZgemmStridedBatched);
+    MAP2CF_D64_V2(hipblasGemmStridedBatched, std::complex<float>, hipblasCgemmStridedBatched);
+    MAP2CF_D64_V2(hipblasGemmStridedBatched, std::complex<double>, hipblasZgemmStridedBatched);
 
     // herk
     template <typename T, typename U, bool FORTRAN = false>
@@ -10512,11 +10513,11 @@ namespace
                                    hipblasOperation_t transA,
                                    int                n,
                                    int                k,
-                                   const U*           alpha,
-                                   const T*           A,
+                                   const hipblas_internal_type<U>*           alpha,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   const U*           beta,
-                                   T*                 C,
+                                   const hipblas_internal_type<U>*           beta,
+                                   hipblas_internal_type<T>*                 C,
                                    int                ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
@@ -10525,11 +10526,11 @@ namespace
                                           hipblasOperation_t transA,
                                           int                n,
                                           int                k,
-                                          const U*           alpha,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<U>*           alpha,
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          const U*           beta,
-                                          T* const           C[],
+                                          const hipblas_internal_type<U>*           beta,
+                                          hipblas_internal_type<T>* const           C[],
                                           int                ldc,
                                           int                batchCount);
 
@@ -10539,12 +10540,12 @@ namespace
                                                  hipblasOperation_t transA,
                                                  int                n,
                                                  int                k,
-                                                 const U*           alpha,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<U>*           alpha,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      strideA,
-                                                 const U*           beta,
-                                                 T*                 C,
+                                                 const hipblas_internal_type<U>*           beta,
+                                                 hipblas_internal_type<T>*                 C,
                                                  int                ldc,
                                                  hipblasStride      strideC,
                                                  int                batchCount);
@@ -10555,11 +10556,11 @@ namespace
                                       hipblasOperation_t transA,
                                       int64_t            n,
                                       int64_t            k,
-                                      const U*           alpha,
-                                      const T*           A,
+                                      const hipblas_internal_type<U>*           alpha,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      const U*           beta,
-                                      T*                 C,
+                                      const hipblas_internal_type<U>*           beta,
+                                      hipblas_internal_type<T>*                 C,
                                       int64_t            ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
@@ -10568,11 +10569,11 @@ namespace
                                              hipblasOperation_t transA,
                                              int64_t            n,
                                              int64_t            k,
-                                             const U*           alpha,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<U>*           alpha,
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             const U*           beta,
-                                             T* const           C[],
+                                             const hipblas_internal_type<U>*           beta,
+                                             hipblas_internal_type<T>* const           C[],
                                              int64_t            ldc,
                                              int64_t            batchCount);
 
@@ -10582,25 +10583,25 @@ namespace
                                                     hipblasOperation_t transA,
                                                     int64_t            n,
                                                     int64_t            k,
-                                                    const U*           alpha,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<U>*           alpha,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      strideA,
-                                                    const U*           beta,
-                                                    T*                 C,
+                                                    const hipblas_internal_type<U>*           beta,
+                                                    hipblas_internal_type<T>*                 C,
                                                     int64_t            ldc,
                                                     hipblasStride      strideC,
                                                     int64_t            batchCount);
 
-    MAP2CF_D64_V2(hipblasHerk, hipblasComplex, float, hipblasCherk);
-    MAP2CF_D64_V2(hipblasHerk, hipblasDoubleComplex, double, hipblasZherk);
+    MAP2CF_D64_V2(hipblasHerk, std::complex<float>, float, hipblasCherk);
+    MAP2CF_D64_V2(hipblasHerk, std::complex<double>, double, hipblasZherk);
 
-    MAP2CF_D64_V2(hipblasHerkBatched, hipblasComplex, float, hipblasCherkBatched);
-    MAP2CF_D64_V2(hipblasHerkBatched, hipblasDoubleComplex, double, hipblasZherkBatched);
+    MAP2CF_D64_V2(hipblasHerkBatched, std::complex<float>, float, hipblasCherkBatched);
+    MAP2CF_D64_V2(hipblasHerkBatched, std::complex<double>, double, hipblasZherkBatched);
 
-    MAP2CF_D64_V2(hipblasHerkStridedBatched, hipblasComplex, float, hipblasCherkStridedBatched);
+    MAP2CF_D64_V2(hipblasHerkStridedBatched, std::complex<float>, float, hipblasCherkStridedBatched);
     MAP2CF_D64_V2(hipblasHerkStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasZherkStridedBatched);
 
@@ -10611,13 +10612,13 @@ namespace
                                     hipblasOperation_t transA,
                                     int                n,
                                     int                k,
-                                    const T*           alpha,
-                                    const T*           A,
+                                    const hipblas_internal_type<T>*           alpha,
+                                    const hipblas_internal_type<T>*           A,
                                     int                lda,
-                                    const T*           B,
+                                    const hipblas_internal_type<T>*           B,
                                     int                ldb,
-                                    const U*           beta,
-                                    T*                 C,
+                                    const hipblas_internal_type<U>*           beta,
+                                    hipblas_internal_type<T>*                 C,
                                     int                ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
@@ -10626,13 +10627,13 @@ namespace
                                            hipblasOperation_t transA,
                                            int                n,
                                            int                k,
-                                           const T*           alpha,
-                                           const T* const     A[],
+                                           const hipblas_internal_type<T>*           alpha,
+                                           const hipblas_internal_type<T>* const     A[],
                                            int                lda,
-                                           const T* const     B[],
+                                           const hipblas_internal_type<T>* const     B[],
                                            int                ldb,
-                                           const U*           beta,
-                                           T* const           C[],
+                                           const hipblas_internal_type<U>*           beta,
+                                           hipblas_internal_type<T>* const           C[],
                                            int                ldc,
                                            int                batchCount);
 
@@ -10642,15 +10643,15 @@ namespace
                                                   hipblasOperation_t transA,
                                                   int                n,
                                                   int                k,
-                                                  const T*           alpha,
-                                                  const T*           A,
+                                                  const hipblas_internal_type<T>*           alpha,
+                                                  const hipblas_internal_type<T>*           A,
                                                   int                lda,
                                                   hipblasStride      strideA,
-                                                  const T*           B,
+                                                  const hipblas_internal_type<T>*           B,
                                                   int                ldb,
                                                   hipblasStride      strideB,
-                                                  const U*           beta,
-                                                  T*                 C,
+                                                  const hipblas_internal_type<U>*           beta,
+                                                  hipblas_internal_type<T>*                 C,
                                                   int                ldc,
                                                   hipblasStride      strideC,
                                                   int                batchCount);
@@ -10661,13 +10662,13 @@ namespace
                                        hipblasOperation_t transA,
                                        int64_t            n,
                                        int64_t            k,
-                                       const T*           alpha,
-                                       const T*           A,
+                                       const hipblas_internal_type<T>*           alpha,
+                                       const hipblas_internal_type<T>*           A,
                                        int64_t            lda,
-                                       const T*           B,
+                                       const hipblas_internal_type<T>*           B,
                                        int64_t            ldb,
-                                       const U*           beta,
-                                       T*                 C,
+                                       const hipblas_internal_type<U>*           beta,
+                                       hipblas_internal_type<T>*                 C,
                                        int64_t            ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
@@ -10676,13 +10677,13 @@ namespace
                                               hipblasOperation_t transA,
                                               int64_t            n,
                                               int64_t            k,
-                                              const T*           alpha,
-                                              const T* const     A[],
+                                              const hipblas_internal_type<T>*           alpha,
+                                              const hipblas_internal_type<T>* const     A[],
                                               int64_t            lda,
-                                              const T* const     B[],
+                                              const hipblas_internal_type<T>* const     B[],
                                               int64_t            ldb,
-                                              const U*           beta,
-                                              T* const           C[],
+                                              const hipblas_internal_type<U>*           beta,
+                                              hipblas_internal_type<T>* const           C[],
                                               int64_t            ldc,
                                               int64_t            batchCount);
 
@@ -10692,28 +10693,28 @@ namespace
                                                      hipblasOperation_t transA,
                                                      int64_t            n,
                                                      int64_t            k,
-                                                     const T*           alpha,
-                                                     const T*           A,
+                                                     const hipblas_internal_type<T>*           alpha,
+                                                     const hipblas_internal_type<T>*           A,
                                                      int64_t            lda,
                                                      hipblasStride      strideA,
-                                                     const T*           B,
+                                                     const hipblas_internal_type<T>*           B,
                                                      int64_t            ldb,
                                                      hipblasStride      strideB,
-                                                     const U*           beta,
-                                                     T*                 C,
+                                                     const hipblas_internal_type<U>*           beta,
+                                                     hipblas_internal_type<T>*                 C,
                                                      int64_t            ldc,
                                                      hipblasStride      strideC,
                                                      int64_t            batchCount);
 
-    MAP2CF_D64_V2(hipblasHer2k, hipblasComplex, float, hipblasCher2k);
-    MAP2CF_D64_V2(hipblasHer2k, hipblasDoubleComplex, double, hipblasZher2k);
+    MAP2CF_D64_V2(hipblasHer2k, std::complex<float>, float, hipblasCher2k);
+    MAP2CF_D64_V2(hipblasHer2k, std::complex<double>, double, hipblasZher2k);
 
-    MAP2CF_D64_V2(hipblasHer2kBatched, hipblasComplex, float, hipblasCher2kBatched);
-    MAP2CF_D64_V2(hipblasHer2kBatched, hipblasDoubleComplex, double, hipblasZher2kBatched);
+    MAP2CF_D64_V2(hipblasHer2kBatched, std::complex<float>, float, hipblasCher2kBatched);
+    MAP2CF_D64_V2(hipblasHer2kBatched, std::complex<double>, double, hipblasZher2kBatched);
 
-    MAP2CF_D64_V2(hipblasHer2kStridedBatched, hipblasComplex, float, hipblasCher2kStridedBatched);
+    MAP2CF_D64_V2(hipblasHer2kStridedBatched, std::complex<float>, float, hipblasCher2kStridedBatched);
     MAP2CF_D64_V2(hipblasHer2kStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasZher2kStridedBatched);
 
@@ -10724,13 +10725,13 @@ namespace
                                     hipblasOperation_t transA,
                                     int                n,
                                     int                k,
-                                    const T*           alpha,
-                                    const T*           A,
+                                    const hipblas_internal_type<T>*           alpha,
+                                    const hipblas_internal_type<T>*           A,
                                     int                lda,
-                                    const T*           B,
+                                    const hipblas_internal_type<T>*           B,
                                     int                ldb,
-                                    const U*           beta,
-                                    T*                 C,
+                                    const hipblas_internal_type<U>*           beta,
+                                    hipblas_internal_type<T>*                 C,
                                     int                ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
@@ -10739,13 +10740,13 @@ namespace
                                            hipblasOperation_t transA,
                                            int                n,
                                            int                k,
-                                           const T*           alpha,
-                                           const T* const     A[],
+                                           const hipblas_internal_type<T>*           alpha,
+                                           const hipblas_internal_type<T>* const     A[],
                                            int                lda,
-                                           const T* const     B[],
+                                           const hipblas_internal_type<T>* const     B[],
                                            int                ldb,
-                                           const U*           beta,
-                                           T* const           C[],
+                                           const hipblas_internal_type<U>*           beta,
+                                           hipblas_internal_type<T>* const           C[],
                                            int                ldc,
                                            int                batchCount);
 
@@ -10755,15 +10756,15 @@ namespace
                                                   hipblasOperation_t transA,
                                                   int                n,
                                                   int                k,
-                                                  const T*           alpha,
-                                                  const T*           A,
+                                                  const hipblas_internal_type<T>*           alpha,
+                                                  const hipblas_internal_type<T>*           A,
                                                   int                lda,
                                                   hipblasStride      strideA,
-                                                  const T*           B,
+                                                  const hipblas_internal_type<T>*           B,
                                                   int                ldb,
                                                   hipblasStride      strideB,
-                                                  const U*           beta,
-                                                  T*                 C,
+                                                  const hipblas_internal_type<U>*           beta,
+                                                  hipblas_internal_type<T>*                 C,
                                                   int                ldc,
                                                   hipblasStride      strideC,
                                                   int                batchCount);
@@ -10774,13 +10775,13 @@ namespace
                                        hipblasOperation_t transA,
                                        int64_t            n,
                                        int64_t            k,
-                                       const T*           alpha,
-                                       const T*           A,
+                                       const hipblas_internal_type<T>*           alpha,
+                                       const hipblas_internal_type<T>*           A,
                                        int64_t            lda,
-                                       const T*           B,
+                                       const hipblas_internal_type<T>*           B,
                                        int64_t            ldb,
-                                       const U*           beta,
-                                       T*                 C,
+                                       const hipblas_internal_type<U>*           beta,
+                                       hipblas_internal_type<T>*                 C,
                                        int64_t            ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
@@ -10789,13 +10790,13 @@ namespace
                                               hipblasOperation_t transA,
                                               int64_t            n,
                                               int64_t            k,
-                                              const T*           alpha,
-                                              const T* const     A[],
+                                              const hipblas_internal_type<T>*           alpha,
+                                              const hipblas_internal_type<T>* const     A[],
                                               int64_t            lda,
-                                              const T* const     B[],
+                                              const hipblas_internal_type<T>* const     B[],
                                               int64_t            ldb,
-                                              const U*           beta,
-                                              T* const           C[],
+                                              const hipblas_internal_type<U>*           beta,
+                                              hipblas_internal_type<T>* const           C[],
                                               int64_t            ldc,
                                               int64_t            batchCount);
 
@@ -10805,28 +10806,28 @@ namespace
                                                      hipblasOperation_t transA,
                                                      int64_t            n,
                                                      int64_t            k,
-                                                     const T*           alpha,
-                                                     const T*           A,
+                                                     const hipblas_internal_type<T>*           alpha,
+                                                     const hipblas_internal_type<T>*           A,
                                                      int64_t            lda,
                                                      hipblasStride      strideA,
-                                                     const T*           B,
+                                                     const hipblas_internal_type<T>*           B,
                                                      int64_t            ldb,
                                                      hipblasStride      strideB,
-                                                     const U*           beta,
-                                                     T*                 C,
+                                                     const hipblas_internal_type<U>*           beta,
+                                                     hipblas_internal_type<T>*                 C,
                                                      int64_t            ldc,
                                                      hipblasStride      strideC,
                                                      int64_t            batchCount);
 
-    MAP2CF_D64_V2(hipblasHerkx, hipblasComplex, float, hipblasCherkx);
-    MAP2CF_D64_V2(hipblasHerkx, hipblasDoubleComplex, double, hipblasZherkx);
+    MAP2CF_D64_V2(hipblasHerkx, std::complex<float>, float, hipblasCherkx);
+    MAP2CF_D64_V2(hipblasHerkx, std::complex<double>, double, hipblasZherkx);
 
-    MAP2CF_D64_V2(hipblasHerkxBatched, hipblasComplex, float, hipblasCherkxBatched);
-    MAP2CF_D64_V2(hipblasHerkxBatched, hipblasDoubleComplex, double, hipblasZherkxBatched);
+    MAP2CF_D64_V2(hipblasHerkxBatched, std::complex<float>, float, hipblasCherkxBatched);
+    MAP2CF_D64_V2(hipblasHerkxBatched, std::complex<double>, double, hipblasZherkxBatched);
 
-    MAP2CF_D64_V2(hipblasHerkxStridedBatched, hipblasComplex, float, hipblasCherkxStridedBatched);
+    MAP2CF_D64_V2(hipblasHerkxStridedBatched, std::complex<float>, float, hipblasCherkxStridedBatched);
     MAP2CF_D64_V2(hipblasHerkxStridedBatched,
-                  hipblasDoubleComplex,
+                  std::complex<double>,
                   double,
                   hipblasZherkxStridedBatched);
 
@@ -10837,13 +10838,13 @@ namespace
                                    hipblasFillMode_t uplo,
                                    int               m,
                                    int               n,
-                                   const T*          alpha,
-                                   const T*          A,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          A,
                                    int               lda,
-                                   const T*          B,
+                                   const hipblas_internal_type<T>*          B,
                                    int               ldb,
-                                   const T*          beta,
-                                   T*                C,
+                                   const hipblas_internal_type<T>*          beta,
+                                   hipblas_internal_type<T>*                C,
                                    int               ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -10852,13 +10853,13 @@ namespace
                                           hipblasFillMode_t uplo,
                                           int               m,
                                           int               n,
-                                          const T*          alpha,
-                                          const T* const    A[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    A[],
                                           int               lda,
-                                          const T* const    B[],
+                                          const hipblas_internal_type<T>* const    B[],
                                           int               ldb,
-                                          const T*          beta,
-                                          T* const          C[],
+                                          const hipblas_internal_type<T>*          beta,
+                                          hipblas_internal_type<T>* const          C[],
                                           int               ldc,
                                           int               batchCount);
 
@@ -10868,15 +10869,15 @@ namespace
                                                  hipblasFillMode_t uplo,
                                                  int               m,
                                                  int               n,
-                                                 const T*          alpha,
-                                                 const T*          A,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          A,
                                                  int               lda,
                                                  hipblasStride     strideA,
-                                                 const T*          B,
+                                                 const hipblas_internal_type<T>*          B,
                                                  int               ldb,
                                                  hipblasStride     strideB,
-                                                 const T*          beta,
-                                                 T*                C,
+                                                 const hipblas_internal_type<T>*          beta,
+                                                 hipblas_internal_type<T>*                C,
                                                  int               ldc,
                                                  hipblasStride     strideC,
                                                  int               batchCount);
@@ -10887,13 +10888,13 @@ namespace
                                       hipblasFillMode_t uplo,
                                       int64_t           m,
                                       int64_t           n,
-                                      const T*          alpha,
-                                      const T*          A,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          A,
                                       int64_t           lda,
-                                      const T*          B,
+                                      const hipblas_internal_type<T>*          B,
                                       int64_t           ldb,
-                                      const T*          beta,
-                                      T*                C,
+                                      const hipblas_internal_type<T>*          beta,
+                                      hipblas_internal_type<T>*                C,
                                       int64_t           ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -10902,13 +10903,13 @@ namespace
                                              hipblasFillMode_t uplo,
                                              int64_t           m,
                                              int64_t           n,
-                                             const T*          alpha,
-                                             const T* const    A[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    A[],
                                              int64_t           lda,
-                                             const T* const    B[],
+                                             const hipblas_internal_type<T>* const    B[],
                                              int64_t           ldb,
-                                             const T*          beta,
-                                             T* const          C[],
+                                             const hipblas_internal_type<T>*          beta,
+                                             hipblas_internal_type<T>* const          C[],
                                              int64_t           ldc,
                                              int64_t           batchCount);
 
@@ -10918,33 +10919,33 @@ namespace
                                                     hipblasFillMode_t uplo,
                                                     int64_t           m,
                                                     int64_t           n,
-                                                    const T*          alpha,
-                                                    const T*          A,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          A,
                                                     int64_t           lda,
                                                     hipblasStride     strideA,
-                                                    const T*          B,
+                                                    const hipblas_internal_type<T>*          B,
                                                     int64_t           ldb,
                                                     hipblasStride     strideB,
-                                                    const T*          beta,
-                                                    T*                C,
+                                                    const hipblas_internal_type<T>*          beta,
+                                                    hipblas_internal_type<T>*                C,
                                                     int64_t           ldc,
                                                     hipblasStride     strideC,
                                                     int64_t           batchCount);
 
     MAP2CF_D64(hipblasSymm, float, hipblasSsymm);
     MAP2CF_D64(hipblasSymm, double, hipblasDsymm);
-    MAP2CF_D64_V2(hipblasSymm, hipblasComplex, hipblasCsymm);
-    MAP2CF_D64_V2(hipblasSymm, hipblasDoubleComplex, hipblasZsymm);
+    MAP2CF_D64_V2(hipblasSymm, std::complex<float>, hipblasCsymm);
+    MAP2CF_D64_V2(hipblasSymm, std::complex<double>, hipblasZsymm);
 
     MAP2CF_D64(hipblasSymmBatched, float, hipblasSsymmBatched);
     MAP2CF_D64(hipblasSymmBatched, double, hipblasDsymmBatched);
-    MAP2CF_D64_V2(hipblasSymmBatched, hipblasComplex, hipblasCsymmBatched);
-    MAP2CF_D64_V2(hipblasSymmBatched, hipblasDoubleComplex, hipblasZsymmBatched);
+    MAP2CF_D64_V2(hipblasSymmBatched, std::complex<float>, hipblasCsymmBatched);
+    MAP2CF_D64_V2(hipblasSymmBatched, std::complex<double>, hipblasZsymmBatched);
 
     MAP2CF_D64(hipblasSymmStridedBatched, float, hipblasSsymmStridedBatched);
     MAP2CF_D64(hipblasSymmStridedBatched, double, hipblasDsymmStridedBatched);
-    MAP2CF_D64_V2(hipblasSymmStridedBatched, hipblasComplex, hipblasCsymmStridedBatched);
-    MAP2CF_D64_V2(hipblasSymmStridedBatched, hipblasDoubleComplex, hipblasZsymmStridedBatched);
+    MAP2CF_D64_V2(hipblasSymmStridedBatched, std::complex<float>, hipblasCsymmStridedBatched);
+    MAP2CF_D64_V2(hipblasSymmStridedBatched, std::complex<double>, hipblasZsymmStridedBatched);
 
     // syrk
     template <typename T, bool FORTRAN = false>
@@ -10953,11 +10954,11 @@ namespace
                                    hipblasOperation_t transA,
                                    int                n,
                                    int                k,
-                                   const T*           alpha,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           alpha,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   const T*           beta,
-                                   T*                 C,
+                                   const hipblas_internal_type<T>*           beta,
+                                   hipblas_internal_type<T>*                 C,
                                    int                ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -10966,11 +10967,11 @@ namespace
                                           hipblasOperation_t transA,
                                           int                n,
                                           int                k,
-                                          const T*           alpha,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>*           alpha,
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          const T*           beta,
-                                          T* const           C[],
+                                          const hipblas_internal_type<T>*           beta,
+                                          hipblas_internal_type<T>* const           C[],
                                           int                ldc,
                                           int                batchCount);
 
@@ -10980,12 +10981,12 @@ namespace
                                                  hipblasOperation_t transA,
                                                  int                n,
                                                  int                k,
-                                                 const T*           alpha,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           alpha,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      strideA,
-                                                 const T*           beta,
-                                                 T*                 C,
+                                                 const hipblas_internal_type<T>*           beta,
+                                                 hipblas_internal_type<T>*                 C,
                                                  int                ldc,
                                                  hipblasStride      strideC,
                                                  int                batchCount);
@@ -10996,11 +10997,11 @@ namespace
                                       hipblasOperation_t transA,
                                       int64_t            n,
                                       int64_t            k,
-                                      const T*           alpha,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           alpha,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      const T*           beta,
-                                      T*                 C,
+                                      const hipblas_internal_type<T>*           beta,
+                                      hipblas_internal_type<T>*                 C,
                                       int64_t            ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11009,11 +11010,11 @@ namespace
                                              hipblasOperation_t transA,
                                              int64_t            n,
                                              int64_t            k,
-                                             const T*           alpha,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>*           alpha,
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             const T*           beta,
-                                             T* const           C[],
+                                             const hipblas_internal_type<T>*           beta,
+                                             hipblas_internal_type<T>* const           C[],
                                              int64_t            ldc,
                                              int64_t            batchCount);
 
@@ -11023,30 +11024,30 @@ namespace
                                                     hipblasOperation_t transA,
                                                     int64_t            n,
                                                     int64_t            k,
-                                                    const T*           alpha,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           alpha,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      strideA,
-                                                    const T*           beta,
-                                                    T*                 C,
+                                                    const hipblas_internal_type<T>*           beta,
+                                                    hipblas_internal_type<T>*                 C,
                                                     int64_t            ldc,
                                                     hipblasStride      strideC,
                                                     int64_t            batchCount);
 
     MAP2CF_D64(hipblasSyrk, float, hipblasSsyrk);
     MAP2CF_D64(hipblasSyrk, double, hipblasDsyrk);
-    MAP2CF_D64_V2(hipblasSyrk, hipblasComplex, hipblasCsyrk);
-    MAP2CF_D64_V2(hipblasSyrk, hipblasDoubleComplex, hipblasZsyrk);
+    MAP2CF_D64_V2(hipblasSyrk, std::complex<float>, hipblasCsyrk);
+    MAP2CF_D64_V2(hipblasSyrk, std::complex<double>, hipblasZsyrk);
 
     MAP2CF_D64(hipblasSyrkBatched, float, hipblasSsyrkBatched);
     MAP2CF_D64(hipblasSyrkBatched, double, hipblasDsyrkBatched);
-    MAP2CF_D64_V2(hipblasSyrkBatched, hipblasComplex, hipblasCsyrkBatched);
-    MAP2CF_D64_V2(hipblasSyrkBatched, hipblasDoubleComplex, hipblasZsyrkBatched);
+    MAP2CF_D64_V2(hipblasSyrkBatched, std::complex<float>, hipblasCsyrkBatched);
+    MAP2CF_D64_V2(hipblasSyrkBatched, std::complex<double>, hipblasZsyrkBatched);
 
     MAP2CF_D64(hipblasSyrkStridedBatched, float, hipblasSsyrkStridedBatched);
     MAP2CF_D64(hipblasSyrkStridedBatched, double, hipblasDsyrkStridedBatched);
-    MAP2CF_D64_V2(hipblasSyrkStridedBatched, hipblasComplex, hipblasCsyrkStridedBatched);
-    MAP2CF_D64_V2(hipblasSyrkStridedBatched, hipblasDoubleComplex, hipblasZsyrkStridedBatched);
+    MAP2CF_D64_V2(hipblasSyrkStridedBatched, std::complex<float>, hipblasCsyrkStridedBatched);
+    MAP2CF_D64_V2(hipblasSyrkStridedBatched, std::complex<double>, hipblasZsyrkStridedBatched);
 
     // syr2k
     template <typename T, bool FORTRAN = false>
@@ -11055,13 +11056,13 @@ namespace
                                     hipblasOperation_t transA,
                                     int                n,
                                     int                k,
-                                    const T*           alpha,
-                                    const T*           A,
+                                    const hipblas_internal_type<T>*           alpha,
+                                    const hipblas_internal_type<T>*           A,
                                     int                lda,
-                                    const T*           B,
+                                    const hipblas_internal_type<T>*           B,
                                     int                ldb,
-                                    const T*           beta,
-                                    T*                 C,
+                                    const hipblas_internal_type<T>*           beta,
+                                    hipblas_internal_type<T>*                 C,
                                     int                ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11070,13 +11071,13 @@ namespace
                                            hipblasOperation_t transA,
                                            int                n,
                                            int                k,
-                                           const T*           alpha,
-                                           const T* const     A[],
+                                           const hipblas_internal_type<T>*           alpha,
+                                           const hipblas_internal_type<T>* const     A[],
                                            int                lda,
-                                           const T* const     B[],
+                                           const hipblas_internal_type<T>* const     B[],
                                            int                ldb,
-                                           const T*           beta,
-                                           T* const           C[],
+                                           const hipblas_internal_type<T>*           beta,
+                                           hipblas_internal_type<T>* const           C[],
                                            int                ldc,
                                            int                batchCount);
 
@@ -11086,15 +11087,15 @@ namespace
                                                   hipblasOperation_t transA,
                                                   int                n,
                                                   int                k,
-                                                  const T*           alpha,
-                                                  const T*           A,
+                                                  const hipblas_internal_type<T>*           alpha,
+                                                  const hipblas_internal_type<T>*           A,
                                                   int                lda,
                                                   hipblasStride      strideA,
-                                                  const T*           B,
+                                                  const hipblas_internal_type<T>*           B,
                                                   int                ldb,
                                                   hipblasStride      strideB,
-                                                  const T*           beta,
-                                                  T*                 C,
+                                                  const hipblas_internal_type<T>*           beta,
+                                                  hipblas_internal_type<T>*                 C,
                                                   int                ldc,
                                                   hipblasStride      strideC,
                                                   int                batchCount);
@@ -11105,13 +11106,13 @@ namespace
                                        hipblasOperation_t transA,
                                        int64_t            n,
                                        int64_t            k,
-                                       const T*           alpha,
-                                       const T*           A,
+                                       const hipblas_internal_type<T>*           alpha,
+                                       const hipblas_internal_type<T>*           A,
                                        int64_t            lda,
-                                       const T*           B,
+                                       const hipblas_internal_type<T>*           B,
                                        int64_t            ldb,
-                                       const T*           beta,
-                                       T*                 C,
+                                       const hipblas_internal_type<T>*           beta,
+                                       hipblas_internal_type<T>*                 C,
                                        int64_t            ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11120,13 +11121,13 @@ namespace
                                               hipblasOperation_t transA,
                                               int64_t            n,
                                               int64_t            k,
-                                              const T*           alpha,
-                                              const T* const     A[],
+                                              const hipblas_internal_type<T>*           alpha,
+                                              const hipblas_internal_type<T>* const     A[],
                                               int64_t            lda,
-                                              const T* const     B[],
+                                              const hipblas_internal_type<T>* const     B[],
                                               int64_t            ldb,
-                                              const T*           beta,
-                                              T* const           C[],
+                                              const hipblas_internal_type<T>*           beta,
+                                              hipblas_internal_type<T>* const           C[],
                                               int64_t            ldc,
                                               int64_t            batchCount);
 
@@ -11136,33 +11137,33 @@ namespace
                                                      hipblasOperation_t transA,
                                                      int64_t            n,
                                                      int64_t            k,
-                                                     const T*           alpha,
-                                                     const T*           A,
+                                                     const hipblas_internal_type<T>*           alpha,
+                                                     const hipblas_internal_type<T>*           A,
                                                      int64_t            lda,
                                                      hipblasStride      strideA,
-                                                     const T*           B,
+                                                     const hipblas_internal_type<T>*           B,
                                                      int64_t            ldb,
                                                      hipblasStride      strideB,
-                                                     const T*           beta,
-                                                     T*                 C,
+                                                     const hipblas_internal_type<T>*           beta,
+                                                     hipblas_internal_type<T>*                 C,
                                                      int64_t            ldc,
                                                      hipblasStride      strideC,
                                                      int64_t            batchCount);
 
     MAP2CF_D64(hipblasSyr2k, float, hipblasSsyr2k);
     MAP2CF_D64(hipblasSyr2k, double, hipblasDsyr2k);
-    MAP2CF_D64_V2(hipblasSyr2k, hipblasComplex, hipblasCsyr2k);
-    MAP2CF_D64_V2(hipblasSyr2k, hipblasDoubleComplex, hipblasZsyr2k);
+    MAP2CF_D64_V2(hipblasSyr2k, std::complex<float>, hipblasCsyr2k);
+    MAP2CF_D64_V2(hipblasSyr2k, std::complex<double>, hipblasZsyr2k);
 
     MAP2CF_D64(hipblasSyr2kBatched, float, hipblasSsyr2kBatched);
     MAP2CF_D64(hipblasSyr2kBatched, double, hipblasDsyr2kBatched);
-    MAP2CF_D64_V2(hipblasSyr2kBatched, hipblasComplex, hipblasCsyr2kBatched);
-    MAP2CF_D64_V2(hipblasSyr2kBatched, hipblasDoubleComplex, hipblasZsyr2kBatched);
+    MAP2CF_D64_V2(hipblasSyr2kBatched, std::complex<float>, hipblasCsyr2kBatched);
+    MAP2CF_D64_V2(hipblasSyr2kBatched, std::complex<double>, hipblasZsyr2kBatched);
 
     MAP2CF_D64(hipblasSyr2kStridedBatched, float, hipblasSsyr2kStridedBatched);
     MAP2CF_D64(hipblasSyr2kStridedBatched, double, hipblasDsyr2kStridedBatched);
-    MAP2CF_D64_V2(hipblasSyr2kStridedBatched, hipblasComplex, hipblasCsyr2kStridedBatched);
-    MAP2CF_D64_V2(hipblasSyr2kStridedBatched, hipblasDoubleComplex, hipblasZsyr2kStridedBatched);
+    MAP2CF_D64_V2(hipblasSyr2kStridedBatched, std::complex<float>, hipblasCsyr2kStridedBatched);
+    MAP2CF_D64_V2(hipblasSyr2kStridedBatched, std::complex<double>, hipblasZsyr2kStridedBatched);
 
     // syrkx
     template <typename T, bool FORTRAN = false>
@@ -11171,13 +11172,13 @@ namespace
                                     hipblasOperation_t transA,
                                     int                n,
                                     int                k,
-                                    const T*           alpha,
-                                    const T*           A,
+                                    const hipblas_internal_type<T>*           alpha,
+                                    const hipblas_internal_type<T>*           A,
                                     int                lda,
-                                    const T*           B,
+                                    const hipblas_internal_type<T>*           B,
                                     int                ldb,
-                                    const T*           beta,
-                                    T*                 C,
+                                    const hipblas_internal_type<T>*           beta,
+                                    hipblas_internal_type<T>*                 C,
                                     int                ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11186,13 +11187,13 @@ namespace
                                            hipblasOperation_t transA,
                                            int                n,
                                            int                k,
-                                           const T*           alpha,
-                                           const T* const     A[],
+                                           const hipblas_internal_type<T>*           alpha,
+                                           const hipblas_internal_type<T>* const     A[],
                                            int                lda,
-                                           const T* const     B[],
+                                           const hipblas_internal_type<T>* const     B[],
                                            int                ldb,
-                                           const T*           beta,
-                                           T* const           C[],
+                                           const hipblas_internal_type<T>*           beta,
+                                           hipblas_internal_type<T>* const           C[],
                                            int                ldc,
                                            int                batchCount);
 
@@ -11202,15 +11203,15 @@ namespace
                                                   hipblasOperation_t transA,
                                                   int                n,
                                                   int                k,
-                                                  const T*           alpha,
-                                                  const T*           A,
+                                                  const hipblas_internal_type<T>*           alpha,
+                                                  const hipblas_internal_type<T>*           A,
                                                   int                lda,
                                                   hipblasStride      strideA,
-                                                  const T*           B,
+                                                  const hipblas_internal_type<T>*           B,
                                                   int                ldb,
                                                   hipblasStride      strideB,
-                                                  const T*           beta,
-                                                  T*                 C,
+                                                  const hipblas_internal_type<T>*           beta,
+                                                  hipblas_internal_type<T>*                 C,
                                                   int                ldc,
                                                   hipblasStride      strideC,
                                                   int                batchCount);
@@ -11221,13 +11222,13 @@ namespace
                                        hipblasOperation_t transA,
                                        int64_t            n,
                                        int64_t            k,
-                                       const T*           alpha,
-                                       const T*           A,
+                                       const hipblas_internal_type<T>*           alpha,
+                                       const hipblas_internal_type<T>*           A,
                                        int64_t            lda,
-                                       const T*           B,
+                                       const hipblas_internal_type<T>*           B,
                                        int64_t            ldb,
-                                       const T*           beta,
-                                       T*                 C,
+                                       const hipblas_internal_type<T>*           beta,
+                                       hipblas_internal_type<T>*                 C,
                                        int64_t            ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11236,13 +11237,13 @@ namespace
                                               hipblasOperation_t transA,
                                               int64_t            n,
                                               int64_t            k,
-                                              const T*           alpha,
-                                              const T* const     A[],
+                                              const hipblas_internal_type<T>*           alpha,
+                                              const hipblas_internal_type<T>* const     A[],
                                               int64_t            lda,
-                                              const T* const     B[],
+                                              const hipblas_internal_type<T>* const     B[],
                                               int64_t            ldb,
-                                              const T*           beta,
-                                              T* const           C[],
+                                              const hipblas_internal_type<T>*           beta,
+                                              hipblas_internal_type<T>* const           C[],
                                               int64_t            ldc,
                                               int64_t            batchCount);
 
@@ -11252,33 +11253,33 @@ namespace
                                                      hipblasOperation_t transA,
                                                      int64_t            n,
                                                      int64_t            k,
-                                                     const T*           alpha,
-                                                     const T*           A,
+                                                     const hipblas_internal_type<T>*           alpha,
+                                                     const hipblas_internal_type<T>*           A,
                                                      int64_t            lda,
                                                      hipblasStride      strideA,
-                                                     const T*           B,
+                                                     const hipblas_internal_type<T>*           B,
                                                      int64_t            ldb,
                                                      hipblasStride      strideB,
-                                                     const T*           beta,
-                                                     T*                 C,
+                                                     const hipblas_internal_type<T>*           beta,
+                                                     hipblas_internal_type<T>*                 C,
                                                      int64_t            ldc,
                                                      hipblasStride      strideC,
                                                      int64_t            batchCount);
 
     MAP2CF_D64(hipblasSyrkx, float, hipblasSsyrkx);
     MAP2CF_D64(hipblasSyrkx, double, hipblasDsyrkx);
-    MAP2CF_D64_V2(hipblasSyrkx, hipblasComplex, hipblasCsyrkx);
-    MAP2CF_D64_V2(hipblasSyrkx, hipblasDoubleComplex, hipblasZsyrkx);
+    MAP2CF_D64_V2(hipblasSyrkx, std::complex<float>, hipblasCsyrkx);
+    MAP2CF_D64_V2(hipblasSyrkx, std::complex<double>, hipblasZsyrkx);
 
     MAP2CF_D64(hipblasSyrkxBatched, float, hipblasSsyrkxBatched);
     MAP2CF_D64(hipblasSyrkxBatched, double, hipblasDsyrkxBatched);
-    MAP2CF_D64_V2(hipblasSyrkxBatched, hipblasComplex, hipblasCsyrkxBatched);
-    MAP2CF_D64_V2(hipblasSyrkxBatched, hipblasDoubleComplex, hipblasZsyrkxBatched);
+    MAP2CF_D64_V2(hipblasSyrkxBatched, std::complex<float>, hipblasCsyrkxBatched);
+    MAP2CF_D64_V2(hipblasSyrkxBatched, std::complex<double>, hipblasZsyrkxBatched);
 
     MAP2CF_D64(hipblasSyrkxStridedBatched, float, hipblasSsyrkxStridedBatched);
     MAP2CF_D64(hipblasSyrkxStridedBatched, double, hipblasDsyrkxStridedBatched);
-    MAP2CF_D64_V2(hipblasSyrkxStridedBatched, hipblasComplex, hipblasCsyrkxStridedBatched);
-    MAP2CF_D64_V2(hipblasSyrkxStridedBatched, hipblasDoubleComplex, hipblasZsyrkxStridedBatched);
+    MAP2CF_D64_V2(hipblasSyrkxStridedBatched, std::complex<float>, hipblasCsyrkxStridedBatched);
+    MAP2CF_D64_V2(hipblasSyrkxStridedBatched, std::complex<double>, hipblasZsyrkxStridedBatched);
 
     // geam
     template <typename T, bool FORTRAN = false>
@@ -11287,13 +11288,13 @@ namespace
                                    hipblasOperation_t transB,
                                    int                m,
                                    int                n,
-                                   const T*           alpha,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           alpha,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   const T*           beta,
-                                   const T*           B,
+                                   const hipblas_internal_type<T>*           beta,
+                                   const hipblas_internal_type<T>*           B,
                                    int                ldb,
-                                   T*                 C,
+                                   hipblas_internal_type<T>*                 C,
                                    int                ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11302,13 +11303,13 @@ namespace
                                           hipblasOperation_t transB,
                                           int                m,
                                           int                n,
-                                          const T*           alpha,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>*           alpha,
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          const T*           beta,
-                                          const T* const     B[],
+                                          const hipblas_internal_type<T>*           beta,
+                                          const hipblas_internal_type<T>* const     B[],
                                           int                ldb,
-                                          T* const           C[],
+                                          hipblas_internal_type<T>* const           C[],
                                           int                ldc,
                                           int                batchCount);
 
@@ -11318,15 +11319,15 @@ namespace
                                                  hipblasOperation_t transB,
                                                  int                m,
                                                  int                n,
-                                                 const T*           alpha,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           alpha,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      strideA,
-                                                 const T*           beta,
-                                                 const T*           B,
+                                                 const hipblas_internal_type<T>*           beta,
+                                                 const hipblas_internal_type<T>*           B,
                                                  int                ldb,
                                                  hipblasStride      strideB,
-                                                 T*                 C,
+                                                 hipblas_internal_type<T>*                 C,
                                                  int                ldc,
                                                  hipblasStride      strideC,
                                                  int                batchCount);
@@ -11337,13 +11338,13 @@ namespace
                                       hipblasOperation_t transB,
                                       int64_t            m,
                                       int64_t            n,
-                                      const T*           alpha,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           alpha,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      const T*           beta,
-                                      const T*           B,
+                                      const hipblas_internal_type<T>*           beta,
+                                      const hipblas_internal_type<T>*           B,
                                       int64_t            ldb,
-                                      T*                 C,
+                                      hipblas_internal_type<T>*                 C,
                                       int64_t            ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11352,13 +11353,13 @@ namespace
                                              hipblasOperation_t transB,
                                              int64_t            m,
                                              int64_t            n,
-                                             const T*           alpha,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>*           alpha,
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             const T*           beta,
-                                             const T* const     B[],
+                                             const hipblas_internal_type<T>*           beta,
+                                             const hipblas_internal_type<T>* const     B[],
                                              int64_t            ldb,
-                                             T* const           C[],
+                                             hipblas_internal_type<T>* const           C[],
                                              int64_t            ldc,
                                              int64_t            batchCount);
 
@@ -11368,33 +11369,33 @@ namespace
                                                     hipblasOperation_t transB,
                                                     int64_t            m,
                                                     int64_t            n,
-                                                    const T*           alpha,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           alpha,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      strideA,
-                                                    const T*           beta,
-                                                    const T*           B,
+                                                    const hipblas_internal_type<T>*           beta,
+                                                    const hipblas_internal_type<T>*           B,
                                                     int64_t            ldb,
                                                     hipblasStride      strideB,
-                                                    T*                 C,
+                                                    hipblas_internal_type<T>*                 C,
                                                     int64_t            ldc,
                                                     hipblasStride      strideC,
                                                     int64_t            batchCount);
 
     MAP2CF_D64(hipblasGeam, float, hipblasSgeam);
     MAP2CF_D64(hipblasGeam, double, hipblasDgeam);
-    MAP2CF_D64_V2(hipblasGeam, hipblasComplex, hipblasCgeam);
-    MAP2CF_D64_V2(hipblasGeam, hipblasDoubleComplex, hipblasZgeam);
+    MAP2CF_D64_V2(hipblasGeam, std::complex<float>, hipblasCgeam);
+    MAP2CF_D64_V2(hipblasGeam, std::complex<double>, hipblasZgeam);
 
     MAP2CF_D64(hipblasGeamBatched, float, hipblasSgeamBatched);
     MAP2CF_D64(hipblasGeamBatched, double, hipblasDgeamBatched);
-    MAP2CF_D64_V2(hipblasGeamBatched, hipblasComplex, hipblasCgeamBatched);
-    MAP2CF_D64_V2(hipblasGeamBatched, hipblasDoubleComplex, hipblasZgeamBatched);
+    MAP2CF_D64_V2(hipblasGeamBatched, std::complex<float>, hipblasCgeamBatched);
+    MAP2CF_D64_V2(hipblasGeamBatched, std::complex<double>, hipblasZgeamBatched);
 
     MAP2CF_D64(hipblasGeamStridedBatched, float, hipblasSgeamStridedBatched);
     MAP2CF_D64(hipblasGeamStridedBatched, double, hipblasDgeamStridedBatched);
-    MAP2CF_D64_V2(hipblasGeamStridedBatched, hipblasComplex, hipblasCgeamStridedBatched);
-    MAP2CF_D64_V2(hipblasGeamStridedBatched, hipblasDoubleComplex, hipblasZgeamStridedBatched);
+    MAP2CF_D64_V2(hipblasGeamStridedBatched, std::complex<float>, hipblasCgeamStridedBatched);
+    MAP2CF_D64_V2(hipblasGeamStridedBatched, std::complex<double>, hipblasZgeamStridedBatched);
 
     // hemm
     template <typename T, bool FORTRAN = false>
@@ -11403,13 +11404,13 @@ namespace
                                    hipblasFillMode_t uplo,
                                    int               n,
                                    int               k,
-                                   const T*          alpha,
-                                   const T*          A,
+                                   const hipblas_internal_type<T>*          alpha,
+                                   const hipblas_internal_type<T>*          A,
                                    int               lda,
-                                   const T*          B,
+                                   const hipblas_internal_type<T>*          B,
                                    int               ldb,
-                                   const T*          beta,
-                                   T*                C,
+                                   const hipblas_internal_type<T>*          beta,
+                                   hipblas_internal_type<T>*                C,
                                    int               ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11418,13 +11419,13 @@ namespace
                                           hipblasFillMode_t uplo,
                                           int               n,
                                           int               k,
-                                          const T*          alpha,
-                                          const T* const    A[],
+                                          const hipblas_internal_type<T>*          alpha,
+                                          const hipblas_internal_type<T>* const    A[],
                                           int               lda,
-                                          const T* const    B[],
+                                          const hipblas_internal_type<T>* const    B[],
                                           int               ldb,
-                                          const T*          beta,
-                                          T* const          C[],
+                                          const hipblas_internal_type<T>*          beta,
+                                          hipblas_internal_type<T>* const          C[],
                                           int               ldc,
                                           int               batchCount);
 
@@ -11434,15 +11435,15 @@ namespace
                                                  hipblasFillMode_t uplo,
                                                  int               n,
                                                  int               k,
-                                                 const T*          alpha,
-                                                 const T*          A,
+                                                 const hipblas_internal_type<T>*          alpha,
+                                                 const hipblas_internal_type<T>*          A,
                                                  int               lda,
                                                  hipblasStride     strideA,
-                                                 const T*          B,
+                                                 const hipblas_internal_type<T>*          B,
                                                  int               ldb,
                                                  hipblasStride     strideB,
-                                                 const T*          beta,
-                                                 T*                C,
+                                                 const hipblas_internal_type<T>*          beta,
+                                                 hipblas_internal_type<T>*                C,
                                                  int               ldc,
                                                  hipblasStride     strideC,
                                                  int               batchCount);
@@ -11453,13 +11454,13 @@ namespace
                                       hipblasFillMode_t uplo,
                                       int64_t           n,
                                       int64_t           k,
-                                      const T*          alpha,
-                                      const T*          A,
+                                      const hipblas_internal_type<T>*          alpha,
+                                      const hipblas_internal_type<T>*          A,
                                       int64_t           lda,
-                                      const T*          B,
+                                      const hipblas_internal_type<T>*          B,
                                       int64_t           ldb,
-                                      const T*          beta,
-                                      T*                C,
+                                      const hipblas_internal_type<T>*          beta,
+                                      hipblas_internal_type<T>*                C,
                                       int64_t           ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11468,13 +11469,13 @@ namespace
                                              hipblasFillMode_t uplo,
                                              int64_t           n,
                                              int64_t           k,
-                                             const T*          alpha,
-                                             const T* const    A[],
+                                             const hipblas_internal_type<T>*          alpha,
+                                             const hipblas_internal_type<T>* const    A[],
                                              int64_t           lda,
-                                             const T* const    B[],
+                                             const hipblas_internal_type<T>* const    B[],
                                              int64_t           ldb,
-                                             const T*          beta,
-                                             T* const          C[],
+                                             const hipblas_internal_type<T>*          beta,
+                                             hipblas_internal_type<T>* const          C[],
                                              int64_t           ldc,
                                              int64_t           batchCount);
 
@@ -11484,27 +11485,27 @@ namespace
                                                     hipblasFillMode_t uplo,
                                                     int64_t           n,
                                                     int64_t           k,
-                                                    const T*          alpha,
-                                                    const T*          A,
+                                                    const hipblas_internal_type<T>*          alpha,
+                                                    const hipblas_internal_type<T>*          A,
                                                     int64_t           lda,
                                                     hipblasStride     strideA,
-                                                    const T*          B,
+                                                    const hipblas_internal_type<T>*          B,
                                                     int64_t           ldb,
                                                     hipblasStride     strideB,
-                                                    const T*          beta,
-                                                    T*                C,
+                                                    const hipblas_internal_type<T>*          beta,
+                                                    hipblas_internal_type<T>*                C,
                                                     int64_t           ldc,
                                                     hipblasStride     strideC,
                                                     int64_t           batchCount);
 
-    MAP2CF_D64_V2(hipblasHemm, hipblasComplex, hipblasChemm);
-    MAP2CF_D64_V2(hipblasHemm, hipblasDoubleComplex, hipblasZhemm);
+    MAP2CF_D64_V2(hipblasHemm, std::complex<float>, hipblasChemm);
+    MAP2CF_D64_V2(hipblasHemm, std::complex<double>, hipblasZhemm);
 
-    MAP2CF_D64_V2(hipblasHemmBatched, hipblasComplex, hipblasChemmBatched);
-    MAP2CF_D64_V2(hipblasHemmBatched, hipblasDoubleComplex, hipblasZhemmBatched);
+    MAP2CF_D64_V2(hipblasHemmBatched, std::complex<float>, hipblasChemmBatched);
+    MAP2CF_D64_V2(hipblasHemmBatched, std::complex<double>, hipblasZhemmBatched);
 
-    MAP2CF_D64_V2(hipblasHemmStridedBatched, hipblasComplex, hipblasChemmStridedBatched);
-    MAP2CF_D64_V2(hipblasHemmStridedBatched, hipblasDoubleComplex, hipblasZhemmStridedBatched);
+    MAP2CF_D64_V2(hipblasHemmStridedBatched, std::complex<float>, hipblasChemmStridedBatched);
+    MAP2CF_D64_V2(hipblasHemmStridedBatched, std::complex<double>, hipblasZhemmStridedBatched);
 
     // trmm
     template <typename T, bool FORTRAN = false>
@@ -11515,12 +11516,12 @@ namespace
                                    hipblasDiagType_t  diag,
                                    int                m,
                                    int                n,
-                                   const T*           alpha,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           alpha,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   const T*           B,
+                                   const hipblas_internal_type<T>*           B,
                                    int                ldb,
-                                   T*                 C,
+                                   hipblas_internal_type<T>*                 C,
                                    int                ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11531,12 +11532,12 @@ namespace
                                           hipblasDiagType_t  diag,
                                           int                m,
                                           int                n,
-                                          const T*           alpha,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>*           alpha,
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          const T* const     B[],
+                                          const hipblas_internal_type<T>* const     B[],
                                           int                ldb,
-                                          T* const           C[],
+                                          hipblas_internal_type<T>* const           C[],
                                           int                ldc,
                                           int                batchCount);
 
@@ -11548,14 +11549,14 @@ namespace
                                                  hipblasDiagType_t  diag,
                                                  int                m,
                                                  int                n,
-                                                 const T*           alpha,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           alpha,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      strideA,
-                                                 const T*           B,
+                                                 const hipblas_internal_type<T>*           B,
                                                  int                ldb,
                                                  hipblasStride      strideB,
-                                                 T*                 C,
+                                                 hipblas_internal_type<T>*                 C,
                                                  int                ldc,
                                                  hipblasStride      strideC,
                                                  int                batchCount);
@@ -11568,12 +11569,12 @@ namespace
                                       hipblasDiagType_t  diag,
                                       int64_t            m,
                                       int64_t            n,
-                                      const T*           alpha,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           alpha,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      const T*           B,
+                                      const hipblas_internal_type<T>*           B,
                                       int64_t            ldb,
-                                      T*                 C,
+                                      hipblas_internal_type<T>*                 C,
                                       int64_t            ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11584,12 +11585,12 @@ namespace
                                              hipblasDiagType_t  diag,
                                              int64_t            m,
                                              int64_t            n,
-                                             const T*           alpha,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>*           alpha,
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             const T* const     B[],
+                                             const hipblas_internal_type<T>* const     B[],
                                              int64_t            ldb,
-                                             T* const           C[],
+                                             hipblas_internal_type<T>* const           C[],
                                              int64_t            ldc,
                                              int64_t            batchCount);
 
@@ -11601,32 +11602,32 @@ namespace
                                                     hipblasDiagType_t  diag,
                                                     int64_t            m,
                                                     int64_t            n,
-                                                    const T*           alpha,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           alpha,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      strideA,
-                                                    const T*           B,
+                                                    const hipblas_internal_type<T>*           B,
                                                     int64_t            ldb,
                                                     hipblasStride      strideB,
-                                                    T*                 C,
+                                                    hipblas_internal_type<T>*                 C,
                                                     int64_t            ldc,
                                                     hipblasStride      strideC,
                                                     int64_t            batchCount);
 
     MAP2CF_D64(hipblasTrmm, float, hipblasStrmm);
     MAP2CF_D64(hipblasTrmm, double, hipblasDtrmm);
-    MAP2CF_D64_V2(hipblasTrmm, hipblasComplex, hipblasCtrmm);
-    MAP2CF_D64_V2(hipblasTrmm, hipblasDoubleComplex, hipblasZtrmm);
+    MAP2CF_D64_V2(hipblasTrmm, std::complex<float>, hipblasCtrmm);
+    MAP2CF_D64_V2(hipblasTrmm, std::complex<double>, hipblasZtrmm);
 
     MAP2CF_D64(hipblasTrmmBatched, float, hipblasStrmmBatched);
     MAP2CF_D64(hipblasTrmmBatched, double, hipblasDtrmmBatched);
-    MAP2CF_D64_V2(hipblasTrmmBatched, hipblasComplex, hipblasCtrmmBatched);
-    MAP2CF_D64_V2(hipblasTrmmBatched, hipblasDoubleComplex, hipblasZtrmmBatched);
+    MAP2CF_D64_V2(hipblasTrmmBatched, std::complex<float>, hipblasCtrmmBatched);
+    MAP2CF_D64_V2(hipblasTrmmBatched, std::complex<double>, hipblasZtrmmBatched);
 
     MAP2CF_D64(hipblasTrmmStridedBatched, float, hipblasStrmmStridedBatched);
     MAP2CF_D64(hipblasTrmmStridedBatched, double, hipblasDtrmmStridedBatched);
-    MAP2CF_D64_V2(hipblasTrmmStridedBatched, hipblasComplex, hipblasCtrmmStridedBatched);
-    MAP2CF_D64_V2(hipblasTrmmStridedBatched, hipblasDoubleComplex, hipblasZtrmmStridedBatched);
+    MAP2CF_D64_V2(hipblasTrmmStridedBatched, std::complex<float>, hipblasCtrmmStridedBatched);
+    MAP2CF_D64_V2(hipblasTrmmStridedBatched, std::complex<double>, hipblasZtrmmStridedBatched);
 
     // trsm
     template <typename T, bool FORTRAN = false>
@@ -11637,10 +11638,10 @@ namespace
                                    hipblasDiagType_t  diag,
                                    int                m,
                                    int                n,
-                                   const T*           alpha,
-                                   const T*           A,
+                                   const hipblas_internal_type<T>*           alpha,
+                                   const hipblas_internal_type<T>*           A,
                                    int                lda,
-                                   T*                 B,
+                                   hipblas_internal_type<T>*                 B,
                                    int                ldb);
 
     template <typename T, bool FORTRAN = false>
@@ -11651,10 +11652,10 @@ namespace
                                           hipblasDiagType_t  diag,
                                           int                m,
                                           int                n,
-                                          const T*           alpha,
-                                          const T* const     A[],
+                                          const hipblas_internal_type<T>*           alpha,
+                                          const hipblas_internal_type<T>* const     A[],
                                           int                lda,
-                                          T* const           B[],
+                                          hipblas_internal_type<T>* const           B[],
                                           int                ldb,
                                           int                batch_count);
 
@@ -11666,11 +11667,11 @@ namespace
                                                  hipblasDiagType_t  diag,
                                                  int                m,
                                                  int                n,
-                                                 const T*           alpha,
-                                                 const T*           A,
+                                                 const hipblas_internal_type<T>*           alpha,
+                                                 const hipblas_internal_type<T>*           A,
                                                  int                lda,
                                                  hipblasStride      strideA,
-                                                 T*                 B,
+                                                 hipblas_internal_type<T>*                 B,
                                                  int                ldb,
                                                  hipblasStride      strideB,
                                                  int                batch_count);
@@ -11683,10 +11684,10 @@ namespace
                                       hipblasDiagType_t  diag,
                                       int64_t            m,
                                       int64_t            n,
-                                      const T*           alpha,
-                                      const T*           A,
+                                      const hipblas_internal_type<T>*           alpha,
+                                      const hipblas_internal_type<T>*           A,
                                       int64_t            lda,
-                                      T*                 B,
+                                      hipblas_internal_type<T>*                 B,
                                       int64_t            ldb);
 
     template <typename T, bool FORTRAN = false>
@@ -11697,10 +11698,10 @@ namespace
                                              hipblasDiagType_t  diag,
                                              int64_t            m,
                                              int64_t            n,
-                                             const T*           alpha,
-                                             const T* const     A[],
+                                             const hipblas_internal_type<T>*           alpha,
+                                             const hipblas_internal_type<T>* const     A[],
                                              int64_t            lda,
-                                             T* const           B[],
+                                             hipblas_internal_type<T>* const           B[],
                                              int64_t            ldb,
                                              int64_t            batch_count);
 
@@ -11712,29 +11713,29 @@ namespace
                                                     hipblasDiagType_t  diag,
                                                     int64_t            m,
                                                     int64_t            n,
-                                                    const T*           alpha,
-                                                    const T*           A,
+                                                    const hipblas_internal_type<T>*           alpha,
+                                                    const hipblas_internal_type<T>*           A,
                                                     int64_t            lda,
                                                     hipblasStride      strideA,
-                                                    T*                 B,
+                                                    hipblas_internal_type<T>*                 B,
                                                     int64_t            ldb,
                                                     hipblasStride      strideB,
                                                     int64_t            batch_count);
 
     MAP2CF_D64(hipblasTrsm, float, hipblasStrsm);
     MAP2CF_D64(hipblasTrsm, double, hipblasDtrsm);
-    MAP2CF_D64_V2(hipblasTrsm, hipblasComplex, hipblasCtrsm);
-    MAP2CF_D64_V2(hipblasTrsm, hipblasDoubleComplex, hipblasZtrsm);
+    MAP2CF_D64_V2(hipblasTrsm, std::complex<float>, hipblasCtrsm);
+    MAP2CF_D64_V2(hipblasTrsm, std::complex<double>, hipblasZtrsm);
 
     MAP2CF_D64(hipblasTrsmBatched, float, hipblasStrsmBatched);
     MAP2CF_D64(hipblasTrsmBatched, double, hipblasDtrsmBatched);
-    MAP2CF_D64_V2(hipblasTrsmBatched, hipblasComplex, hipblasCtrsmBatched);
-    MAP2CF_D64_V2(hipblasTrsmBatched, hipblasDoubleComplex, hipblasZtrsmBatched);
+    MAP2CF_D64_V2(hipblasTrsmBatched, std::complex<float>, hipblasCtrsmBatched);
+    MAP2CF_D64_V2(hipblasTrsmBatched, std::complex<double>, hipblasZtrsmBatched);
 
     MAP2CF_D64(hipblasTrsmStridedBatched, float, hipblasStrsmStridedBatched);
     MAP2CF_D64(hipblasTrsmStridedBatched, double, hipblasDtrsmStridedBatched);
-    MAP2CF_D64_V2(hipblasTrsmStridedBatched, hipblasComplex, hipblasCtrsmStridedBatched);
-    MAP2CF_D64_V2(hipblasTrsmStridedBatched, hipblasDoubleComplex, hipblasZtrsmStridedBatched);
+    MAP2CF_D64_V2(hipblasTrsmStridedBatched, std::complex<float>, hipblasCtrsmStridedBatched);
+    MAP2CF_D64_V2(hipblasTrsmStridedBatched, std::complex<double>, hipblasZtrsmStridedBatched);
 
     // dgmm
     template <typename T, bool FORTRAN = false>
@@ -11742,11 +11743,11 @@ namespace
                                    hipblasSideMode_t side,
                                    int               m,
                                    int               n,
-                                   const T*          A,
+                                   const hipblas_internal_type<T>*          A,
                                    int               lda,
-                                   const T*          x,
+                                   const hipblas_internal_type<T>*          x,
                                    int               incx,
-                                   T*                C,
+                                   hipblas_internal_type<T>*                C,
                                    int               ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11754,11 +11755,11 @@ namespace
                                           hipblasSideMode_t side,
                                           int               m,
                                           int               n,
-                                          const T* const    A[],
+                                          const hipblas_internal_type<T>* const    A[],
                                           int               lda,
-                                          const T* const    x[],
+                                          const hipblas_internal_type<T>* const    x[],
                                           int               incx,
-                                          T* const          C[],
+                                          hipblas_internal_type<T>* const          C[],
                                           int               ldc,
                                           int               batch_count);
 
@@ -11767,13 +11768,13 @@ namespace
                                                  hipblasSideMode_t side,
                                                  int               m,
                                                  int               n,
-                                                 const T*          A,
+                                                 const hipblas_internal_type<T>*          A,
                                                  int               lda,
                                                  hipblasStride     stride_A,
-                                                 const T*          x,
+                                                 const hipblas_internal_type<T>*          x,
                                                  int               incx,
                                                  hipblasStride     stride_x,
-                                                 T*                C,
+                                                 hipblas_internal_type<T>*                C,
                                                  int               ldc,
                                                  hipblasStride     stride_C,
                                                  int               batch_count);
@@ -11783,11 +11784,11 @@ namespace
                                       hipblasSideMode_t side,
                                       int64_t           m,
                                       int64_t           n,
-                                      const T*          A,
+                                      const hipblas_internal_type<T>*          A,
                                       int64_t           lda,
-                                      const T*          x,
+                                      const hipblas_internal_type<T>*          x,
                                       int64_t           incx,
-                                      T*                C,
+                                      hipblas_internal_type<T>*                C,
                                       int64_t           ldc);
 
     template <typename T, bool FORTRAN = false>
@@ -11795,11 +11796,11 @@ namespace
                                              hipblasSideMode_t side,
                                              int64_t           m,
                                              int64_t           n,
-                                             const T* const    A[],
+                                             const hipblas_internal_type<T>* const    A[],
                                              int64_t           lda,
-                                             const T* const    x[],
+                                             const hipblas_internal_type<T>* const    x[],
                                              int64_t           incx,
-                                             T* const          C[],
+                                             hipblas_internal_type<T>* const          C[],
                                              int64_t           ldc,
                                              int64_t           batch_count);
 
@@ -11808,31 +11809,31 @@ namespace
                                                     hipblasSideMode_t side,
                                                     int64_t           m,
                                                     int64_t           n,
-                                                    const T*          A,
+                                                    const hipblas_internal_type<T>*          A,
                                                     int64_t           lda,
                                                     hipblasStride     stride_A,
-                                                    const T*          x,
+                                                    const hipblas_internal_type<T>*          x,
                                                     int64_t           incx,
                                                     hipblasStride     stride_x,
-                                                    T*                C,
+                                                    hipblas_internal_type<T>*                C,
                                                     int64_t           ldc,
                                                     hipblasStride     stride_C,
                                                     int64_t           batch_count);
 
     MAP2CF_D64(hipblasDgmm, float, hipblasSdgmm);
     MAP2CF_D64(hipblasDgmm, double, hipblasDdgmm);
-    MAP2CF_D64_V2(hipblasDgmm, hipblasComplex, hipblasCdgmm);
-    MAP2CF_D64_V2(hipblasDgmm, hipblasDoubleComplex, hipblasZdgmm);
+    MAP2CF_D64_V2(hipblasDgmm, std::complex<float>, hipblasCdgmm);
+    MAP2CF_D64_V2(hipblasDgmm, std::complex<double>, hipblasZdgmm);
 
     MAP2CF_D64(hipblasDgmmBatched, float, hipblasSdgmmBatched);
     MAP2CF_D64(hipblasDgmmBatched, double, hipblasDdgmmBatched);
-    MAP2CF_D64_V2(hipblasDgmmBatched, hipblasComplex, hipblasCdgmmBatched);
-    MAP2CF_D64_V2(hipblasDgmmBatched, hipblasDoubleComplex, hipblasZdgmmBatched);
+    MAP2CF_D64_V2(hipblasDgmmBatched, std::complex<float>, hipblasCdgmmBatched);
+    MAP2CF_D64_V2(hipblasDgmmBatched, std::complex<double>, hipblasZdgmmBatched);
 
     MAP2CF_D64(hipblasDgmmStridedBatched, float, hipblasSdgmmStridedBatched);
     MAP2CF_D64(hipblasDgmmStridedBatched, double, hipblasDdgmmStridedBatched);
-    MAP2CF_D64_V2(hipblasDgmmStridedBatched, hipblasComplex, hipblasCdgmmStridedBatched);
-    MAP2CF_D64_V2(hipblasDgmmStridedBatched, hipblasDoubleComplex, hipblasZdgmmStridedBatched);
+    MAP2CF_D64_V2(hipblasDgmmStridedBatched, std::complex<float>, hipblasCdgmmStridedBatched);
+    MAP2CF_D64_V2(hipblasDgmmStridedBatched, std::complex<double>, hipblasZdgmmStridedBatched);
 
     // trtri
     template <typename T, bool FORTRAN = false>
@@ -11840,9 +11841,9 @@ namespace
                                     hipblasFillMode_t uplo,
                                     hipblasDiagType_t diag,
                                     int               n,
-                                    const T*          A,
+                                    const hipblas_internal_type<T>*          A,
                                     int               lda,
-                                    T*                invA,
+                                    hipblas_internal_type<T>*                invA,
                                     int               ldinvA);
 
     template <typename T, bool FORTRAN = false>
@@ -11850,9 +11851,9 @@ namespace
                                            hipblasFillMode_t uplo,
                                            hipblasDiagType_t diag,
                                            int               n,
-                                           const T* const    A[],
+                                           const hipblas_internal_type<T>* const    A[],
                                            int               lda,
-                                           T*                invA[],
+                                           hipblas_internal_type<T>*                invA[],
                                            int               ldinvA,
                                            int               batch_count);
 
@@ -11861,40 +11862,40 @@ namespace
                                                   hipblasFillMode_t uplo,
                                                   hipblasDiagType_t diag,
                                                   int               n,
-                                                  const T*          A,
+                                                  const hipblas_internal_type<T>*          A,
                                                   int               lda,
                                                   hipblasStride     stride_A,
-                                                  T*                invA,
+                                                  hipblas_internal_type<T>*                invA,
                                                   int               ldinvA,
                                                   hipblasStride     stride_invA,
                                                   int               batch_count);
 
     MAP2CF(hipblasTrtri, float, hipblasStrtri);
     MAP2CF(hipblasTrtri, double, hipblasDtrtri);
-    MAP2CF_V2(hipblasTrtri, hipblasComplex, hipblasCtrtri);
-    MAP2CF_V2(hipblasTrtri, hipblasDoubleComplex, hipblasZtrtri);
+    MAP2CF_V2(hipblasTrtri, std::complex<float>, hipblasCtrtri);
+    MAP2CF_V2(hipblasTrtri, std::complex<double>, hipblasZtrtri);
 
     MAP2CF(hipblasTrtriBatched, float, hipblasStrtriBatched);
     MAP2CF(hipblasTrtriBatched, double, hipblasDtrtriBatched);
-    MAP2CF_V2(hipblasTrtriBatched, hipblasComplex, hipblasCtrtriBatched);
-    MAP2CF_V2(hipblasTrtriBatched, hipblasDoubleComplex, hipblasZtrtriBatched);
+    MAP2CF_V2(hipblasTrtriBatched, std::complex<float>, hipblasCtrtriBatched);
+    MAP2CF_V2(hipblasTrtriBatched, std::complex<double>, hipblasZtrtriBatched);
 
     MAP2CF(hipblasTrtriStridedBatched, float, hipblasStrtriStridedBatched);
     MAP2CF(hipblasTrtriStridedBatched, double, hipblasDtrtriStridedBatched);
-    MAP2CF_V2(hipblasTrtriStridedBatched, hipblasComplex, hipblasCtrtriStridedBatched);
-    MAP2CF_V2(hipblasTrtriStridedBatched, hipblasDoubleComplex, hipblasZtrtriStridedBatched);
+    MAP2CF_V2(hipblasTrtriStridedBatched, std::complex<float>, hipblasCtrtriStridedBatched);
+    MAP2CF_V2(hipblasTrtriStridedBatched, std::complex<double>, hipblasZtrtriStridedBatched);
 
 #ifdef __HIP_PLATFORM_SOLVER__
 
     // getrf
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGetrf)(
-        hipblasHandle_t handle, const int n, T* A, const int lda, int* ipiv, int* info);
+        hipblasHandle_t handle, const int n, hipblas_internal_type<T>* A, const int lda, int* ipiv, int* info);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGetrfBatched)(hipblasHandle_t handle,
                                            const int       n,
-                                           T* const        A[],
+                                           hipblas_internal_type<T>* const        A[],
                                            const int       lda,
                                            int*            ipiv,
                                            int*            info,
@@ -11903,7 +11904,7 @@ namespace
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGetrfStridedBatched)(hipblasHandle_t     handle,
                                                   const int           n,
-                                                  T*                  A,
+                                                  hipblas_internal_type<T>*                  A,
                                                   const int           lda,
                                                   const hipblasStride strideA,
                                                   int*                ipiv,
@@ -11913,18 +11914,18 @@ namespace
 
     MAP2CF(hipblasGetrf, float, hipblasSgetrf);
     MAP2CF(hipblasGetrf, double, hipblasDgetrf);
-    MAP2CF_V2(hipblasGetrf, hipblasComplex, hipblasCgetrf);
-    MAP2CF_V2(hipblasGetrf, hipblasDoubleComplex, hipblasZgetrf);
+    MAP2CF_V2(hipblasGetrf, std::complex<float>, hipblasCgetrf);
+    MAP2CF_V2(hipblasGetrf, std::complex<double>, hipblasZgetrf);
 
     MAP2CF(hipblasGetrfBatched, float, hipblasSgetrfBatched);
     MAP2CF(hipblasGetrfBatched, double, hipblasDgetrfBatched);
-    MAP2CF_V2(hipblasGetrfBatched, hipblasComplex, hipblasCgetrfBatched);
-    MAP2CF_V2(hipblasGetrfBatched, hipblasDoubleComplex, hipblasZgetrfBatched);
+    MAP2CF_V2(hipblasGetrfBatched, std::complex<float>, hipblasCgetrfBatched);
+    MAP2CF_V2(hipblasGetrfBatched, std::complex<double>, hipblasZgetrfBatched);
 
     MAP2CF(hipblasGetrfStridedBatched, float, hipblasSgetrfStridedBatched);
     MAP2CF(hipblasGetrfStridedBatched, double, hipblasDgetrfStridedBatched);
-    MAP2CF_V2(hipblasGetrfStridedBatched, hipblasComplex, hipblasCgetrfStridedBatched);
-    MAP2CF_V2(hipblasGetrfStridedBatched, hipblasDoubleComplex, hipblasZgetrfStridedBatched);
+    MAP2CF_V2(hipblasGetrfStridedBatched, std::complex<float>, hipblasCgetrfStridedBatched);
+    MAP2CF_V2(hipblasGetrfStridedBatched, std::complex<double>, hipblasZgetrfStridedBatched);
 
     // getrs
     template <typename T, bool FORTRAN = false>
@@ -11932,10 +11933,10 @@ namespace
                                     const hipblasOperation_t trans,
                                     const int                n,
                                     const int                nrhs,
-                                    T*                       A,
+                                    hipblas_internal_type<T>*                       A,
                                     const int                lda,
                                     const int*               ipiv,
-                                    T*                       B,
+                                    hipblas_internal_type<T>*                       B,
                                     const int                ldb,
                                     int*                     info);
 
@@ -11944,10 +11945,10 @@ namespace
                                            const hipblasOperation_t trans,
                                            const int                n,
                                            const int                nrhs,
-                                           T* const                 A[],
+                                           hipblas_internal_type<T>* const                 A[],
                                            const int                lda,
                                            const int*               ipiv,
-                                           T* const                 B[],
+                                           hipblas_internal_type<T>* const                 B[],
                                            const int                ldb,
                                            int*                     info,
                                            const int                batchCount);
@@ -11957,12 +11958,12 @@ namespace
                                                   const hipblasOperation_t trans,
                                                   const int                n,
                                                   const int                nrhs,
-                                                  T*                       A,
+                                                  hipblas_internal_type<T>*                       A,
                                                   const int                lda,
                                                   const hipblasStride      strideA,
                                                   const int*               ipiv,
                                                   const hipblasStride      strideP,
-                                                  T*                       B,
+                                                  hipblas_internal_type<T>*                       B,
                                                   const int                ldb,
                                                   const hipblasStride      strideB,
                                                   int*                     info,
@@ -11970,48 +11971,48 @@ namespace
 
     MAP2CF(hipblasGetrs, float, hipblasSgetrs);
     MAP2CF(hipblasGetrs, double, hipblasDgetrs);
-    MAP2CF_V2(hipblasGetrs, hipblasComplex, hipblasCgetrs);
-    MAP2CF_V2(hipblasGetrs, hipblasDoubleComplex, hipblasZgetrs);
+    MAP2CF_V2(hipblasGetrs, std::complex<float>, hipblasCgetrs);
+    MAP2CF_V2(hipblasGetrs, std::complex<double>, hipblasZgetrs);
 
     MAP2CF(hipblasGetrsBatched, float, hipblasSgetrsBatched);
     MAP2CF(hipblasGetrsBatched, double, hipblasDgetrsBatched);
-    MAP2CF_V2(hipblasGetrsBatched, hipblasComplex, hipblasCgetrsBatched);
-    MAP2CF_V2(hipblasGetrsBatched, hipblasDoubleComplex, hipblasZgetrsBatched);
+    MAP2CF_V2(hipblasGetrsBatched, std::complex<float>, hipblasCgetrsBatched);
+    MAP2CF_V2(hipblasGetrsBatched, std::complex<double>, hipblasZgetrsBatched);
 
     MAP2CF(hipblasGetrsStridedBatched, float, hipblasSgetrsStridedBatched);
     MAP2CF(hipblasGetrsStridedBatched, double, hipblasDgetrsStridedBatched);
-    MAP2CF_V2(hipblasGetrsStridedBatched, hipblasComplex, hipblasCgetrsStridedBatched);
-    MAP2CF_V2(hipblasGetrsStridedBatched, hipblasDoubleComplex, hipblasZgetrsStridedBatched);
+    MAP2CF_V2(hipblasGetrsStridedBatched, std::complex<float>, hipblasCgetrsStridedBatched);
+    MAP2CF_V2(hipblasGetrsStridedBatched, std::complex<double>, hipblasZgetrsStridedBatched);
 
     // getri
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGetriBatched)(hipblasHandle_t handle,
                                            const int       n,
-                                           T* const        A[],
+                                           hipblas_internal_type<T>* const        A[],
                                            const int       lda,
                                            int*            ipiv,
-                                           T* const        C[],
+                                           hipblas_internal_type<T>* const        C[],
                                            const int       ldc,
                                            int*            info,
                                            const int       batchCount);
 
     MAP2CF(hipblasGetriBatched, float, hipblasSgetriBatched);
     MAP2CF(hipblasGetriBatched, double, hipblasDgetriBatched);
-    MAP2CF_V2(hipblasGetriBatched, hipblasComplex, hipblasCgetriBatched);
-    MAP2CF_V2(hipblasGetriBatched, hipblasDoubleComplex, hipblasZgetriBatched);
+    MAP2CF_V2(hipblasGetriBatched, std::complex<float>, hipblasCgetriBatched);
+    MAP2CF_V2(hipblasGetriBatched, std::complex<double>, hipblasZgetriBatched);
 
     // geqrf
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGeqrf)(
-        hipblasHandle_t handle, const int m, const int n, T* A, const int lda, T* ipiv, int* info);
+        hipblasHandle_t handle, const int m, const int n, hipblas_internal_type<T>* A, const int lda, hipblas_internal_type<T>* ipiv, int* info);
 
     template <typename T, bool FORTRAN = false>
     hipblasStatus_t (*hipblasGeqrfBatched)(hipblasHandle_t handle,
                                            const int       m,
                                            const int       n,
-                                           T* const        A[],
+                                           hipblas_internal_type<T>* const        A[],
                                            const int       lda,
-                                           T* const        ipiv[],
+                                           hipblas_internal_type<T>* const        ipiv[],
                                            int*            info,
                                            const int       batchCount);
 
@@ -12019,28 +12020,28 @@ namespace
     hipblasStatus_t (*hipblasGeqrfStridedBatched)(hipblasHandle_t     handle,
                                                   const int           m,
                                                   const int           n,
-                                                  T*                  A,
+                                                  hipblas_internal_type<T>*                  A,
                                                   const int           lda,
                                                   const hipblasStride strideA,
-                                                  T*                  ipiv,
+                                                  hipblas_internal_type<T>*                  ipiv,
                                                   const hipblasStride strideP,
                                                   int*                info,
                                                   const int           batchCount);
 
     MAP2CF(hipblasGeqrf, float, hipblasSgeqrf);
     MAP2CF(hipblasGeqrf, double, hipblasDgeqrf);
-    MAP2CF_V2(hipblasGeqrf, hipblasComplex, hipblasCgeqrf);
-    MAP2CF_V2(hipblasGeqrf, hipblasDoubleComplex, hipblasZgeqrf);
+    MAP2CF_V2(hipblasGeqrf, std::complex<float>, hipblasCgeqrf);
+    MAP2CF_V2(hipblasGeqrf, std::complex<double>, hipblasZgeqrf);
 
     MAP2CF(hipblasGeqrfBatched, float, hipblasSgeqrfBatched);
     MAP2CF(hipblasGeqrfBatched, double, hipblasDgeqrfBatched);
-    MAP2CF_V2(hipblasGeqrfBatched, hipblasComplex, hipblasCgeqrfBatched);
-    MAP2CF_V2(hipblasGeqrfBatched, hipblasDoubleComplex, hipblasZgeqrfBatched);
+    MAP2CF_V2(hipblasGeqrfBatched, std::complex<float>, hipblasCgeqrfBatched);
+    MAP2CF_V2(hipblasGeqrfBatched, std::complex<double>, hipblasZgeqrfBatched);
 
     MAP2CF(hipblasGeqrfStridedBatched, float, hipblasSgeqrfStridedBatched);
     MAP2CF(hipblasGeqrfStridedBatched, double, hipblasDgeqrfStridedBatched);
-    MAP2CF_V2(hipblasGeqrfStridedBatched, hipblasComplex, hipblasCgeqrfStridedBatched);
-    MAP2CF_V2(hipblasGeqrfStridedBatched, hipblasDoubleComplex, hipblasZgeqrfStridedBatched);
+    MAP2CF_V2(hipblasGeqrfStridedBatched, std::complex<float>, hipblasCgeqrfStridedBatched);
+    MAP2CF_V2(hipblasGeqrfStridedBatched, std::complex<double>, hipblasZgeqrfStridedBatched);
 
     // gels
     template <typename T, bool FORTRAN = false>
@@ -12049,9 +12050,9 @@ namespace
                                    const int          m,
                                    const int          n,
                                    const int          nrhs,
-                                   T*                 A,
+                                   hipblas_internal_type<T>*                 A,
                                    const int          lda,
-                                   T*                 B,
+                                   hipblas_internal_type<T>*                 B,
                                    const int          ldb,
                                    int*               info,
                                    int*               deviceInfo);
@@ -12062,9 +12063,9 @@ namespace
                                           const int          m,
                                           const int          n,
                                           const int          nrhs,
-                                          T* const           A[],
+                                          hipblas_internal_type<T>* const           A[],
                                           const int          lda,
-                                          T* const           B[],
+                                          hipblas_internal_type<T>* const           B[],
                                           const int          ldb,
                                           int*               info,
                                           int*               deviceInfo,
@@ -12076,10 +12077,10 @@ namespace
                                                  const int           m,
                                                  const int           n,
                                                  const int           nrhs,
-                                                 T*                  A,
+                                                 hipblas_internal_type<T>*                  A,
                                                  const int           lda,
                                                  const hipblasStride strideA,
-                                                 T*                  B,
+                                                 hipblas_internal_type<T>*                  B,
                                                  const int           ldb,
                                                  const hipblasStride strideB,
                                                  int*                info,
@@ -12088,18 +12089,18 @@ namespace
 
     MAP2CF(hipblasGels, float, hipblasSgels);
     MAP2CF(hipblasGels, double, hipblasDgels);
-    MAP2CF_V2(hipblasGels, hipblasComplex, hipblasCgels);
-    MAP2CF_V2(hipblasGels, hipblasDoubleComplex, hipblasZgels);
+    MAP2CF_V2(hipblasGels, std::complex<float>, hipblasCgels);
+    MAP2CF_V2(hipblasGels, std::complex<double>, hipblasZgels);
 
     MAP2CF(hipblasGelsBatched, float, hipblasSgelsBatched);
     MAP2CF(hipblasGelsBatched, double, hipblasDgelsBatched);
-    MAP2CF_V2(hipblasGelsBatched, hipblasComplex, hipblasCgelsBatched);
-    MAP2CF_V2(hipblasGelsBatched, hipblasDoubleComplex, hipblasZgelsBatched);
+    MAP2CF_V2(hipblasGelsBatched, std::complex<float>, hipblasCgelsBatched);
+    MAP2CF_V2(hipblasGelsBatched, std::complex<double>, hipblasZgelsBatched);
 
     MAP2CF(hipblasGelsStridedBatched, float, hipblasSgelsStridedBatched);
     MAP2CF(hipblasGelsStridedBatched, double, hipblasDgelsStridedBatched);
-    MAP2CF_V2(hipblasGelsStridedBatched, hipblasComplex, hipblasCgelsStridedBatched);
-    MAP2CF_V2(hipblasGelsStridedBatched, hipblasDoubleComplex, hipblasZgelsStridedBatched);
+    MAP2CF_V2(hipblasGelsStridedBatched, std::complex<float>, hipblasCgelsStridedBatched);
+    MAP2CF_V2(hipblasGelsStridedBatched, std::complex<double>, hipblasZgelsStridedBatched);
 
 #endif
 }

--- a/clients/include/hipblas.hpp
+++ b/clients/include/hipblas.hpp
@@ -7301,41 +7301,52 @@ namespace
 {
     // Scal
     template <typename T, typename U = T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasScal)(hipblasHandle_t handle, int n, const hipblas_internal_type<U>* alpha, hipblas_internal_type<T>* x, int incx);
+    hipblasStatus_t (*hipblasScal)(hipblasHandle_t                 handle,
+                                   int                             n,
+                                   const hipblas_internal_type<U>* alpha,
+                                   hipblas_internal_type<T>*       x,
+                                   int                             incx);
 
     template <typename T, typename U = T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasScalBatched)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<U>* alpha, hipblas_internal_type<T>* const x[], int incx, int batch_count);
+    hipblasStatus_t (*hipblasScalBatched)(hipblasHandle_t                 handle,
+                                          int                             n,
+                                          const hipblas_internal_type<U>* alpha,
+                                          hipblas_internal_type<T>* const x[],
+                                          int                             incx,
+                                          int                             batch_count);
 
     template <typename T, typename U = T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasScalStridedBatched)(hipblasHandle_t handle,
-                                                 int             n,
-                                                 const hipblas_internal_type<U>*        alpha,
-                                                 hipblas_internal_type<T>*              x,
-                                                 int             incx,
-                                                 hipblasStride   stridex,
-                                                 int             batch_count);
+    hipblasStatus_t (*hipblasScalStridedBatched)(hipblasHandle_t                 handle,
+                                                 int                             n,
+                                                 const hipblas_internal_type<U>* alpha,
+                                                 hipblas_internal_type<T>*       x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 int                             batch_count);
 
     template <typename T, typename U = T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasScal_64)(
-        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<U>* alpha, hipblas_internal_type<T>* x, int64_t incx);
+    hipblasStatus_t (*hipblasScal_64)(hipblasHandle_t                 handle,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<U>* alpha,
+                                      hipblas_internal_type<T>*       x,
+                                      int64_t                         incx);
 
     template <typename T, typename U = T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasScalBatched_64)(hipblasHandle_t handle,
-                                             int64_t         n,
-                                             const hipblas_internal_type<U>*        alpha,
-                                             hipblas_internal_type<T>* const        x[],
-                                             int64_t         incx,
-                                             int64_t         batch_count);
+    hipblasStatus_t (*hipblasScalBatched_64)(hipblasHandle_t                 handle,
+                                             int64_t                         n,
+                                             const hipblas_internal_type<U>* alpha,
+                                             hipblas_internal_type<T>* const x[],
+                                             int64_t                         incx,
+                                             int64_t                         batch_count);
 
     template <typename T, typename U = T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasScalStridedBatched_64)(hipblasHandle_t handle,
-                                                    int64_t         n,
-                                                    const hipblas_internal_type<U>*        alpha,
-                                                    hipblas_internal_type<T>*              x,
-                                                    int64_t         incx,
-                                                    hipblasStride   stridex,
-                                                    int64_t         batch_count);
+    hipblasStatus_t (*hipblasScalStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<U>* alpha,
+                                                    hipblas_internal_type<T>*       x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasScal, float, float, hipblasSscal);
     MAP2CF_D64(hipblasScal, double, double, hipblasDscal);
@@ -7346,7 +7357,10 @@ namespace
 
     MAP2CF_D64(hipblasScalBatched, float, float, hipblasSscalBatched);
     MAP2CF_D64(hipblasScalBatched, double, double, hipblasDscalBatched);
-    MAP2CF_D64_V2(hipblasScalBatched, std::complex<float>, std::complex<float>, hipblasCscalBatched);
+    MAP2CF_D64_V2(hipblasScalBatched,
+                  std::complex<float>,
+                  std::complex<float>,
+                  hipblasCscalBatched);
     MAP2CF_D64_V2(hipblasScalBatched,
                   std::complex<double>,
                   std::complex<double>,
@@ -7364,7 +7378,10 @@ namespace
                   std::complex<double>,
                   std::complex<double>,
                   hipblasZscalStridedBatched);
-    MAP2CF_D64_V2(hipblasScalStridedBatched, std::complex<float>, float, hipblasCsscalStridedBatched);
+    MAP2CF_D64_V2(hipblasScalStridedBatched,
+                  std::complex<float>,
+                  float,
+                  hipblasCsscalStridedBatched);
     MAP2CF_D64_V2(hipblasScalStridedBatched,
                   std::complex<double>,
                   double,
@@ -7372,52 +7389,60 @@ namespace
 
     // Copy
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasCopy)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, hipblas_internal_type<T>* y, int incy);
+    hipblasStatus_t (*hipblasCopy)(hipblasHandle_t                 handle,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasCopyBatched)(hipblasHandle_t handle,
-                                          int             n,
-                                          const hipblas_internal_type<T>* const  x[],
-                                          int             incx,
-                                          hipblas_internal_type<T>* const        y[],
-                                          int             incy,
-                                          int             batch_count);
+    hipblasStatus_t (*hipblasCopyBatched)(hipblasHandle_t                       handle,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasCopyStridedBatched)(hipblasHandle_t handle,
-                                                 int             n,
-                                                 const hipblas_internal_type<T>*        x,
-                                                 int             incx,
-                                                 hipblasStride   stridex,
-                                                 hipblas_internal_type<T>*              y,
-                                                 int             incy,
-                                                 hipblasStride   stridey,
-                                                 int             batch_count);
+    hipblasStatus_t (*hipblasCopyStridedBatched)(hipblasHandle_t                 handle,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasCopy_64)(
-        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T>* x, int64_t incx, hipblas_internal_type<T>* y, int64_t incy);
+    hipblasStatus_t (*hipblasCopy_64)(hipblasHandle_t                 handle,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasCopyBatched_64)(hipblasHandle_t handle,
-                                             int64_t         n,
-                                             const hipblas_internal_type<T>* const  x[],
-                                             int64_t         incx,
-                                             hipblas_internal_type<T>* const        y[],
-                                             int64_t         incy,
-                                             int64_t         batch_count);
+    hipblasStatus_t (*hipblasCopyBatched_64)(hipblasHandle_t                       handle,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasCopyStridedBatched_64)(hipblasHandle_t handle,
-                                                    int64_t         n,
-                                                    const hipblas_internal_type<T>*        x,
-                                                    int64_t         incx,
-                                                    hipblasStride   stridex,
-                                                    hipblas_internal_type<T>*              y,
-                                                    int64_t         incy,
-                                                    hipblasStride   stridey,
-                                                    int64_t         batch_count);
+    hipblasStatus_t (*hipblasCopyStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasCopy, float, hipblasScopy);
     MAP2CF_D64(hipblasCopy, double, hipblasDcopy);
@@ -7436,51 +7461,60 @@ namespace
 
     // Swap
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSwap)(hipblasHandle_t handle, int n, hipblas_internal_type<T>* x, int incx, hipblas_internal_type<T>* y, int incy);
+    hipblasStatus_t (*hipblasSwap)(hipblasHandle_t           handle,
+                                   int                       n,
+                                   hipblas_internal_type<T>* x,
+                                   int                       incx,
+                                   hipblas_internal_type<T>* y,
+                                   int                       incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSwapBatched)(hipblasHandle_t handle,
-                                          int             n,
-                                          hipblas_internal_type<T>* const        x[],
-                                          int             incx,
-                                          hipblas_internal_type<T>* const        y[],
-                                          int             incy,
-                                          int             batch_count);
+    hipblasStatus_t (*hipblasSwapBatched)(hipblasHandle_t                 handle,
+                                          int                             n,
+                                          hipblas_internal_type<T>* const x[],
+                                          int                             incx,
+                                          hipblas_internal_type<T>* const y[],
+                                          int                             incy,
+                                          int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSwapStridedBatched)(hipblasHandle_t handle,
-                                                 int             n,
-                                                 hipblas_internal_type<T>*              x,
-                                                 int             incx,
-                                                 hipblasStride   stridex,
-                                                 hipblas_internal_type<T>*              y,
-                                                 int             incy,
-                                                 hipblasStride   stridey,
-                                                 int             batch_count);
+    hipblasStatus_t (*hipblasSwapStridedBatched)(hipblasHandle_t           handle,
+                                                 int                       n,
+                                                 hipblas_internal_type<T>* x,
+                                                 int                       incx,
+                                                 hipblasStride             stridex,
+                                                 hipblas_internal_type<T>* y,
+                                                 int                       incy,
+                                                 hipblasStride             stridey,
+                                                 int                       batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSwap_64)(
-        hipblasHandle_t handle, int64_t n, hipblas_internal_type<T>* x, int64_t incx, hipblas_internal_type<T>* y, int64_t incy);
+    hipblasStatus_t (*hipblasSwap_64)(hipblasHandle_t           handle,
+                                      int64_t                   n,
+                                      hipblas_internal_type<T>* x,
+                                      int64_t                   incx,
+                                      hipblas_internal_type<T>* y,
+                                      int64_t                   incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSwapBatched_64)(hipblasHandle_t handle,
-                                             int64_t         n,
-                                             hipblas_internal_type<T>* const        x[],
-                                             int64_t         incx,
-                                             hipblas_internal_type<T>* const        y[],
-                                             int64_t         incy,
-                                             int64_t         batch_count);
+    hipblasStatus_t (*hipblasSwapBatched_64)(hipblasHandle_t                 handle,
+                                             int64_t                         n,
+                                             hipblas_internal_type<T>* const x[],
+                                             int64_t                         incx,
+                                             hipblas_internal_type<T>* const y[],
+                                             int64_t                         incy,
+                                             int64_t                         batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSwapStridedBatched_64)(hipblasHandle_t handle,
-                                                    int64_t         n,
-                                                    hipblas_internal_type<T>*              x,
-                                                    int64_t         incx,
-                                                    hipblasStride   stridex,
-                                                    hipblas_internal_type<T>*              y,
-                                                    int64_t         incy,
-                                                    hipblasStride   stridey,
-                                                    int64_t         batch_count);
+    hipblasStatus_t (*hipblasSwapStridedBatched_64)(hipblasHandle_t           handle,
+                                                    int64_t                   n,
+                                                    hipblas_internal_type<T>* x,
+                                                    int64_t                   incx,
+                                                    hipblasStride             stridex,
+                                                    hipblas_internal_type<T>* y,
+                                                    int64_t                   incy,
+                                                    hipblasStride             stridey,
+                                                    int64_t                   batch_count);
 
     MAP2CF_D64(hipblasSwap, float, hipblasSswap);
     MAP2CF_D64(hipblasSwap, double, hipblasDswap);
@@ -7499,118 +7533,128 @@ namespace
 
     // Dot
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDot)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, const hipblas_internal_type<T>* y, int incy, hipblas_internal_type<T>* result);
+    hipblasStatus_t (*hipblasDot)(hipblasHandle_t                 handle,
+                                  int                             n,
+                                  const hipblas_internal_type<T>* x,
+                                  int                             incx,
+                                  const hipblas_internal_type<T>* y,
+                                  int                             incy,
+                                  hipblas_internal_type<T>*       result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotc)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, const hipblas_internal_type<T>* y, int incy, hipblas_internal_type<T>* result);
+    hipblasStatus_t (*hipblasDotc)(hipblasHandle_t                 handle,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* y,
+                                   int                             incy,
+                                   hipblas_internal_type<T>*       result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotBatched)(hipblasHandle_t handle,
-                                         int             n,
-                                         const hipblas_internal_type<T>* const  x[],
-                                         int             incx,
-                                         const hipblas_internal_type<T>* const  y[],
-                                         int             incy,
-                                         int             batch_count,
-                                         hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotBatched)(hipblasHandle_t                       handle,
+                                         int                                   n,
+                                         const hipblas_internal_type<T>* const x[],
+                                         int                                   incx,
+                                         const hipblas_internal_type<T>* const y[],
+                                         int                                   incy,
+                                         int                                   batch_count,
+                                         hipblas_internal_type<T>*             result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotcBatched)(hipblasHandle_t handle,
-                                          int             n,
-                                          const hipblas_internal_type<T>* const  x[],
-                                          int             incx,
-                                          const hipblas_internal_type<T>* const  y[],
-                                          int             incy,
-                                          int             batch_count,
-                                          hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotcBatched)(hipblasHandle_t                       handle,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>* const y[],
+                                          int                                   incy,
+                                          int                                   batch_count,
+                                          hipblas_internal_type<T>*             result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotStridedBatched)(hipblasHandle_t handle,
-                                                int             n,
-                                                const hipblas_internal_type<T>*        x,
-                                                int             incx,
-                                                hipblasStride   stridex,
-                                                const hipblas_internal_type<T>*        y,
-                                                int             incy,
-                                                hipblasStride   stridey,
-                                                int             batch_count,
-                                                hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotStridedBatched)(hipblasHandle_t                 handle,
+                                                int                             n,
+                                                const hipblas_internal_type<T>* x,
+                                                int                             incx,
+                                                hipblasStride                   stridex,
+                                                const hipblas_internal_type<T>* y,
+                                                int                             incy,
+                                                hipblasStride                   stridey,
+                                                int                             batch_count,
+                                                hipblas_internal_type<T>*       result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotcStridedBatched)(hipblasHandle_t handle,
-                                                 int             n,
-                                                 const hipblas_internal_type<T>*        x,
-                                                 int             incx,
-                                                 hipblasStride   stridex,
-                                                 const hipblas_internal_type<T>*        y,
-                                                 int             incy,
-                                                 hipblasStride   stridey,
-                                                 int             batch_count,
-                                                 hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotcStridedBatched)(hipblasHandle_t                 handle,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 int                             batch_count,
+                                                 hipblas_internal_type<T>*       result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDot_64)(hipblasHandle_t handle,
-                                     int64_t         n,
-                                     const hipblas_internal_type<T>*        x,
-                                     int64_t         incx,
-                                     const hipblas_internal_type<T>*        y,
-                                     int64_t         incy,
-                                     hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDot_64)(hipblasHandle_t                 handle,
+                                     int64_t                         n,
+                                     const hipblas_internal_type<T>* x,
+                                     int64_t                         incx,
+                                     const hipblas_internal_type<T>* y,
+                                     int64_t                         incy,
+                                     hipblas_internal_type<T>*       result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotc_64)(hipblasHandle_t handle,
-                                      int64_t         n,
-                                      const hipblas_internal_type<T>*        x,
-                                      int64_t         incx,
-                                      const hipblas_internal_type<T>*        y,
-                                      int64_t         incy,
-                                      hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotc_64)(hipblasHandle_t                 handle,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* y,
+                                      int64_t                         incy,
+                                      hipblas_internal_type<T>*       result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotBatched_64)(hipblasHandle_t handle,
-                                            int64_t         n,
-                                            const hipblas_internal_type<T>* const  x[],
-                                            int64_t         incx,
-                                            const hipblas_internal_type<T>* const  y[],
-                                            int64_t         incy,
-                                            int64_t         batch_count,
-                                            hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotBatched_64)(hipblasHandle_t                       handle,
+                                            int64_t                               n,
+                                            const hipblas_internal_type<T>* const x[],
+                                            int64_t                               incx,
+                                            const hipblas_internal_type<T>* const y[],
+                                            int64_t                               incy,
+                                            int64_t                               batch_count,
+                                            hipblas_internal_type<T>*             result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotcBatched_64)(hipblasHandle_t handle,
-                                             int64_t         n,
-                                             const hipblas_internal_type<T>* const  x[],
-                                             int64_t         incx,
-                                             const hipblas_internal_type<T>* const  y[],
-                                             int64_t         incy,
-                                             int64_t         batch_count,
-                                             hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotcBatched_64)(hipblasHandle_t                       handle,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>* const y[],
+                                             int64_t                               incy,
+                                             int64_t                               batch_count,
+                                             hipblas_internal_type<T>*             result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotStridedBatched_64)(hipblasHandle_t handle,
-                                                   int64_t         n,
-                                                   const hipblas_internal_type<T>*        x,
-                                                   int64_t         incx,
-                                                   hipblasStride   stridex,
-                                                   const hipblas_internal_type<T>*        y,
-                                                   int64_t         incy,
-                                                   hipblasStride   stridey,
-                                                   int64_t         batch_count,
-                                                   hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotStridedBatched_64)(hipblasHandle_t                 handle,
+                                                   int64_t                         n,
+                                                   const hipblas_internal_type<T>* x,
+                                                   int64_t                         incx,
+                                                   hipblasStride                   stridex,
+                                                   const hipblas_internal_type<T>* y,
+                                                   int64_t                         incy,
+                                                   hipblasStride                   stridey,
+                                                   int64_t                         batch_count,
+                                                   hipblas_internal_type<T>*       result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDotcStridedBatched_64)(hipblasHandle_t handle,
-                                                    int64_t         n,
-                                                    const hipblas_internal_type<T>*        x,
-                                                    int64_t         incx,
-                                                    hipblasStride   stridex,
-                                                    const hipblas_internal_type<T>*        y,
-                                                    int64_t         incy,
-                                                    hipblasStride   stridey,
-                                            hipblas_internal_type<        int64_t>         batch_count,
-                                                    hipblas_internal_type<T>*              result);
+    hipblasStatus_t (*hipblasDotcStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    hipblas_internal_type<int64_t>  batch_count,
+                                                    hipblas_internal_type<T>*       result);
 
     MAP2CF_D64(hipblasDot, hipblasHalf, hipblasHdot);
     MAP2CF_D64(hipblasDot, hipblasBfloat16, hipblasBfdot);
@@ -7641,42 +7685,52 @@ namespace
 
     // Asum
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAsum)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T1>* x, int incx, hipblas_internal_type<T2>* result);
+    hipblasStatus_t (*hipblasAsum)(hipblasHandle_t                  handle,
+                                   int                              n,
+                                   const hipblas_internal_type<T1>* x,
+                                   int                              incx,
+                                   hipblas_internal_type<T2>*       result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAsumBatched)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T1>* const x[], int incx, int batch_count, hipblas_internal_type<T2>* result);
+    hipblasStatus_t (*hipblasAsumBatched)(hipblasHandle_t                        handle,
+                                          int                                    n,
+                                          const hipblas_internal_type<T1>* const x[],
+                                          int                                    incx,
+                                          int                                    batch_count,
+                                          hipblas_internal_type<T2>*             result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAsumStridedBatched)(hipblasHandle_t handle,
-                                                 int             n,
-                                                 const hipblas_internal_type<T1>*       x,
-                                                 int             incx,
-                                                 hipblasStride   stridex,
-                                                 int             batch_count,
-                                                 hipblas_internal_type<T2>*             result);
+    hipblasStatus_t (*hipblasAsumStridedBatched)(hipblasHandle_t                  handle,
+                                                 int                              n,
+                                                 const hipblas_internal_type<T1>* x,
+                                                 int                              incx,
+                                                 hipblasStride                    stridex,
+                                                 int                              batch_count,
+                                                 hipblas_internal_type<T2>*       result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAsum_64)(
-        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T1>* x, int64_t incx, hipblas_internal_type<T2>* result);
+    hipblasStatus_t (*hipblasAsum_64)(hipblasHandle_t                  handle,
+                                      int64_t                          n,
+                                      const hipblas_internal_type<T1>* x,
+                                      int64_t                          incx,
+                                      hipblas_internal_type<T2>*       result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAsumBatched_64)(hipblasHandle_t handle,
-                                             int64_t         n,
+    hipblasStatus_t (*hipblasAsumBatched_64)(hipblasHandle_t                        handle,
+                                             int64_t                                n,
                                              const hipblas_internal_type<T1>* const x[],
-                                             int64_t         incx,
-                                             int64_t         batch_count,
+                                             int64_t                                incx,
+                                             int64_t                                batch_count,
                                              hipblas_internal_type<T2>*             result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAsumStridedBatched_64)(hipblasHandle_t handle,
-                                                    int64_t         n,
-                                                    const hipblas_internal_type<T1>*       x,
-                                                    int64_t         incx,
-                                                    hipblasStride   stridex,
-                                                    int64_t         batch_count,
-                                                    hipblas_internal_type<T2>*             result);
+    hipblasStatus_t (*hipblasAsumStridedBatched_64)(hipblasHandle_t                  handle,
+                                                    int64_t                          n,
+                                                    const hipblas_internal_type<T1>* x,
+                                                    int64_t                          incx,
+                                                    hipblasStride                    stridex,
+                                                    int64_t                          batch_count,
+                                                    hipblas_internal_type<T2>*       result);
 
     MAP2CF_D64(hipblasAsum, float, float, hipblasSasum);
     MAP2CF_D64(hipblasAsum, double, double, hipblasDasum);
@@ -7690,7 +7744,10 @@ namespace
 
     MAP2CF_D64(hipblasAsumStridedBatched, float, float, hipblasSasumStridedBatched);
     MAP2CF_D64(hipblasAsumStridedBatched, double, double, hipblasDasumStridedBatched);
-    MAP2CF_D64_V2(hipblasAsumStridedBatched, std::complex<float>, float, hipblasScasumStridedBatched);
+    MAP2CF_D64_V2(hipblasAsumStridedBatched,
+                  std::complex<float>,
+                  float,
+                  hipblasScasumStridedBatched);
     MAP2CF_D64_V2(hipblasAsumStridedBatched,
                   std::complex<double>,
                   double,
@@ -7698,42 +7755,52 @@ namespace
 
     // nrm2
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasNrm2)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T1>* x, int incx, hipblas_internal_type<T2>* result);
+    hipblasStatus_t (*hipblasNrm2)(hipblasHandle_t                  handle,
+                                   int                              n,
+                                   const hipblas_internal_type<T1>* x,
+                                   int                              incx,
+                                   hipblas_internal_type<T2>*       result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasNrm2Batched)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T1>* const x[], int incx, int batch_count, hipblas_internal_type<T2>* result);
+    hipblasStatus_t (*hipblasNrm2Batched)(hipblasHandle_t                        handle,
+                                          int                                    n,
+                                          const hipblas_internal_type<T1>* const x[],
+                                          int                                    incx,
+                                          int                                    batch_count,
+                                          hipblas_internal_type<T2>*             result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasNrm2StridedBatched)(hipblasHandle_t handle,
-                                                 int             n,
-                                                 const hipblas_internal_type<T1>*       x,
-                                                 int             incx,
-                                                 hipblasStride   stridex,
-                                                 int             batch_count,
-                                                 hipblas_internal_type<T2>*             result);
+    hipblasStatus_t (*hipblasNrm2StridedBatched)(hipblasHandle_t                  handle,
+                                                 int                              n,
+                                                 const hipblas_internal_type<T1>* x,
+                                                 int                              incx,
+                                                 hipblasStride                    stridex,
+                                                 int                              batch_count,
+                                                 hipblas_internal_type<T2>*       result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasNrm2_64)(
-        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T1>* x, int64_t incx, hipblas_internal_type<T2>* result);
+    hipblasStatus_t (*hipblasNrm2_64)(hipblasHandle_t                  handle,
+                                      int64_t                          n,
+                                      const hipblas_internal_type<T1>* x,
+                                      int64_t                          incx,
+                                      hipblas_internal_type<T2>*       result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasNrm2Batched_64)(hipblasHandle_t handle,
-                                             int64_t         n,
+    hipblasStatus_t (*hipblasNrm2Batched_64)(hipblasHandle_t                        handle,
+                                             int64_t                                n,
                                              const hipblas_internal_type<T1>* const x[],
-                                             int64_t         incx,
-                                             int64_t         batch_count,
+                                             int64_t                                incx,
+                                             int64_t                                batch_count,
                                              hipblas_internal_type<T2>*             result);
 
     template <typename T1, typename T2, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasNrm2StridedBatched_64)(hipblasHandle_t handle,
-                                                    int64_t         n,
-                                                    const hipblas_internal_type<T1>*       x,
-                                                    int64_t         incx,
-                                                    hipblasStride   stridex,
-                                                    int64_t         batch_count,
-                                                    hipblas_internal_type<T2>*             result);
+    hipblasStatus_t (*hipblasNrm2StridedBatched_64)(hipblasHandle_t                  handle,
+                                                    int64_t                          n,
+                                                    const hipblas_internal_type<T1>* x,
+                                                    int64_t                          incx,
+                                                    hipblasStride                    stridex,
+                                                    int64_t                          batch_count,
+                                                    hipblas_internal_type<T2>*       result);
 
     MAP2CF_D64(hipblasNrm2, float, float, hipblasSnrm2);
     MAP2CF_D64(hipblasNrm2, double, double, hipblasDnrm2);
@@ -7747,7 +7814,10 @@ namespace
 
     MAP2CF_D64(hipblasNrm2StridedBatched, float, float, hipblasSnrm2StridedBatched);
     MAP2CF_D64(hipblasNrm2StridedBatched, double, double, hipblasDnrm2StridedBatched);
-    MAP2CF_D64_V2(hipblasNrm2StridedBatched, std::complex<float>, float, hipblasScnrm2StridedBatched);
+    MAP2CF_D64_V2(hipblasNrm2StridedBatched,
+                  std::complex<float>,
+                  float,
+                  hipblasScnrm2StridedBatched);
     MAP2CF_D64_V2(hipblasNrm2StridedBatched,
                   std::complex<double>,
                   double,
@@ -7755,66 +7825,72 @@ namespace
 
     // Rot
     template <typename T1, typename T2, typename T3 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRot)(
-        hipblasHandle_t handle, int n, hipblas_internal_type<T1>* x, int incx, hipblas_internal_type<T1>* y, int incy, const hipblas_internal_type<T2>* c, const hipblas_internal_type<T3>* s);
+    hipblasStatus_t (*hipblasRot)(hipblasHandle_t                  handle,
+                                  int                              n,
+                                  hipblas_internal_type<T1>*       x,
+                                  int                              incx,
+                                  hipblas_internal_type<T1>*       y,
+                                  int                              incy,
+                                  const hipblas_internal_type<T2>* c,
+                                  const hipblas_internal_type<T3>* s);
 
     template <typename T1, typename T2 = T1, typename T3 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotBatched)(hipblasHandle_t handle,
-                                         int             n,
-                                         hipblas_internal_type<T1>* const       x[],
-                                         int             incx,
-                                         hipblas_internal_type<T1>* const       y[],
-                                         int             incy,
-                                         const hipblas_internal_type<T2>*       c,
-                                         const hipblas_internal_type<T3>*       s,
-                                         int             batch_count);
+    hipblasStatus_t (*hipblasRotBatched)(hipblasHandle_t                  handle,
+                                         int                              n,
+                                         hipblas_internal_type<T1>* const x[],
+                                         int                              incx,
+                                         hipblas_internal_type<T1>* const y[],
+                                         int                              incy,
+                                         const hipblas_internal_type<T2>* c,
+                                         const hipblas_internal_type<T3>* s,
+                                         int                              batch_count);
 
     template <typename T1, typename T2 = T1, typename T3 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotStridedBatched)(hipblasHandle_t handle,
-                                                int             n,
-                                                hipblas_internal_type<T1>*             x,
-                                                int             incx,
-                                                hipblasStride   stridex,
-                                                hipblas_internal_type<T1>*             y,
-                                                int             incy,
-                                                hipblasStride   stridey,
-                                                const hipblas_internal_type<T2>*       c,
-                                                const hipblas_internal_type<T3>*       s,
-                                                int             batch_count);
+    hipblasStatus_t (*hipblasRotStridedBatched)(hipblasHandle_t                  handle,
+                                                int                              n,
+                                                hipblas_internal_type<T1>*       x,
+                                                int                              incx,
+                                                hipblasStride                    stridex,
+                                                hipblas_internal_type<T1>*       y,
+                                                int                              incy,
+                                                hipblasStride                    stridey,
+                                                const hipblas_internal_type<T2>* c,
+                                                const hipblas_internal_type<T3>* s,
+                                                int                              batch_count);
 
     template <typename T1, typename T2, typename T3 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRot_64)(hipblasHandle_t handle,
-                                     int64_t         n,
-                                     hipblas_internal_type<T1>*             x,
-                                     int64_t         incx,
-                                     hipblas_internal_type<T1>*             y,
-                                     int64_t         incy,
-                                     const hipblas_internal_type<T2>*       c,
-                                     const hipblas_internal_type<T3>*       s);
+    hipblasStatus_t (*hipblasRot_64)(hipblasHandle_t                  handle,
+                                     int64_t                          n,
+                                     hipblas_internal_type<T1>*       x,
+                                     int64_t                          incx,
+                                     hipblas_internal_type<T1>*       y,
+                                     int64_t                          incy,
+                                     const hipblas_internal_type<T2>* c,
+                                     const hipblas_internal_type<T3>* s);
 
     template <typename T1, typename T2 = T1, typename T3 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotBatched_64)(hipblasHandle_t handle,
-                                            int64_t         n,
-                                            hipblas_internal_type<T1>* const       x[],
-                                            int64_t         incx,
-                                            hipblas_internal_type<T1>* const       y[],
-                                            int64_t         incy,
-                                            const hipblas_internal_type<T2>*       c,
-                                            const hipblas_internal_type<T3>*       s,
-                                            int64_t         batch_count);
+    hipblasStatus_t (*hipblasRotBatched_64)(hipblasHandle_t                  handle,
+                                            int64_t                          n,
+                                            hipblas_internal_type<T1>* const x[],
+                                            int64_t                          incx,
+                                            hipblas_internal_type<T1>* const y[],
+                                            int64_t                          incy,
+                                            const hipblas_internal_type<T2>* c,
+                                            const hipblas_internal_type<T3>* s,
+                                            int64_t                          batch_count);
 
     template <typename T1, typename T2 = T1, typename T3 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotStridedBatched_64)(hipblasHandle_t handle,
-                                                   int64_t         n,
-                                                   hipblas_internal_type<T1>*             x,
-                                                   int64_t         incx,
-                                                   hipblasStride   stridex,
-                                                   hipblas_internal_type<T1>*             y,
-                                                   int64_t         incy,
-                                                   hipblasStride   stridey,
-                                                   const hipblas_internal_type<T2>*       c,
-                                                   const hipblas_internal_type<T3>*       s,
-                                                   int64_t         batch_count);
+    hipblasStatus_t (*hipblasRotStridedBatched_64)(hipblasHandle_t                  handle,
+                                                   int64_t                          n,
+                                                   hipblas_internal_type<T1>*       x,
+                                                   int64_t                          incx,
+                                                   hipblasStride                    stridex,
+                                                   hipblas_internal_type<T1>*       y,
+                                                   int64_t                          incy,
+                                                   hipblasStride                    stridey,
+                                                   const hipblas_internal_type<T2>* c,
+                                                   const hipblas_internal_type<T3>* s,
+                                                   int64_t                          batch_count);
 
     MAP2CF_D64(hipblasRot, float, float, float, hipblasSrot);
     MAP2CF_D64(hipblasRot, double, double, double, hipblasDrot);
@@ -7825,7 +7901,8 @@ namespace
 
     MAP2CF_D64(hipblasRotBatched, float, float, float, hipblasSrotBatched);
     MAP2CF_D64(hipblasRotBatched, double, double, double, hipblasDrotBatched);
-    MAP2CF_D64_V2(hipblasRotBatched, std::complex<float>, float, std::complex<float>, hipblasCrotBatched);
+    MAP2CF_D64_V2(
+        hipblasRotBatched, std::complex<float>, float, std::complex<float>, hipblasCrotBatched);
     MAP2CF_D64_V2(
         hipblasRotBatched, std::complex<double>, double, std::complex<double>, hipblasZrotBatched);
     MAP2CF_D64_V2(hipblasRotBatched, std::complex<float>, float, float, hipblasCsrotBatched);
@@ -7833,8 +7910,11 @@ namespace
 
     MAP2CF_D64(hipblasRotStridedBatched, float, float, float, hipblasSrotStridedBatched);
     MAP2CF_D64(hipblasRotStridedBatched, double, double, double, hipblasDrotStridedBatched);
-    MAP2CF_D64_V2(
-        hipblasRotStridedBatched, std::complex<float>, float, std::complex<float>, hipblasCrotStridedBatched);
+    MAP2CF_D64_V2(hipblasRotStridedBatched,
+                  std::complex<float>,
+                  float,
+                  std::complex<float>,
+                  hipblasCrotStridedBatched);
     MAP2CF_D64_V2(hipblasRotStridedBatched,
                   std::complex<double>,
                   double,
@@ -7847,50 +7927,58 @@ namespace
 
     // Rotg
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotg)(hipblasHandle_t handle, hipblas_internal_type<T1>* a, hipblas_internal_type<T1>* b, T2* c, hipblas_internal_type<T1>* s);
+    hipblasStatus_t (*hipblasRotg)(hipblasHandle_t            handle,
+                                   hipblas_internal_type<T1>* a,
+                                   hipblas_internal_type<T1>* b,
+                                   T2*                        c,
+                                   hipblas_internal_type<T1>* s);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotgBatched)(hipblasHandle_t handle,
-                                          hipblas_internal_type<T1>* const       a[],
-                                          hipblas_internal_type<T1>* const       b[],
-                                          hipblas_internal_type<T2>* const       c[],
-                                          hipblas_internal_type<T1>* const       s[],
-                                          int             batch_count);
+    hipblasStatus_t (*hipblasRotgBatched)(hipblasHandle_t                  handle,
+                                          hipblas_internal_type<T1>* const a[],
+                                          hipblas_internal_type<T1>* const b[],
+                                          hipblas_internal_type<T2>* const c[],
+                                          hipblas_internal_type<T1>* const s[],
+                                          int                              batch_count);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotgStridedBatched)(hipblasHandle_t handle,
-                                                 hipblas_internal_type<T1>*             a,
-                                                 hipblasStride   stridea,
-                                                 hipblas_internal_type<T1>*             b,
-                                                 hipblasStride   strideb,
-                                                 hipblas_internal_type<T2>*             c,
-                                                 hipblasStride   stridec,
-                                                 hipblas_internal_type<T1>*             s,
-                                                 hipblasStride   strides,
-                                                 int             batch_count);
+    hipblasStatus_t (*hipblasRotgStridedBatched)(hipblasHandle_t            handle,
+                                                 hipblas_internal_type<T1>* a,
+                                                 hipblasStride              stridea,
+                                                 hipblas_internal_type<T1>* b,
+                                                 hipblasStride              strideb,
+                                                 hipblas_internal_type<T2>* c,
+                                                 hipblasStride              stridec,
+                                                 hipblas_internal_type<T1>* s,
+                                                 hipblasStride              strides,
+                                                 int                        batch_count);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotg_64)(hipblasHandle_t handle, hipblas_internal_type<T1>* a, hipblas_internal_type<T1>* b, hipblas_internal_type<T2>* c, hipblas_internal_type<T1>* s);
+    hipblasStatus_t (*hipblasRotg_64)(hipblasHandle_t            handle,
+                                      hipblas_internal_type<T1>* a,
+                                      hipblas_internal_type<T1>* b,
+                                      hipblas_internal_type<T2>* c,
+                                      hipblas_internal_type<T1>* s);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotgBatched_64)(hipblasHandle_t handle,
-                                             hipblas_internal_type<T1>* const       a[],
-                                             hipblas_internal_type<T1>* const       b[],
-                                             hipblas_internal_type<T2>* const       c[],
-                                             hipblas_internal_type<T1>* const       s[],
-                                             int64_t         batch_count);
+    hipblasStatus_t (*hipblasRotgBatched_64)(hipblasHandle_t                  handle,
+                                             hipblas_internal_type<T1>* const a[],
+                                             hipblas_internal_type<T1>* const b[],
+                                             hipblas_internal_type<T2>* const c[],
+                                             hipblas_internal_type<T1>* const s[],
+                                             int64_t                          batch_count);
 
     template <typename T1, typename T2 = T1, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotgStridedBatched_64)(hipblasHandle_t handle,
-                                                    hipblas_internal_type<T1>*             a,
-                                                    hipblasStride   stridea,
-                                                    hipblas_internal_type<T1>*             b,
-                                                    hipblasStride   strideb,
-                                                    hipblas_internal_type<T2>*             c,
-                                                    hipblasStride   stridec,
-                                                    hipblas_internal_type<T1>*             s,
-                                                    hipblasStride   strides,
-                                                    int64_t         batch_count);
+    hipblasStatus_t (*hipblasRotgStridedBatched_64)(hipblasHandle_t            handle,
+                                                    hipblas_internal_type<T1>* a,
+                                                    hipblasStride              stridea,
+                                                    hipblas_internal_type<T1>* b,
+                                                    hipblasStride              strideb,
+                                                    hipblas_internal_type<T2>* c,
+                                                    hipblasStride              stridec,
+                                                    hipblas_internal_type<T1>* s,
+                                                    hipblasStride              strides,
+                                                    int64_t                    batch_count);
 
     MAP2CF_D64(hipblasRotg, float, float, hipblasSrotg);
     MAP2CF_D64(hipblasRotg, double, double, hipblasDrotg);
@@ -7904,7 +7992,10 @@ namespace
 
     MAP2CF_D64(hipblasRotgStridedBatched, float, float, hipblasSrotgStridedBatched);
     MAP2CF_D64(hipblasRotgStridedBatched, double, double, hipblasDrotgStridedBatched);
-    MAP2CF_D64_V2(hipblasRotgStridedBatched, std::complex<float>, float, hipblasCrotgStridedBatched);
+    MAP2CF_D64_V2(hipblasRotgStridedBatched,
+                  std::complex<float>,
+                  float,
+                  hipblasCrotgStridedBatched);
     MAP2CF_D64_V2(hipblasRotgStridedBatched,
                   std::complex<double>,
                   double,
@@ -7912,58 +8003,68 @@ namespace
 
     // rotm
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotm)(
-        hipblasHandle_t handle, int n, hipblas_internal_type<T>* x, int incx, hipblas_internal_type<T>* y, int incy, const hipblas_internal_type<T>* param);
+    hipblasStatus_t (*hipblasRotm)(hipblasHandle_t                 handle,
+                                   int                             n,
+                                   hipblas_internal_type<T>*       x,
+                                   int                             incx,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy,
+                                   const hipblas_internal_type<T>* param);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmBatched)(hipblasHandle_t handle,
-                                          int             n,
-                                          hipblas_internal_type<T>* const        x[],
-                                          int             incx,
-                                          hipblas_internal_type<T>* const        y[],
-                                          int             incy,
-                                          const hipblas_internal_type<T>* const  param[],
-                                          int             batch_count);
+    hipblasStatus_t (*hipblasRotmBatched)(hipblasHandle_t                       handle,
+                                          int                                   n,
+                                          hipblas_internal_type<T>* const       x[],
+                                          int                                   incx,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          const hipblas_internal_type<T>* const param[],
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmStridedBatched)(hipblasHandle_t handle,
-                                                 int             n,
-                                                 hipblas_internal_type<T>*              x,
-                                                 int             incx,
-                                                 hipblasStride   stridex,
-                                                 hipblas_internal_type<T>*              y,
-                                                 int             incy,
-                                                 hipblasStride   stridey,
-                                                 const hipblas_internal_type<T>*        param,
-                                                 hipblasStride   strideparam,
-                                                 int             batch_count);
+    hipblasStatus_t (*hipblasRotmStridedBatched)(hipblasHandle_t                 handle,
+                                                 int                             n,
+                                                 hipblas_internal_type<T>*       x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 const hipblas_internal_type<T>* param,
+                                                 hipblasStride                   strideparam,
+                                                 int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotm_64)(
-        hipblasHandle_t handle, int64_t n, hipblas_internal_type<T>* x, int64_t incx, hipblas_internal_type<T>* y, int64_t incy, const hipblas_internal_type<T>* param);
+    hipblasStatus_t (*hipblasRotm_64)(hipblasHandle_t                 handle,
+                                      int64_t                         n,
+                                      hipblas_internal_type<T>*       x,
+                                      int64_t                         incx,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy,
+                                      const hipblas_internal_type<T>* param);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmBatched_64)(hipblasHandle_t handle,
-                                             int64_t         n,
-                                             hipblas_internal_type<T>* const        x[],
-                                             int64_t         incx,
-                                             hipblas_internal_type<T>* const        y[],
-                                             int64_t         incy,
-                                             const hipblas_internal_type<T>* const  param[],
-                                             int64_t         batch_count);
+    hipblasStatus_t (*hipblasRotmBatched_64)(hipblasHandle_t                       handle,
+                                             int64_t                               n,
+                                             hipblas_internal_type<T>* const       x[],
+                                             int64_t                               incx,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             const hipblas_internal_type<T>* const param[],
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmStridedBatched_64)(hipblasHandle_t handle,
-                                                    int64_t         n,
-                                                    hipblas_internal_type<T>*              x,
-                                                    int64_t         incx,
-                                                    hipblasStride   stridex,
-                                                    hipblas_internal_type<T>*              y,
-                                                    int64_t         incy,
-                                                    hipblasStride   stridey,
-                                                    const hipblas_internal_type<T>*        param,
-                                                    hipblasStride   strideparam,
-                                                    int64_t         batch_count);
+    hipblasStatus_t (*hipblasRotmStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    int64_t                         n,
+                                                    hipblas_internal_type<T>*       x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    const hipblas_internal_type<T>* param,
+                                                    hipblasStride                   strideparam,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasRotm, float, hipblasSrotm);
     MAP2CF_D64(hipblasRotm, double, hipblasDrotm);
@@ -7976,58 +8077,66 @@ namespace
 
     // rotmg
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmg)(
-        hipblasHandle_t handle, hipblas_internal_type<T>* d1, hipblas_internal_type<T>* d2, hipblas_internal_type<T>* x1, const hipblas_internal_type<T>* y1, hipblas_internal_type<T>* param);
+    hipblasStatus_t (*hipblasRotmg)(hipblasHandle_t                 handle,
+                                    hipblas_internal_type<T>*       d1,
+                                    hipblas_internal_type<T>*       d2,
+                                    hipblas_internal_type<T>*       x1,
+                                    const hipblas_internal_type<T>* y1,
+                                    hipblas_internal_type<T>*       param);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmgBatched)(hipblasHandle_t handle,
-                                           hipblas_internal_type<T>* const        d1[],
-                                           hipblas_internal_type<T>* const        d2[],
-                                           hipblas_internal_type<T>* const        x1[],
-                                           const hipblas_internal_type<T>* const  y1[],
-                                           hipblas_internal_type<T>* const        param[],
-                                           int             batch_count);
+    hipblasStatus_t (*hipblasRotmgBatched)(hipblasHandle_t                       handle,
+                                           hipblas_internal_type<T>* const       d1[],
+                                           hipblas_internal_type<T>* const       d2[],
+                                           hipblas_internal_type<T>* const       x1[],
+                                           const hipblas_internal_type<T>* const y1[],
+                                           hipblas_internal_type<T>* const       param[],
+                                           int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmgStridedBatched)(hipblasHandle_t handle,
-                                                  hipblas_internal_type<T>*              d1,
-                                                  hipblasStride   stride_d1,
-                                                  hipblas_internal_type<T>*              d2,
-                                                  hipblasStride   stride_d2,
-                                                  hipblas_internal_type<T>*              x1,
-                                                  hipblasStride   stride_x1,
-                                                  const hipblas_internal_type<T>*        y1,
-                                                  hipblasStride   stride_y1,
-                                                  hipblas_internal_type<T>*              param,
-                                                  hipblasStride   strideparam,
-                                                  int             batch_count);
+    hipblasStatus_t (*hipblasRotmgStridedBatched)(hipblasHandle_t                 handle,
+                                                  hipblas_internal_type<T>*       d1,
+                                                  hipblasStride                   stride_d1,
+                                                  hipblas_internal_type<T>*       d2,
+                                                  hipblasStride                   stride_d2,
+                                                  hipblas_internal_type<T>*       x1,
+                                                  hipblasStride                   stride_x1,
+                                                  const hipblas_internal_type<T>* y1,
+                                                  hipblasStride                   stride_y1,
+                                                  hipblas_internal_type<T>*       param,
+                                                  hipblasStride                   strideparam,
+                                                  int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmg_64)(
-        hipblasHandle_t handle, hipblas_internal_type<T>* d1, hipblas_internal_type<T>* d2, hipblas_internal_type<T>* x1, const hipblas_internal_type<T>* y1, hipblas_internal_type<T>* param);
+    hipblasStatus_t (*hipblasRotmg_64)(hipblasHandle_t                 handle,
+                                       hipblas_internal_type<T>*       d1,
+                                       hipblas_internal_type<T>*       d2,
+                                       hipblas_internal_type<T>*       x1,
+                                       const hipblas_internal_type<T>* y1,
+                                       hipblas_internal_type<T>*       param);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmgBatched_64)(hipblasHandle_t handle,
-                                              hipblas_internal_type<T>* const        d1[],
-                                              hipblas_internal_type<T>* const        d2[],
-                                              hipblas_internal_type<T>* const        x1[],
-                                              const hipblas_internal_type<T>* const  y1[],
-                                              hipblas_internal_type<T>* const        param[],
-                                              int64_t         batch_count);
+    hipblasStatus_t (*hipblasRotmgBatched_64)(hipblasHandle_t                       handle,
+                                              hipblas_internal_type<T>* const       d1[],
+                                              hipblas_internal_type<T>* const       d2[],
+                                              hipblas_internal_type<T>* const       x1[],
+                                              const hipblas_internal_type<T>* const y1[],
+                                              hipblas_internal_type<T>* const       param[],
+                                              int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasRotmgStridedBatched_64)(hipblasHandle_t handle,
-                                                     hipblas_internal_type<T>*              d1,
-                                                     hipblasStride   stride_d1,
-                                                     hipblas_internal_type<T>*              d2,
-                                                     hipblasStride   stride_d2,
-                                                     hipblas_internal_type<T>*              x1,
-                                                     hipblasStride   stride_x1,
-                                                     const hipblas_internal_type<T>*        y1,
-                                                     hipblasStride   stride_y1,
-                                                     hipblas_internal_type<T>*              param,
-                                                     hipblasStride   strideparam,
-                                                     int64_t         batch_count);
+    hipblasStatus_t (*hipblasRotmgStridedBatched_64)(hipblasHandle_t                 handle,
+                                                     hipblas_internal_type<T>*       d1,
+                                                     hipblasStride                   stride_d1,
+                                                     hipblas_internal_type<T>*       d2,
+                                                     hipblasStride                   stride_d2,
+                                                     hipblas_internal_type<T>*       x1,
+                                                     hipblasStride                   stride_x1,
+                                                     const hipblas_internal_type<T>* y1,
+                                                     hipblasStride                   stride_y1,
+                                                     hipblas_internal_type<T>*       param,
+                                                     hipblasStride                   strideparam,
+                                                     int64_t                         batch_count);
 
     MAP2CF_D64(hipblasRotmg, float, hipblasSrotmg);
     MAP2CF_D64(hipblasRotmg, double, hipblasDrotmg);
@@ -8044,38 +8153,45 @@ namespace
         hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, int* result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIamaxBatched)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* const x[], int incx, int batch_count, int* result);
+    hipblasStatus_t (*hipblasIamaxBatched)(hipblasHandle_t                       handle,
+                                           int                                   n,
+                                           const hipblas_internal_type<T>* const x[],
+                                           int                                   incx,
+                                           int                                   batch_count,
+                                           int*                                  result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIamaxStridedBatched)(hipblasHandle_t handle,
-                                                  int             n,
-                                                  const hipblas_internal_type<T>*        x,
-                                                  int             incx,
-                                                  hipblasStride   stridex,
-                                                  int             batch_count,
-                                                  int*            result);
+    hipblasStatus_t (*hipblasIamaxStridedBatched)(hipblasHandle_t                 handle,
+                                                  int                             n,
+                                                  const hipblas_internal_type<T>* x,
+                                                  int                             incx,
+                                                  hipblasStride                   stridex,
+                                                  int                             batch_count,
+                                                  int*                            result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIamax_64)(
-        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T>* x, int64_t incx, int64_t* result);
+    hipblasStatus_t (*hipblasIamax_64)(hipblasHandle_t                 handle,
+                                       int64_t                         n,
+                                       const hipblas_internal_type<T>* x,
+                                       int64_t                         incx,
+                                       int64_t*                        result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIamaxBatched_64)(hipblasHandle_t handle,
-                                              int64_t         n,
-                                              const hipblas_internal_type<T>* const  x[],
-                                              int64_t         incx,
-                                              int64_t         batch_count,
-                                              int64_t*        result);
+    hipblasStatus_t (*hipblasIamaxBatched_64)(hipblasHandle_t                       handle,
+                                              int64_t                               n,
+                                              const hipblas_internal_type<T>* const x[],
+                                              int64_t                               incx,
+                                              int64_t                               batch_count,
+                                              int64_t*                              result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIamaxStridedBatched_64)(hipblasHandle_t handle,
-                                                     int64_t         n,
-                                                     const hipblas_internal_type<T>*        x,
-                                                     int64_t         incx,
-                                                     hipblasStride   stridex,
-                                                     int64_t         batch_count,
-                                                     int64_t*        result);
+    hipblasStatus_t (*hipblasIamaxStridedBatched_64)(hipblasHandle_t                 handle,
+                                                     int64_t                         n,
+                                                     const hipblas_internal_type<T>* x,
+                                                     int64_t                         incx,
+                                                     hipblasStride                   stridex,
+                                                     int64_t                         batch_count,
+                                                     int64_t*                        result);
 
     MAP2CF_D64(hipblasIamax, float, hipblasIsamax);
     MAP2CF_D64(hipblasIamax, double, hipblasIdamax);
@@ -8098,38 +8214,45 @@ namespace
         hipblasHandle_t handle, int n, const hipblas_internal_type<T>* x, int incx, int* result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIaminBatched)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* const x[], int incx, int batch_count, int* result);
+    hipblasStatus_t (*hipblasIaminBatched)(hipblasHandle_t                       handle,
+                                           int                                   n,
+                                           const hipblas_internal_type<T>* const x[],
+                                           int                                   incx,
+                                           int                                   batch_count,
+                                           int*                                  result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIaminStridedBatched)(hipblasHandle_t handle,
-                                                  int             n,
-                                                  const hipblas_internal_type<T>*        x,
-                                                  int             incx,
-                                                  hipblasStride   stridex,
-                                                  int             batch_count,
-                                                  int*            result);
+    hipblasStatus_t (*hipblasIaminStridedBatched)(hipblasHandle_t                 handle,
+                                                  int                             n,
+                                                  const hipblas_internal_type<T>* x,
+                                                  int                             incx,
+                                                  hipblasStride                   stridex,
+                                                  int                             batch_count,
+                                                  int*                            result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIamin_64)(
-        hipblasHandle_t handle, int64_t n, const hipblas_internal_type<T>* x, int64_t incx, int64_t* result);
+    hipblasStatus_t (*hipblasIamin_64)(hipblasHandle_t                 handle,
+                                       int64_t                         n,
+                                       const hipblas_internal_type<T>* x,
+                                       int64_t                         incx,
+                                       int64_t*                        result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIaminBatched_64)(hipblasHandle_t handle,
-                                              int64_t         n,
-                                              const hipblas_internal_type<T>* const  x[],
-                                              int64_t         incx,
-                                              int64_t         batch_count,
-                                              int64_t*        result);
+    hipblasStatus_t (*hipblasIaminBatched_64)(hipblasHandle_t                       handle,
+                                              int64_t                               n,
+                                              const hipblas_internal_type<T>* const x[],
+                                              int64_t                               incx,
+                                              int64_t                               batch_count,
+                                              int64_t*                              result);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasIaminStridedBatched_64)(hipblasHandle_t handle,
-                                                     int64_t         n,
-                                                     const hipblas_internal_type<T>*        x,
-                                                     int64_t         incx,
-                                                     hipblasStride   stridex,
-                                                     int64_t         batch_count,
-                                                     int64_t*        result);
+    hipblasStatus_t (*hipblasIaminStridedBatched_64)(hipblasHandle_t                 handle,
+                                                     int64_t                         n,
+                                                     const hipblas_internal_type<T>* x,
+                                                     int64_t                         incx,
+                                                     hipblasStride                   stridex,
+                                                     int64_t                         batch_count,
+                                                     int64_t*                        result);
 
     MAP2CF_D64(hipblasIamin, float, hipblasIsamin);
     MAP2CF_D64(hipblasIamin, double, hipblasIdamin);
@@ -8148,61 +8271,66 @@ namespace
 
     // axpy
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAxpy)(
-        hipblasHandle_t handle, int n, const hipblas_internal_type<T>* alpha, const hipblas_internal_type<T>* x, int incx, hipblas_internal_type<T>* y, int incy);
+    hipblasStatus_t (*hipblasAxpy)(hipblasHandle_t                 handle,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAxpyBatched)(hipblasHandle_t handle,
-                                          int             n,
-                                          const hipblas_internal_type<T>*        alpha,
-                                          const hipblas_internal_type<T>* const  x[],
-                                          int             incx,
-                                          hipblas_internal_type<T>* const        y[],
-                                          int             incy,
-                                          int             batch_count);
+    hipblasStatus_t (*hipblasAxpyBatched)(hipblasHandle_t                       handle,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAxpyStridedBatched)(hipblasHandle_t handle,
-                                                 int             n,
-                                                 const hipblas_internal_type<T>*        alpha,
-                                                 const hipblas_internal_type<T>*        x,
-                                                 int             incx,
-                                                 hipblasStride   stridex,
-                                                 hipblas_internal_type<T>*              y,
-                                                 int             incy,
-                                                 hipblasStride   stridey,
-                                                 int             batch_count);
+    hipblasStatus_t (*hipblasAxpyStridedBatched)(hipblasHandle_t                 handle,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAxpy_64)(hipblasHandle_t handle,
-                                      int64_t         n,
-                                      const hipblas_internal_type<T>*        alpha,
-                                      const hipblas_internal_type<T>*        x,
-                                      int64_t         incx,
-                                      hipblas_internal_type<T>*              y,
-                                      int64_t         incy);
+    hipblasStatus_t (*hipblasAxpy_64)(hipblasHandle_t                 handle,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAxpyBatched_64)(hipblasHandle_t handle,
-                                             int64_t         n,
-                                             const hipblas_internal_type<T>*        alpha,
-                                             const hipblas_internal_type<T>* const  x[],
-                                             int64_t         incx,
-                                             hipblas_internal_type<T>* const        y[],
-                                             int64_t         incy,
-                                             int64_t         batch_count);
+    hipblasStatus_t (*hipblasAxpyBatched_64)(hipblasHandle_t                       handle,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasAxpyStridedBatched_64)(hipblasHandle_t handle,
-                                                    int64_t         n,
-                                                    const hipblas_internal_type<T>*        alpha,
-                                                    const hipblas_internal_type<T>*        x,
-                                                    int64_t         incx,
-                                                    hipblasStride   stridex,
-                                                    hipblas_internal_type<T>*              y,
-                                                    int64_t         incy,
-                                                    hipblasStride   stridey,
-                                                    int64_t         batch_count);
+    hipblasStatus_t (*hipblasAxpyStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasAxpy, hipblasHalf, hipblasHaxpy);
     MAP2CF_D64(hipblasAxpy, float, hipblasSaxpy);
@@ -8224,87 +8352,87 @@ namespace
 
     // ger
     template <typename T, bool CONJ, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGer)(hipblasHandle_t handle,
-                                  int             m,
-                                  int             n,
-                                  const hipblas_internal_type<T>*        alpha,
-                                  const hipblas_internal_type<T>*        x,
-                                  int             incx,
-                                  const hipblas_internal_type<T>*        y,
-                                  int             incy,
-                                  hipblas_internal_type<T>*              A,
-                                  int             lda);
+    hipblasStatus_t (*hipblasGer)(hipblasHandle_t                 handle,
+                                  int                             m,
+                                  int                             n,
+                                  const hipblas_internal_type<T>* alpha,
+                                  const hipblas_internal_type<T>* x,
+                                  int                             incx,
+                                  const hipblas_internal_type<T>* y,
+                                  int                             incy,
+                                  hipblas_internal_type<T>*       A,
+                                  int                             lda);
 
     template <typename T, bool CONJ, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGerBatched)(hipblasHandle_t handle,
-                                         int             m,
-                                         int             n,
-                                         const hipblas_internal_type<T>*        alpha,
-                                         const hipblas_internal_type<T>* const  x[],
-                                         int             incx,
-                                         const hipblas_internal_type<T>* const  y[],
-                                         int             incy,
-                                         hipblas_internal_type<T>* const        A[],
-                                         int             lda,
-                                         int             batch_count);
+    hipblasStatus_t (*hipblasGerBatched)(hipblasHandle_t                       handle,
+                                         int                                   m,
+                                         int                                   n,
+                                         const hipblas_internal_type<T>*       alpha,
+                                         const hipblas_internal_type<T>* const x[],
+                                         int                                   incx,
+                                         const hipblas_internal_type<T>* const y[],
+                                         int                                   incy,
+                                         hipblas_internal_type<T>* const       A[],
+                                         int                                   lda,
+                                         int                                   batch_count);
 
     template <typename T, bool CONJ, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGerStridedBatched)(hipblasHandle_t handle,
-                                                int             m,
-                                                int             n,
-                                                const hipblas_internal_type<T>*        alpha,
-                                                const hipblas_internal_type<T>*        x,
-                                                int             incx,
-                                                hipblasStride   stridex,
-                                                const hipblas_internal_type<T>*        y,
-                                                int             incy,
-                                                hipblasStride   stridey,
-                                                hipblas_internal_type<T>*              A,
-                                                int             lda,
-                                                hipblasStride   strideA,
-                                                int             batch_count);
+    hipblasStatus_t (*hipblasGerStridedBatched)(hipblasHandle_t                 handle,
+                                                int                             m,
+                                                int                             n,
+                                                const hipblas_internal_type<T>* alpha,
+                                                const hipblas_internal_type<T>* x,
+                                                int                             incx,
+                                                hipblasStride                   stridex,
+                                                const hipblas_internal_type<T>* y,
+                                                int                             incy,
+                                                hipblasStride                   stridey,
+                                                hipblas_internal_type<T>*       A,
+                                                int                             lda,
+                                                hipblasStride                   strideA,
+                                                int                             batch_count);
 
     // ger_64
     template <typename T, bool CONJ, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGer_64)(hipblasHandle_t handle,
-                                     int64_t         m,
-                                     int64_t         n,
-                                     const hipblas_internal_type<T>*        alpha,
-                                     const hipblas_internal_type<T>*        x,
-                                     int64_t         incx,
-                                     const hipblas_internal_type<T>*        y,
-                                     int64_t         incy,
-                                     hipblas_internal_type<T>*              A,
-                                     int64_t         lda);
+    hipblasStatus_t (*hipblasGer_64)(hipblasHandle_t                 handle,
+                                     int64_t                         m,
+                                     int64_t                         n,
+                                     const hipblas_internal_type<T>* alpha,
+                                     const hipblas_internal_type<T>* x,
+                                     int64_t                         incx,
+                                     const hipblas_internal_type<T>* y,
+                                     int64_t                         incy,
+                                     hipblas_internal_type<T>*       A,
+                                     int64_t                         lda);
 
     template <typename T, bool CONJ, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGerBatched_64)(hipblasHandle_t handle,
-                                            int64_t         m,
-                                            int64_t         n,
-                                            const hipblas_internal_type<T>*        alpha,
-                                            const hipblas_internal_type<T>* const  x[],
-                                            int64_t         incx,
-                                            const hipblas_internal_type<T>* const  y[],
-                                            int64_t         incy,
-                                            hipblas_internal_type<T>* const        A[],
-                                            int64_t         lda,
-                                            int64_t         batch_count);
+    hipblasStatus_t (*hipblasGerBatched_64)(hipblasHandle_t                       handle,
+                                            int64_t                               m,
+                                            int64_t                               n,
+                                            const hipblas_internal_type<T>*       alpha,
+                                            const hipblas_internal_type<T>* const x[],
+                                            int64_t                               incx,
+                                            const hipblas_internal_type<T>* const y[],
+                                            int64_t                               incy,
+                                            hipblas_internal_type<T>* const       A[],
+                                            int64_t                               lda,
+                                            int64_t                               batch_count);
 
     template <typename T, bool CONJ, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGerStridedBatched_64)(hipblasHandle_t handle,
-                                                   int64_t         m,
-                                                   int64_t         n,
-                                                   const hipblas_internal_type<T>*        alpha,
-                                                   const hipblas_internal_type<T>*        x,
-                                                   int64_t         incx,
-                                                   hipblasStride   stridex,
-                                                   const hipblas_internal_type<T>*        y,
-                                                   int64_t         incy,
-                                                   hipblasStride   stridey,
-                                                   hipblas_internal_type<T>*              A,
-                                                   int64_t         lda,
-                                                   hipblasStride   strideA,
-                                                   int64_t         batch_count);
+    hipblasStatus_t (*hipblasGerStridedBatched_64)(hipblasHandle_t                 handle,
+                                                   int64_t                         m,
+                                                   int64_t                         n,
+                                                   const hipblas_internal_type<T>* alpha,
+                                                   const hipblas_internal_type<T>* x,
+                                                   int64_t                         incx,
+                                                   hipblasStride                   stridex,
+                                                   const hipblas_internal_type<T>* y,
+                                                   int64_t                         incy,
+                                                   hipblasStride                   stridey,
+                                                   hipblas_internal_type<T>*       A,
+                                                   int64_t                         lda,
+                                                   hipblasStride                   strideA,
+                                                   int64_t                         batch_count);
 
     MAP2CF_D64(hipblasGer, float, false, hipblasSger);
     MAP2CF_D64(hipblasGer, double, false, hipblasDger);
@@ -8332,280 +8460,280 @@ namespace
 
     // hbmv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHbmv)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   int               k,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          A,
-                                   int               lda,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          beta,
-                                   hipblas_internal_type<T>*                y,
-                                   int               incy);
+    hipblasStatus_t (*hipblasHbmv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   int                             k,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHbmv_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      int64_t           k,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          A,
-                                      int64_t           lda,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          beta,
-                                      hipblas_internal_type<T>*                y,
-                                      int64_t           incy);
+    hipblasStatus_t (*hipblasHbmv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      int64_t                         k,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     MAP2CF_D64_V2(hipblasHbmv, std::complex<float>, hipblasChbmv);
     MAP2CF_D64_V2(hipblasHbmv, std::complex<double>, hipblasZhbmv);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHbmvBatched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          int               k,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    A[],
-                                          int               lda,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>*          beta,
-                                          hipblas_internal_type<T>* const          y[],
-                                          int               incy,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasHbmvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          int                                   k,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHbmvBatched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             int64_t           k,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    A[],
-                                             int64_t           lda,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>*          beta,
-                                             hipblas_internal_type<T>* const          y[],
-                                             int64_t           incy,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasHbmvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             int64_t                               k,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batchCount);
 
     MAP2CF_D64_V2(hipblasHbmvBatched, std::complex<float>, hipblasChbmvBatched);
     MAP2CF_D64_V2(hipblasHbmvBatched, std::complex<double>, hipblasZhbmvBatched);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHbmvStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 int               k,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          A,
-                                                 int               lda,
-                                                 hipblasStride     strideA,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          beta,
-                                                 hipblas_internal_type<T>*                y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasHbmvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 int                             k,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHbmvStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    int64_t           k,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          A,
-                                                    int64_t           lda,
-                                                    hipblasStride     strideA,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          beta,
-                                                    hipblas_internal_type<T>*                y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasHbmvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    int64_t                         k,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHbmvStridedBatched, std::complex<float>, hipblasChbmvStridedBatched);
     MAP2CF_D64_V2(hipblasHbmvStridedBatched, std::complex<double>, hipblasZhbmvStridedBatched);
 
     // hemv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemv)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          A,
-                                   int               lda,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          beta,
-                                   hipblas_internal_type<T>*                y,
-                                   int               incy);
+    hipblasStatus_t (*hipblasHemv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemv_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          A,
-                                      int64_t           lda,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          beta,
-                                      hipblas_internal_type<T>*                y,
-                                      int64_t           incy);
+    hipblasStatus_t (*hipblasHemv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     MAP2CF_D64_V2(hipblasHemv, std::complex<float>, hipblasChemv);
     MAP2CF_D64_V2(hipblasHemv, std::complex<double>, hipblasZhemv);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemvBatched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    A[],
-                                          int               lda,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>*          beta,
-                                          hipblas_internal_type<T>* const          y[],
-                                          int               incy,
-                                          int               batch_count);
+    hipblasStatus_t (*hipblasHemvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemvBatched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    A[],
-                                             int64_t           lda,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>*          beta,
-                                             hipblas_internal_type<T>* const          y[],
-                                             int64_t           incy,
-                                             int64_t           batch_count);
+    hipblasStatus_t (*hipblasHemvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batch_count);
 
     MAP2CF_D64_V2(hipblasHemvBatched, std::complex<float>, hipblasChemvBatched);
     MAP2CF_D64_V2(hipblasHemvBatched, std::complex<double>, hipblasZhemvBatched);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemvStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          A,
-                                                 int               lda,
-                                                 hipblasStride     stride_a,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stride_x,
-                                                 const hipblas_internal_type<T>*          beta,
-                                                 hipblas_internal_type<T>*                y,
-                                                 int               incy,
-                                                 hipblasStride     stride_y,
-                                                 int               batch_count);
+    hipblasStatus_t (*hipblasHemvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   stride_a,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stride_x,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stride_y,
+                                                 int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemvStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          A,
-                                                    int64_t           lda,
-                                                    hipblasStride     stride_a,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stride_x,
-                                                    const hipblas_internal_type<T>*          beta,
-                                                    hipblas_internal_type<T>*                y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stride_y,
-                                                    int64_t           batch_count);
+    hipblasStatus_t (*hipblasHemvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   stride_a,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stride_x,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stride_y,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64_V2(hipblasHemvStridedBatched, std::complex<float>, hipblasChemvStridedBatched);
     MAP2CF_D64_V2(hipblasHemvStridedBatched, std::complex<double>, hipblasZhemvStridedBatched);
 
     // her
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer)(hipblasHandle_t   handle,
-                                  hipblasFillMode_t uplo,
-                                  int               n,
-                                  const hipblas_internal_type<U>*          alpha,
-                                  const hipblas_internal_type<T>*          x,
-                                  int               incx,
-                                  hipblas_internal_type<T>*                A,
-                                  int               lda);
+    hipblasStatus_t (*hipblasHer)(hipblasHandle_t                 handle,
+                                  hipblasFillMode_t               uplo,
+                                  int                             n,
+                                  const hipblas_internal_type<U>* alpha,
+                                  const hipblas_internal_type<T>* x,
+                                  int                             incx,
+                                  hipblas_internal_type<T>*       A,
+                                  int                             lda);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer_64)(hipblasHandle_t   handle,
-                                     hipblasFillMode_t uplo,
-                                     int64_t           n,
-                                     const hipblas_internal_type<U>*          alpha,
-                                     const hipblas_internal_type<T>*          x,
-                                     int64_t           incx,
-                                     hipblas_internal_type<T>*                A,
-                                     int64_t           lda);
+    hipblasStatus_t (*hipblasHer_64)(hipblasHandle_t                 handle,
+                                     hipblasFillMode_t               uplo,
+                                     int64_t                         n,
+                                     const hipblas_internal_type<U>* alpha,
+                                     const hipblas_internal_type<T>* x,
+                                     int64_t                         incx,
+                                     hipblas_internal_type<T>*       A,
+                                     int64_t                         lda);
 
     MAP2CF_D64_V2(hipblasHer, std::complex<float>, float, hipblasCher);
     MAP2CF_D64_V2(hipblasHer, std::complex<double>, double, hipblasZher);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerBatched)(hipblasHandle_t   handle,
-                                         hipblasFillMode_t uplo,
-                                         int               n,
-                                         const hipblas_internal_type<U>*          alpha,
-                                         const hipblas_internal_type<T>* const    x[],
-                                         int               incx,
-                                         hipblas_internal_type<T>* const          A[],
-                                         int               lda,
-                                         int               batchCount);
+    hipblasStatus_t (*hipblasHerBatched)(hipblasHandle_t                       handle,
+                                         hipblasFillMode_t                     uplo,
+                                         int                                   n,
+                                         const hipblas_internal_type<U>*       alpha,
+                                         const hipblas_internal_type<T>* const x[],
+                                         int                                   incx,
+                                         hipblas_internal_type<T>* const       A[],
+                                         int                                   lda,
+                                         int                                   batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerBatched_64)(hipblasHandle_t   handle,
-                                            hipblasFillMode_t uplo,
-                                            int64_t           n,
-                                            const hipblas_internal_type<U>*          alpha,
-                                            const hipblas_internal_type<T>* const    x[],
-                                            int64_t           incx,
-                                            hipblas_internal_type<T>* const          A[],
-                                            int64_t           lda,
-                                            int64_t           batchCount);
+    hipblasStatus_t (*hipblasHerBatched_64)(hipblasHandle_t                       handle,
+                                            hipblasFillMode_t                     uplo,
+                                            int64_t                               n,
+                                            const hipblas_internal_type<U>*       alpha,
+                                            const hipblas_internal_type<T>* const x[],
+                                            int64_t                               incx,
+                                            hipblas_internal_type<T>* const       A[],
+                                            int64_t                               lda,
+                                            int64_t                               batchCount);
 
     MAP2CF_D64_V2(hipblasHerBatched, std::complex<float>, float, hipblasCherBatched);
     MAP2CF_D64_V2(hipblasHerBatched, std::complex<double>, double, hipblasZherBatched);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerStridedBatched)(hipblasHandle_t   handle,
-                                                hipblasFillMode_t uplo,
-                                                int               n,
-                                                const hipblas_internal_type<U>*          alpha,
-                                                const hipblas_internal_type<T>*          x,
-                                                int               incx,
-                                                hipblasStride     stridex,
-                                                hipblas_internal_type<T>*                A,
-                                                int               lda,
-                                                hipblasStride     strideA,
-                                                int               batchCount);
+    hipblasStatus_t (*hipblasHerStridedBatched)(hipblasHandle_t                 handle,
+                                                hipblasFillMode_t               uplo,
+                                                int                             n,
+                                                const hipblas_internal_type<U>* alpha,
+                                                const hipblas_internal_type<T>* x,
+                                                int                             incx,
+                                                hipblasStride                   stridex,
+                                                hipblas_internal_type<T>*       A,
+                                                int                             lda,
+                                                hipblasStride                   strideA,
+                                                int                             batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerStridedBatched_64)(hipblasHandle_t   handle,
-                                                   hipblasFillMode_t uplo,
-                                                   int64_t           n,
-                                                   const hipblas_internal_type<U>*          alpha,
-                                                   const hipblas_internal_type<T>*          x,
-                                                   int64_t           incx,
-                                                   hipblasStride     stridex,
-                                                   hipblas_internal_type<T>*                A,
-                                                   int64_t           lda,
-                                                   hipblasStride     strideA,
-                                                   int64_t           batchCount);
+    hipblasStatus_t (*hipblasHerStridedBatched_64)(hipblasHandle_t                 handle,
+                                                   hipblasFillMode_t               uplo,
+                                                   int64_t                         n,
+                                                   const hipblas_internal_type<U>* alpha,
+                                                   const hipblas_internal_type<T>* x,
+                                                   int64_t                         incx,
+                                                   hipblasStride                   stridex,
+                                                   hipblas_internal_type<T>*       A,
+                                                   int64_t                         lda,
+                                                   hipblasStride                   strideA,
+                                                   int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHerStridedBatched, std::complex<float>, float, hipblasCherStridedBatched);
     MAP2CF_D64_V2(hipblasHerStridedBatched,
@@ -8615,256 +8743,256 @@ namespace
 
     // her2
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          y,
-                                   int               incy,
-                                   hipblas_internal_type<T>*                A,
-                                   int               lda);
+    hipblasStatus_t (*hipblasHer2)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* y,
+                                   int                             incy,
+                                   hipblas_internal_type<T>*       A,
+                                   int                             lda);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          y,
-                                      int64_t           incy,
-                                      hipblas_internal_type<T>*                A,
-                                      int64_t           lda);
+    hipblasStatus_t (*hipblasHer2_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* y,
+                                      int64_t                         incy,
+                                      hipblas_internal_type<T>*       A,
+                                      int64_t                         lda);
 
     MAP2CF_D64_V2(hipblasHer2, std::complex<float>, hipblasCher2);
     MAP2CF_D64_V2(hipblasHer2, std::complex<double>, hipblasZher2);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2Batched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>* const    y[],
-                                          int               incy,
-                                          hipblas_internal_type<T>* const          A[],
-                                          int               lda,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasHer2Batched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>* const y[],
+                                          int                                   incy,
+                                          hipblas_internal_type<T>* const       A[],
+                                          int                                   lda,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2Batched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>* const    y[],
-                                             int64_t           incy,
-                                             hipblas_internal_type<T>* const          A[],
-                                             int64_t           lda,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasHer2Batched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>* const y[],
+                                             int64_t                               incy,
+                                             hipblas_internal_type<T>* const       A[],
+                                             int64_t                               lda,
+                                             int64_t                               batchCount);
 
     MAP2CF_D64_V2(hipblasHer2Batched, std::complex<float>, hipblasCher2Batched);
     MAP2CF_D64_V2(hipblasHer2Batched, std::complex<double>, hipblasZher2Batched);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2StridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 hipblas_internal_type<T>*                A,
-                                                 int               lda,
-                                                 hipblasStride     strideA,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasHer2StridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 hipblas_internal_type<T>*       A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2StridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    hipblas_internal_type<T>*                A,
-                                                    int64_t           lda,
-                                                    hipblasStride     strideA,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasHer2StridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    hipblas_internal_type<T>*       A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHer2StridedBatched, std::complex<float>, hipblasCher2StridedBatched);
     MAP2CF_D64_V2(hipblasHer2StridedBatched, std::complex<double>, hipblasZher2StridedBatched);
 
     // hpmv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpmv)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          AP,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          beta,
-                                   hipblas_internal_type<T>*                y,
-                                   int               incy);
+    hipblasStatus_t (*hipblasHpmv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* AP,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpmv_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          AP,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          beta,
-                                      hipblas_internal_type<T>*                y,
-                                      int64_t           incy);
+    hipblasStatus_t (*hipblasHpmv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* AP,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     MAP2CF_D64_V2(hipblasHpmv, std::complex<float>, hipblasChpmv);
     MAP2CF_D64_V2(hipblasHpmv, std::complex<double>, hipblasZhpmv);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpmvBatched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    AP[],
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>*          beta,
-                                          hipblas_internal_type<T>* const          y[],
-                                          int               incy,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasHpmvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const AP[],
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpmvBatched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    AP[],
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>*          beta,
-                                             hipblas_internal_type<T>* const          y[],
-                                             int64_t           incy,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasHpmvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const AP[],
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batchCount);
 
     MAP2CF_D64_V2(hipblasHpmvBatched, std::complex<float>, hipblasChpmvBatched);
     MAP2CF_D64_V2(hipblasHpmvBatched, std::complex<double>, hipblasZhpmvBatched);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpmvStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          AP,
-                                                 hipblasStride     strideAP,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          beta,
-                                                 hipblas_internal_type<T>*                y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasHpmvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* AP,
+                                                 hipblasStride                   strideAP,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpmvStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          AP,
-                                                    hipblasStride     strideAP,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          beta,
-                                                    hipblas_internal_type<T>*                y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasHpmvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* AP,
+                                                    hipblasStride                   strideAP,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHpmvStridedBatched, std::complex<float>, hipblasChpmvStridedBatched);
     MAP2CF_D64_V2(hipblasHpmvStridedBatched, std::complex<double>, hipblasZhpmvStridedBatched);
 
     // hpr
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpr)(hipblasHandle_t   handle,
-                                  hipblasFillMode_t uplo,
-                                  int               n,
-                                  const hipblas_internal_type<U>*          alpha,
-                                  const hipblas_internal_type<T>*          x,
-                                  int               incx,
-                                  hipblas_internal_type<T>*                AP);
+    hipblasStatus_t (*hipblasHpr)(hipblasHandle_t                 handle,
+                                  hipblasFillMode_t               uplo,
+                                  int                             n,
+                                  const hipblas_internal_type<U>* alpha,
+                                  const hipblas_internal_type<T>* x,
+                                  int                             incx,
+                                  hipblas_internal_type<T>*       AP);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpr_64)(hipblasHandle_t   handle,
-                                     hipblasFillMode_t uplo,
-                                     int64_t           n,
-                                     const hipblas_internal_type<U>*          alpha,
-                                     const hipblas_internal_type<T>*          x,
-                                     int64_t           incx,
-                                     hipblas_internal_type<T>*                AP);
+    hipblasStatus_t (*hipblasHpr_64)(hipblasHandle_t                 handle,
+                                     hipblasFillMode_t               uplo,
+                                     int64_t                         n,
+                                     const hipblas_internal_type<U>* alpha,
+                                     const hipblas_internal_type<T>* x,
+                                     int64_t                         incx,
+                                     hipblas_internal_type<T>*       AP);
 
     MAP2CF_D64_V2(hipblasHpr, std::complex<float>, float, hipblasChpr);
     MAP2CF_D64_V2(hipblasHpr, std::complex<double>, double, hipblasZhpr);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHprBatched)(hipblasHandle_t   handle,
-                                         hipblasFillMode_t uplo,
-                                         int               n,
-                                         const hipblas_internal_type<U>*          alpha,
-                                         const hipblas_internal_type<T>* const    x[],
-                                         int               incx,
-                                         hipblas_internal_type<T>* const          AP[],
-                                         int               batchCount);
+    hipblasStatus_t (*hipblasHprBatched)(hipblasHandle_t                       handle,
+                                         hipblasFillMode_t                     uplo,
+                                         int                                   n,
+                                         const hipblas_internal_type<U>*       alpha,
+                                         const hipblas_internal_type<T>* const x[],
+                                         int                                   incx,
+                                         hipblas_internal_type<T>* const       AP[],
+                                         int                                   batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHprBatched_64)(hipblasHandle_t   handle,
-                                            hipblasFillMode_t uplo,
-                                            int64_t           n,
-                                            const hipblas_internal_type<U>*          alpha,
-                                            const hipblas_internal_type<T>* const    x[],
-                                            int64_t           incx,
-                                            hipblas_internal_type<T>* const          AP[],
-                                            int64_t           batchCount);
+    hipblasStatus_t (*hipblasHprBatched_64)(hipblasHandle_t                       handle,
+                                            hipblasFillMode_t                     uplo,
+                                            int64_t                               n,
+                                            const hipblas_internal_type<U>*       alpha,
+                                            const hipblas_internal_type<T>* const x[],
+                                            int64_t                               incx,
+                                            hipblas_internal_type<T>* const       AP[],
+                                            int64_t                               batchCount);
 
     MAP2CF_D64_V2(hipblasHprBatched, std::complex<float>, float, hipblasChprBatched);
     MAP2CF_D64_V2(hipblasHprBatched, std::complex<double>, double, hipblasZhprBatched);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHprStridedBatched)(hipblasHandle_t   handle,
-                                                hipblasFillMode_t uplo,
-                                                int               n,
-                                                const hipblas_internal_type<U>*          alpha,
-                                                const hipblas_internal_type<T>*          x,
-                                                int               incx,
-                                                hipblasStride     stridex,
-                                                hipblas_internal_type<T>*                AP,
-                                                hipblasStride     strideAP,
-                                                int               batchCount);
+    hipblasStatus_t (*hipblasHprStridedBatched)(hipblasHandle_t                 handle,
+                                                hipblasFillMode_t               uplo,
+                                                int                             n,
+                                                const hipblas_internal_type<U>* alpha,
+                                                const hipblas_internal_type<T>* x,
+                                                int                             incx,
+                                                hipblasStride                   stridex,
+                                                hipblas_internal_type<T>*       AP,
+                                                hipblasStride                   strideAP,
+                                                int                             batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHprStridedBatched_64)(hipblasHandle_t   handle,
-                                                   hipblasFillMode_t uplo,
-                                                   int64_t           n,
-                                                   const hipblas_internal_type<U>*          alpha,
-                                                   const hipblas_internal_type<T>*          x,
-                                                   int64_t           incx,
-                                                   hipblasStride     stridex,
-                                                   hipblas_internal_type<T>*                AP,
-                                                   hipblasStride     strideAP,
-                                                   int64_t           batchCount);
+    hipblasStatus_t (*hipblasHprStridedBatched_64)(hipblasHandle_t                 handle,
+                                                   hipblasFillMode_t               uplo,
+                                                   int64_t                         n,
+                                                   const hipblas_internal_type<U>* alpha,
+                                                   const hipblas_internal_type<T>* x,
+                                                   int64_t                         incx,
+                                                   hipblasStride                   stridex,
+                                                   hipblas_internal_type<T>*       AP,
+                                                   hipblasStride                   strideAP,
+                                                   int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHprStridedBatched, std::complex<float>, float, hipblasChprStridedBatched);
     MAP2CF_D64_V2(hipblasHprStridedBatched,
@@ -8874,183 +9002,183 @@ namespace
 
     // hpr2
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpr2)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          y,
-                                   int               incy,
-                                   hipblas_internal_type<T>*                AP);
+    hipblasStatus_t (*hipblasHpr2)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* y,
+                                   int                             incy,
+                                   hipblas_internal_type<T>*       AP);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpr2_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          y,
-                                      int64_t           incy,
-                                      hipblas_internal_type<T>*                AP);
+    hipblasStatus_t (*hipblasHpr2_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* y,
+                                      int64_t                         incy,
+                                      hipblas_internal_type<T>*       AP);
 
     MAP2CF_D64_V2(hipblasHpr2, std::complex<float>, hipblasChpr2);
     MAP2CF_D64_V2(hipblasHpr2, std::complex<double>, hipblasZhpr2);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpr2Batched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>* const    y[],
-                                          int               incy,
-                                          hipblas_internal_type<T>* const          AP[],
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasHpr2Batched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>* const y[],
+                                          int                                   incy,
+                                          hipblas_internal_type<T>* const       AP[],
+                                          int                                   batchCount);
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpr2Batched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>* const    y[],
-                                             int64_t           incy,
-                                             hipblas_internal_type<T>* const          AP[],
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasHpr2Batched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>* const y[],
+                                             int64_t                               incy,
+                                             hipblas_internal_type<T>* const       AP[],
+                                             int64_t                               batchCount);
 
     MAP2CF_D64_V2(hipblasHpr2Batched, std::complex<float>, hipblasChpr2Batched);
     MAP2CF_D64_V2(hipblasHpr2Batched, std::complex<double>, hipblasZhpr2Batched);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpr2StridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 hipblas_internal_type<T>*                AP,
-                                                 hipblasStride     strideAP,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasHpr2StridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 hipblas_internal_type<T>*       AP,
+                                                 hipblasStride                   strideAP,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHpr2StridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    hipblas_internal_type<T>*                AP,
-                                                    hipblasStride     strideAP,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasHpr2StridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    hipblas_internal_type<T>*       AP,
+                                                    hipblasStride                   strideAP,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHpr2StridedBatched, std::complex<float>, hipblasChpr2StridedBatched);
     MAP2CF_D64_V2(hipblasHpr2StridedBatched, std::complex<double>, hipblasZhpr2StridedBatched);
 
     // sbmv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSbmv)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   int               k,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          A,
-                                   int               lda,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          beta,
-                                   hipblas_internal_type<T>*                y,
-                                   int               incy);
+    hipblasStatus_t (*hipblasSbmv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   int                             k,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSbmvBatched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          int               k,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    A[],
-                                          int               lda,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>*          beta,
-                                          hipblas_internal_type<T>* const          y[],
-                                          int               incy,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasSbmvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          int                                   k,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSbmvStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 int               k,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          A,
-                                                 int               lda,
-                                                 hipblasStride     strideA,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          beta,
-                                                 hipblas_internal_type<T>*                y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasSbmvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 int                             k,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSbmv_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      int64_t           k,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          A,
-                                      int64_t           lda,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          beta,
-                                      hipblas_internal_type<T>*                y,
-                                      int64_t           incy);
+    hipblasStatus_t (*hipblasSbmv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      int64_t                         k,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSbmvBatched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             int64_t           k,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    A[],
-                                             int64_t           lda,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>*          beta,
-                                             hipblas_internal_type<T>* const          y[],
-                                             int64_t           incy,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasSbmvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             int64_t                               k,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSbmvStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    int64_t           k,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          A,
-                                                    int64_t           lda,
-                                                    hipblasStride     strideA,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          beta,
-                                                    hipblas_internal_type<T>*                y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasSbmvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    int64_t                         k,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSbmv, float, hipblasSsbmv);
     MAP2CF_D64(hipblasSbmv, double, hipblasDsbmv);
@@ -9063,86 +9191,86 @@ namespace
 
     // spmv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpmv)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          AP,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          beta,
-                                   hipblas_internal_type<T>*                y,
-                                   int               incy);
+    hipblasStatus_t (*hipblasSpmv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* AP,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpmvBatched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    AP[],
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>*          beta,
-                                          hipblas_internal_type<T>* const          y[],
-                                          int               incy,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasSpmvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const AP[],
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpmvStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          AP,
-                                                 hipblasStride     strideAP,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          beta,
-                                                 hipblas_internal_type<T>*                y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasSpmvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* AP,
+                                                 hipblasStride                   strideAP,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpmv_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          AP,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          beta,
-                                      hipblas_internal_type<T>*                y,
-                                      int64_t           incy);
+    hipblasStatus_t (*hipblasSpmv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* AP,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpmvBatched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    AP[],
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>*          beta,
-                                             hipblas_internal_type<T>* const          y[],
-                                             int64_t           incy,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasSpmvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const AP[],
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpmvStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          AP,
-                                                    hipblasStride     strideAP,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          beta,
-                                                    hipblas_internal_type<T>*                y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasSpmvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* AP,
+                                                    hipblasStride                   strideAP,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSpmv, float, hipblasSspmv);
     MAP2CF_D64(hipblasSpmv, double, hipblasDspmv);
@@ -9155,66 +9283,66 @@ namespace
 
     // spr
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpr)(hipblasHandle_t   handle,
-                                  hipblasFillMode_t uplo,
-                                  int               n,
-                                  const hipblas_internal_type<T>*          alpha,
-                                  const hipblas_internal_type<T>*          x,
-                                  int               incx,
-                                  hipblas_internal_type<T>*                AP);
+    hipblasStatus_t (*hipblasSpr)(hipblasHandle_t                 handle,
+                                  hipblasFillMode_t               uplo,
+                                  int                             n,
+                                  const hipblas_internal_type<T>* alpha,
+                                  const hipblas_internal_type<T>* x,
+                                  int                             incx,
+                                  hipblas_internal_type<T>*       AP);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSprBatched)(hipblasHandle_t   handle,
-                                         hipblasFillMode_t uplo,
-                                         int               n,
-                                         const hipblas_internal_type<T>*          alpha,
-                                         const hipblas_internal_type<T>* const    x[],
-                                         int               incx,
-                                         hipblas_internal_type<T>* const          AP[],
-                                         int               batchCount);
+    hipblasStatus_t (*hipblasSprBatched)(hipblasHandle_t                       handle,
+                                         hipblasFillMode_t                     uplo,
+                                         int                                   n,
+                                         const hipblas_internal_type<T>*       alpha,
+                                         const hipblas_internal_type<T>* const x[],
+                                         int                                   incx,
+                                         hipblas_internal_type<T>* const       AP[],
+                                         int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSprStridedBatched)(hipblasHandle_t   handle,
-                                                hipblasFillMode_t uplo,
-                                                int               n,
-                                                const hipblas_internal_type<T>*          alpha,
-                                                const hipblas_internal_type<T>*          x,
-                                                int               incx,
-                                                hipblasStride     stridex,
-                                                hipblas_internal_type<T>*                AP,
-                                                hipblasStride     strideAP,
-                                                int               batchCount);
+    hipblasStatus_t (*hipblasSprStridedBatched)(hipblasHandle_t                 handle,
+                                                hipblasFillMode_t               uplo,
+                                                int                             n,
+                                                const hipblas_internal_type<T>* alpha,
+                                                const hipblas_internal_type<T>* x,
+                                                int                             incx,
+                                                hipblasStride                   stridex,
+                                                hipblas_internal_type<T>*       AP,
+                                                hipblasStride                   strideAP,
+                                                int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpr_64)(hipblasHandle_t   handle,
-                                     hipblasFillMode_t uplo,
-                                     int64_t           n,
-                                     const hipblas_internal_type<T>*          alpha,
-                                     const hipblas_internal_type<T>*          x,
-                                     int64_t           incx,
-                                     hipblas_internal_type<T>*                AP);
+    hipblasStatus_t (*hipblasSpr_64)(hipblasHandle_t                 handle,
+                                     hipblasFillMode_t               uplo,
+                                     int64_t                         n,
+                                     const hipblas_internal_type<T>* alpha,
+                                     const hipblas_internal_type<T>* x,
+                                     int64_t                         incx,
+                                     hipblas_internal_type<T>*       AP);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSprBatched_64)(hipblasHandle_t   handle,
-                                            hipblasFillMode_t uplo,
-                                            int64_t           n,
-                                            const hipblas_internal_type<T>*          alpha,
-                                            const hipblas_internal_type<T>* const    x[],
-                                            int64_t           incx,
-                                            hipblas_internal_type<T>* const          AP[],
-                                            int64_t           batchCount);
+    hipblasStatus_t (*hipblasSprBatched_64)(hipblasHandle_t                       handle,
+                                            hipblasFillMode_t                     uplo,
+                                            int64_t                               n,
+                                            const hipblas_internal_type<T>*       alpha,
+                                            const hipblas_internal_type<T>* const x[],
+                                            int64_t                               incx,
+                                            hipblas_internal_type<T>* const       AP[],
+                                            int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSprStridedBatched_64)(hipblasHandle_t   handle,
-                                                   hipblasFillMode_t uplo,
-                                                   int64_t           n,
-                                                   const hipblas_internal_type<T>*          alpha,
-                                                   const hipblas_internal_type<T>*          x,
-                                                   int64_t           incx,
-                                                   hipblasStride     stridex,
-                                                   hipblas_internal_type<T>*                AP,
-                                                   hipblasStride     strideAP,
-                                                   int64_t           batchCount);
+    hipblasStatus_t (*hipblasSprStridedBatched_64)(hipblasHandle_t                 handle,
+                                                   hipblasFillMode_t               uplo,
+                                                   int64_t                         n,
+                                                   const hipblas_internal_type<T>* alpha,
+                                                   const hipblas_internal_type<T>* x,
+                                                   int64_t                         incx,
+                                                   hipblasStride                   stridex,
+                                                   hipblas_internal_type<T>*       AP,
+                                                   hipblasStride                   strideAP,
+                                                   int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSpr, float, hipblasSspr);
     MAP2CF_D64(hipblasSpr, double, hipblasDspr);
@@ -9233,80 +9361,80 @@ namespace
 
     // spr2
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpr2)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          y,
-                                   int               incy,
-                                   hipblas_internal_type<T>*                AP);
+    hipblasStatus_t (*hipblasSpr2)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* y,
+                                   int                             incy,
+                                   hipblas_internal_type<T>*       AP);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpr2Batched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>* const    y[],
-                                          int               incy,
-                                          hipblas_internal_type<T>* const          AP[],
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasSpr2Batched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>* const y[],
+                                          int                                   incy,
+                                          hipblas_internal_type<T>* const       AP[],
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpr2StridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 hipblas_internal_type<T>*                AP,
-                                                 hipblasStride     strideAP,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasSpr2StridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 hipblas_internal_type<T>*       AP,
+                                                 hipblasStride                   strideAP,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpr2_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          y,
-                                      int64_t           incy,
-                                      hipblas_internal_type<T>*                AP);
+    hipblasStatus_t (*hipblasSpr2_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* y,
+                                      int64_t                         incy,
+                                      hipblas_internal_type<T>*       AP);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpr2Batched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>* const    y[],
-                                             int64_t           incy,
-                                             hipblas_internal_type<T>* const          AP[],
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasSpr2Batched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>* const y[],
+                                             int64_t                               incy,
+                                             hipblas_internal_type<T>* const       AP[],
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSpr2StridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    hipblas_internal_type<T>*                AP,
-                                                    hipblasStride     strideAP,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasSpr2StridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    hipblas_internal_type<T>*       AP,
+                                                    hipblasStride                   strideAP,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSpr2, float, hipblasSspr2);
     MAP2CF_D64(hipblasSpr2, double, hipblasDspr2);
@@ -9319,92 +9447,92 @@ namespace
 
     // symv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymv)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          A,
-                                   int               lda,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          beta,
-                                   hipblas_internal_type<T>*                y,
-                                   int               incy);
+    hipblasStatus_t (*hipblasSymv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymvBatched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    A[],
-                                          int               lda,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>*          beta,
-                                          hipblas_internal_type<T>* const          y[],
-                                          int               incy,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasSymvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymvStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          A,
-                                                 int               lda,
-                                                 hipblasStride     strideA,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          beta,
-                                                 hipblas_internal_type<T>*                y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasSymvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymv_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          A,
-                                      int64_t           lda,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          beta,
-                                      hipblas_internal_type<T>*                y,
-                                      int64_t           incy);
+    hipblasStatus_t (*hipblasSymv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymvBatched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    A[],
-                                             int64_t           lda,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>*          beta,
-                                             hipblas_internal_type<T>* const          y[],
-                                             int64_t           incy,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasSymvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymvStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          A,
-                                                    int64_t           lda,
-                                                    hipblasStride     strideA,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          beta,
-                                                    hipblas_internal_type<T>*                y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasSymvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSymv, float, hipblasSsymv);
     MAP2CF_D64(hipblasSymv, double, hipblasDsymv);
@@ -9423,72 +9551,72 @@ namespace
 
     // syr
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr)(hipblasHandle_t   handle,
-                                  hipblasFillMode_t uplo,
-                                  int               n,
-                                  const hipblas_internal_type<T>*          alpha,
-                                  const hipblas_internal_type<T>*          x,
-                                  int               incx,
-                                  hipblas_internal_type<T>*                A,
-                                  int               lda);
+    hipblasStatus_t (*hipblasSyr)(hipblasHandle_t                 handle,
+                                  hipblasFillMode_t               uplo,
+                                  int                             n,
+                                  const hipblas_internal_type<T>* alpha,
+                                  const hipblas_internal_type<T>* x,
+                                  int                             incx,
+                                  hipblas_internal_type<T>*       A,
+                                  int                             lda);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrBatched)(hipblasHandle_t   handle,
-                                         hipblasFillMode_t uplo,
-                                         int               n,
-                                         const hipblas_internal_type<T>*          alpha,
-                                         const hipblas_internal_type<T>* const    x[],
-                                         int               incx,
-                                         hipblas_internal_type<T>* const          A[],
-                                         int               lda,
-                                         int               batch_count);
+    hipblasStatus_t (*hipblasSyrBatched)(hipblasHandle_t                       handle,
+                                         hipblasFillMode_t                     uplo,
+                                         int                                   n,
+                                         const hipblas_internal_type<T>*       alpha,
+                                         const hipblas_internal_type<T>* const x[],
+                                         int                                   incx,
+                                         hipblas_internal_type<T>* const       A[],
+                                         int                                   lda,
+                                         int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrStridedBatched)(hipblasHandle_t   handle,
-                                                hipblasFillMode_t uplo,
-                                                int               n,
-                                                const hipblas_internal_type<T>*          alpha,
-                                                const hipblas_internal_type<T>*          x,
-                                                int               incx,
-                                                hipblasStride     stridex,
-                                                hipblas_internal_type<T>*                A,
-                                                int               lda,
-                                                hipblasStride     strideA,
-                                                int               batch_count);
+    hipblasStatus_t (*hipblasSyrStridedBatched)(hipblasHandle_t                 handle,
+                                                hipblasFillMode_t               uplo,
+                                                int                             n,
+                                                const hipblas_internal_type<T>* alpha,
+                                                const hipblas_internal_type<T>* x,
+                                                int                             incx,
+                                                hipblasStride                   stridex,
+                                                hipblas_internal_type<T>*       A,
+                                                int                             lda,
+                                                hipblasStride                   strideA,
+                                                int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr_64)(hipblasHandle_t   handle,
-                                     hipblasFillMode_t uplo,
-                                     int64_t           n,
-                                     const hipblas_internal_type<T>*          alpha,
-                                     const hipblas_internal_type<T>*          x,
-                                     int64_t           incx,
-                                     hipblas_internal_type<T>*                A,
-                                     int64_t           lda);
+    hipblasStatus_t (*hipblasSyr_64)(hipblasHandle_t                 handle,
+                                     hipblasFillMode_t               uplo,
+                                     int64_t                         n,
+                                     const hipblas_internal_type<T>* alpha,
+                                     const hipblas_internal_type<T>* x,
+                                     int64_t                         incx,
+                                     hipblas_internal_type<T>*       A,
+                                     int64_t                         lda);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrBatched_64)(hipblasHandle_t   handle,
-                                            hipblasFillMode_t uplo,
-                                            int64_t           n,
-                                            const hipblas_internal_type<T>*          alpha,
-                                            const hipblas_internal_type<T>* const    x[],
-                                            int64_t           incx,
-                                            hipblas_internal_type<T>* const          A[],
-                                            int64_t           lda,
-                                            int64_t           batch_count);
+    hipblasStatus_t (*hipblasSyrBatched_64)(hipblasHandle_t                       handle,
+                                            hipblasFillMode_t                     uplo,
+                                            int64_t                               n,
+                                            const hipblas_internal_type<T>*       alpha,
+                                            const hipblas_internal_type<T>* const x[],
+                                            int64_t                               incx,
+                                            hipblas_internal_type<T>* const       A[],
+                                            int64_t                               lda,
+                                            int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrStridedBatched_64)(hipblasHandle_t   handle,
-                                                   hipblasFillMode_t uplo,
-                                                   int64_t           n,
-                                                   const hipblas_internal_type<T>*          alpha,
-                                                   const hipblas_internal_type<T>*          x,
-                                                   int64_t           incx,
-                                                   hipblasStride     stridex,
-                                                   hipblas_internal_type<T>*                A,
-                                                   int64_t           lda,
-                                                   hipblasStride     strideA,
-                                                   int64_t           batch_count);
+    hipblasStatus_t (*hipblasSyrStridedBatched_64)(hipblasHandle_t                 handle,
+                                                   hipblasFillMode_t               uplo,
+                                                   int64_t                         n,
+                                                   const hipblas_internal_type<T>* alpha,
+                                                   const hipblas_internal_type<T>* x,
+                                                   int64_t                         incx,
+                                                   hipblasStride                   stridex,
+                                                   hipblas_internal_type<T>*       A,
+                                                   int64_t                         lda,
+                                                   hipblasStride                   strideA,
+                                                   int64_t                         batch_count);
 
     MAP2CF_D64(hipblasSyr, float, hipblasSsyr);
     MAP2CF_D64(hipblasSyr, double, hipblasDsyr);
@@ -9507,86 +9635,86 @@ namespace
 
     // syr2
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2)(hipblasHandle_t   handle,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   const hipblas_internal_type<T>*          y,
-                                   int               incy,
-                                   hipblas_internal_type<T>*                A,
-                                   int               lda);
+    hipblasStatus_t (*hipblasSyr2)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* y,
+                                   int                             incy,
+                                   hipblas_internal_type<T>*       A,
+                                   int                             lda);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2Batched)(hipblasHandle_t   handle,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          const hipblas_internal_type<T>* const    y[],
-                                          int               incy,
-                                          hipblas_internal_type<T>* const          A[],
-                                          int               lda,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasSyr2Batched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>* const y[],
+                                          int                                   incy,
+                                          hipblas_internal_type<T>* const       A[],
+                                          int                                   lda,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2StridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stridex,
-                                                 const hipblas_internal_type<T>*          y,
-                                                 int               incy,
-                                                 hipblasStride     stridey,
-                                                 hipblas_internal_type<T>*                A,
-                                                 int               lda,
-                                                 hipblasStride     strideA,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasSyr2StridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 const hipblas_internal_type<T>* y,
+                                                 int                             incy,
+                                                 hipblasStride                   stridey,
+                                                 hipblas_internal_type<T>*       A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2_64)(hipblasHandle_t   handle,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      const hipblas_internal_type<T>*          y,
-                                      int64_t           incy,
-                                      hipblas_internal_type<T>*                A,
-                                      int64_t           lda);
+    hipblasStatus_t (*hipblasSyr2_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* y,
+                                      int64_t                         incy,
+                                      hipblas_internal_type<T>*       A,
+                                      int64_t                         lda);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2Batched_64)(hipblasHandle_t   handle,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             const hipblas_internal_type<T>* const    y[],
-                                             int64_t           incy,
-                                             hipblas_internal_type<T>* const          A[],
-                                             int64_t           lda,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasSyr2Batched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>* const y[],
+                                             int64_t                               incy,
+                                             hipblas_internal_type<T>* const       A[],
+                                             int64_t                               lda,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2StridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stridex,
-                                                    const hipblas_internal_type<T>*          y,
-                                                    int64_t           incy,
-                                                    hipblasStride     stridey,
-                                                    hipblas_internal_type<T>*                A,
-                                                    int64_t           lda,
-                                                    hipblasStride     strideA,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasSyr2StridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    const hipblas_internal_type<T>* y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stridey,
+                                                    hipblas_internal_type<T>*       A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSyr2, float, hipblasSsyr2);
     MAP2CF_D64(hipblasSyr2, double, hipblasDsyr2);
@@ -9605,84 +9733,84 @@ namespace
 
     // tbmv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbmv)(hipblasHandle_t    handle,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   hipblasDiagType_t  diag,
-                                   int                m,
-                                   int                k,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   hipblas_internal_type<T>*                 x,
-                                   int                incx);
+    hipblasStatus_t (*hipblasTbmv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   hipblasDiagType_t               diag,
+                                   int                             m,
+                                   int                             k,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   hipblas_internal_type<T>*       x,
+                                   int                             incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbmvBatched)(hipblasHandle_t    handle,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          hipblasDiagType_t  diag,
-                                          int                m,
-                                          int                k,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          hipblas_internal_type<T>* const           x[],
-                                          int                incx,
-                                          int                batch_count);
+    hipblasStatus_t (*hipblasTbmvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          hipblasDiagType_t                     diag,
+                                          int                                   m,
+                                          int                                   k,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          hipblas_internal_type<T>* const       x[],
+                                          int                                   incx,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbmvStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 hipblasDiagType_t  diag,
-                                                 int                m,
-                                                 int                k,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      stride_a,
-                                                 hipblas_internal_type<T>*                 x,
-                                                 int                incx,
-                                                 hipblasStride      stride_x,
-                                                 int                batch_count);
+    hipblasStatus_t (*hipblasTbmvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasDiagType_t               diag,
+                                                 int                             m,
+                                                 int                             k,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   stride_a,
+                                                 hipblas_internal_type<T>*       x,
+                                                 int                             incx,
+                                                 hipblasStride                   stride_x,
+                                                 int                             batch_count);
     //tbmv_64
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbmv_64)(hipblasHandle_t    handle,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      hipblasDiagType_t  diag,
-                                      int64_t            m,
-                                      int64_t            k,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      hipblas_internal_type<T>*                 x,
-                                      int64_t            incx);
+    hipblasStatus_t (*hipblasTbmv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      hipblasDiagType_t               diag,
+                                      int64_t                         m,
+                                      int64_t                         k,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      hipblas_internal_type<T>*       x,
+                                      int64_t                         incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbmvBatched_64)(hipblasHandle_t    handle,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             hipblasDiagType_t  diag,
-                                             int64_t            m,
-                                             int64_t            k,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             hipblas_internal_type<T>* const           x[],
-                                             int64_t            incx,
-                                             int64_t            batch_count);
+    hipblasStatus_t (*hipblasTbmvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             hipblasDiagType_t                     diag,
+                                             int64_t                               m,
+                                             int64_t                               k,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             hipblas_internal_type<T>* const       x[],
+                                             int64_t                               incx,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbmvStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    hipblasDiagType_t  diag,
-                                                    int64_t            m,
-                                                    int64_t            k,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      stride_a,
-                                                    hipblas_internal_type<T>*                 x,
-                                                    int64_t            incx,
-                                                    hipblasStride      stride_x,
-                                                    int64_t            batch_count);
+    hipblasStatus_t (*hipblasTbmvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasDiagType_t               diag,
+                                                    int64_t                         m,
+                                                    int64_t                         k,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   stride_a,
+                                                    hipblas_internal_type<T>*       x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stride_x,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasTbmv, float, hipblasStbmv);
     MAP2CF_D64(hipblasTbmv, double, hipblasDtbmv);
@@ -9701,85 +9829,85 @@ namespace
 
     // tbsv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbsv)(hipblasHandle_t    handle,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   hipblasDiagType_t  diag,
-                                   int                m,
-                                   int                k,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   hipblas_internal_type<T>*                 x,
-                                   int                incx);
+    hipblasStatus_t (*hipblasTbsv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   hipblasDiagType_t               diag,
+                                   int                             m,
+                                   int                             k,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   hipblas_internal_type<T>*       x,
+                                   int                             incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbsvBatched)(hipblasHandle_t    handle,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          hipblasDiagType_t  diag,
-                                          int                m,
-                                          int                k,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          hipblas_internal_type<T>* const           x[],
-                                          int                incx,
-                                          int                batchCount);
+    hipblasStatus_t (*hipblasTbsvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          hipblasDiagType_t                     diag,
+                                          int                                   m,
+                                          int                                   k,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          hipblas_internal_type<T>* const       x[],
+                                          int                                   incx,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbsvStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 hipblasDiagType_t  diag,
-                                                 int                m,
-                                                 int                k,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      strideA,
-                                                 hipblas_internal_type<T>*                 x,
-                                                 int                incx,
-                                                 hipblasStride      stridex,
-                                                 int                batchCount);
+    hipblasStatus_t (*hipblasTbsvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasDiagType_t               diag,
+                                                 int                             m,
+                                                 int                             k,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 hipblas_internal_type<T>*       x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 int                             batchCount);
 
     // tbsv_64
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbsv_64)(hipblasHandle_t    handle,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      hipblasDiagType_t  diag,
-                                      int64_t            m,
-                                      int64_t            k,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      hipblas_internal_type<T>*                 x,
-                                      int64_t            incx);
+    hipblasStatus_t (*hipblasTbsv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      hipblasDiagType_t               diag,
+                                      int64_t                         m,
+                                      int64_t                         k,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      hipblas_internal_type<T>*       x,
+                                      int64_t                         incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbsvBatched_64)(hipblasHandle_t    handle,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             hipblasDiagType_t  diag,
-                                             int64_t            m,
-                                             int64_t            k,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             hipblas_internal_type<T>* const           x[],
-                                             int64_t            incx,
-                                             int64_t            batchCount);
+    hipblasStatus_t (*hipblasTbsvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             hipblasDiagType_t                     diag,
+                                             int64_t                               m,
+                                             int64_t                               k,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             hipblas_internal_type<T>* const       x[],
+                                             int64_t                               incx,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTbsvStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    hipblasDiagType_t  diag,
-                                                    int64_t            m,
-                                                    int64_t            k,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      strideA,
-                                                    hipblas_internal_type<T>*                 x,
-                                                    int64_t            incx,
-                                                    hipblasStride      stridex,
-                                                    int64_t            batchCount);
+    hipblasStatus_t (*hipblasTbsvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasDiagType_t               diag,
+                                                    int64_t                         m,
+                                                    int64_t                         k,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    hipblas_internal_type<T>*       x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasTbsv, float, hipblasStbsv);
     MAP2CF_D64(hipblasTbsv, double, hipblasDtbsv);
@@ -9798,73 +9926,73 @@ namespace
 
     // tpmv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpmv)(hipblasHandle_t    handle,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   hipblasDiagType_t  diag,
-                                   int                m,
-                                   const hipblas_internal_type<T>*           AP,
-                                   hipblas_internal_type<T>*                 x,
-                                   int                incx);
+    hipblasStatus_t (*hipblasTpmv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   hipblasDiagType_t               diag,
+                                   int                             m,
+                                   const hipblas_internal_type<T>* AP,
+                                   hipblas_internal_type<T>*       x,
+                                   int                             incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpmvBatched)(hipblasHandle_t    handle,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          hipblasDiagType_t  diag,
-                                          int                m,
-                                          const hipblas_internal_type<T>* const     AP[],
-                                          hipblas_internal_type<T>* const           x[],
-                                          int                incx,
-                                          int                batchCount);
+    hipblasStatus_t (*hipblasTpmvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          hipblasDiagType_t                     diag,
+                                          int                                   m,
+                                          const hipblas_internal_type<T>* const AP[],
+                                          hipblas_internal_type<T>* const       x[],
+                                          int                                   incx,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpmvStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 hipblasDiagType_t  diag,
-                                                 int                m,
-                                                 const hipblas_internal_type<T>*           AP,
-                                                 hipblasStride      strideAP,
-                                                 hipblas_internal_type<T>*                 x,
-                                                 int                incx,
-                                                 hipblasStride      stridex,
-                                                 int                batchCount);
+    hipblasStatus_t (*hipblasTpmvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasDiagType_t               diag,
+                                                 int                             m,
+                                                 const hipblas_internal_type<T>* AP,
+                                                 hipblasStride                   strideAP,
+                                                 hipblas_internal_type<T>*       x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 int                             batchCount);
 
     // tpmv_64
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpmv_64)(hipblasHandle_t    handle,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      hipblasDiagType_t  diag,
-                                      int64_t            m,
-                                      const hipblas_internal_type<T>*           AP,
-                                      hipblas_internal_type<T>*                 x,
-                                      int64_t            incx);
+    hipblasStatus_t (*hipblasTpmv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      hipblasDiagType_t               diag,
+                                      int64_t                         m,
+                                      const hipblas_internal_type<T>* AP,
+                                      hipblas_internal_type<T>*       x,
+                                      int64_t                         incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpmvBatched_64)(hipblasHandle_t    handle,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             hipblasDiagType_t  diag,
-                                             int64_t            m,
-                                             const hipblas_internal_type<T>* const     AP[],
-                                             hipblas_internal_type<T>* const           x[],
-                                             int64_t            incx,
-                                             int64_t            batchCount);
+    hipblasStatus_t (*hipblasTpmvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             hipblasDiagType_t                     diag,
+                                             int64_t                               m,
+                                             const hipblas_internal_type<T>* const AP[],
+                                             hipblas_internal_type<T>* const       x[],
+                                             int64_t                               incx,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpmvStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    hipblasDiagType_t  diag,
-                                                    int64_t            m,
-                                                    const hipblas_internal_type<T>*           AP,
-                                                    hipblasStride      strideAP,
-                                                    hipblas_internal_type<T>*                 x,
-                                                    int64_t            incx,
-                                                    hipblasStride      stridex,
-                                                    int64_t            batchCount);
+    hipblasStatus_t (*hipblasTpmvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasDiagType_t               diag,
+                                                    int64_t                         m,
+                                                    const hipblas_internal_type<T>* AP,
+                                                    hipblasStride                   strideAP,
+                                                    hipblas_internal_type<T>*       x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasTpmv, float, hipblasStpmv);
     MAP2CF_D64(hipblasTpmv, double, hipblasDtpmv);
@@ -9883,73 +10011,73 @@ namespace
 
     // tpsv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpsv)(hipblasHandle_t    handle,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   hipblasDiagType_t  diag,
-                                   int                m,
-                                   const hipblas_internal_type<T>*           AP,
-                                   hipblas_internal_type<T>*                 x,
-                                   int                incx);
+    hipblasStatus_t (*hipblasTpsv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   hipblasDiagType_t               diag,
+                                   int                             m,
+                                   const hipblas_internal_type<T>* AP,
+                                   hipblas_internal_type<T>*       x,
+                                   int                             incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpsvBatched)(hipblasHandle_t    handle,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          hipblasDiagType_t  diag,
-                                          int                m,
-                                          const hipblas_internal_type<T>* const     AP[],
-                                          hipblas_internal_type<T>* const           x[],
-                                          int                incx,
-                                          int                batchCount);
+    hipblasStatus_t (*hipblasTpsvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          hipblasDiagType_t                     diag,
+                                          int                                   m,
+                                          const hipblas_internal_type<T>* const AP[],
+                                          hipblas_internal_type<T>* const       x[],
+                                          int                                   incx,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpsvStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 hipblasDiagType_t  diag,
-                                                 int                m,
-                                                 const hipblas_internal_type<T>*           AP,
-                                                 hipblasStride      strideAP,
-                                                 hipblas_internal_type<T>*                 x,
-                                                 int                incx,
-                                                 hipblasStride      stridex,
-                                                 int                batchCount);
+    hipblasStatus_t (*hipblasTpsvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasDiagType_t               diag,
+                                                 int                             m,
+                                                 const hipblas_internal_type<T>* AP,
+                                                 hipblasStride                   strideAP,
+                                                 hipblas_internal_type<T>*       x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 int                             batchCount);
 
     // tpsv_64
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpsv_64)(hipblasHandle_t    handle,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      hipblasDiagType_t  diag,
-                                      int64_t            m,
-                                      const hipblas_internal_type<T>*           AP,
-                                      hipblas_internal_type<T>*                 x,
-                                      int64_t            incx);
+    hipblasStatus_t (*hipblasTpsv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      hipblasDiagType_t               diag,
+                                      int64_t                         m,
+                                      const hipblas_internal_type<T>* AP,
+                                      hipblas_internal_type<T>*       x,
+                                      int64_t                         incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpsvBatched_64)(hipblasHandle_t    handle,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             hipblasDiagType_t  diag,
-                                             int64_t            m,
-                                             const hipblas_internal_type<T>* const     AP[],
-                                             hipblas_internal_type<T>* const           x[],
-                                             int64_t            incx,
-                                             int64_t            batchCount);
+    hipblasStatus_t (*hipblasTpsvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             hipblasDiagType_t                     diag,
+                                             int64_t                               m,
+                                             const hipblas_internal_type<T>* const AP[],
+                                             hipblas_internal_type<T>* const       x[],
+                                             int64_t                               incx,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTpsvStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    hipblasDiagType_t  diag,
-                                                    int64_t            m,
-                                                    const hipblas_internal_type<T>*           AP,
-                                                    hipblasStride      strideAP,
-                                                    hipblas_internal_type<T>*                 x,
-                                                    int64_t            incx,
-                                                    hipblasStride      stridex,
-                                                    int64_t            batchCount);
+    hipblasStatus_t (*hipblasTpsvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasDiagType_t               diag,
+                                                    int64_t                         m,
+                                                    const hipblas_internal_type<T>* AP,
+                                                    hipblasStride                   strideAP,
+                                                    hipblas_internal_type<T>*       x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasTpsv, float, hipblasStpsv);
     MAP2CF_D64(hipblasTpsv, double, hipblasDtpsv);
@@ -9968,79 +10096,79 @@ namespace
 
     // trmv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmv)(hipblasHandle_t    handle,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   hipblasDiagType_t  diag,
-                                   int                m,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   hipblas_internal_type<T>*                 x,
-                                   int                incx);
+    hipblasStatus_t (*hipblasTrmv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   hipblasDiagType_t               diag,
+                                   int                             m,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   hipblas_internal_type<T>*       x,
+                                   int                             incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmvBatched)(hipblasHandle_t    handle,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          hipblasDiagType_t  diag,
-                                          int                m,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          hipblas_internal_type<T>* const           x[],
-                                          int                incx,
-                                          int                batch_count);
+    hipblasStatus_t (*hipblasTrmvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          hipblasDiagType_t                     diag,
+                                          int                                   m,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          hipblas_internal_type<T>* const       x[],
+                                          int                                   incx,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmvStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 hipblasDiagType_t  diag,
-                                                 int                m,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      stride_a,
-                                                 hipblas_internal_type<T>*                 x,
-                                                 int                incx,
-                                                 hipblasStride      stride_x,
-                                                 int                batch_count);
+    hipblasStatus_t (*hipblasTrmvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasDiagType_t               diag,
+                                                 int                             m,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   stride_a,
+                                                 hipblas_internal_type<T>*       x,
+                                                 int                             incx,
+                                                 hipblasStride                   stride_x,
+                                                 int                             batch_count);
 
     // trmv_64
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmv_64)(hipblasHandle_t    handle,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      hipblasDiagType_t  diag,
-                                      int64_t            m,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      hipblas_internal_type<T>*                 x,
-                                      int64_t            incx);
+    hipblasStatus_t (*hipblasTrmv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      hipblasDiagType_t               diag,
+                                      int64_t                         m,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      hipblas_internal_type<T>*       x,
+                                      int64_t                         incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmvBatched_64)(hipblasHandle_t    handle,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             hipblasDiagType_t  diag,
-                                             int64_t            m,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             hipblas_internal_type<T>* const           x[],
-                                             int64_t            incx,
-                                             int64_t            batch_count);
+    hipblasStatus_t (*hipblasTrmvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             hipblasDiagType_t                     diag,
+                                             int64_t                               m,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             hipblas_internal_type<T>* const       x[],
+                                             int64_t                               incx,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmvStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    hipblasDiagType_t  diag,
-                                                    int64_t            m,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      stride_a,
-                                                    hipblas_internal_type<T>*                 x,
-                                                    int64_t            incx,
-                                                    hipblasStride      stride_x,
-                                                    int64_t            batch_count);
+    hipblasStatus_t (*hipblasTrmvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasDiagType_t               diag,
+                                                    int64_t                         m,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   stride_a,
+                                                    hipblas_internal_type<T>*       x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stride_x,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasTrmv, float, hipblasStrmv);
     MAP2CF_D64(hipblasTrmv, double, hipblasDtrmv);
@@ -10059,79 +10187,79 @@ namespace
 
     // trsv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsv)(hipblasHandle_t    handle,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   hipblasDiagType_t  diag,
-                                   int                m,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   hipblas_internal_type<T>*                 x,
-                                   int                incx);
+    hipblasStatus_t (*hipblasTrsv)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   hipblasDiagType_t               diag,
+                                   int                             m,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   hipblas_internal_type<T>*       x,
+                                   int                             incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsvBatched)(hipblasHandle_t    handle,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          hipblasDiagType_t  diag,
-                                          int                m,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          hipblas_internal_type<T>* const           x[],
-                                          int                incx,
-                                          int                batch_count);
+    hipblasStatus_t (*hipblasTrsvBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          hipblasDiagType_t                     diag,
+                                          int                                   m,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          hipblas_internal_type<T>* const       x[],
+                                          int                                   incx,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsvStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 hipblasDiagType_t  diag,
-                                                 int                m,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      strideA,
-                                                 hipblas_internal_type<T>*                 x,
-                                                 int                incx,
-                                                 hipblasStride      stridex,
-                                                 int                batch_count);
+    hipblasStatus_t (*hipblasTrsvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasDiagType_t               diag,
+                                                 int                             m,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 hipblas_internal_type<T>*       x,
+                                                 int                             incx,
+                                                 hipblasStride                   stridex,
+                                                 int                             batch_count);
 
     // trsv_64
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsv_64)(hipblasHandle_t    handle,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      hipblasDiagType_t  diag,
-                                      int64_t            m,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      hipblas_internal_type<T>*                 x,
-                                      int64_t            incx);
+    hipblasStatus_t (*hipblasTrsv_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      hipblasDiagType_t               diag,
+                                      int64_t                         m,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      hipblas_internal_type<T>*       x,
+                                      int64_t                         incx);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsvBatched_64)(hipblasHandle_t    handle,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             hipblasDiagType_t  diag,
-                                             int64_t            m,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             hipblas_internal_type<T>* const           x[],
-                                             int64_t            incx,
-                                             int64_t            batch_count);
+    hipblasStatus_t (*hipblasTrsvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             hipblasDiagType_t                     diag,
+                                             int64_t                               m,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             hipblas_internal_type<T>* const       x[],
+                                             int64_t                               incx,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsvStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    hipblasDiagType_t  diag,
-                                                    int64_t            m,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      strideA,
-                                                    hipblas_internal_type<T>*                 x,
-                                                    int64_t            incx,
-                                                    hipblasStride      stridex,
-                                                    int64_t            batch_count);
+    hipblasStatus_t (*hipblasTrsvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasDiagType_t               diag,
+                                                    int64_t                         m,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    hipblas_internal_type<T>*       x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stridex,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasTrsv, float, hipblasStrsv);
     MAP2CF_D64(hipblasTrsv, double, hipblasDtrsv);
@@ -10150,111 +10278,111 @@ namespace
 
     // gbmv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGbmv)(hipblasHandle_t    handle,
-                                   hipblasOperation_t transA,
-                                   int                m,
-                                   int                n,
-                                   int                kl,
-                                   int                ku,
-                                   const hipblas_internal_type<T>*           alpha,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   const hipblas_internal_type<T>*           x,
-                                   int                incx,
-                                   const hipblas_internal_type<T>*           beta,
-                                   hipblas_internal_type<T>*                 y,
-                                   int                incy);
+    hipblasStatus_t (*hipblasGbmv)(hipblasHandle_t                 handle,
+                                   hipblasOperation_t              transA,
+                                   int                             m,
+                                   int                             n,
+                                   int                             kl,
+                                   int                             ku,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGbmvBatched)(hipblasHandle_t    handle,
-                                          hipblasOperation_t transA,
-                                          int                m,
-                                          int                n,
-                                          int                kl,
-                                          int                ku,
-                                          const hipblas_internal_type<T>*           alpha,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          const hipblas_internal_type<T>* const     x[],
-                                          int                incx,
-                                          const hipblas_internal_type<T>*           beta,
-                                          hipblas_internal_type<T>* const           y[],
-                                          int                incy,
-                                          int                batch_count);
+    hipblasStatus_t (*hipblasGbmvBatched)(hipblasHandle_t                       handle,
+                                          hipblasOperation_t                    transA,
+                                          int                                   m,
+                                          int                                   n,
+                                          int                                   kl,
+                                          int                                   ku,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGbmvStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasOperation_t transA,
-                                                 int                m,
-                                                 int                n,
-                                                 int                kl,
-                                                 int                ku,
-                                                 const hipblas_internal_type<T>*           alpha,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      stride_a,
-                                                 const hipblas_internal_type<T>*           x,
-                                                 int                incx,
-                                                 hipblasStride      stride_x,
-                                                 const hipblas_internal_type<T>*           beta,
-                                                 hipblas_internal_type<T>*                 y,
-                                                 int                incy,
-                                                 hipblasStride      stride_y,
-                                                 int                batch_count);
+    hipblasStatus_t (*hipblasGbmvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasOperation_t              transA,
+                                                 int                             m,
+                                                 int                             n,
+                                                 int                             kl,
+                                                 int                             ku,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   stride_a,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stride_x,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stride_y,
+                                                 int                             batch_count);
 
     // gbmv_64
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGbmv_64)(hipblasHandle_t    handle,
-                                      hipblasOperation_t transA,
-                                      int64_t            m,
-                                      int64_t            n,
-                                      int64_t            kl,
-                                      int64_t            ku,
-                                      const hipblas_internal_type<T>*           alpha,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      const hipblas_internal_type<T>*           x,
-                                      int64_t            incx,
-                                      const hipblas_internal_type<T>*           beta,
-                                      hipblas_internal_type<T>*                 y,
-                                      int64_t            incy);
+    hipblasStatus_t (*hipblasGbmv_64)(hipblasHandle_t                 handle,
+                                      hipblasOperation_t              transA,
+                                      int64_t                         m,
+                                      int64_t                         n,
+                                      int64_t                         kl,
+                                      int64_t                         ku,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGbmvBatched_64)(hipblasHandle_t    handle,
-                                             hipblasOperation_t transA,
-                                             int64_t            m,
-                                             int64_t            n,
-                                             int64_t            kl,
-                                             int64_t            ku,
-                                             const hipblas_internal_type<T>*           alpha,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             const hipblas_internal_type<T>* const     x[],
-                                             int64_t            incx,
-                                             const hipblas_internal_type<T>*           beta,
-                                             hipblas_internal_type<T>* const           y[],
-                                             int64_t            incy,
-                                             int64_t            batch_count);
+    hipblasStatus_t (*hipblasGbmvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasOperation_t                    transA,
+                                             int64_t                               m,
+                                             int64_t                               n,
+                                             int64_t                               kl,
+                                             int64_t                               ku,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGbmvStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasOperation_t transA,
-                                                    int64_t            m,
-                                                    int64_t            n,
-                                                    int64_t            kl,
-                                                    int64_t            ku,
-                                                    const hipblas_internal_type<T>*           alpha,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      stride_a,
-                                                    const hipblas_internal_type<T>*           x,
-                                                    int64_t            incx,
-                                                    hipblasStride      stride_x,
-                                                    const hipblas_internal_type<T>*           beta,
-                                                    hipblas_internal_type<T>*                 y,
-                                                    int64_t            incy,
-                                                    hipblasStride      stride_y,
-                                                    int64_t            batch_count);
+    hipblasStatus_t (*hipblasGbmvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasOperation_t              transA,
+                                                    int64_t                         m,
+                                                    int64_t                         n,
+                                                    int64_t                         kl,
+                                                    int64_t                         ku,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   stride_a,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stride_x,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stride_y,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasGbmv, float, hipblasSgbmv);
     MAP2CF_D64(hipblasGbmv, double, hipblasDgbmv);
@@ -10273,99 +10401,99 @@ namespace
 
     // gemv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemv)(hipblasHandle_t    handle,
-                                   hipblasOperation_t transA,
-                                   int                m,
-                                   int                n,
-                                   const hipblas_internal_type<T>*           alpha,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   const hipblas_internal_type<T>*           x,
-                                   int                incx,
-                                   const hipblas_internal_type<T>*           beta,
-                                   hipblas_internal_type<T>*                 y,
-                                   int                incy);
+    hipblasStatus_t (*hipblasGemv)(hipblasHandle_t                 handle,
+                                   hipblasOperation_t              transA,
+                                   int                             m,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       y,
+                                   int                             incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemvBatched)(hipblasHandle_t    handle,
-                                          hipblasOperation_t transA,
-                                          int                m,
-                                          int                n,
-                                          const hipblas_internal_type<T>*           alpha,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          const hipblas_internal_type<T>* const     x[],
-                                          int                incx,
-                                          const hipblas_internal_type<T>*           beta,
-                                          hipblas_internal_type<T>* const           y[],
-                                          int                incy,
-                                          int                batch_count);
+    hipblasStatus_t (*hipblasGemvBatched)(hipblasHandle_t                       handle,
+                                          hipblasOperation_t                    transA,
+                                          int                                   m,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       y[],
+                                          int                                   incy,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemvStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasOperation_t transA,
-                                                 int                m,
-                                                 int                n,
-                                                 const hipblas_internal_type<T>*           alpha,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      stride_a,
-                                                 const hipblas_internal_type<T>*           x,
-                                                 int                incx,
-                                                 hipblasStride      stride_x,
-                                                 const hipblas_internal_type<T>*           beta,
-                                                 hipblas_internal_type<T>*                 y,
-                                                 int                incy,
-                                                 hipblasStride      stride_y,
-                                                 int                batch_count);
+    hipblasStatus_t (*hipblasGemvStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasOperation_t              transA,
+                                                 int                             m,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   stride_a,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stride_x,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       y,
+                                                 int                             incy,
+                                                 hipblasStride                   stride_y,
+                                                 int                             batch_count);
 
     // gemv
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemv_64)(hipblasHandle_t    handle,
-                                      hipblasOperation_t transA,
-                                      int64_t            m,
-                                      int64_t            n,
-                                      const hipblas_internal_type<T>*           alpha,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      const hipblas_internal_type<T>*           x,
-                                      int64_t            incx,
-                                      const hipblas_internal_type<T>*           beta,
-                                      hipblas_internal_type<T>*                 y,
-                                      int64_t            incy);
+    hipblasStatus_t (*hipblasGemv_64)(hipblasHandle_t                 handle,
+                                      hipblasOperation_t              transA,
+                                      int64_t                         m,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       y,
+                                      int64_t                         incy);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemvBatched_64)(hipblasHandle_t    handle,
-                                             hipblasOperation_t transA,
-                                             int64_t            m,
-                                             int64_t            n,
-                                             const hipblas_internal_type<T>*           alpha,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             const hipblas_internal_type<T>* const     x[],
-                                             int64_t            incx,
-                                             const hipblas_internal_type<T>*           beta,
-                                             hipblas_internal_type<T>* const           y[],
-                                             int64_t            incy,
-                                             int64_t            batch_count);
+    hipblasStatus_t (*hipblasGemvBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasOperation_t                    transA,
+                                             int64_t                               m,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       y[],
+                                             int64_t                               incy,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemvStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasOperation_t transA,
-                                                    int64_t            m,
-                                                    int64_t            n,
-                                                    const hipblas_internal_type<T>*           alpha,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      stride_a,
-                                                    const hipblas_internal_type<T>*           x,
-                                                    int64_t            incx,
-                                                    hipblasStride      stride_x,
-                                                    const hipblas_internal_type<T>*           beta,
-                                                    hipblas_internal_type<T>*                 y,
-                                                    int64_t            incy,
-                                                    hipblasStride      stride_y,
-                                                    int64_t            batch_count);
+    hipblasStatus_t (*hipblasGemvStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasOperation_t              transA,
+                                                    int64_t                         m,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   stride_a,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stride_x,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       y,
+                                                    int64_t                         incy,
+                                                    hipblasStride                   stride_y,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasGemv, float, hipblasSgemv);
     MAP2CF_D64(hipblasGemv, double, hipblasDgemv);
@@ -10383,110 +10511,110 @@ namespace
     MAP2CF_D64_V2(hipblasGemvStridedBatched, std::complex<double>, hipblasZgemvStridedBatched);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemm)(hipblasHandle_t    handle,
-                                   hipblasOperation_t transA,
-                                   hipblasOperation_t transB,
-                                   int                m,
-                                   int                n,
-                                   int                k,
-                                   const hipblas_internal_type<T>*           alpha,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   const hipblas_internal_type<T>*           B,
-                                   int                ldb,
-                                   const hipblas_internal_type<T>*           beta,
-                                   hipblas_internal_type<T>*                 C,
-                                   int                ldc);
+    hipblasStatus_t (*hipblasGemm)(hipblasHandle_t                 handle,
+                                   hipblasOperation_t              transA,
+                                   hipblasOperation_t              transB,
+                                   int                             m,
+                                   int                             n,
+                                   int                             k,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* B,
+                                   int                             ldb,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       C,
+                                   int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemmStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasOperation_t transA,
-                                                 hipblasOperation_t transB,
-                                                 int                m,
-                                                 int                n,
-                                                 int                k,
-                                                 const hipblas_internal_type<T>*           alpha,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 int                bsa,
-                                                 const hipblas_internal_type<T>*           B,
-                                                 int                ldb,
-                                                 int                bsb,
-                                                 const hipblas_internal_type<T>*           beta,
-                                                 hipblas_internal_type<T>*                 C,
-                                                 int                ldc,
-                                                 int                bsc,
-                                                 int                batch_count);
+    hipblasStatus_t (*hipblasGemmStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasOperation_t              transB,
+                                                 int                             m,
+                                                 int                             n,
+                                                 int                             k,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 int                             bsa,
+                                                 const hipblas_internal_type<T>* B,
+                                                 int                             ldb,
+                                                 int                             bsb,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       C,
+                                                 int                             ldc,
+                                                 int                             bsc,
+                                                 int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemmBatched)(hipblasHandle_t    handle,
-                                          hipblasOperation_t transA,
-                                          hipblasOperation_t transB,
-                                          int                m,
-                                          int                n,
-                                          int                k,
-                                          const hipblas_internal_type<T>*           alpha,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          const hipblas_internal_type<T>* const     B[],
-                                          int                ldb,
-                                          const hipblas_internal_type<T>*           beta,
-                                          hipblas_internal_type<T>* const           C[],
-                                          int                ldc,
-                                          int                batch_count);
+    hipblasStatus_t (*hipblasGemmBatched)(hipblasHandle_t                       handle,
+                                          hipblasOperation_t                    transA,
+                                          hipblasOperation_t                    transB,
+                                          int                                   m,
+                                          int                                   n,
+                                          int                                   k,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const B[],
+                                          int                                   ldb,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       C[],
+                                          int                                   ldc,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemm_64)(hipblasHandle_t    handle,
-                                      hipblasOperation_t transA,
-                                      hipblasOperation_t transB,
-                                      int64_t            m,
-                                      int64_t            n,
-                                      int64_t            k,
-                                      const hipblas_internal_type<T>*           alpha,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      const hipblas_internal_type<T>*           B,
-                                      int64_t            ldb,
-                                      const hipblas_internal_type<T>*           beta,
-                                      hipblas_internal_type<T>*                 C,
-                                      int64_t            ldc);
+    hipblasStatus_t (*hipblasGemm_64)(hipblasHandle_t                 handle,
+                                      hipblasOperation_t              transA,
+                                      hipblasOperation_t              transB,
+                                      int64_t                         m,
+                                      int64_t                         n,
+                                      int64_t                         k,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* B,
+                                      int64_t                         ldb,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       C,
+                                      int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemmStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasOperation_t transA,
-                                                    hipblasOperation_t transB,
-                                                    int64_t            m,
-                                                    int64_t            n,
-                                                    int64_t            k,
-                                                    const hipblas_internal_type<T>*           alpha,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    int64_t            bsa,
-                                                    const hipblas_internal_type<T>*           B,
-                                                    int64_t            ldb,
-                                                    int64_t            bsb,
-                                                    const hipblas_internal_type<T>*           beta,
-                                                    hipblas_internal_type<T>*                 C,
-                                                    int64_t            ldc,
-                                                    int64_t            bsc,
-                                                    int64_t            batch_count);
+    hipblasStatus_t (*hipblasGemmStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasOperation_t              transB,
+                                                    int64_t                         m,
+                                                    int64_t                         n,
+                                                    int64_t                         k,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    int64_t                         bsa,
+                                                    const hipblas_internal_type<T>* B,
+                                                    int64_t                         ldb,
+                                                    int64_t                         bsb,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       C,
+                                                    int64_t                         ldc,
+                                                    int64_t                         bsc,
+                                                    int64_t                         batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGemmBatched_64)(hipblasHandle_t    handle,
-                                             hipblasOperation_t transA,
-                                             hipblasOperation_t transB,
-                                             int64_t            m,
-                                             int64_t            n,
-                                             int64_t            k,
-                                             const hipblas_internal_type<T>*           alpha,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             const hipblas_internal_type<T>* const     B[],
-                                             int64_t            ldb,
-                                             const hipblas_internal_type<T>*           beta,
-                                             hipblas_internal_type<T>* const           C[],
-                                             int64_t            ldc,
-                                             int64_t            batch_count);
+    hipblasStatus_t (*hipblasGemmBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasOperation_t                    transA,
+                                             hipblasOperation_t                    transB,
+                                             int64_t                               m,
+                                             int64_t                               n,
+                                             int64_t                               k,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const B[],
+                                             int64_t                               ldb,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       C[],
+                                             int64_t                               ldc,
+                                             int64_t                               batch_count);
 
     MAP2CF_D64(hipblasGemm, hipblasHalf, hipblasHgemm);
     MAP2CF_D64(hipblasGemm, float, hipblasSgemm);
@@ -10508,90 +10636,90 @@ namespace
 
     // herk
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerk)(hipblasHandle_t    handle,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   int                n,
-                                   int                k,
-                                   const hipblas_internal_type<U>*           alpha,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   const hipblas_internal_type<U>*           beta,
-                                   hipblas_internal_type<T>*                 C,
-                                   int                ldc);
+    hipblasStatus_t (*hipblasHerk)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   int                             n,
+                                   int                             k,
+                                   const hipblas_internal_type<U>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<U>* beta,
+                                   hipblas_internal_type<T>*       C,
+                                   int                             ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkBatched)(hipblasHandle_t    handle,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          int                n,
-                                          int                k,
-                                          const hipblas_internal_type<U>*           alpha,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          const hipblas_internal_type<U>*           beta,
-                                          hipblas_internal_type<T>* const           C[],
-                                          int                ldc,
-                                          int                batchCount);
+    hipblasStatus_t (*hipblasHerkBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          int                                   n,
+                                          int                                   k,
+                                          const hipblas_internal_type<U>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<U>*       beta,
+                                          hipblas_internal_type<T>* const       C[],
+                                          int                                   ldc,
+                                          int                                   batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 int                n,
-                                                 int                k,
-                                                 const hipblas_internal_type<U>*           alpha,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      strideA,
-                                                 const hipblas_internal_type<U>*           beta,
-                                                 hipblas_internal_type<T>*                 C,
-                                                 int                ldc,
-                                                 hipblasStride      strideC,
-                                                 int                batchCount);
+    hipblasStatus_t (*hipblasHerkStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 int                             n,
+                                                 int                             k,
+                                                 const hipblas_internal_type<U>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<U>* beta,
+                                                 hipblas_internal_type<T>*       C,
+                                                 int                             ldc,
+                                                 hipblasStride                   strideC,
+                                                 int                             batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerk_64)(hipblasHandle_t    handle,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      int64_t            n,
-                                      int64_t            k,
-                                      const hipblas_internal_type<U>*           alpha,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      const hipblas_internal_type<U>*           beta,
-                                      hipblas_internal_type<T>*                 C,
-                                      int64_t            ldc);
+    hipblasStatus_t (*hipblasHerk_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      int64_t                         n,
+                                      int64_t                         k,
+                                      const hipblas_internal_type<U>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<U>* beta,
+                                      hipblas_internal_type<T>*       C,
+                                      int64_t                         ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkBatched_64)(hipblasHandle_t    handle,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             int64_t            n,
-                                             int64_t            k,
-                                             const hipblas_internal_type<U>*           alpha,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             const hipblas_internal_type<U>*           beta,
-                                             hipblas_internal_type<T>* const           C[],
-                                             int64_t            ldc,
-                                             int64_t            batchCount);
+    hipblasStatus_t (*hipblasHerkBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             int64_t                               n,
+                                             int64_t                               k,
+                                             const hipblas_internal_type<U>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<U>*       beta,
+                                             hipblas_internal_type<T>* const       C[],
+                                             int64_t                               ldc,
+                                             int64_t                               batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    int64_t            n,
-                                                    int64_t            k,
-                                                    const hipblas_internal_type<U>*           alpha,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      strideA,
-                                                    const hipblas_internal_type<U>*           beta,
-                                                    hipblas_internal_type<T>*                 C,
-                                                    int64_t            ldc,
-                                                    hipblasStride      strideC,
-                                                    int64_t            batchCount);
+    hipblasStatus_t (*hipblasHerkStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    int64_t                         n,
+                                                    int64_t                         k,
+                                                    const hipblas_internal_type<U>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<U>* beta,
+                                                    hipblas_internal_type<T>*       C,
+                                                    int64_t                         ldc,
+                                                    hipblasStride                   strideC,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHerk, std::complex<float>, float, hipblasCherk);
     MAP2CF_D64_V2(hipblasHerk, std::complex<double>, double, hipblasZherk);
@@ -10599,7 +10727,10 @@ namespace
     MAP2CF_D64_V2(hipblasHerkBatched, std::complex<float>, float, hipblasCherkBatched);
     MAP2CF_D64_V2(hipblasHerkBatched, std::complex<double>, double, hipblasZherkBatched);
 
-    MAP2CF_D64_V2(hipblasHerkStridedBatched, std::complex<float>, float, hipblasCherkStridedBatched);
+    MAP2CF_D64_V2(hipblasHerkStridedBatched,
+                  std::complex<float>,
+                  float,
+                  hipblasCherkStridedBatched);
     MAP2CF_D64_V2(hipblasHerkStridedBatched,
                   std::complex<double>,
                   double,
@@ -10607,104 +10738,104 @@ namespace
 
     // her2k
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2k)(hipblasHandle_t    handle,
-                                    hipblasFillMode_t  uplo,
-                                    hipblasOperation_t transA,
-                                    int                n,
-                                    int                k,
-                                    const hipblas_internal_type<T>*           alpha,
-                                    const hipblas_internal_type<T>*           A,
-                                    int                lda,
-                                    const hipblas_internal_type<T>*           B,
-                                    int                ldb,
-                                    const hipblas_internal_type<U>*           beta,
-                                    hipblas_internal_type<T>*                 C,
-                                    int                ldc);
+    hipblasStatus_t (*hipblasHer2k)(hipblasHandle_t                 handle,
+                                    hipblasFillMode_t               uplo,
+                                    hipblasOperation_t              transA,
+                                    int                             n,
+                                    int                             k,
+                                    const hipblas_internal_type<T>* alpha,
+                                    const hipblas_internal_type<T>* A,
+                                    int                             lda,
+                                    const hipblas_internal_type<T>* B,
+                                    int                             ldb,
+                                    const hipblas_internal_type<U>* beta,
+                                    hipblas_internal_type<T>*       C,
+                                    int                             ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2kBatched)(hipblasHandle_t    handle,
-                                           hipblasFillMode_t  uplo,
-                                           hipblasOperation_t transA,
-                                           int                n,
-                                           int                k,
-                                           const hipblas_internal_type<T>*           alpha,
-                                           const hipblas_internal_type<T>* const     A[],
-                                           int                lda,
-                                           const hipblas_internal_type<T>* const     B[],
-                                           int                ldb,
-                                           const hipblas_internal_type<U>*           beta,
-                                           hipblas_internal_type<T>* const           C[],
-                                           int                ldc,
-                                           int                batchCount);
+    hipblasStatus_t (*hipblasHer2kBatched)(hipblasHandle_t                       handle,
+                                           hipblasFillMode_t                     uplo,
+                                           hipblasOperation_t                    transA,
+                                           int                                   n,
+                                           int                                   k,
+                                           const hipblas_internal_type<T>*       alpha,
+                                           const hipblas_internal_type<T>* const A[],
+                                           int                                   lda,
+                                           const hipblas_internal_type<T>* const B[],
+                                           int                                   ldb,
+                                           const hipblas_internal_type<U>*       beta,
+                                           hipblas_internal_type<T>* const       C[],
+                                           int                                   ldc,
+                                           int                                   batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2kStridedBatched)(hipblasHandle_t    handle,
-                                                  hipblasFillMode_t  uplo,
-                                                  hipblasOperation_t transA,
-                                                  int                n,
-                                                  int                k,
-                                                  const hipblas_internal_type<T>*           alpha,
-                                                  const hipblas_internal_type<T>*           A,
-                                                  int                lda,
-                                                  hipblasStride      strideA,
-                                                  const hipblas_internal_type<T>*           B,
-                                                  int                ldb,
-                                                  hipblasStride      strideB,
-                                                  const hipblas_internal_type<U>*           beta,
-                                                  hipblas_internal_type<T>*                 C,
-                                                  int                ldc,
-                                                  hipblasStride      strideC,
-                                                  int                batchCount);
+    hipblasStatus_t (*hipblasHer2kStridedBatched)(hipblasHandle_t                 handle,
+                                                  hipblasFillMode_t               uplo,
+                                                  hipblasOperation_t              transA,
+                                                  int                             n,
+                                                  int                             k,
+                                                  const hipblas_internal_type<T>* alpha,
+                                                  const hipblas_internal_type<T>* A,
+                                                  int                             lda,
+                                                  hipblasStride                   strideA,
+                                                  const hipblas_internal_type<T>* B,
+                                                  int                             ldb,
+                                                  hipblasStride                   strideB,
+                                                  const hipblas_internal_type<U>* beta,
+                                                  hipblas_internal_type<T>*       C,
+                                                  int                             ldc,
+                                                  hipblasStride                   strideC,
+                                                  int                             batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2k_64)(hipblasHandle_t    handle,
-                                       hipblasFillMode_t  uplo,
-                                       hipblasOperation_t transA,
-                                       int64_t            n,
-                                       int64_t            k,
-                                       const hipblas_internal_type<T>*           alpha,
-                                       const hipblas_internal_type<T>*           A,
-                                       int64_t            lda,
-                                       const hipblas_internal_type<T>*           B,
-                                       int64_t            ldb,
-                                       const hipblas_internal_type<U>*           beta,
-                                       hipblas_internal_type<T>*                 C,
-                                       int64_t            ldc);
+    hipblasStatus_t (*hipblasHer2k_64)(hipblasHandle_t                 handle,
+                                       hipblasFillMode_t               uplo,
+                                       hipblasOperation_t              transA,
+                                       int64_t                         n,
+                                       int64_t                         k,
+                                       const hipblas_internal_type<T>* alpha,
+                                       const hipblas_internal_type<T>* A,
+                                       int64_t                         lda,
+                                       const hipblas_internal_type<T>* B,
+                                       int64_t                         ldb,
+                                       const hipblas_internal_type<U>* beta,
+                                       hipblas_internal_type<T>*       C,
+                                       int64_t                         ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2kBatched_64)(hipblasHandle_t    handle,
-                                              hipblasFillMode_t  uplo,
-                                              hipblasOperation_t transA,
-                                              int64_t            n,
-                                              int64_t            k,
-                                              const hipblas_internal_type<T>*           alpha,
-                                              const hipblas_internal_type<T>* const     A[],
-                                              int64_t            lda,
-                                              const hipblas_internal_type<T>* const     B[],
-                                              int64_t            ldb,
-                                              const hipblas_internal_type<U>*           beta,
-                                              hipblas_internal_type<T>* const           C[],
-                                              int64_t            ldc,
-                                              int64_t            batchCount);
+    hipblasStatus_t (*hipblasHer2kBatched_64)(hipblasHandle_t                       handle,
+                                              hipblasFillMode_t                     uplo,
+                                              hipblasOperation_t                    transA,
+                                              int64_t                               n,
+                                              int64_t                               k,
+                                              const hipblas_internal_type<T>*       alpha,
+                                              const hipblas_internal_type<T>* const A[],
+                                              int64_t                               lda,
+                                              const hipblas_internal_type<T>* const B[],
+                                              int64_t                               ldb,
+                                              const hipblas_internal_type<U>*       beta,
+                                              hipblas_internal_type<T>* const       C[],
+                                              int64_t                               ldc,
+                                              int64_t                               batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHer2kStridedBatched_64)(hipblasHandle_t    handle,
-                                                     hipblasFillMode_t  uplo,
-                                                     hipblasOperation_t transA,
-                                                     int64_t            n,
-                                                     int64_t            k,
-                                                     const hipblas_internal_type<T>*           alpha,
-                                                     const hipblas_internal_type<T>*           A,
-                                                     int64_t            lda,
-                                                     hipblasStride      strideA,
-                                                     const hipblas_internal_type<T>*           B,
-                                                     int64_t            ldb,
-                                                     hipblasStride      strideB,
-                                                     const hipblas_internal_type<U>*           beta,
-                                                     hipblas_internal_type<T>*                 C,
-                                                     int64_t            ldc,
-                                                     hipblasStride      strideC,
-                                                     int64_t            batchCount);
+    hipblasStatus_t (*hipblasHer2kStridedBatched_64)(hipblasHandle_t                 handle,
+                                                     hipblasFillMode_t               uplo,
+                                                     hipblasOperation_t              transA,
+                                                     int64_t                         n,
+                                                     int64_t                         k,
+                                                     const hipblas_internal_type<T>* alpha,
+                                                     const hipblas_internal_type<T>* A,
+                                                     int64_t                         lda,
+                                                     hipblasStride                   strideA,
+                                                     const hipblas_internal_type<T>* B,
+                                                     int64_t                         ldb,
+                                                     hipblasStride                   strideB,
+                                                     const hipblas_internal_type<U>* beta,
+                                                     hipblas_internal_type<T>*       C,
+                                                     int64_t                         ldc,
+                                                     hipblasStride                   strideC,
+                                                     int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHer2k, std::complex<float>, float, hipblasCher2k);
     MAP2CF_D64_V2(hipblasHer2k, std::complex<double>, double, hipblasZher2k);
@@ -10712,7 +10843,10 @@ namespace
     MAP2CF_D64_V2(hipblasHer2kBatched, std::complex<float>, float, hipblasCher2kBatched);
     MAP2CF_D64_V2(hipblasHer2kBatched, std::complex<double>, double, hipblasZher2kBatched);
 
-    MAP2CF_D64_V2(hipblasHer2kStridedBatched, std::complex<float>, float, hipblasCher2kStridedBatched);
+    MAP2CF_D64_V2(hipblasHer2kStridedBatched,
+                  std::complex<float>,
+                  float,
+                  hipblasCher2kStridedBatched);
     MAP2CF_D64_V2(hipblasHer2kStridedBatched,
                   std::complex<double>,
                   double,
@@ -10720,104 +10854,104 @@ namespace
 
     // herkx
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkx)(hipblasHandle_t    handle,
-                                    hipblasFillMode_t  uplo,
-                                    hipblasOperation_t transA,
-                                    int                n,
-                                    int                k,
-                                    const hipblas_internal_type<T>*           alpha,
-                                    const hipblas_internal_type<T>*           A,
-                                    int                lda,
-                                    const hipblas_internal_type<T>*           B,
-                                    int                ldb,
-                                    const hipblas_internal_type<U>*           beta,
-                                    hipblas_internal_type<T>*                 C,
-                                    int                ldc);
+    hipblasStatus_t (*hipblasHerkx)(hipblasHandle_t                 handle,
+                                    hipblasFillMode_t               uplo,
+                                    hipblasOperation_t              transA,
+                                    int                             n,
+                                    int                             k,
+                                    const hipblas_internal_type<T>* alpha,
+                                    const hipblas_internal_type<T>* A,
+                                    int                             lda,
+                                    const hipblas_internal_type<T>* B,
+                                    int                             ldb,
+                                    const hipblas_internal_type<U>* beta,
+                                    hipblas_internal_type<T>*       C,
+                                    int                             ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkxBatched)(hipblasHandle_t    handle,
-                                           hipblasFillMode_t  uplo,
-                                           hipblasOperation_t transA,
-                                           int                n,
-                                           int                k,
-                                           const hipblas_internal_type<T>*           alpha,
-                                           const hipblas_internal_type<T>* const     A[],
-                                           int                lda,
-                                           const hipblas_internal_type<T>* const     B[],
-                                           int                ldb,
-                                           const hipblas_internal_type<U>*           beta,
-                                           hipblas_internal_type<T>* const           C[],
-                                           int                ldc,
-                                           int                batchCount);
+    hipblasStatus_t (*hipblasHerkxBatched)(hipblasHandle_t                       handle,
+                                           hipblasFillMode_t                     uplo,
+                                           hipblasOperation_t                    transA,
+                                           int                                   n,
+                                           int                                   k,
+                                           const hipblas_internal_type<T>*       alpha,
+                                           const hipblas_internal_type<T>* const A[],
+                                           int                                   lda,
+                                           const hipblas_internal_type<T>* const B[],
+                                           int                                   ldb,
+                                           const hipblas_internal_type<U>*       beta,
+                                           hipblas_internal_type<T>* const       C[],
+                                           int                                   ldc,
+                                           int                                   batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkxStridedBatched)(hipblasHandle_t    handle,
-                                                  hipblasFillMode_t  uplo,
-                                                  hipblasOperation_t transA,
-                                                  int                n,
-                                                  int                k,
-                                                  const hipblas_internal_type<T>*           alpha,
-                                                  const hipblas_internal_type<T>*           A,
-                                                  int                lda,
-                                                  hipblasStride      strideA,
-                                                  const hipblas_internal_type<T>*           B,
-                                                  int                ldb,
-                                                  hipblasStride      strideB,
-                                                  const hipblas_internal_type<U>*           beta,
-                                                  hipblas_internal_type<T>*                 C,
-                                                  int                ldc,
-                                                  hipblasStride      strideC,
-                                                  int                batchCount);
+    hipblasStatus_t (*hipblasHerkxStridedBatched)(hipblasHandle_t                 handle,
+                                                  hipblasFillMode_t               uplo,
+                                                  hipblasOperation_t              transA,
+                                                  int                             n,
+                                                  int                             k,
+                                                  const hipblas_internal_type<T>* alpha,
+                                                  const hipblas_internal_type<T>* A,
+                                                  int                             lda,
+                                                  hipblasStride                   strideA,
+                                                  const hipblas_internal_type<T>* B,
+                                                  int                             ldb,
+                                                  hipblasStride                   strideB,
+                                                  const hipblas_internal_type<U>* beta,
+                                                  hipblas_internal_type<T>*       C,
+                                                  int                             ldc,
+                                                  hipblasStride                   strideC,
+                                                  int                             batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkx_64)(hipblasHandle_t    handle,
-                                       hipblasFillMode_t  uplo,
-                                       hipblasOperation_t transA,
-                                       int64_t            n,
-                                       int64_t            k,
-                                       const hipblas_internal_type<T>*           alpha,
-                                       const hipblas_internal_type<T>*           A,
-                                       int64_t            lda,
-                                       const hipblas_internal_type<T>*           B,
-                                       int64_t            ldb,
-                                       const hipblas_internal_type<U>*           beta,
-                                       hipblas_internal_type<T>*                 C,
-                                       int64_t            ldc);
+    hipblasStatus_t (*hipblasHerkx_64)(hipblasHandle_t                 handle,
+                                       hipblasFillMode_t               uplo,
+                                       hipblasOperation_t              transA,
+                                       int64_t                         n,
+                                       int64_t                         k,
+                                       const hipblas_internal_type<T>* alpha,
+                                       const hipblas_internal_type<T>* A,
+                                       int64_t                         lda,
+                                       const hipblas_internal_type<T>* B,
+                                       int64_t                         ldb,
+                                       const hipblas_internal_type<U>* beta,
+                                       hipblas_internal_type<T>*       C,
+                                       int64_t                         ldc);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkxBatched_64)(hipblasHandle_t    handle,
-                                              hipblasFillMode_t  uplo,
-                                              hipblasOperation_t transA,
-                                              int64_t            n,
-                                              int64_t            k,
-                                              const hipblas_internal_type<T>*           alpha,
-                                              const hipblas_internal_type<T>* const     A[],
-                                              int64_t            lda,
-                                              const hipblas_internal_type<T>* const     B[],
-                                              int64_t            ldb,
-                                              const hipblas_internal_type<U>*           beta,
-                                              hipblas_internal_type<T>* const           C[],
-                                              int64_t            ldc,
-                                              int64_t            batchCount);
+    hipblasStatus_t (*hipblasHerkxBatched_64)(hipblasHandle_t                       handle,
+                                              hipblasFillMode_t                     uplo,
+                                              hipblasOperation_t                    transA,
+                                              int64_t                               n,
+                                              int64_t                               k,
+                                              const hipblas_internal_type<T>*       alpha,
+                                              const hipblas_internal_type<T>* const A[],
+                                              int64_t                               lda,
+                                              const hipblas_internal_type<T>* const B[],
+                                              int64_t                               ldb,
+                                              const hipblas_internal_type<U>*       beta,
+                                              hipblas_internal_type<T>* const       C[],
+                                              int64_t                               ldc,
+                                              int64_t                               batchCount);
 
     template <typename T, typename U, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHerkxStridedBatched_64)(hipblasHandle_t    handle,
-                                                     hipblasFillMode_t  uplo,
-                                                     hipblasOperation_t transA,
-                                                     int64_t            n,
-                                                     int64_t            k,
-                                                     const hipblas_internal_type<T>*           alpha,
-                                                     const hipblas_internal_type<T>*           A,
-                                                     int64_t            lda,
-                                                     hipblasStride      strideA,
-                                                     const hipblas_internal_type<T>*           B,
-                                                     int64_t            ldb,
-                                                     hipblasStride      strideB,
-                                                     const hipblas_internal_type<U>*           beta,
-                                                     hipblas_internal_type<T>*                 C,
-                                                     int64_t            ldc,
-                                                     hipblasStride      strideC,
-                                                     int64_t            batchCount);
+    hipblasStatus_t (*hipblasHerkxStridedBatched_64)(hipblasHandle_t                 handle,
+                                                     hipblasFillMode_t               uplo,
+                                                     hipblasOperation_t              transA,
+                                                     int64_t                         n,
+                                                     int64_t                         k,
+                                                     const hipblas_internal_type<T>* alpha,
+                                                     const hipblas_internal_type<T>* A,
+                                                     int64_t                         lda,
+                                                     hipblasStride                   strideA,
+                                                     const hipblas_internal_type<T>* B,
+                                                     int64_t                         ldb,
+                                                     hipblasStride                   strideB,
+                                                     const hipblas_internal_type<U>* beta,
+                                                     hipblas_internal_type<T>*       C,
+                                                     int64_t                         ldc,
+                                                     hipblasStride                   strideC,
+                                                     int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHerkx, std::complex<float>, float, hipblasCherkx);
     MAP2CF_D64_V2(hipblasHerkx, std::complex<double>, double, hipblasZherkx);
@@ -10825,7 +10959,10 @@ namespace
     MAP2CF_D64_V2(hipblasHerkxBatched, std::complex<float>, float, hipblasCherkxBatched);
     MAP2CF_D64_V2(hipblasHerkxBatched, std::complex<double>, double, hipblasZherkxBatched);
 
-    MAP2CF_D64_V2(hipblasHerkxStridedBatched, std::complex<float>, float, hipblasCherkxStridedBatched);
+    MAP2CF_D64_V2(hipblasHerkxStridedBatched,
+                  std::complex<float>,
+                  float,
+                  hipblasCherkxStridedBatched);
     MAP2CF_D64_V2(hipblasHerkxStridedBatched,
                   std::complex<double>,
                   double,
@@ -10833,104 +10970,104 @@ namespace
 
     // symm
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymm)(hipblasHandle_t   handle,
-                                   hipblasSideMode_t side,
-                                   hipblasFillMode_t uplo,
-                                   int               m,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          A,
-                                   int               lda,
-                                   const hipblas_internal_type<T>*          B,
-                                   int               ldb,
-                                   const hipblas_internal_type<T>*          beta,
-                                   hipblas_internal_type<T>*                C,
-                                   int               ldc);
+    hipblasStatus_t (*hipblasSymm)(hipblasHandle_t                 handle,
+                                   hipblasSideMode_t               side,
+                                   hipblasFillMode_t               uplo,
+                                   int                             m,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* B,
+                                   int                             ldb,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       C,
+                                   int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymmBatched)(hipblasHandle_t   handle,
-                                          hipblasSideMode_t side,
-                                          hipblasFillMode_t uplo,
-                                          int               m,
-                                          int               n,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    A[],
-                                          int               lda,
-                                          const hipblas_internal_type<T>* const    B[],
-                                          int               ldb,
-                                          const hipblas_internal_type<T>*          beta,
-                                          hipblas_internal_type<T>* const          C[],
-                                          int               ldc,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasSymmBatched)(hipblasHandle_t                       handle,
+                                          hipblasSideMode_t                     side,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   m,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const B[],
+                                          int                                   ldb,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       C[],
+                                          int                                   ldc,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymmStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasSideMode_t side,
-                                                 hipblasFillMode_t uplo,
-                                                 int               m,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          A,
-                                                 int               lda,
-                                                 hipblasStride     strideA,
-                                                 const hipblas_internal_type<T>*          B,
-                                                 int               ldb,
-                                                 hipblasStride     strideB,
-                                                 const hipblas_internal_type<T>*          beta,
-                                                 hipblas_internal_type<T>*                C,
-                                                 int               ldc,
-                                                 hipblasStride     strideC,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasSymmStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasSideMode_t               side,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             m,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<T>* B,
+                                                 int                             ldb,
+                                                 hipblasStride                   strideB,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       C,
+                                                 int                             ldc,
+                                                 hipblasStride                   strideC,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymm_64)(hipblasHandle_t   handle,
-                                      hipblasSideMode_t side,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           m,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          A,
-                                      int64_t           lda,
-                                      const hipblas_internal_type<T>*          B,
-                                      int64_t           ldb,
-                                      const hipblas_internal_type<T>*          beta,
-                                      hipblas_internal_type<T>*                C,
-                                      int64_t           ldc);
+    hipblasStatus_t (*hipblasSymm_64)(hipblasHandle_t                 handle,
+                                      hipblasSideMode_t               side,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         m,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* B,
+                                      int64_t                         ldb,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       C,
+                                      int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymmBatched_64)(hipblasHandle_t   handle,
-                                             hipblasSideMode_t side,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           m,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    A[],
-                                             int64_t           lda,
-                                             const hipblas_internal_type<T>* const    B[],
-                                             int64_t           ldb,
-                                             const hipblas_internal_type<T>*          beta,
-                                             hipblas_internal_type<T>* const          C[],
-                                             int64_t           ldc,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasSymmBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasSideMode_t                     side,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               m,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const B[],
+                                             int64_t                               ldb,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       C[],
+                                             int64_t                               ldc,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSymmStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasSideMode_t side,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           m,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          A,
-                                                    int64_t           lda,
-                                                    hipblasStride     strideA,
-                                                    const hipblas_internal_type<T>*          B,
-                                                    int64_t           ldb,
-                                                    hipblasStride     strideB,
-                                                    const hipblas_internal_type<T>*          beta,
-                                                    hipblas_internal_type<T>*                C,
-                                                    int64_t           ldc,
-                                                    hipblasStride     strideC,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasSymmStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasSideMode_t               side,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         m,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<T>* B,
+                                                    int64_t                         ldb,
+                                                    hipblasStride                   strideB,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       C,
+                                                    int64_t                         ldc,
+                                                    hipblasStride                   strideC,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSymm, float, hipblasSsymm);
     MAP2CF_D64(hipblasSymm, double, hipblasDsymm);
@@ -10949,90 +11086,90 @@ namespace
 
     // syrk
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrk)(hipblasHandle_t    handle,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   int                n,
-                                   int                k,
-                                   const hipblas_internal_type<T>*           alpha,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   const hipblas_internal_type<T>*           beta,
-                                   hipblas_internal_type<T>*                 C,
-                                   int                ldc);
+    hipblasStatus_t (*hipblasSyrk)(hipblasHandle_t                 handle,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   int                             n,
+                                   int                             k,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       C,
+                                   int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkBatched)(hipblasHandle_t    handle,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          int                n,
-                                          int                k,
-                                          const hipblas_internal_type<T>*           alpha,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          const hipblas_internal_type<T>*           beta,
-                                          hipblas_internal_type<T>* const           C[],
-                                          int                ldc,
-                                          int                batchCount);
+    hipblasStatus_t (*hipblasSyrkBatched)(hipblasHandle_t                       handle,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          int                                   n,
+                                          int                                   k,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       C[],
+                                          int                                   ldc,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 int                n,
-                                                 int                k,
-                                                 const hipblas_internal_type<T>*           alpha,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      strideA,
-                                                 const hipblas_internal_type<T>*           beta,
-                                                 hipblas_internal_type<T>*                 C,
-                                                 int                ldc,
-                                                 hipblasStride      strideC,
-                                                 int                batchCount);
+    hipblasStatus_t (*hipblasSyrkStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 int                             n,
+                                                 int                             k,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       C,
+                                                 int                             ldc,
+                                                 hipblasStride                   strideC,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrk_64)(hipblasHandle_t    handle,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      int64_t            n,
-                                      int64_t            k,
-                                      const hipblas_internal_type<T>*           alpha,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      const hipblas_internal_type<T>*           beta,
-                                      hipblas_internal_type<T>*                 C,
-                                      int64_t            ldc);
+    hipblasStatus_t (*hipblasSyrk_64)(hipblasHandle_t                 handle,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      int64_t                         n,
+                                      int64_t                         k,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       C,
+                                      int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkBatched_64)(hipblasHandle_t    handle,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             int64_t            n,
-                                             int64_t            k,
-                                             const hipblas_internal_type<T>*           alpha,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             const hipblas_internal_type<T>*           beta,
-                                             hipblas_internal_type<T>* const           C[],
-                                             int64_t            ldc,
-                                             int64_t            batchCount);
+    hipblasStatus_t (*hipblasSyrkBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             int64_t                               n,
+                                             int64_t                               k,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       C[],
+                                             int64_t                               ldc,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    int64_t            n,
-                                                    int64_t            k,
-                                                    const hipblas_internal_type<T>*           alpha,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      strideA,
-                                                    const hipblas_internal_type<T>*           beta,
-                                                    hipblas_internal_type<T>*                 C,
-                                                    int64_t            ldc,
-                                                    hipblasStride      strideC,
-                                                    int64_t            batchCount);
+    hipblasStatus_t (*hipblasSyrkStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    int64_t                         n,
+                                                    int64_t                         k,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       C,
+                                                    int64_t                         ldc,
+                                                    hipblasStride                   strideC,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSyrk, float, hipblasSsyrk);
     MAP2CF_D64(hipblasSyrk, double, hipblasDsyrk);
@@ -11051,104 +11188,104 @@ namespace
 
     // syr2k
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2k)(hipblasHandle_t    handle,
-                                    hipblasFillMode_t  uplo,
-                                    hipblasOperation_t transA,
-                                    int                n,
-                                    int                k,
-                                    const hipblas_internal_type<T>*           alpha,
-                                    const hipblas_internal_type<T>*           A,
-                                    int                lda,
-                                    const hipblas_internal_type<T>*           B,
-                                    int                ldb,
-                                    const hipblas_internal_type<T>*           beta,
-                                    hipblas_internal_type<T>*                 C,
-                                    int                ldc);
+    hipblasStatus_t (*hipblasSyr2k)(hipblasHandle_t                 handle,
+                                    hipblasFillMode_t               uplo,
+                                    hipblasOperation_t              transA,
+                                    int                             n,
+                                    int                             k,
+                                    const hipblas_internal_type<T>* alpha,
+                                    const hipblas_internal_type<T>* A,
+                                    int                             lda,
+                                    const hipblas_internal_type<T>* B,
+                                    int                             ldb,
+                                    const hipblas_internal_type<T>* beta,
+                                    hipblas_internal_type<T>*       C,
+                                    int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2kBatched)(hipblasHandle_t    handle,
-                                           hipblasFillMode_t  uplo,
-                                           hipblasOperation_t transA,
-                                           int                n,
-                                           int                k,
-                                           const hipblas_internal_type<T>*           alpha,
-                                           const hipblas_internal_type<T>* const     A[],
-                                           int                lda,
-                                           const hipblas_internal_type<T>* const     B[],
-                                           int                ldb,
-                                           const hipblas_internal_type<T>*           beta,
-                                           hipblas_internal_type<T>* const           C[],
-                                           int                ldc,
-                                           int                batchCount);
+    hipblasStatus_t (*hipblasSyr2kBatched)(hipblasHandle_t                       handle,
+                                           hipblasFillMode_t                     uplo,
+                                           hipblasOperation_t                    transA,
+                                           int                                   n,
+                                           int                                   k,
+                                           const hipblas_internal_type<T>*       alpha,
+                                           const hipblas_internal_type<T>* const A[],
+                                           int                                   lda,
+                                           const hipblas_internal_type<T>* const B[],
+                                           int                                   ldb,
+                                           const hipblas_internal_type<T>*       beta,
+                                           hipblas_internal_type<T>* const       C[],
+                                           int                                   ldc,
+                                           int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2kStridedBatched)(hipblasHandle_t    handle,
-                                                  hipblasFillMode_t  uplo,
-                                                  hipblasOperation_t transA,
-                                                  int                n,
-                                                  int                k,
-                                                  const hipblas_internal_type<T>*           alpha,
-                                                  const hipblas_internal_type<T>*           A,
-                                                  int                lda,
-                                                  hipblasStride      strideA,
-                                                  const hipblas_internal_type<T>*           B,
-                                                  int                ldb,
-                                                  hipblasStride      strideB,
-                                                  const hipblas_internal_type<T>*           beta,
-                                                  hipblas_internal_type<T>*                 C,
-                                                  int                ldc,
-                                                  hipblasStride      strideC,
-                                                  int                batchCount);
+    hipblasStatus_t (*hipblasSyr2kStridedBatched)(hipblasHandle_t                 handle,
+                                                  hipblasFillMode_t               uplo,
+                                                  hipblasOperation_t              transA,
+                                                  int                             n,
+                                                  int                             k,
+                                                  const hipblas_internal_type<T>* alpha,
+                                                  const hipblas_internal_type<T>* A,
+                                                  int                             lda,
+                                                  hipblasStride                   strideA,
+                                                  const hipblas_internal_type<T>* B,
+                                                  int                             ldb,
+                                                  hipblasStride                   strideB,
+                                                  const hipblas_internal_type<T>* beta,
+                                                  hipblas_internal_type<T>*       C,
+                                                  int                             ldc,
+                                                  hipblasStride                   strideC,
+                                                  int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2k_64)(hipblasHandle_t    handle,
-                                       hipblasFillMode_t  uplo,
-                                       hipblasOperation_t transA,
-                                       int64_t            n,
-                                       int64_t            k,
-                                       const hipblas_internal_type<T>*           alpha,
-                                       const hipblas_internal_type<T>*           A,
-                                       int64_t            lda,
-                                       const hipblas_internal_type<T>*           B,
-                                       int64_t            ldb,
-                                       const hipblas_internal_type<T>*           beta,
-                                       hipblas_internal_type<T>*                 C,
-                                       int64_t            ldc);
+    hipblasStatus_t (*hipblasSyr2k_64)(hipblasHandle_t                 handle,
+                                       hipblasFillMode_t               uplo,
+                                       hipblasOperation_t              transA,
+                                       int64_t                         n,
+                                       int64_t                         k,
+                                       const hipblas_internal_type<T>* alpha,
+                                       const hipblas_internal_type<T>* A,
+                                       int64_t                         lda,
+                                       const hipblas_internal_type<T>* B,
+                                       int64_t                         ldb,
+                                       const hipblas_internal_type<T>* beta,
+                                       hipblas_internal_type<T>*       C,
+                                       int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2kBatched_64)(hipblasHandle_t    handle,
-                                              hipblasFillMode_t  uplo,
-                                              hipblasOperation_t transA,
-                                              int64_t            n,
-                                              int64_t            k,
-                                              const hipblas_internal_type<T>*           alpha,
-                                              const hipblas_internal_type<T>* const     A[],
-                                              int64_t            lda,
-                                              const hipblas_internal_type<T>* const     B[],
-                                              int64_t            ldb,
-                                              const hipblas_internal_type<T>*           beta,
-                                              hipblas_internal_type<T>* const           C[],
-                                              int64_t            ldc,
-                                              int64_t            batchCount);
+    hipblasStatus_t (*hipblasSyr2kBatched_64)(hipblasHandle_t                       handle,
+                                              hipblasFillMode_t                     uplo,
+                                              hipblasOperation_t                    transA,
+                                              int64_t                               n,
+                                              int64_t                               k,
+                                              const hipblas_internal_type<T>*       alpha,
+                                              const hipblas_internal_type<T>* const A[],
+                                              int64_t                               lda,
+                                              const hipblas_internal_type<T>* const B[],
+                                              int64_t                               ldb,
+                                              const hipblas_internal_type<T>*       beta,
+                                              hipblas_internal_type<T>* const       C[],
+                                              int64_t                               ldc,
+                                              int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyr2kStridedBatched_64)(hipblasHandle_t    handle,
-                                                     hipblasFillMode_t  uplo,
-                                                     hipblasOperation_t transA,
-                                                     int64_t            n,
-                                                     int64_t            k,
-                                                     const hipblas_internal_type<T>*           alpha,
-                                                     const hipblas_internal_type<T>*           A,
-                                                     int64_t            lda,
-                                                     hipblasStride      strideA,
-                                                     const hipblas_internal_type<T>*           B,
-                                                     int64_t            ldb,
-                                                     hipblasStride      strideB,
-                                                     const hipblas_internal_type<T>*           beta,
-                                                     hipblas_internal_type<T>*                 C,
-                                                     int64_t            ldc,
-                                                     hipblasStride      strideC,
-                                                     int64_t            batchCount);
+    hipblasStatus_t (*hipblasSyr2kStridedBatched_64)(hipblasHandle_t                 handle,
+                                                     hipblasFillMode_t               uplo,
+                                                     hipblasOperation_t              transA,
+                                                     int64_t                         n,
+                                                     int64_t                         k,
+                                                     const hipblas_internal_type<T>* alpha,
+                                                     const hipblas_internal_type<T>* A,
+                                                     int64_t                         lda,
+                                                     hipblasStride                   strideA,
+                                                     const hipblas_internal_type<T>* B,
+                                                     int64_t                         ldb,
+                                                     hipblasStride                   strideB,
+                                                     const hipblas_internal_type<T>* beta,
+                                                     hipblas_internal_type<T>*       C,
+                                                     int64_t                         ldc,
+                                                     hipblasStride                   strideC,
+                                                     int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSyr2k, float, hipblasSsyr2k);
     MAP2CF_D64(hipblasSyr2k, double, hipblasDsyr2k);
@@ -11167,104 +11304,104 @@ namespace
 
     // syrkx
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkx)(hipblasHandle_t    handle,
-                                    hipblasFillMode_t  uplo,
-                                    hipblasOperation_t transA,
-                                    int                n,
-                                    int                k,
-                                    const hipblas_internal_type<T>*           alpha,
-                                    const hipblas_internal_type<T>*           A,
-                                    int                lda,
-                                    const hipblas_internal_type<T>*           B,
-                                    int                ldb,
-                                    const hipblas_internal_type<T>*           beta,
-                                    hipblas_internal_type<T>*                 C,
-                                    int                ldc);
+    hipblasStatus_t (*hipblasSyrkx)(hipblasHandle_t                 handle,
+                                    hipblasFillMode_t               uplo,
+                                    hipblasOperation_t              transA,
+                                    int                             n,
+                                    int                             k,
+                                    const hipblas_internal_type<T>* alpha,
+                                    const hipblas_internal_type<T>* A,
+                                    int                             lda,
+                                    const hipblas_internal_type<T>* B,
+                                    int                             ldb,
+                                    const hipblas_internal_type<T>* beta,
+                                    hipblas_internal_type<T>*       C,
+                                    int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkxBatched)(hipblasHandle_t    handle,
-                                           hipblasFillMode_t  uplo,
-                                           hipblasOperation_t transA,
-                                           int                n,
-                                           int                k,
-                                           const hipblas_internal_type<T>*           alpha,
-                                           const hipblas_internal_type<T>* const     A[],
-                                           int                lda,
-                                           const hipblas_internal_type<T>* const     B[],
-                                           int                ldb,
-                                           const hipblas_internal_type<T>*           beta,
-                                           hipblas_internal_type<T>* const           C[],
-                                           int                ldc,
-                                           int                batchCount);
+    hipblasStatus_t (*hipblasSyrkxBatched)(hipblasHandle_t                       handle,
+                                           hipblasFillMode_t                     uplo,
+                                           hipblasOperation_t                    transA,
+                                           int                                   n,
+                                           int                                   k,
+                                           const hipblas_internal_type<T>*       alpha,
+                                           const hipblas_internal_type<T>* const A[],
+                                           int                                   lda,
+                                           const hipblas_internal_type<T>* const B[],
+                                           int                                   ldb,
+                                           const hipblas_internal_type<T>*       beta,
+                                           hipblas_internal_type<T>* const       C[],
+                                           int                                   ldc,
+                                           int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkxStridedBatched)(hipblasHandle_t    handle,
-                                                  hipblasFillMode_t  uplo,
-                                                  hipblasOperation_t transA,
-                                                  int                n,
-                                                  int                k,
-                                                  const hipblas_internal_type<T>*           alpha,
-                                                  const hipblas_internal_type<T>*           A,
-                                                  int                lda,
-                                                  hipblasStride      strideA,
-                                                  const hipblas_internal_type<T>*           B,
-                                                  int                ldb,
-                                                  hipblasStride      strideB,
-                                                  const hipblas_internal_type<T>*           beta,
-                                                  hipblas_internal_type<T>*                 C,
-                                                  int                ldc,
-                                                  hipblasStride      strideC,
-                                                  int                batchCount);
+    hipblasStatus_t (*hipblasSyrkxStridedBatched)(hipblasHandle_t                 handle,
+                                                  hipblasFillMode_t               uplo,
+                                                  hipblasOperation_t              transA,
+                                                  int                             n,
+                                                  int                             k,
+                                                  const hipblas_internal_type<T>* alpha,
+                                                  const hipblas_internal_type<T>* A,
+                                                  int                             lda,
+                                                  hipblasStride                   strideA,
+                                                  const hipblas_internal_type<T>* B,
+                                                  int                             ldb,
+                                                  hipblasStride                   strideB,
+                                                  const hipblas_internal_type<T>* beta,
+                                                  hipblas_internal_type<T>*       C,
+                                                  int                             ldc,
+                                                  hipblasStride                   strideC,
+                                                  int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkx_64)(hipblasHandle_t    handle,
-                                       hipblasFillMode_t  uplo,
-                                       hipblasOperation_t transA,
-                                       int64_t            n,
-                                       int64_t            k,
-                                       const hipblas_internal_type<T>*           alpha,
-                                       const hipblas_internal_type<T>*           A,
-                                       int64_t            lda,
-                                       const hipblas_internal_type<T>*           B,
-                                       int64_t            ldb,
-                                       const hipblas_internal_type<T>*           beta,
-                                       hipblas_internal_type<T>*                 C,
-                                       int64_t            ldc);
+    hipblasStatus_t (*hipblasSyrkx_64)(hipblasHandle_t                 handle,
+                                       hipblasFillMode_t               uplo,
+                                       hipblasOperation_t              transA,
+                                       int64_t                         n,
+                                       int64_t                         k,
+                                       const hipblas_internal_type<T>* alpha,
+                                       const hipblas_internal_type<T>* A,
+                                       int64_t                         lda,
+                                       const hipblas_internal_type<T>* B,
+                                       int64_t                         ldb,
+                                       const hipblas_internal_type<T>* beta,
+                                       hipblas_internal_type<T>*       C,
+                                       int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkxBatched_64)(hipblasHandle_t    handle,
-                                              hipblasFillMode_t  uplo,
-                                              hipblasOperation_t transA,
-                                              int64_t            n,
-                                              int64_t            k,
-                                              const hipblas_internal_type<T>*           alpha,
-                                              const hipblas_internal_type<T>* const     A[],
-                                              int64_t            lda,
-                                              const hipblas_internal_type<T>* const     B[],
-                                              int64_t            ldb,
-                                              const hipblas_internal_type<T>*           beta,
-                                              hipblas_internal_type<T>* const           C[],
-                                              int64_t            ldc,
-                                              int64_t            batchCount);
+    hipblasStatus_t (*hipblasSyrkxBatched_64)(hipblasHandle_t                       handle,
+                                              hipblasFillMode_t                     uplo,
+                                              hipblasOperation_t                    transA,
+                                              int64_t                               n,
+                                              int64_t                               k,
+                                              const hipblas_internal_type<T>*       alpha,
+                                              const hipblas_internal_type<T>* const A[],
+                                              int64_t                               lda,
+                                              const hipblas_internal_type<T>* const B[],
+                                              int64_t                               ldb,
+                                              const hipblas_internal_type<T>*       beta,
+                                              hipblas_internal_type<T>* const       C[],
+                                              int64_t                               ldc,
+                                              int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasSyrkxStridedBatched_64)(hipblasHandle_t    handle,
-                                                     hipblasFillMode_t  uplo,
-                                                     hipblasOperation_t transA,
-                                                     int64_t            n,
-                                                     int64_t            k,
-                                                     const hipblas_internal_type<T>*           alpha,
-                                                     const hipblas_internal_type<T>*           A,
-                                                     int64_t            lda,
-                                                     hipblasStride      strideA,
-                                                     const hipblas_internal_type<T>*           B,
-                                                     int64_t            ldb,
-                                                     hipblasStride      strideB,
-                                                     const hipblas_internal_type<T>*           beta,
-                                                     hipblas_internal_type<T>*                 C,
-                                                     int64_t            ldc,
-                                                     hipblasStride      strideC,
-                                                     int64_t            batchCount);
+    hipblasStatus_t (*hipblasSyrkxStridedBatched_64)(hipblasHandle_t                 handle,
+                                                     hipblasFillMode_t               uplo,
+                                                     hipblasOperation_t              transA,
+                                                     int64_t                         n,
+                                                     int64_t                         k,
+                                                     const hipblas_internal_type<T>* alpha,
+                                                     const hipblas_internal_type<T>* A,
+                                                     int64_t                         lda,
+                                                     hipblasStride                   strideA,
+                                                     const hipblas_internal_type<T>* B,
+                                                     int64_t                         ldb,
+                                                     hipblasStride                   strideB,
+                                                     const hipblas_internal_type<T>* beta,
+                                                     hipblas_internal_type<T>*       C,
+                                                     int64_t                         ldc,
+                                                     hipblasStride                   strideC,
+                                                     int64_t                         batchCount);
 
     MAP2CF_D64(hipblasSyrkx, float, hipblasSsyrkx);
     MAP2CF_D64(hipblasSyrkx, double, hipblasDsyrkx);
@@ -11283,104 +11420,104 @@ namespace
 
     // geam
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeam)(hipblasHandle_t    handle,
-                                   hipblasOperation_t transA,
-                                   hipblasOperation_t transB,
-                                   int                m,
-                                   int                n,
-                                   const hipblas_internal_type<T>*           alpha,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   const hipblas_internal_type<T>*           beta,
-                                   const hipblas_internal_type<T>*           B,
-                                   int                ldb,
-                                   hipblas_internal_type<T>*                 C,
-                                   int                ldc);
+    hipblasStatus_t (*hipblasGeam)(hipblasHandle_t                 handle,
+                                   hipblasOperation_t              transA,
+                                   hipblasOperation_t              transB,
+                                   int                             m,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* beta,
+                                   const hipblas_internal_type<T>* B,
+                                   int                             ldb,
+                                   hipblas_internal_type<T>*       C,
+                                   int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeamBatched)(hipblasHandle_t    handle,
-                                          hipblasOperation_t transA,
-                                          hipblasOperation_t transB,
-                                          int                m,
-                                          int                n,
-                                          const hipblas_internal_type<T>*           alpha,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          const hipblas_internal_type<T>*           beta,
-                                          const hipblas_internal_type<T>* const     B[],
-                                          int                ldb,
-                                          hipblas_internal_type<T>* const           C[],
-                                          int                ldc,
-                                          int                batchCount);
+    hipblasStatus_t (*hipblasGeamBatched)(hipblasHandle_t                       handle,
+                                          hipblasOperation_t                    transA,
+                                          hipblasOperation_t                    transB,
+                                          int                                   m,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>*       beta,
+                                          const hipblas_internal_type<T>* const B[],
+                                          int                                   ldb,
+                                          hipblas_internal_type<T>* const       C[],
+                                          int                                   ldc,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeamStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasOperation_t transA,
-                                                 hipblasOperation_t transB,
-                                                 int                m,
-                                                 int                n,
-                                                 const hipblas_internal_type<T>*           alpha,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      strideA,
-                                                 const hipblas_internal_type<T>*           beta,
-                                                 const hipblas_internal_type<T>*           B,
-                                                 int                ldb,
-                                                 hipblasStride      strideB,
-                                                 hipblas_internal_type<T>*                 C,
-                                                 int                ldc,
-                                                 hipblasStride      strideC,
-                                                 int                batchCount);
+    hipblasStatus_t (*hipblasGeamStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasOperation_t              transB,
+                                                 int                             m,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 const hipblas_internal_type<T>* B,
+                                                 int                             ldb,
+                                                 hipblasStride                   strideB,
+                                                 hipblas_internal_type<T>*       C,
+                                                 int                             ldc,
+                                                 hipblasStride                   strideC,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeam_64)(hipblasHandle_t    handle,
-                                      hipblasOperation_t transA,
-                                      hipblasOperation_t transB,
-                                      int64_t            m,
-                                      int64_t            n,
-                                      const hipblas_internal_type<T>*           alpha,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      const hipblas_internal_type<T>*           beta,
-                                      const hipblas_internal_type<T>*           B,
-                                      int64_t            ldb,
-                                      hipblas_internal_type<T>*                 C,
-                                      int64_t            ldc);
+    hipblasStatus_t (*hipblasGeam_64)(hipblasHandle_t                 handle,
+                                      hipblasOperation_t              transA,
+                                      hipblasOperation_t              transB,
+                                      int64_t                         m,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* beta,
+                                      const hipblas_internal_type<T>* B,
+                                      int64_t                         ldb,
+                                      hipblas_internal_type<T>*       C,
+                                      int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeamBatched_64)(hipblasHandle_t    handle,
-                                             hipblasOperation_t transA,
-                                             hipblasOperation_t transB,
-                                             int64_t            m,
-                                             int64_t            n,
-                                             const hipblas_internal_type<T>*           alpha,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             const hipblas_internal_type<T>*           beta,
-                                             const hipblas_internal_type<T>* const     B[],
-                                             int64_t            ldb,
-                                             hipblas_internal_type<T>* const           C[],
-                                             int64_t            ldc,
-                                             int64_t            batchCount);
+    hipblasStatus_t (*hipblasGeamBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasOperation_t                    transA,
+                                             hipblasOperation_t                    transB,
+                                             int64_t                               m,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>*       beta,
+                                             const hipblas_internal_type<T>* const B[],
+                                             int64_t                               ldb,
+                                             hipblas_internal_type<T>* const       C[],
+                                             int64_t                               ldc,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeamStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasOperation_t transA,
-                                                    hipblasOperation_t transB,
-                                                    int64_t            m,
-                                                    int64_t            n,
-                                                    const hipblas_internal_type<T>*           alpha,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      strideA,
-                                                    const hipblas_internal_type<T>*           beta,
-                                                    const hipblas_internal_type<T>*           B,
-                                                    int64_t            ldb,
-                                                    hipblasStride      strideB,
-                                                    hipblas_internal_type<T>*                 C,
-                                                    int64_t            ldc,
-                                                    hipblasStride      strideC,
-                                                    int64_t            batchCount);
+    hipblasStatus_t (*hipblasGeamStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasOperation_t              transB,
+                                                    int64_t                         m,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    const hipblas_internal_type<T>* B,
+                                                    int64_t                         ldb,
+                                                    hipblasStride                   strideB,
+                                                    hipblas_internal_type<T>*       C,
+                                                    int64_t                         ldc,
+                                                    hipblasStride                   strideC,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasGeam, float, hipblasSgeam);
     MAP2CF_D64(hipblasGeam, double, hipblasDgeam);
@@ -11399,104 +11536,104 @@ namespace
 
     // hemm
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemm)(hipblasHandle_t   handle,
-                                   hipblasSideMode_t side,
-                                   hipblasFillMode_t uplo,
-                                   int               n,
-                                   int               k,
-                                   const hipblas_internal_type<T>*          alpha,
-                                   const hipblas_internal_type<T>*          A,
-                                   int               lda,
-                                   const hipblas_internal_type<T>*          B,
-                                   int               ldb,
-                                   const hipblas_internal_type<T>*          beta,
-                                   hipblas_internal_type<T>*                C,
-                                   int               ldc);
+    hipblasStatus_t (*hipblasHemm)(hipblasHandle_t                 handle,
+                                   hipblasSideMode_t               side,
+                                   hipblasFillMode_t               uplo,
+                                   int                             n,
+                                   int                             k,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* B,
+                                   int                             ldb,
+                                   const hipblas_internal_type<T>* beta,
+                                   hipblas_internal_type<T>*       C,
+                                   int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemmBatched)(hipblasHandle_t   handle,
-                                          hipblasSideMode_t side,
-                                          hipblasFillMode_t uplo,
-                                          int               n,
-                                          int               k,
-                                          const hipblas_internal_type<T>*          alpha,
-                                          const hipblas_internal_type<T>* const    A[],
-                                          int               lda,
-                                          const hipblas_internal_type<T>* const    B[],
-                                          int               ldb,
-                                          const hipblas_internal_type<T>*          beta,
-                                          hipblas_internal_type<T>* const          C[],
-                                          int               ldc,
-                                          int               batchCount);
+    hipblasStatus_t (*hipblasHemmBatched)(hipblasHandle_t                       handle,
+                                          hipblasSideMode_t                     side,
+                                          hipblasFillMode_t                     uplo,
+                                          int                                   n,
+                                          int                                   k,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const B[],
+                                          int                                   ldb,
+                                          const hipblas_internal_type<T>*       beta,
+                                          hipblas_internal_type<T>* const       C[],
+                                          int                                   ldc,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemmStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasSideMode_t side,
-                                                 hipblasFillMode_t uplo,
-                                                 int               n,
-                                                 int               k,
-                                                 const hipblas_internal_type<T>*          alpha,
-                                                 const hipblas_internal_type<T>*          A,
-                                                 int               lda,
-                                                 hipblasStride     strideA,
-                                                 const hipblas_internal_type<T>*          B,
-                                                 int               ldb,
-                                                 hipblasStride     strideB,
-                                                 const hipblas_internal_type<T>*          beta,
-                                                 hipblas_internal_type<T>*                C,
-                                                 int               ldc,
-                                                 hipblasStride     strideC,
-                                                 int               batchCount);
+    hipblasStatus_t (*hipblasHemmStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasSideMode_t               side,
+                                                 hipblasFillMode_t               uplo,
+                                                 int                             n,
+                                                 int                             k,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<T>* B,
+                                                 int                             ldb,
+                                                 hipblasStride                   strideB,
+                                                 const hipblas_internal_type<T>* beta,
+                                                 hipblas_internal_type<T>*       C,
+                                                 int                             ldc,
+                                                 hipblasStride                   strideC,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemm_64)(hipblasHandle_t   handle,
-                                      hipblasSideMode_t side,
-                                      hipblasFillMode_t uplo,
-                                      int64_t           n,
-                                      int64_t           k,
-                                      const hipblas_internal_type<T>*          alpha,
-                                      const hipblas_internal_type<T>*          A,
-                                      int64_t           lda,
-                                      const hipblas_internal_type<T>*          B,
-                                      int64_t           ldb,
-                                      const hipblas_internal_type<T>*          beta,
-                                      hipblas_internal_type<T>*                C,
-                                      int64_t           ldc);
+    hipblasStatus_t (*hipblasHemm_64)(hipblasHandle_t                 handle,
+                                      hipblasSideMode_t               side,
+                                      hipblasFillMode_t               uplo,
+                                      int64_t                         n,
+                                      int64_t                         k,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* B,
+                                      int64_t                         ldb,
+                                      const hipblas_internal_type<T>* beta,
+                                      hipblas_internal_type<T>*       C,
+                                      int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemmBatched_64)(hipblasHandle_t   handle,
-                                             hipblasSideMode_t side,
-                                             hipblasFillMode_t uplo,
-                                             int64_t           n,
-                                             int64_t           k,
-                                             const hipblas_internal_type<T>*          alpha,
-                                             const hipblas_internal_type<T>* const    A[],
-                                             int64_t           lda,
-                                             const hipblas_internal_type<T>* const    B[],
-                                             int64_t           ldb,
-                                             const hipblas_internal_type<T>*          beta,
-                                             hipblas_internal_type<T>* const          C[],
-                                             int64_t           ldc,
-                                             int64_t           batchCount);
+    hipblasStatus_t (*hipblasHemmBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasSideMode_t                     side,
+                                             hipblasFillMode_t                     uplo,
+                                             int64_t                               n,
+                                             int64_t                               k,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const B[],
+                                             int64_t                               ldb,
+                                             const hipblas_internal_type<T>*       beta,
+                                             hipblas_internal_type<T>* const       C[],
+                                             int64_t                               ldc,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasHemmStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasSideMode_t side,
-                                                    hipblasFillMode_t uplo,
-                                                    int64_t           n,
-                                                    int64_t           k,
-                                                    const hipblas_internal_type<T>*          alpha,
-                                                    const hipblas_internal_type<T>*          A,
-                                                    int64_t           lda,
-                                                    hipblasStride     strideA,
-                                                    const hipblas_internal_type<T>*          B,
-                                                    int64_t           ldb,
-                                                    hipblasStride     strideB,
-                                                    const hipblas_internal_type<T>*          beta,
-                                                    hipblas_internal_type<T>*                C,
-                                                    int64_t           ldc,
-                                                    hipblasStride     strideC,
-                                                    int64_t           batchCount);
+    hipblasStatus_t (*hipblasHemmStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasSideMode_t               side,
+                                                    hipblasFillMode_t               uplo,
+                                                    int64_t                         n,
+                                                    int64_t                         k,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<T>* B,
+                                                    int64_t                         ldb,
+                                                    hipblasStride                   strideB,
+                                                    const hipblas_internal_type<T>* beta,
+                                                    hipblas_internal_type<T>*       C,
+                                                    int64_t                         ldc,
+                                                    hipblasStride                   strideC,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64_V2(hipblasHemm, std::complex<float>, hipblasChemm);
     MAP2CF_D64_V2(hipblasHemm, std::complex<double>, hipblasZhemm);
@@ -11509,110 +11646,110 @@ namespace
 
     // trmm
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmm)(hipblasHandle_t    handle,
-                                   hipblasSideMode_t  side,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   hipblasDiagType_t  diag,
-                                   int                m,
-                                   int                n,
-                                   const hipblas_internal_type<T>*           alpha,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   const hipblas_internal_type<T>*           B,
-                                   int                ldb,
-                                   hipblas_internal_type<T>*                 C,
-                                   int                ldc);
+    hipblasStatus_t (*hipblasTrmm)(hipblasHandle_t                 handle,
+                                   hipblasSideMode_t               side,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   hipblasDiagType_t               diag,
+                                   int                             m,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* B,
+                                   int                             ldb,
+                                   hipblas_internal_type<T>*       C,
+                                   int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmmBatched)(hipblasHandle_t    handle,
-                                          hipblasSideMode_t  side,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          hipblasDiagType_t  diag,
-                                          int                m,
-                                          int                n,
-                                          const hipblas_internal_type<T>*           alpha,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          const hipblas_internal_type<T>* const     B[],
-                                          int                ldb,
-                                          hipblas_internal_type<T>* const           C[],
-                                          int                ldc,
-                                          int                batchCount);
+    hipblasStatus_t (*hipblasTrmmBatched)(hipblasHandle_t                       handle,
+                                          hipblasSideMode_t                     side,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          hipblasDiagType_t                     diag,
+                                          int                                   m,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const B[],
+                                          int                                   ldb,
+                                          hipblas_internal_type<T>* const       C[],
+                                          int                                   ldc,
+                                          int                                   batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmmStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasSideMode_t  side,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 hipblasDiagType_t  diag,
-                                                 int                m,
-                                                 int                n,
-                                                 const hipblas_internal_type<T>*           alpha,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      strideA,
-                                                 const hipblas_internal_type<T>*           B,
-                                                 int                ldb,
-                                                 hipblasStride      strideB,
-                                                 hipblas_internal_type<T>*                 C,
-                                                 int                ldc,
-                                                 hipblasStride      strideC,
-                                                 int                batchCount);
+    hipblasStatus_t (*hipblasTrmmStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasSideMode_t               side,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasDiagType_t               diag,
+                                                 int                             m,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 const hipblas_internal_type<T>* B,
+                                                 int                             ldb,
+                                                 hipblasStride                   strideB,
+                                                 hipblas_internal_type<T>*       C,
+                                                 int                             ldc,
+                                                 hipblasStride                   strideC,
+                                                 int                             batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmm_64)(hipblasHandle_t    handle,
-                                      hipblasSideMode_t  side,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      hipblasDiagType_t  diag,
-                                      int64_t            m,
-                                      int64_t            n,
-                                      const hipblas_internal_type<T>*           alpha,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      const hipblas_internal_type<T>*           B,
-                                      int64_t            ldb,
-                                      hipblas_internal_type<T>*                 C,
-                                      int64_t            ldc);
+    hipblasStatus_t (*hipblasTrmm_64)(hipblasHandle_t                 handle,
+                                      hipblasSideMode_t               side,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      hipblasDiagType_t               diag,
+                                      int64_t                         m,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* B,
+                                      int64_t                         ldb,
+                                      hipblas_internal_type<T>*       C,
+                                      int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmmBatched_64)(hipblasHandle_t    handle,
-                                             hipblasSideMode_t  side,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             hipblasDiagType_t  diag,
-                                             int64_t            m,
-                                             int64_t            n,
-                                             const hipblas_internal_type<T>*           alpha,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             const hipblas_internal_type<T>* const     B[],
-                                             int64_t            ldb,
-                                             hipblas_internal_type<T>* const           C[],
-                                             int64_t            ldc,
-                                             int64_t            batchCount);
+    hipblasStatus_t (*hipblasTrmmBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasSideMode_t                     side,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             hipblasDiagType_t                     diag,
+                                             int64_t                               m,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const B[],
+                                             int64_t                               ldb,
+                                             hipblas_internal_type<T>* const       C[],
+                                             int64_t                               ldc,
+                                             int64_t                               batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrmmStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasSideMode_t  side,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    hipblasDiagType_t  diag,
-                                                    int64_t            m,
-                                                    int64_t            n,
-                                                    const hipblas_internal_type<T>*           alpha,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      strideA,
-                                                    const hipblas_internal_type<T>*           B,
-                                                    int64_t            ldb,
-                                                    hipblasStride      strideB,
-                                                    hipblas_internal_type<T>*                 C,
-                                                    int64_t            ldc,
-                                                    hipblasStride      strideC,
-                                                    int64_t            batchCount);
+    hipblasStatus_t (*hipblasTrmmStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasSideMode_t               side,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasDiagType_t               diag,
+                                                    int64_t                         m,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    const hipblas_internal_type<T>* B,
+                                                    int64_t                         ldb,
+                                                    hipblasStride                   strideB,
+                                                    hipblas_internal_type<T>*       C,
+                                                    int64_t                         ldc,
+                                                    hipblasStride                   strideC,
+                                                    int64_t                         batchCount);
 
     MAP2CF_D64(hipblasTrmm, float, hipblasStrmm);
     MAP2CF_D64(hipblasTrmm, double, hipblasDtrmm);
@@ -11631,96 +11768,96 @@ namespace
 
     // trsm
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsm)(hipblasHandle_t    handle,
-                                   hipblasSideMode_t  side,
-                                   hipblasFillMode_t  uplo,
-                                   hipblasOperation_t transA,
-                                   hipblasDiagType_t  diag,
-                                   int                m,
-                                   int                n,
-                                   const hipblas_internal_type<T>*           alpha,
-                                   const hipblas_internal_type<T>*           A,
-                                   int                lda,
-                                   hipblas_internal_type<T>*                 B,
-                                   int                ldb);
+    hipblasStatus_t (*hipblasTrsm)(hipblasHandle_t                 handle,
+                                   hipblasSideMode_t               side,
+                                   hipblasFillMode_t               uplo,
+                                   hipblasOperation_t              transA,
+                                   hipblasDiagType_t               diag,
+                                   int                             m,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* alpha,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   hipblas_internal_type<T>*       B,
+                                   int                             ldb);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsmBatched)(hipblasHandle_t    handle,
-                                          hipblasSideMode_t  side,
-                                          hipblasFillMode_t  uplo,
-                                          hipblasOperation_t transA,
-                                          hipblasDiagType_t  diag,
-                                          int                m,
-                                          int                n,
-                                          const hipblas_internal_type<T>*           alpha,
-                                          const hipblas_internal_type<T>* const     A[],
-                                          int                lda,
-                                          hipblas_internal_type<T>* const           B[],
-                                          int                ldb,
-                                          int                batch_count);
+    hipblasStatus_t (*hipblasTrsmBatched)(hipblasHandle_t                       handle,
+                                          hipblasSideMode_t                     side,
+                                          hipblasFillMode_t                     uplo,
+                                          hipblasOperation_t                    transA,
+                                          hipblasDiagType_t                     diag,
+                                          int                                   m,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>*       alpha,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          hipblas_internal_type<T>* const       B[],
+                                          int                                   ldb,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsmStridedBatched)(hipblasHandle_t    handle,
-                                                 hipblasSideMode_t  side,
-                                                 hipblasFillMode_t  uplo,
-                                                 hipblasOperation_t transA,
-                                                 hipblasDiagType_t  diag,
-                                                 int                m,
-                                                 int                n,
-                                                 const hipblas_internal_type<T>*           alpha,
-                                                 const hipblas_internal_type<T>*           A,
-                                                 int                lda,
-                                                 hipblasStride      strideA,
-                                                 hipblas_internal_type<T>*                 B,
-                                                 int                ldb,
-                                                 hipblasStride      strideB,
-                                                 int                batch_count);
+    hipblasStatus_t (*hipblasTrsmStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasSideMode_t               side,
+                                                 hipblasFillMode_t               uplo,
+                                                 hipblasOperation_t              transA,
+                                                 hipblasDiagType_t               diag,
+                                                 int                             m,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* alpha,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   strideA,
+                                                 hipblas_internal_type<T>*       B,
+                                                 int                             ldb,
+                                                 hipblasStride                   strideB,
+                                                 int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsm_64)(hipblasHandle_t    handle,
-                                      hipblasSideMode_t  side,
-                                      hipblasFillMode_t  uplo,
-                                      hipblasOperation_t transA,
-                                      hipblasDiagType_t  diag,
-                                      int64_t            m,
-                                      int64_t            n,
-                                      const hipblas_internal_type<T>*           alpha,
-                                      const hipblas_internal_type<T>*           A,
-                                      int64_t            lda,
-                                      hipblas_internal_type<T>*                 B,
-                                      int64_t            ldb);
+    hipblasStatus_t (*hipblasTrsm_64)(hipblasHandle_t                 handle,
+                                      hipblasSideMode_t               side,
+                                      hipblasFillMode_t               uplo,
+                                      hipblasOperation_t              transA,
+                                      hipblasDiagType_t               diag,
+                                      int64_t                         m,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* alpha,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      hipblas_internal_type<T>*       B,
+                                      int64_t                         ldb);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsmBatched_64)(hipblasHandle_t    handle,
-                                             hipblasSideMode_t  side,
-                                             hipblasFillMode_t  uplo,
-                                             hipblasOperation_t transA,
-                                             hipblasDiagType_t  diag,
-                                             int64_t            m,
-                                             int64_t            n,
-                                             const hipblas_internal_type<T>*           alpha,
-                                             const hipblas_internal_type<T>* const     A[],
-                                             int64_t            lda,
-                                             hipblas_internal_type<T>* const           B[],
-                                             int64_t            ldb,
-                                             int64_t            batch_count);
+    hipblasStatus_t (*hipblasTrsmBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasSideMode_t                     side,
+                                             hipblasFillMode_t                     uplo,
+                                             hipblasOperation_t                    transA,
+                                             hipblasDiagType_t                     diag,
+                                             int64_t                               m,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>*       alpha,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             hipblas_internal_type<T>* const       B[],
+                                             int64_t                               ldb,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrsmStridedBatched_64)(hipblasHandle_t    handle,
-                                                    hipblasSideMode_t  side,
-                                                    hipblasFillMode_t  uplo,
-                                                    hipblasOperation_t transA,
-                                                    hipblasDiagType_t  diag,
-                                                    int64_t            m,
-                                                    int64_t            n,
-                                                    const hipblas_internal_type<T>*           alpha,
-                                                    const hipblas_internal_type<T>*           A,
-                                                    int64_t            lda,
-                                                    hipblasStride      strideA,
-                                                    hipblas_internal_type<T>*                 B,
-                                                    int64_t            ldb,
-                                                    hipblasStride      strideB,
-                                                    int64_t            batch_count);
+    hipblasStatus_t (*hipblasTrsmStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasSideMode_t               side,
+                                                    hipblasFillMode_t               uplo,
+                                                    hipblasOperation_t              transA,
+                                                    hipblasDiagType_t               diag,
+                                                    int64_t                         m,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* alpha,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   strideA,
+                                                    hipblas_internal_type<T>*       B,
+                                                    int64_t                         ldb,
+                                                    hipblasStride                   strideB,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasTrsm, float, hipblasStrsm);
     MAP2CF_D64(hipblasTrsm, double, hipblasDtrsm);
@@ -11739,86 +11876,86 @@ namespace
 
     // dgmm
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDgmm)(hipblasHandle_t   handle,
-                                   hipblasSideMode_t side,
-                                   int               m,
-                                   int               n,
-                                   const hipblas_internal_type<T>*          A,
-                                   int               lda,
-                                   const hipblas_internal_type<T>*          x,
-                                   int               incx,
-                                   hipblas_internal_type<T>*                C,
-                                   int               ldc);
+    hipblasStatus_t (*hipblasDgmm)(hipblasHandle_t                 handle,
+                                   hipblasSideMode_t               side,
+                                   int                             m,
+                                   int                             n,
+                                   const hipblas_internal_type<T>* A,
+                                   int                             lda,
+                                   const hipblas_internal_type<T>* x,
+                                   int                             incx,
+                                   hipblas_internal_type<T>*       C,
+                                   int                             ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDgmmBatched)(hipblasHandle_t   handle,
-                                          hipblasSideMode_t side,
-                                          int               m,
-                                          int               n,
-                                          const hipblas_internal_type<T>* const    A[],
-                                          int               lda,
-                                          const hipblas_internal_type<T>* const    x[],
-                                          int               incx,
-                                          hipblas_internal_type<T>* const          C[],
-                                          int               ldc,
-                                          int               batch_count);
+    hipblasStatus_t (*hipblasDgmmBatched)(hipblasHandle_t                       handle,
+                                          hipblasSideMode_t                     side,
+                                          int                                   m,
+                                          int                                   n,
+                                          const hipblas_internal_type<T>* const A[],
+                                          int                                   lda,
+                                          const hipblas_internal_type<T>* const x[],
+                                          int                                   incx,
+                                          hipblas_internal_type<T>* const       C[],
+                                          int                                   ldc,
+                                          int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDgmmStridedBatched)(hipblasHandle_t   handle,
-                                                 hipblasSideMode_t side,
-                                                 int               m,
-                                                 int               n,
-                                                 const hipblas_internal_type<T>*          A,
-                                                 int               lda,
-                                                 hipblasStride     stride_A,
-                                                 const hipblas_internal_type<T>*          x,
-                                                 int               incx,
-                                                 hipblasStride     stride_x,
-                                                 hipblas_internal_type<T>*                C,
-                                                 int               ldc,
-                                                 hipblasStride     stride_C,
-                                                 int               batch_count);
+    hipblasStatus_t (*hipblasDgmmStridedBatched)(hipblasHandle_t                 handle,
+                                                 hipblasSideMode_t               side,
+                                                 int                             m,
+                                                 int                             n,
+                                                 const hipblas_internal_type<T>* A,
+                                                 int                             lda,
+                                                 hipblasStride                   stride_A,
+                                                 const hipblas_internal_type<T>* x,
+                                                 int                             incx,
+                                                 hipblasStride                   stride_x,
+                                                 hipblas_internal_type<T>*       C,
+                                                 int                             ldc,
+                                                 hipblasStride                   stride_C,
+                                                 int                             batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDgmm_64)(hipblasHandle_t   handle,
-                                      hipblasSideMode_t side,
-                                      int64_t           m,
-                                      int64_t           n,
-                                      const hipblas_internal_type<T>*          A,
-                                      int64_t           lda,
-                                      const hipblas_internal_type<T>*          x,
-                                      int64_t           incx,
-                                      hipblas_internal_type<T>*                C,
-                                      int64_t           ldc);
+    hipblasStatus_t (*hipblasDgmm_64)(hipblasHandle_t                 handle,
+                                      hipblasSideMode_t               side,
+                                      int64_t                         m,
+                                      int64_t                         n,
+                                      const hipblas_internal_type<T>* A,
+                                      int64_t                         lda,
+                                      const hipblas_internal_type<T>* x,
+                                      int64_t                         incx,
+                                      hipblas_internal_type<T>*       C,
+                                      int64_t                         ldc);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDgmmBatched_64)(hipblasHandle_t   handle,
-                                             hipblasSideMode_t side,
-                                             int64_t           m,
-                                             int64_t           n,
-                                             const hipblas_internal_type<T>* const    A[],
-                                             int64_t           lda,
-                                             const hipblas_internal_type<T>* const    x[],
-                                             int64_t           incx,
-                                             hipblas_internal_type<T>* const          C[],
-                                             int64_t           ldc,
-                                             int64_t           batch_count);
+    hipblasStatus_t (*hipblasDgmmBatched_64)(hipblasHandle_t                       handle,
+                                             hipblasSideMode_t                     side,
+                                             int64_t                               m,
+                                             int64_t                               n,
+                                             const hipblas_internal_type<T>* const A[],
+                                             int64_t                               lda,
+                                             const hipblas_internal_type<T>* const x[],
+                                             int64_t                               incx,
+                                             hipblas_internal_type<T>* const       C[],
+                                             int64_t                               ldc,
+                                             int64_t                               batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasDgmmStridedBatched_64)(hipblasHandle_t   handle,
-                                                    hipblasSideMode_t side,
-                                                    int64_t           m,
-                                                    int64_t           n,
-                                                    const hipblas_internal_type<T>*          A,
-                                                    int64_t           lda,
-                                                    hipblasStride     stride_A,
-                                                    const hipblas_internal_type<T>*          x,
-                                                    int64_t           incx,
-                                                    hipblasStride     stride_x,
-                                                    hipblas_internal_type<T>*                C,
-                                                    int64_t           ldc,
-                                                    hipblasStride     stride_C,
-                                                    int64_t           batch_count);
+    hipblasStatus_t (*hipblasDgmmStridedBatched_64)(hipblasHandle_t                 handle,
+                                                    hipblasSideMode_t               side,
+                                                    int64_t                         m,
+                                                    int64_t                         n,
+                                                    const hipblas_internal_type<T>* A,
+                                                    int64_t                         lda,
+                                                    hipblasStride                   stride_A,
+                                                    const hipblas_internal_type<T>* x,
+                                                    int64_t                         incx,
+                                                    hipblasStride                   stride_x,
+                                                    hipblas_internal_type<T>*       C,
+                                                    int64_t                         ldc,
+                                                    hipblasStride                   stride_C,
+                                                    int64_t                         batch_count);
 
     MAP2CF_D64(hipblasDgmm, float, hipblasSdgmm);
     MAP2CF_D64(hipblasDgmm, double, hipblasDdgmm);
@@ -11837,38 +11974,38 @@ namespace
 
     // trtri
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrtri)(hipblasHandle_t   handle,
-                                    hipblasFillMode_t uplo,
-                                    hipblasDiagType_t diag,
-                                    int               n,
-                                    const hipblas_internal_type<T>*          A,
-                                    int               lda,
-                                    hipblas_internal_type<T>*                invA,
-                                    int               ldinvA);
+    hipblasStatus_t (*hipblasTrtri)(hipblasHandle_t                 handle,
+                                    hipblasFillMode_t               uplo,
+                                    hipblasDiagType_t               diag,
+                                    int                             n,
+                                    const hipblas_internal_type<T>* A,
+                                    int                             lda,
+                                    hipblas_internal_type<T>*       invA,
+                                    int                             ldinvA);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrtriBatched)(hipblasHandle_t   handle,
-                                           hipblasFillMode_t uplo,
-                                           hipblasDiagType_t diag,
-                                           int               n,
-                                           const hipblas_internal_type<T>* const    A[],
-                                           int               lda,
-                                           hipblas_internal_type<T>*                invA[],
-                                           int               ldinvA,
-                                           int               batch_count);
+    hipblasStatus_t (*hipblasTrtriBatched)(hipblasHandle_t                       handle,
+                                           hipblasFillMode_t                     uplo,
+                                           hipblasDiagType_t                     diag,
+                                           int                                   n,
+                                           const hipblas_internal_type<T>* const A[],
+                                           int                                   lda,
+                                           hipblas_internal_type<T>*             invA[],
+                                           int                                   ldinvA,
+                                           int                                   batch_count);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasTrtriStridedBatched)(hipblasHandle_t   handle,
-                                                  hipblasFillMode_t uplo,
-                                                  hipblasDiagType_t diag,
-                                                  int               n,
-                                                  const hipblas_internal_type<T>*          A,
-                                                  int               lda,
-                                                  hipblasStride     stride_A,
-                                                  hipblas_internal_type<T>*                invA,
-                                                  int               ldinvA,
-                                                  hipblasStride     stride_invA,
-                                                  int               batch_count);
+    hipblasStatus_t (*hipblasTrtriStridedBatched)(hipblasHandle_t                 handle,
+                                                  hipblasFillMode_t               uplo,
+                                                  hipblasDiagType_t               diag,
+                                                  int                             n,
+                                                  const hipblas_internal_type<T>* A,
+                                                  int                             lda,
+                                                  hipblasStride                   stride_A,
+                                                  hipblas_internal_type<T>*       invA,
+                                                  int                             ldinvA,
+                                                  hipblasStride                   stride_invA,
+                                                  int                             batch_count);
 
     MAP2CF(hipblasTrtri, float, hipblasStrtri);
     MAP2CF(hipblasTrtri, double, hipblasDtrtri);
@@ -11889,28 +12026,32 @@ namespace
 
     // getrf
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGetrf)(
-        hipblasHandle_t handle, const int n, hipblas_internal_type<T>* A, const int lda, int* ipiv, int* info);
+    hipblasStatus_t (*hipblasGetrf)(hipblasHandle_t           handle,
+                                    const int                 n,
+                                    hipblas_internal_type<T>* A,
+                                    const int                 lda,
+                                    int*                      ipiv,
+                                    int*                      info);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGetrfBatched)(hipblasHandle_t handle,
-                                           const int       n,
-                                           hipblas_internal_type<T>* const        A[],
-                                           const int       lda,
-                                           int*            ipiv,
-                                           int*            info,
-                                           const int       batchCount);
+    hipblasStatus_t (*hipblasGetrfBatched)(hipblasHandle_t                 handle,
+                                           const int                       n,
+                                           hipblas_internal_type<T>* const A[],
+                                           const int                       lda,
+                                           int*                            ipiv,
+                                           int*                            info,
+                                           const int                       batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGetrfStridedBatched)(hipblasHandle_t     handle,
-                                                  const int           n,
-                                                  hipblas_internal_type<T>*                  A,
-                                                  const int           lda,
-                                                  const hipblasStride strideA,
-                                                  int*                ipiv,
-                                                  const hipblasStride strideP,
-                                                  int*                info,
-                                                  const int           batchCount);
+    hipblasStatus_t (*hipblasGetrfStridedBatched)(hipblasHandle_t           handle,
+                                                  const int                 n,
+                                                  hipblas_internal_type<T>* A,
+                                                  const int                 lda,
+                                                  const hipblasStride       strideA,
+                                                  int*                      ipiv,
+                                                  const hipblasStride       strideP,
+                                                  int*                      info,
+                                                  const int                 batchCount);
 
     MAP2CF(hipblasGetrf, float, hipblasSgetrf);
     MAP2CF(hipblasGetrf, double, hipblasDgetrf);
@@ -11929,45 +12070,45 @@ namespace
 
     // getrs
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGetrs)(hipblasHandle_t          handle,
-                                    const hipblasOperation_t trans,
-                                    const int                n,
-                                    const int                nrhs,
-                                    hipblas_internal_type<T>*                       A,
-                                    const int                lda,
-                                    const int*               ipiv,
-                                    hipblas_internal_type<T>*                       B,
-                                    const int                ldb,
-                                    int*                     info);
+    hipblasStatus_t (*hipblasGetrs)(hipblasHandle_t           handle,
+                                    const hipblasOperation_t  trans,
+                                    const int                 n,
+                                    const int                 nrhs,
+                                    hipblas_internal_type<T>* A,
+                                    const int                 lda,
+                                    const int*                ipiv,
+                                    hipblas_internal_type<T>* B,
+                                    const int                 ldb,
+                                    int*                      info);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGetrsBatched)(hipblasHandle_t          handle,
-                                           const hipblasOperation_t trans,
-                                           const int                n,
-                                           const int                nrhs,
-                                           hipblas_internal_type<T>* const                 A[],
-                                           const int                lda,
-                                           const int*               ipiv,
-                                           hipblas_internal_type<T>* const                 B[],
-                                           const int                ldb,
-                                           int*                     info,
-                                           const int                batchCount);
+    hipblasStatus_t (*hipblasGetrsBatched)(hipblasHandle_t                 handle,
+                                           const hipblasOperation_t        trans,
+                                           const int                       n,
+                                           const int                       nrhs,
+                                           hipblas_internal_type<T>* const A[],
+                                           const int                       lda,
+                                           const int*                      ipiv,
+                                           hipblas_internal_type<T>* const B[],
+                                           const int                       ldb,
+                                           int*                            info,
+                                           const int                       batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGetrsStridedBatched)(hipblasHandle_t          handle,
-                                                  const hipblasOperation_t trans,
-                                                  const int                n,
-                                                  const int                nrhs,
-                                                  hipblas_internal_type<T>*                       A,
-                                                  const int                lda,
-                                                  const hipblasStride      strideA,
-                                                  const int*               ipiv,
-                                                  const hipblasStride      strideP,
-                                                  hipblas_internal_type<T>*                       B,
-                                                  const int                ldb,
-                                                  const hipblasStride      strideB,
-                                                  int*                     info,
-                                                  const int                batchCount);
+    hipblasStatus_t (*hipblasGetrsStridedBatched)(hipblasHandle_t           handle,
+                                                  const hipblasOperation_t  trans,
+                                                  const int                 n,
+                                                  const int                 nrhs,
+                                                  hipblas_internal_type<T>* A,
+                                                  const int                 lda,
+                                                  const hipblasStride       strideA,
+                                                  const int*                ipiv,
+                                                  const hipblasStride       strideP,
+                                                  hipblas_internal_type<T>* B,
+                                                  const int                 ldb,
+                                                  const hipblasStride       strideB,
+                                                  int*                      info,
+                                                  const int                 batchCount);
 
     MAP2CF(hipblasGetrs, float, hipblasSgetrs);
     MAP2CF(hipblasGetrs, double, hipblasDgetrs);
@@ -11986,15 +12127,15 @@ namespace
 
     // getri
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGetriBatched)(hipblasHandle_t handle,
-                                           const int       n,
-                                           hipblas_internal_type<T>* const        A[],
-                                           const int       lda,
-                                           int*            ipiv,
-                                           hipblas_internal_type<T>* const        C[],
-                                           const int       ldc,
-                                           int*            info,
-                                           const int       batchCount);
+    hipblasStatus_t (*hipblasGetriBatched)(hipblasHandle_t                 handle,
+                                           const int                       n,
+                                           hipblas_internal_type<T>* const A[],
+                                           const int                       lda,
+                                           int*                            ipiv,
+                                           hipblas_internal_type<T>* const C[],
+                                           const int                       ldc,
+                                           int*                            info,
+                                           const int                       batchCount);
 
     MAP2CF(hipblasGetriBatched, float, hipblasSgetriBatched);
     MAP2CF(hipblasGetriBatched, double, hipblasDgetriBatched);
@@ -12003,30 +12144,35 @@ namespace
 
     // geqrf
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeqrf)(
-        hipblasHandle_t handle, const int m, const int n, hipblas_internal_type<T>* A, const int lda, hipblas_internal_type<T>* ipiv, int* info);
+    hipblasStatus_t (*hipblasGeqrf)(hipblasHandle_t           handle,
+                                    const int                 m,
+                                    const int                 n,
+                                    hipblas_internal_type<T>* A,
+                                    const int                 lda,
+                                    hipblas_internal_type<T>* ipiv,
+                                    int*                      info);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeqrfBatched)(hipblasHandle_t handle,
-                                           const int       m,
-                                           const int       n,
-                                           hipblas_internal_type<T>* const        A[],
-                                           const int       lda,
-                                           hipblas_internal_type<T>* const        ipiv[],
-                                           int*            info,
-                                           const int       batchCount);
+    hipblasStatus_t (*hipblasGeqrfBatched)(hipblasHandle_t                 handle,
+                                           const int                       m,
+                                           const int                       n,
+                                           hipblas_internal_type<T>* const A[],
+                                           const int                       lda,
+                                           hipblas_internal_type<T>* const ipiv[],
+                                           int*                            info,
+                                           const int                       batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGeqrfStridedBatched)(hipblasHandle_t     handle,
-                                                  const int           m,
-                                                  const int           n,
-                                                  hipblas_internal_type<T>*                  A,
-                                                  const int           lda,
-                                                  const hipblasStride strideA,
-                                                  hipblas_internal_type<T>*                  ipiv,
-                                                  const hipblasStride strideP,
-                                                  int*                info,
-                                                  const int           batchCount);
+    hipblasStatus_t (*hipblasGeqrfStridedBatched)(hipblasHandle_t           handle,
+                                                  const int                 m,
+                                                  const int                 n,
+                                                  hipblas_internal_type<T>* A,
+                                                  const int                 lda,
+                                                  const hipblasStride       strideA,
+                                                  hipblas_internal_type<T>* ipiv,
+                                                  const hipblasStride       strideP,
+                                                  int*                      info,
+                                                  const int                 batchCount);
 
     MAP2CF(hipblasGeqrf, float, hipblasSgeqrf);
     MAP2CF(hipblasGeqrf, double, hipblasDgeqrf);
@@ -12045,47 +12191,47 @@ namespace
 
     // gels
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGels)(hipblasHandle_t    handle,
-                                   hipblasOperation_t trans,
-                                   const int          m,
-                                   const int          n,
-                                   const int          nrhs,
-                                   hipblas_internal_type<T>*                 A,
-                                   const int          lda,
-                                   hipblas_internal_type<T>*                 B,
-                                   const int          ldb,
-                                   int*               info,
-                                   int*               deviceInfo);
+    hipblasStatus_t (*hipblasGels)(hipblasHandle_t           handle,
+                                   hipblasOperation_t        trans,
+                                   const int                 m,
+                                   const int                 n,
+                                   const int                 nrhs,
+                                   hipblas_internal_type<T>* A,
+                                   const int                 lda,
+                                   hipblas_internal_type<T>* B,
+                                   const int                 ldb,
+                                   int*                      info,
+                                   int*                      deviceInfo);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGelsBatched)(hipblasHandle_t    handle,
-                                          hipblasOperation_t trans,
-                                          const int          m,
-                                          const int          n,
-                                          const int          nrhs,
-                                          hipblas_internal_type<T>* const           A[],
-                                          const int          lda,
-                                          hipblas_internal_type<T>* const           B[],
-                                          const int          ldb,
-                                          int*               info,
-                                          int*               deviceInfo,
-                                          const int          batchCount);
+    hipblasStatus_t (*hipblasGelsBatched)(hipblasHandle_t                 handle,
+                                          hipblasOperation_t              trans,
+                                          const int                       m,
+                                          const int                       n,
+                                          const int                       nrhs,
+                                          hipblas_internal_type<T>* const A[],
+                                          const int                       lda,
+                                          hipblas_internal_type<T>* const B[],
+                                          const int                       ldb,
+                                          int*                            info,
+                                          int*                            deviceInfo,
+                                          const int                       batchCount);
 
     template <typename T, bool FORTRAN = false>
-    hipblasStatus_t (*hipblasGelsStridedBatched)(hipblasHandle_t     handle,
-                                                 hipblasOperation_t  trans,
-                                                 const int           m,
-                                                 const int           n,
-                                                 const int           nrhs,
-                                                 hipblas_internal_type<T>*                  A,
-                                                 const int           lda,
-                                                 const hipblasStride strideA,
-                                                 hipblas_internal_type<T>*                  B,
-                                                 const int           ldb,
-                                                 const hipblasStride strideB,
-                                                 int*                info,
-                                                 int*                deviceInfo,
-                                                 const int           batchCount);
+    hipblasStatus_t (*hipblasGelsStridedBatched)(hipblasHandle_t           handle,
+                                                 hipblasOperation_t        trans,
+                                                 const int                 m,
+                                                 const int                 n,
+                                                 const int                 nrhs,
+                                                 hipblas_internal_type<T>* A,
+                                                 const int                 lda,
+                                                 const hipblasStride       strideA,
+                                                 hipblas_internal_type<T>* B,
+                                                 const int                 ldb,
+                                                 const hipblasStride       strideB,
+                                                 int*                      info,
+                                                 int*                      deviceInfo,
+                                                 const int                 batchCount);
 
     MAP2CF(hipblasGels, float, hipblasSgels);
     MAP2CF(hipblasGels, double, hipblasDgels);

--- a/clients/include/hipblas_arguments.hpp
+++ b/clients/include/hipblas_arguments.hpp
@@ -93,15 +93,15 @@ inline hipblasHalf convert_alpha_beta<hipblasHalf>(double r, double i)
 }
 
 template <>
-inline hipblasComplex convert_alpha_beta<hipblasComplex>(double r, double i)
+inline std::complex<float> convert_alpha_beta<std::complex<float>>(double r, double i)
 {
-    return hipblasComplex(r, i);
+    return std::complex<float>(r, i);
 }
 
 template <>
-inline hipblasDoubleComplex convert_alpha_beta<hipblasDoubleComplex>(double r, double i)
+inline std::complex<double> convert_alpha_beta<std::complex<double>>(double r, double i)
 {
-    return hipblasDoubleComplex(r, i);
+    return std::complex<double>(r, i);
 }
 
 /*! \brief Class used to parse command arguments in both benchmark & gtest   */

--- a/clients/include/hipblas_datatype2string.hpp
+++ b/clients/include/hipblas_datatype2string.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 #define hipblas_DATATYPE2STRING_H_
 
 #include "hipblas.h"
+#include <complex>
 #include <ostream>
 #include <string>
 
@@ -57,13 +58,13 @@ inline std::ostream& operator<<(std::ostream& os, hipblas_initialization init)
 }
 
 // Complex output
-inline std::ostream& operator<<(std::ostream& os, const hipblasComplex& x)
+inline std::ostream& operator<<(std::ostream& os, const std::complex<float>& x)
 {
     os << "'(" << x.real() << ":" << x.imag() << ")'";
     return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const hipblasDoubleComplex& x)
+inline std::ostream& operator<<(std::ostream& os, const std::complex<double>& x)
 {
     os << "'(" << x.real() << ":" << x.imag() << ")'";
     return os;

--- a/clients/include/host_batch_vector.hpp
+++ b/clients/include/host_batch_vector.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "host_alloc.hpp"
+#include "type_utils.h"
 #include <cmath>
 #include <string.h>
 //
@@ -158,6 +159,14 @@ public:
     operator const T* const *()
     {
         return this->m_data;
+    }
+
+    //!
+    //! @brief Get data reinterpretted as hipblas_internal_type
+    //!
+    inline hipblas_internal_type<T>** internal_type()
+    {
+        return reinterpret_cast<hipblas_internal_type<T>**>(this->m_data);
     }
 
     //!

--- a/clients/include/host_strided_batch_vector.hpp
+++ b/clients/include/host_strided_batch_vector.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -176,6 +176,14 @@ public:
     explicit operator bool() const
     {
         return nullptr != m_data;
+    }
+
+    //!
+    //! @brief Get data reinterpretted as hipblas_internal_type
+    //!
+    inline hipblas_internal_type<T>* internal_type()
+    {
+        return reinterpret_cast<hipblas_internal_type<T>*>((*this)[0]);
     }
 
     //!

--- a/clients/include/host_vector.hpp
+++ b/clients/include/host_vector.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -98,6 +98,14 @@ struct host_vector : std::vector<T, host_memory_allocator<T>>
     inline const T& operator[](int64_t idx) const
     {
         return std::vector<T, host_memory_allocator<T>>::operator[]((size_t)idx);
+    }
+
+    //!
+    //! @brief Get data reinterpretted as hipblas_internal_type
+    //!
+    inline hipblas_internal_type<T>* internal_type()
+    {
+        return reinterpret_cast<hipblas_internal_type<T>*>(this->data());
     }
 
     //!

--- a/clients/include/lapack_utilities.hpp
+++ b/clients/include/lapack_utilities.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -82,7 +82,7 @@ void lapack_xcombssq(T* ssq, T* colssq)
 {
     if(ssq[0] >= colssq[0])
     {
-        if(ssq[0] != 0)
+        if(ssq[0] != T(0))
         {
             ssq[1] = ssq[1] + std::sqrt(colssq[0] / ssq[0]) * colssq[1];
         }
@@ -358,7 +358,7 @@ void lapack_xrotg(T& ca, T& cb, U& c, T& s)
         const U norm  = scale
                        * std::sqrt((hipblas_abs(ca / scale)) * (hipblas_abs(ca / scale))
                                    + (hipblas_abs(cb / scale)) * (hipblas_abs(cb / scale)));
-        T alpha = ca / hipblas_abs(ca);
+        T alpha = ca / T(hipblas_abs(ca));
         c       = hipblas_abs(ca) / norm;
         s       = alpha * hipblas_conjugate(cb) / norm;
         ca      = alpha * norm;
@@ -375,7 +375,7 @@ void lapack_xrotg(T& ca, T& cb, U& c, T& s)
 template <typename T>
 void lapack_xsyr(hipblasFillMode_t uplo, int64_t n, T alpha, T* xa, int64_t incx, T* A, int64_t lda)
 {
-    if(n <= 0 || alpha == 0)
+    if(n <= 0 || alpha == T(0))
         return;
 
     T* x = (incx < 0) ? xa - ptrdiff_t(incx) * (n - 1) : xa;
@@ -423,7 +423,7 @@ void lapack_xsymv(hipblasFillMode_t uplo,
     T* x = (incx < 0) ? xa - incx * (n - 1) : xa;
     T* y = (incy < 0) ? ya - incy * (n - 1) : ya;
 
-    if(beta != 1)
+    if(beta != T(1))
     {
         for(int64_t j = 0; j < n; j++)
         {
@@ -431,7 +431,7 @@ void lapack_xsymv(hipblasFillMode_t uplo,
         }
     }
 
-    if(alpha == 0)
+    if(alpha == T(0))
         return;
 
     T temp1 = T(0);
@@ -471,7 +471,7 @@ void lapack_xsymv(hipblasFillMode_t uplo,
 template <typename T>
 void lapack_xspr(hipblasFillMode_t uplo, int64_t n, T alpha, T* xa, int64_t incx, T* A)
 {
-    if(n <= 0 || alpha == 0)
+    if(n <= 0 || alpha == T(0))
         return;
 
     T*      x  = (incx < 0) ? xa - incx * (n - 1) : xa;
@@ -481,7 +481,7 @@ void lapack_xspr(hipblasFillMode_t uplo, int64_t n, T alpha, T* xa, int64_t incx
     {
         for(int64_t j = 0; j < n; ++j)
         {
-            if(x[j * incx] != 0)
+            if(x[j * incx] != T(0))
             {
                 tmpx = alpha * x[j * incx];
                 k    = kk;
@@ -499,7 +499,7 @@ void lapack_xspr(hipblasFillMode_t uplo, int64_t n, T alpha, T* xa, int64_t incx
     {
         for(int64_t j = 0; j < n; ++j)
         {
-            if(x[j * incx] != 0)
+            if(x[j * incx] != T(0))
             {
                 tmpx = alpha * x[j * incx];
                 A[kk] += x[j * incx] * tmpx;
@@ -527,7 +527,7 @@ inline void lapack_xsyr2(hipblasFillMode_t uplo,
                          T*                A,
                          int64_t           lda)
 {
-    if(n <= 0 || alpha == 0)
+    if(n <= 0 || alpha == T(0))
         return;
 
     T* x = (incx < 0) ? xa - incx * (n - 1) : xa;

--- a/clients/include/near.h
+++ b/clients/include/near.h
@@ -122,7 +122,9 @@ HIPBLAS_CLANG_STATIC constexpr double
 
 template <>
 HIPBLAS_CLANG_STATIC constexpr double
-    sum_error_tolerance_for_gfx11<std::complex<float>, std::complex<float>, std::complex<float>> = 1 / 10000.0;
+    sum_error_tolerance_for_gfx11<std::complex<float>,
+                                  std::complex<float>,
+                                  std::complex<float>> = 1 / 10000.0;
 
 template <>
 HIPBLAS_CLANG_STATIC constexpr double

--- a/clients/include/near.h
+++ b/clients/include/near.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,10 +91,10 @@ template <>
 HIPBLAS_CLANG_STATIC constexpr double error_tolerance<hipblasHalf> = 0.000061035;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double error_tolerance<hipblasComplex> = 1 / 10000.0;
+HIPBLAS_CLANG_STATIC constexpr double error_tolerance<std::complex<float>> = 1 / 10000.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double error_tolerance<hipblasDoubleComplex> = 1 / 1000000.0;
+HIPBLAS_CLANG_STATIC constexpr double error_tolerance<std::complex<double>> = 1 / 1000000.0;
 
 // currently only used for gemm_ex
 template <class Tc, class Ti, class To>
@@ -122,12 +122,12 @@ HIPBLAS_CLANG_STATIC constexpr double
 
 template <>
 HIPBLAS_CLANG_STATIC constexpr double
-    sum_error_tolerance_for_gfx11<hipblasComplex, hipblasComplex, hipblasComplex> = 1 / 10000.0;
+    sum_error_tolerance_for_gfx11<std::complex<float>, std::complex<float>, std::complex<float>> = 1 / 10000.0;
 
 template <>
 HIPBLAS_CLANG_STATIC constexpr double
-    sum_error_tolerance_for_gfx11<hipblasDoubleComplex,
-                                  hipblasDoubleComplex,
-                                  hipblasDoubleComplex> = 1 / 1000000.0;
+    sum_error_tolerance_for_gfx11<std::complex<double>,
+                                  std::complex<double>,
+                                  std::complex<double>> = 1 / 1000000.0;
 
 #endif

--- a/clients/include/solver/testing_gels_batched.hpp
+++ b/clients/include/solver/testing_gels_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -61,8 +61,8 @@ void testing_gels_batched_bad_arg(const Arguments& arg)
     int                info = 0;
     int                expectedInfo;
 
-    T* const* dAp = dA.ptr_on_device();
-    T* const* dBp = dB.ptr_on_device();
+    hipblas_internal_type<T>* const* dAp = dA.ptr_on_device();
+    hipblas_internal_type<T>* const* dBp = dB.ptr_on_device();
 
     EXPECT_HIPBLAS_STATUS(
         hipblasGelsBatchedFn(

--- a/clients/include/solver/testing_geqrf_batched.hpp
+++ b/clients/include/solver/testing_geqrf_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,8 +91,8 @@ void testing_geqrf_batched_bad_arg(const Arguments& arg)
     int                    info = 0;
     int                    expectedInfo;
 
-    T* const* dAp    = dA.ptr_on_device();
-    T* const* dIpivp = dIpiv.ptr_on_device();
+    hipblas_internal_type<T>* const* dAp    = dA.ptr_on_device();
+    hipblas_internal_type<T>* const* dIpivp = dIpiv.ptr_on_device();
 
     setup_geqrf_batched_testing(arg, hA, hIpiv, dA, dIpiv, M, N, lda, batch_count);
 

--- a/clients/include/solver/testing_getrs_batched.hpp
+++ b/clients/include/solver/testing_getrs_batched.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -124,8 +124,8 @@ void testing_getrs_batched_bad_arg(const Arguments& arg)
     int                    info         = 0;
     int                    expectedInfo = 0;
 
-    T* const* dAp = dA.ptr_on_device();
-    T* const* dBp = dB.ptr_on_device();
+    hipblas_internal_type<T>* const* dAp = dA.ptr_on_device();
+    hipblas_internal_type<T>* const* dBp = dB.ptr_on_device();
 
     // Need initialization code because even with bad params we call roc/cu-solver
     // so want to give reasonable data

--- a/clients/include/syrkx_reference.hpp
+++ b/clients/include/syrkx_reference.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,7 +81,7 @@ void syrkx_reference(hipblasFillMode_t  uplo,
     }
 
     // quick return
-    if((n == 0) || (((alpha == 0) || (k == 0)) && (beta == 1)))
+    if((n == 0) || (((alpha == T(0)) || (k == 0)) && (beta == T(1))))
         return;
 
     // rank kx update with special cases for alpha == 0, beta == 0
@@ -91,11 +91,11 @@ void syrkx_reference(hipblasFillMode_t  uplo,
         int i2_end   = HIPBLAS_FILL_MODE_LOWER == uplo ? i1 + 1 : n;
         for(int i2 = i2_start; i2 < i2_end; i2++)
         {
-            if(alpha == 0 && beta == 0)
+            if(alpha == T(0) && beta == T(0))
             {
                 c[i1 * c_s1 + i2 * c_s2] = 0.0;
             }
-            else if(alpha == 0)
+            else if(alpha == T(0))
             {
                 c[i1 * c_s1 + i2 * c_s2] *= beta;
             }

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,9 +54,9 @@ auto hipblas_simple_dispatch(const Arguments& arg)
     //  case hipblas_datatype_f16_c:
     //      return TEST<hipblas_half_complex>{}(arg);
     case HIPBLAS_C_32F:
-        return TEST<hipblasComplex>{}(arg);
+        return TEST<std::complex<float>>{}(arg);
     case HIPBLAS_C_64F:
-        return TEST<hipblasDoubleComplex>{}(arg);
+        return TEST<std::complex<double>>{}(arg);
     default:
         return TEST<void>{}(arg);
     }
@@ -74,15 +74,15 @@ auto hipblas_blas1_dispatch(const Arguments& arg)
         else
         { // for csscal and zdscal and complex rotg only
             if(Ti == HIPBLAS_C_32F && Tb == HIPBLAS_R_32F)
-                return TEST<hipblasComplex, float>{}(arg);
+                return TEST<std::complex<float>, float>{}(arg);
             else if(Ti == HIPBLAS_C_64F && Tb == HIPBLAS_R_64F)
-                return TEST<hipblasDoubleComplex, double>{}(arg);
+                return TEST<std::complex<double>, double>{}(arg);
         }
     }
     else if(Ti == HIPBLAS_C_32F && Tb == HIPBLAS_R_32F)
-        return TEST<hipblasComplex, float>{}(arg);
+        return TEST<std::complex<float>, float>{}(arg);
     else if(Ti == HIPBLAS_C_64F && Tb == HIPBLAS_R_64F)
-        return TEST<hipblasDoubleComplex, double>{}(arg);
+        return TEST<std::complex<double>, double>{}(arg);
     else if(Ti == HIPBLAS_R_32F && Tb == HIPBLAS_R_32F)
         return TEST<float, float>{}(arg);
     else if(Ti == HIPBLAS_R_64F && Tb == HIPBLAS_R_64F)
@@ -168,12 +168,12 @@ auto hipblas_blas1_ex_dispatch(const Arguments& arg)
         else if(Ta == HIPBLAS_R_32F && Tx == HIPBLAS_C_32F && Tex == HIPBLAS_C_32F)
         {
             // csscal-like
-            return TEST<float, hipblasComplex, hipblasComplex>{}(arg);
+            return TEST<float, std::complex<float>, std::complex<float>>{}(arg);
         }
         else if(Ta == HIPBLAS_R_64F && Tx == HIPBLAS_C_64F && Tex == HIPBLAS_C_64F)
         {
             // zdscal-like
-            return TEST<double, hipblasDoubleComplex, hipblasDoubleComplex>{}(arg);
+            return TEST<double, std::complex<double>, std::complex<double>>{}(arg);
         }
     }
     else if(is_nrm2)
@@ -181,12 +181,12 @@ auto hipblas_blas1_ex_dispatch(const Arguments& arg)
         if(Ta == HIPBLAS_C_32F && Tx == HIPBLAS_R_32F && Tex == HIPBLAS_R_32F)
         {
             // scnrm2
-            return TEST<hipblasComplex, float, float>{}(arg);
+            return TEST<std::complex<float>, float, float>{}(arg);
         }
         else if(Ta == HIPBLAS_C_64F && Tx == HIPBLAS_R_64F && Tex == HIPBLAS_R_64F)
         {
             // dznrm2
-            return TEST<hipblasDoubleComplex, double, double>{}(arg);
+            return TEST<std::complex<double>, double, double>{}(arg);
         }
     }
     else if(is_rot)
@@ -195,13 +195,13 @@ auto hipblas_blas1_ex_dispatch(const Arguments& arg)
            && Tex == HIPBLAS_C_32F)
         {
             // rot with complex x/y/compute and real cs
-            return TEST<hipblasComplex, hipblasComplex, float, hipblasComplex>{}(arg);
+            return TEST<std::complex<float>, std::complex<float>, float, std::complex<float>>{}(arg);
         }
         else if(Ta == HIPBLAS_C_64F && Tx == HIPBLAS_C_64F && Ty == HIPBLAS_R_64F
                 && Tex == HIPBLAS_C_64F)
         {
             // rot with complex x/y/compute and real cs
-            return TEST<hipblasDoubleComplex, hipblasDoubleComplex, double, hipblasDoubleComplex>{}(
+            return TEST<std::complex<double>, std::complex<double>, double, std::complex<double>>{}(
                 arg);
         }
     }
@@ -223,22 +223,22 @@ auto hipblas_rot_dispatch(const Arguments& arg)
     else if(Ta == HIPBLAS_C_32F && Tb == HIPBLAS_R_32F && Tc == Tb)
     {
         // csrot
-        return TEST<hipblasComplex, float, float>{}(arg);
+        return TEST<std::complex<float>, float, float>{}(arg);
     }
     else if(Ta == HIPBLAS_C_64F && Tb == HIPBLAS_R_64F && Tc == Tb)
     {
         // zdrot
-        return TEST<hipblasDoubleComplex, double, double>{}(arg);
+        return TEST<std::complex<double>, double, double>{}(arg);
     }
     else if(Ta == HIPBLAS_C_32F && Tb == HIPBLAS_R_32F && Tc == Ta)
     {
         // crot
-        return TEST<hipblasComplex, float, hipblasComplex>{}(arg);
+        return TEST<std::complex<float>, float, std::complex<float>>{}(arg);
     }
     else if(Ta == HIPBLAS_C_64F && Tb == HIPBLAS_R_64F && Tc == Ta)
     {
         // zrot
-        return TEST<hipblasDoubleComplex, double, hipblasDoubleComplex>{}(arg);
+        return TEST<std::complex<double>, double, std::complex<double>>{}(arg);
     }
 
     return TEST<void>{}(arg);

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -195,7 +195,8 @@ auto hipblas_blas1_ex_dispatch(const Arguments& arg)
            && Tex == HIPBLAS_C_32F)
         {
             // rot with complex x/y/compute and real cs
-            return TEST<std::complex<float>, std::complex<float>, float, std::complex<float>>{}(arg);
+            return TEST<std::complex<float>, std::complex<float>, float, std::complex<float>>{}(
+                arg);
         }
         else if(Ta == HIPBLAS_C_64F && Tx == HIPBLAS_C_64F && Ty == HIPBLAS_R_64F
                 && Tex == HIPBLAS_C_64F)

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -84,10 +84,10 @@ HIPBLAS_CLANG_STATIC constexpr double
     hipblas_type_epsilon<double> = std::numeric_limits<double>::epsilon();
 template <>
 HIPBLAS_CLANG_STATIC constexpr double
-    hipblas_type_epsilon<hipblasComplex> = std::numeric_limits<float>::epsilon();
+    hipblas_type_epsilon<std::complex<float>> = std::numeric_limits<float>::epsilon();
 template <>
 HIPBLAS_CLANG_STATIC constexpr double
-    hipblas_type_epsilon<hipblasDoubleComplex> = std::numeric_limits<double>::epsilon();
+    hipblas_type_epsilon<std::complex<double>> = std::numeric_limits<double>::epsilon();
 template <>
 HIPBLAS_CLANG_STATIC constexpr double hipblas_type_epsilon<
     hipblasHalf> = 0.0009765625; // in fp16 diff between 0x3C00 (1.0) and fp16 0x3C01
@@ -174,12 +174,22 @@ public:
     }
 
     // Random NaN Complex
-    explicit operator hipblasComplex()
+    explicit operator std::complex<float>()
     {
         return {float(*this), float(*this)};
     }
 
     // Random NaN Double Complex
+    explicit operator std::complex<double>()
+    {
+        return {double(*this), double(*this)};
+    }
+
+    explicit operator hipblasComplex()
+    {
+        return {float(*this), float(*this)};
+    }
+
     explicit operator hipblasDoubleComplex()
     {
         return {double(*this), double(*this)};
@@ -258,18 +268,18 @@ inline hipblasBfloat16 random_generator<hipblasBfloat16>()
         float((rand() % 3 + 1))); // generate an integer number in range [1,2,3]
 }
 
-// for hipblasComplex, generate 2 floats
+// for std::complex<float>, generate 2 floats
 /*! \brief  generate two random numbers in range [1,2,3,4,5,6,7,8,9,10] */
 template <>
-inline hipblasComplex random_generator<hipblasComplex>()
+inline std::complex<float> random_generator<std::complex<float>>()
 {
     return {float(rand() % 10 + 1), float(rand() % 10 + 1)};
 }
 
-// for hipblasDoubleComplex, generate 2 doubles
+// for std::complex<double>, generate 2 doubles
 /*! \brief  generate two random numbers in range [1,2,3,4,5,6,7,8,9,10] */
 template <>
-inline hipblasDoubleComplex random_generator<hipblasDoubleComplex>()
+inline std::complex<double> random_generator<std::complex<double>>()
 {
     return {double(rand() % 10 + 1), double(rand() % 10 + 1)};
 }
@@ -303,13 +313,13 @@ inline hipblasBfloat16 random_generator_negative<hipblasBfloat16>()
 *           imaginary value in range [-1, -10]
 */
 template <>
-inline hipblasComplex random_generator_negative<hipblasComplex>()
+inline std::complex<float> random_generator_negative<std::complex<float>>()
 {
     return {float(-(rand() % 10 + 1)), float(-(rand() % 10 + 1))};
 }
 
 template <>
-inline hipblasDoubleComplex random_generator_negative<hipblasDoubleComplex>()
+inline std::complex<double> random_generator_negative<std::complex<double>>()
 {
     return {double(-(rand() % 10 + 1)), double(-(rand() % 10 + 1))};
 }


### PR DESCRIPTION
Client-side changes in prep for removing hipblas_v2 API. Uses std::complex for everything client-side, and cast to hipblasComplex when calling hipblas API. Client-side changes should then be minimal when switching to hipComplex types.