### PR TITLE
Docs: Fix broken links to hipblas-common

### DIFF
--- a/docs/reference/hipblas-api-functions.rst
+++ b/docs/reference/hipblas-api-functions.rst
@@ -147,7 +147,7 @@ hipBLAS types
 *************
 
 For information about the ``hipblasStatus_t``, ``hipblasComputeType_t``, and ``hipblasOperation_t`` enumerations,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 Definitions
 ===========
@@ -189,13 +189,13 @@ hipblasStatus_t
 -----------------
 
 For information about ``hipblasStatus_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 hipblasOperation_t
 ------------------
 
 For information about ``hipblasOperation_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 
 hipblasPointerMode_t
@@ -218,7 +218,7 @@ hipblasComputeType_t
 --------------------
 
 For information about ``hipblasComputeType_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 
 hipblasGemmAlgo_t


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- Fixed some broken links in reference/hipblas-api-functions.htm to hipblas-common. They were pointing to a page that did not exist.
- The links now point to https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h
-
