### PR TITLE
remove mf16c and use C++11 _Float16

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -72,9 +72,6 @@ if (NOT WIN32)
     target_link_libraries( hipblas-bench PRIVATE hipblas_fortran_client )
 endif()
 
-# need mf16c flag for float->half convertion
-target_compile_options( hipblas-bench PRIVATE -mf16c ) # -Wno-deprecated-declarations )
-
 target_compile_options(hipblas-bench PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COMMON_CXX_OPTIONS}>)
 
 target_compile_definitions( hipblas-bench PRIVATE HIPBLAS_BENCH ${COMMON_DEFINES} ${BLIS_DEFINES} )

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -331,15 +331,15 @@ void ref_axpy<hipblasHalf, hipblasHalf>(int64_t            n,
 
     for(size_t i = 0; i < n; i++)
     {
-        x_float[i * abs_incx] = half_to_float(x[i * abs_incx]);
-        y_float[i * abs_incy] = half_to_float(y[i * abs_incy]);
+        x_float[i * abs_incx] = float(x[i * abs_incx]);
+        y_float[i * abs_incy] = float(y[i * abs_incy]);
     }
 
-    cblas_saxpy(n, half_to_float(alpha), x_float.data(), incx, y_float.data(), incy);
+    cblas_saxpy(n, float(alpha), x_float.data(), incx, y_float.data(), incy);
 
     for(size_t i = 0; i < n; i++)
     {
-        y[i * abs_incy] = float_to_half(y_float[i * abs_incy]);
+        y[i * abs_incy] = hipblasHalf(y_float[i * abs_incy]);
     }
 }
 
@@ -354,15 +354,15 @@ void ref_axpy<float, hipblasHalf>(
 
     for(size_t i = 0; i < n; i++)
     {
-        x_float[i * abs_incx] = half_to_float(x[i * abs_incx]);
-        y_float[i * abs_incy] = half_to_float(y[i * abs_incy]);
+        x_float[i * abs_incx] = float(x[i * abs_incx]);
+        y_float[i * abs_incy] = float(y[i * abs_incy]);
     }
 
     cblas_saxpy(n, alpha, x_float.data(), incx, y_float.data(), incy);
 
     for(size_t i = 0; i < n; i++)
     {
-        y[i * abs_incy] = float_to_half(y_float[i * abs_incy]);
+        y[i * abs_incy] = hipblasHalf(y_float[i * abs_incy]);
     }
 }
 
@@ -438,12 +438,12 @@ void ref_scal<hipblasHalf>(int64_t n, const hipblasHalf alpha, hipblasHalf* x, i
     std::vector<float> x_float(n * incx);
 
     for(size_t i = 0; i < n; i++)
-        x_float[i * incx] = half_to_float(x[i * incx]);
+        x_float[i * incx] = float(x[i * incx]);
 
-    cblas_sscal(n, half_to_float(alpha), x_float.data(), incx);
+    cblas_sscal(n, float(alpha), x_float.data(), incx);
 
     for(size_t i = 0; i < n; i++)
-        x[i * incx] = float_to_half(x_float[i * incx]);
+        x[i * incx] = hipblasHalf(x_float[i * incx]);
 }
 
 template <>
@@ -475,12 +475,12 @@ void ref_scal<hipblasHalf, float>(int64_t n, const float alpha, hipblasHalf* x, 
     std::vector<float> x_float(n * incx);
 
     for(size_t i = 0; i < n; i++)
-        x_float[i * incx] = half_to_float(x[i * incx]);
+        x_float[i * incx] = float(x[i * incx]);
 
     cblas_sscal(n, alpha, x_float.data(), incx);
 
     for(size_t i = 0; i < n; i++)
-        x[i * incx] = float_to_half(x_float[i * incx]);
+        x[i * incx] = hipblasHalf(x_float[i * incx]);
 }
 
 template <>
@@ -621,10 +621,10 @@ void ref_dot<hipblasHalf>(int64_t            n,
 
     for(size_t i = 0; i < n; i++)
     {
-        x_float[i * abs_incx] = half_to_float(x[i * abs_incx]);
-        y_float[i * abs_incy] = half_to_float(y[i * abs_incy]);
+        x_float[i * abs_incx] = float(x[i * abs_incx]);
+        y_float[i * abs_incy] = float(y[i * abs_incy]);
     }
-    *result = float_to_half(cblas_sdot(n, x_float.data(), incx, y_float.data(), incy));
+    *result = hipblasHalf(cblas_sdot(n, x_float.data(), incx, y_float.data(), incy));
 }
 
 template <>
@@ -759,9 +759,9 @@ void ref_nrm2<hipblasHalf, hipblasHalf>(int64_t            n,
     std::vector<float> x_float(n * incx);
 
     for(size_t i = 0; i < n; i++)
-        x_float[i * incx] = half_to_float(x[i * incx]);
+        x_float[i * incx] = float(x[i * incx]);
 
-    *result = float_to_half(cblas_snrm2(n, x_float.data(), incx));
+    *result = hipblasHalf(cblas_snrm2(n, x_float.data(), incx));
 }
 
 template <>
@@ -872,19 +872,19 @@ void ref_rot<hipblasHalf>(int64_t      n,
 
     for(size_t i = 0; i < n; i++)
     {
-        x_float[i * abs_incx] = half_to_float(x[i * abs_incx]);
-        y_float[i * abs_incy] = half_to_float(y[i * abs_incy]);
+        x_float[i * abs_incx] = float(x[i * abs_incx]);
+        y_float[i * abs_incy] = float(y[i * abs_incy]);
     }
 
-    const float c_float = half_to_float(c);
-    const float s_float = half_to_float(s);
+    const float c_float = float(c);
+    const float s_float = float(s);
 
     cblas_srot(n, x_float.data(), incx, y_float.data(), incy, c_float, s_float);
 
     for(size_t i = 0; i < n; i++)
     {
-        x[i * abs_incx] = float_to_half(x_float[i * abs_incx]);
-        y[i * abs_incy] = float_to_half(y_float[i * abs_incy]);
+        x[i * abs_incx] = hipblasHalf(x_float[i * abs_incx]);
+        y[i * abs_incy] = hipblasHalf(y_float[i * abs_incy]);
     }
 }
 
@@ -2629,8 +2629,8 @@ void ref_gemm<hipblasHalf>(hipblasOperation_t transA,
 {
     // cblas does not support hipblasHalf, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
-    float alpha_float = half_to_float(alpha);
-    float beta_float  = half_to_float(beta);
+    float alpha_float = float(alpha);
+    float beta_float  = float(beta);
 
     size_t sizeA = transA == HIPBLAS_OP_N ? size_t(k) * lda : size_t(m) * lda;
     size_t sizeB = transB == HIPBLAS_OP_N ? size_t(n) * ldb : size_t(k) * ldb;
@@ -2642,15 +2642,15 @@ void ref_gemm<hipblasHalf>(hipblasOperation_t transA,
 
     for(size_t i = 0; i < sizeA; i++)
     {
-        A_float[i] = half_to_float(A[i]);
+        A_float[i] = float(A[i]);
     }
     for(size_t i = 0; i < sizeB; i++)
     {
-        B_float[i] = half_to_float(B[i]);
+        B_float[i] = float(B[i]);
     }
     for(size_t i = 0; i < sizeC; i++)
     {
-        C_float[i] = half_to_float(C[i]);
+        C_float[i] = float(C[i]);
     }
 
     // just directly cast, since transA, transB are integers in the enum
@@ -2672,7 +2672,7 @@ void ref_gemm<hipblasHalf>(hipblasOperation_t transA,
 
     for(size_t i = 0; i < sizeC; i++)
     {
-        C[i] = float_to_half(C_float[i]);
+        C[i] = hipblasHalf(C_float[i]);
     }
 }
 
@@ -2704,15 +2704,15 @@ void ref_gemm<hipblasHalf, hipblasHalf, float>(hipblasOperation_t transA,
 
     for(size_t i = 0; i < sizeA; i++)
     {
-        A_float[i] = half_to_float(A[i]);
+        A_float[i] = float(A[i]);
     }
     for(size_t i = 0; i < sizeB; i++)
     {
-        B_float[i] = half_to_float(B[i]);
+        B_float[i] = float(B[i]);
     }
     for(size_t i = 0; i < sizeC; i++)
     {
-        C_float[i] = half_to_float(C[i]);
+        C_float[i] = float(C[i]);
     }
 
     // just directly cast, since transA, transB are integers in the enum
@@ -2734,7 +2734,7 @@ void ref_gemm<hipblasHalf, hipblasHalf, float>(hipblasOperation_t transA,
 
     for(size_t i = 0; i < sizeC; i++)
     {
-        C[i] = float_to_half(C_float[i]);
+        C[i] = hipblasHalf(C_float[i]);
     }
 }
 
@@ -2764,11 +2764,11 @@ void ref_gemm<hipblasHalf, float, float>(hipblasOperation_t transA,
 
     for(size_t i = 0; i < sizeA; i++)
     {
-        A_float[i] = half_to_float(A[i]);
+        A_float[i] = float(A[i]);
     }
     for(size_t i = 0; i < sizeB; i++)
     {
-        B_float[i] = half_to_float(B[i]);
+        B_float[i] = float(B[i]);
     }
 
     // just directly cast, since transA, transB are integers in the enum

--- a/clients/common/near.cpp
+++ b/clients/common/near.cpp
@@ -76,7 +76,7 @@
 
 #endif
 
-#define NEAR_ASSERT_HALF(a, b, err) ASSERT_NEAR(half_to_float(a), half_to_float(b), err)
+#define NEAR_ASSERT_HALF(a, b, err) ASSERT_NEAR(float(a), float(b), err)
 #define NEAR_ASSERT_BF16(a, b, err) ASSERT_NEAR(bfloat16_to_float(a), bfloat16_to_float(b), err)
 
 #define NEAR_ASSERT_COMPLEX(a, b, err)          \

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -74,7 +74,7 @@
 
 #endif // GOOGLE_TEST
 
-#define ASSERT_HALF_EQ(a, b) ASSERT_FLOAT_EQ(half_to_float(a), half_to_float(b))
+#define ASSERT_HALF_EQ(a, b) ASSERT_FLOAT_EQ(float(a), float(b))
 #define ASSERT_BFLOAT16_EQ(a, b) ASSERT_FLOAT_EQ(bfloat16_to_float(a), bfloat16_to_float(b))
 
 #define ASSERT_FLOAT_COMPLEX_EQ(a, b)        \

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -144,9 +144,6 @@ if (NOT WIN32)
     target_link_libraries( hipblas-test PRIVATE hipblas_fortran_client )
 endif()
 
-# need mf16c flag for float->half convertion
-target_compile_options( hipblas-test PRIVATE -mf16c ) # -Wno-deprecated-declarations )
-
 target_compile_options(hipblas-test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COMMON_CXX_OPTIONS}>)
 
 target_compile_definitions( hipblas-test PRIVATE ${COMMON_DEFINES} )

--- a/clients/include/argument_model.hpp
+++ b/clients/include/argument_model.hpp
@@ -34,6 +34,12 @@ namespace ArgumentLogging
     const double NA_value = -1.0; // invalid for time, GFlop, GB
 }
 
+// iostream operator << does not print _Float16. Overload << to cast from _Float16 to float
+std::ostream& operator<<(std::ostream& os, const _Float16& value) {
+    os << float(value);
+    return os;
+}
+
 // these aren't static as ArgumentModel is instantiated for many Arg lists
 void ArgumentModel_set_log_function_name(bool f);
 bool ArgumentModel_get_log_function_name();

--- a/clients/include/blas3/testing_gemm.hpp
+++ b/clients/include/blas3/testing_gemm.hpp
@@ -82,7 +82,7 @@ void testing_gemm_bad_arg(const Arguments& arg)
     Ts               h_alpha{1}, h_beta{2}, h_one{1}, h_zero{0};
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
-        h_one = float_to_half(1.0f);
+        h_one = hipblasHalf(1.0f);
     else if constexpr(is_complex<T>)
         h_one = {1, 0};
 

--- a/clients/include/blas3/testing_gemm_batched.hpp
+++ b/clients/include/blas3/testing_gemm_batched.hpp
@@ -86,7 +86,7 @@ void testing_gemm_batched_bad_arg(const Arguments& arg)
     Ts               h_alpha{1}, h_beta{2}, h_one{1}, h_zero{0};
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
-        h_one = float_to_half(1.0f);
+        h_one = hipblasHalf(1.0f);
     else if constexpr(is_complex<T>)
         h_one = {1, 0};
 

--- a/clients/include/blas3/testing_gemm_strided_batched.hpp
+++ b/clients/include/blas3/testing_gemm_strided_batched.hpp
@@ -92,7 +92,7 @@ void testing_gemm_strided_batched_bad_arg(const Arguments& arg)
     Ts               h_alpha{1}, h_beta{2}, h_one{1}, h_zero{0};
 
     if constexpr(std::is_same_v<T, hipblasHalf>)
-        h_one = float_to_half(1.0f);
+        h_one = hipblasHalf(1.0f);
     else if constexpr(is_complex<T>)
         h_one = {1, 0};
 

--- a/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -100,7 +100,7 @@ void testing_gemm_batched_ex_bad_arg(const Arguments& arg)
     Ts                 h_alpha{1}, h_beta{2}, h_one{1}, h_zero{0};
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
-        h_one = float_to_half(1.0f);
+        h_one = hipblasHalf(1.0f);
     else if constexpr(is_complex<Tex>)
         h_one = {1, 0};
 

--- a/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -98,7 +98,7 @@ void testing_gemm_ex_bad_arg(const Arguments& arg)
     Ts                 h_alpha{1}, h_beta{2}, h_one{1}, h_zero{0};
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
-        h_one = float_to_half(1.0f);
+        h_one = hipblasHalf(1.0f);
     else if constexpr(is_complex<Tex>)
         h_one = {1, 0};
 

--- a/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -108,7 +108,7 @@ void testing_gemm_strided_batched_ex_bad_arg(const Arguments& arg)
     Ts                 h_alpha{1}, h_beta{2}, h_one{1}, h_zero{0};
 
     if constexpr(std::is_same_v<Tex, hipblasHalf>)
-        h_one = float_to_half(1.0f);
+        h_one = hipblasHalf(1.0f);
     else if constexpr(is_complex<Tex>)
         h_one = {1, 0};
 

--- a/clients/include/hipblas_arguments.hpp
+++ b/clients/include/hipblas_arguments.hpp
@@ -88,7 +88,7 @@ inline hipblasBfloat16 convert_alpha_beta<hipblasBfloat16>(double r, double i)
 template <>
 inline hipblasHalf convert_alpha_beta<hipblasHalf>(double r, double i)
 {
-    return float_to_half(r);
+    return hipblasHalf(r);
 }
 
 template <>

--- a/clients/include/type_utils.h
+++ b/clients/include/type_utils.h
@@ -71,16 +71,6 @@ inline bool hipblas_isnan(std::complex<double> arg)
     return std::isnan(arg.real()) || std::isnan(arg.imag());
 }
 
-inline hipblasHalf float_to_half(float val)
-{
-#ifdef HIPBLAS_USE_HIP_HALF
-    return __float2half(val);
-#else
-    uint16_t a = _cvtss_sh(val, 0);
-    return a;
-#endif
-}
-
 inline float bfloat16_to_float(hipblasBfloat16 bf)
 {
     union
@@ -111,15 +101,6 @@ inline hipblasBfloat16 float_to_bfloat16(float f)
     return rv;
 }
 
-inline float half_to_float(hipblasHalf val)
-{
-#ifdef HIPBLAS_USE_HIP_HALF
-    return __half2float(val);
-#else
-    return _cvtsh_ss(val);
-#endif
-}
-
 /* =============================================================================================== */
 /* Absolute values                                                                                 */
 // template <typename T>
@@ -131,7 +112,7 @@ inline float half_to_float(hipblasHalf val)
 // template <>
 // inline double hipblas_abs(const hipblasHalf& x)
 // {
-//     return std::abs(half_to_float(x));
+//     return std::abs(float(x));
 // }
 
 // template <>

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -257,7 +257,7 @@ inline T random_nan_generator()
 template <>
 inline hipblasHalf random_generator<hipblasHalf>()
 {
-    return float_to_half(float((rand() % 3 + 1))); // generate an integer number in range [1,2,3]
+    return hipblasHalf(float((rand() % 3 + 1))); // generate an integer number in range [1,2,3]
 };
 
 // for hipblasBfloat16, generate float, and convert to hipblasBfloat16
@@ -297,7 +297,7 @@ inline T random_generator_negative()
 template <>
 inline hipblasHalf random_generator_negative<hipblasHalf>()
 {
-    return float_to_half(-float((rand() % 3 + 1)));
+    return hipblasHalf(-float((rand() % 3 + 1)));
 };
 
 // for hipblasBfloat16, generate float, and convert to hipblasBfloat16
@@ -345,7 +345,7 @@ template <>
 inline hipblasHalf random_hpl_generator()
 {
     return hipblasHalf(
-        float_to_half(std::uniform_real_distribution<float>(-0.5f, 0.5f)(hipblas_rng)));
+        hipblasHalf(std::uniform_real_distribution<float>(-0.5f, 0.5f)(hipblas_rng)));
 }
 
 /* ============================================================================================= */

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -71,9 +71,6 @@ if(HIP_PLATFORM STREQUAL amd)
   target_compile_options(hipblas-example-bfdot-hip-bfloat16 PRIVATE -DHIPBLAS_USE_HIP_BFLOAT16)
 endif()
 
-target_compile_options( hipblas-example-hgemm-half PRIVATE -DHIPBLAS_USE_HIP_HALF )
-target_compile_options( hipblas-example-gemmEx PRIVATE -DHIPBLAS_USE_HIP_HALF )
-
 # HIP on Windows: xhip is required with clang++ to get __half defined
 if ( WIN32 )
 target_compile_options( hipblas-example-hgemm-half PRIVATE -xhip )
@@ -90,7 +87,7 @@ foreach( exe IN LISTS hipblas-example-executables)
 
   target_include_directories( ${exe} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> )
 
-  target_compile_options( ${exe} PRIVATE -mf16c -DHIPBLAS_BFLOAT16_CLASS )
+  target_compile_options( ${exe} PRIVATE -DHIPBLAS_BFLOAT16_CLASS )
   target_compile_definitions( ${exe} PRIVATE HIPBLAS_NO_DEPRECATED_WARNINGS )
 
   target_link_libraries( ${exe} PRIVATE roc::hipblas )

--- a/clients/samples/example_gemm_ex.cpp
+++ b/clients/samples/example_gemm_ex.cpp
@@ -79,13 +79,13 @@ void mat_mat_mult_hpa_half(float   alpha,
                            int     M,
                            int     N,
                            int     K,
-                           __half* A,
+                           _Float16* A,
                            size_t  As1,
                            size_t  As2,
-                           __half* B,
+                           _Float16* B,
                            size_t  Bs1,
                            size_t  Bs2,
-                           __half* C,
+                           _Float16* C,
                            size_t  Cs1,
                            size_t  Cs2)
 {
@@ -96,14 +96,14 @@ void mat_mat_mult_hpa_half(float   alpha,
         for(int i2 = 0; i2 < N; i2++)
         {
             float t     = 0.0;
-            float C_val = __half2float(C[i1 * Cs1 + i2 * Cs2]);
+            float C_val = float(C[i1 * Cs1 + i2 * Cs2]);
             for(int i3 = 0; i3 < K; i3++)
             {
-                float A_val = __half2float(A[i1 * As1 + i3 * As2]);
-                float B_val = __half2float(B[i3 * Bs1 + i2 * Bs2]);
+                float A_val = float(A[i1 * As1 + i3 * As2]);
+                float B_val = float(B[i3 * Bs1 + i2 * Bs2]);
                 t += A_val * B_val;
             }
-            C[i1 * Cs1 + i2 * Cs2] = __float2half(beta_float * C_val + alpha_float * t);
+            C[i1 * Cs1 + i2 * Cs2] = _Float16(beta_float * C_val + alpha_float * t);
         }
     }
 }
@@ -120,7 +120,7 @@ int main()
     hipblasGemmAlgo_t algo = HIPBLAS_GEMM_DEFAULT;
 
     // HPA
-    using T                           = __half;
+    using T                           = _Float16;
     using Tex                         = float;
     hipDataType          a_type       = HIP_R_16F;
     hipDataType          b_type       = HIP_R_16F;
@@ -176,15 +176,15 @@ int main()
     for(int i = 0; i < size_a; ++i)
     {
         // random number in [-2, 2]
-        ha[i] = __float2half(rand() % 5 - 2.0f);
+        ha[i] = _Float16(rand() % 5 - 2.0f);
     }
     for(int i = 0; i < size_b; ++i)
     {
-        hb[i] = __float2half(rand() % 5 - 2.0f);
+        hb[i] = _Float16(rand() % 5 - 2.0f);
     }
     for(int i = 0; i < size_c; ++i)
     {
-        hc[i] = __float2half(rand() % 5 - 2.0f);
+        hc[i] = _Float16(rand() % 5 - 2.0f);
     }
     hc_gold = hc;
 
@@ -250,8 +250,8 @@ int main()
 
     for(int i = 0; i < size_c; i++)
     {
-        float hc_gold_val    = __half2float(hc_gold[i]);
-        float hc_val         = __half2float(hc[i]);
+        float hc_gold_val    = float(hc_gold[i]);
+        float hc_val         = float(hc[i]);
         float relative_error = hc_gold_val == 0 ? std::abs(hc_gold_val - hc_val)
                                                 : (hc_gold_val - hc_val) / hc_gold_val;
         relative_error       = relative_error > 0 ? relative_error : -relative_error;

--- a/clients/samples/example_hgemm_hip_half.cpp
+++ b/clients/samples/example_hgemm_hip_half.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2016-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -74,36 +74,36 @@
 #define DIM2 1024
 #define DIM3 1025
 
-void mat_mat_mult_half(__half  alpha,
-                       __half  beta,
+void mat_mat_mult_half(_Float16  alpha,
+                       _Float16  beta,
                        int     M,
                        int     N,
                        int     K,
-                       __half* A,
+                       _Float16* A,
                        int     As1,
                        int     As2,
-                       __half* B,
+                       _Float16* B,
                        int     Bs1,
                        int     Bs2,
-                       __half* C,
+                       _Float16* C,
                        int     Cs1,
                        int     Cs2)
 {
-    float beta_float  = __half2float(beta);
-    float alpha_float = __half2float(alpha);
+    float beta_float  = float(beta);
+    float alpha_float = float(alpha);
     for(int i1 = 0; i1 < M; i1++)
     {
         for(int i2 = 0; i2 < N; i2++)
         {
             float t     = 0.0;
-            float C_val = __half2float(C[i1 * Cs1 + i2 * Cs2]);
+            float C_val = float(C[i1 * Cs1 + i2 * Cs2]);
             for(int i3 = 0; i3 < K; i3++)
             {
-                float A_val = __half2float(A[i1 * As1 + i3 * As2]);
-                float B_val = __half2float(B[i3 * Bs1 + i2 * Bs2]);
+                float A_val = float(A[i1 * As1 + i3 * As2]);
+                float B_val = float(B[i3 * Bs1 + i2 * Bs2]);
                 t += A_val * B_val;
             }
-            C[i1 * Cs1 + i2 * Cs2] = __float2half(beta_float * C_val + alpha_float * t);
+            C[i1 * Cs1 + i2 * Cs2] = _Float16(beta_float * C_val + alpha_float * t);
         }
     }
 }
@@ -111,12 +111,12 @@ void mat_mat_mult_half(__half  alpha,
 int main()
 {
     hipblasOperation_t transa = HIPBLAS_OP_N, transb = HIPBLAS_OP_T;
-    const __half       alpha = 1.1, beta = 0.9;
+    const _Float16       alpha = 1.1, beta = 0.9;
 
     int m = DIM1, n = DIM2, k = DIM3;
     int lda, ldb, ldc, size_a, size_b, size_c;
     int a_stride_1, a_stride_2, b_stride_1, b_stride_2;
-    std::cout << "hgemm __half example" << std::endl;
+    std::cout << "hgemm _Float16 example" << std::endl;
     if(transa == HIPBLAS_OP_N)
     {
         lda        = m;
@@ -153,38 +153,38 @@ int main()
     size_c = n * ldc;
 
     // Naming: da is in GPU (device) memory. ha is in CPU (host) memory
-    std::vector<__half> ha(size_a);
-    std::vector<__half> hb(size_b);
-    std::vector<__half> hc(size_c);
-    std::vector<__half> hc_gold(size_c);
+    std::vector<_Float16> ha(size_a);
+    std::vector<_Float16> hb(size_b);
+    std::vector<_Float16> hc(size_c);
+    std::vector<_Float16> hc_gold(size_c);
 
     // initial data on host
     srand(1);
     for(int i = 0; i < size_a; ++i)
     {
         // random number in [-2, 2]
-        ha[i] = __float2half(rand() % 5 - 2.0f);
+        ha[i] = _Float16(rand() % 5 - 2.0f);
     }
     for(int i = 0; i < size_b; ++i)
     {
-        hb[i] = __float2half(rand() % 5 - 2.0f);
+        hb[i] = _Float16(rand() % 5 - 2.0f);
     }
     for(int i = 0; i < size_c; ++i)
     {
-        hc[i] = __float2half(rand() % 5 - 2.0f);
+        hc[i] = _Float16(rand() % 5 - 2.0f);
     }
     hc_gold = hc;
 
     // allocate memory on device
-    __half *da, *db, *dc;
-    CHECK_HIP_ERROR(hipMalloc(&da, size_a * sizeof(__half)));
-    CHECK_HIP_ERROR(hipMalloc(&db, size_b * sizeof(__half)));
-    CHECK_HIP_ERROR(hipMalloc(&dc, size_c * sizeof(__half)));
+    _Float16 *da, *db, *dc;
+    CHECK_HIP_ERROR(hipMalloc(&da, size_a * sizeof(_Float16)));
+    CHECK_HIP_ERROR(hipMalloc(&db, size_b * sizeof(_Float16)));
+    CHECK_HIP_ERROR(hipMalloc(&dc, size_c * sizeof(_Float16)));
 
     // copy matrices from host to device
-    CHECK_HIP_ERROR(hipMemcpy(da, ha.data(), sizeof(__half) * size_a, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(db, hb.data(), sizeof(__half) * size_b, hipMemcpyHostToDevice));
-    CHECK_HIP_ERROR(hipMemcpy(dc, hc.data(), sizeof(__half) * size_c, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(da, ha.data(), sizeof(_Float16) * size_a, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(db, hb.data(), sizeof(_Float16) * size_b, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(dc, hc.data(), sizeof(_Float16) * size_c, hipMemcpyHostToDevice));
 
     hipblasHandle_t handle;
     CHECK_HIPBLAS_ERROR(hipblasCreate(&handle));
@@ -193,7 +193,7 @@ int main()
         hipblasHgemm(handle, transa, transb, m, n, k, &alpha, da, lda, db, ldb, &beta, dc, ldc));
 
     // copy output from device to CPU
-    CHECK_HIP_ERROR(hipMemcpy(hc.data(), dc, sizeof(__half) * size_c, hipMemcpyDeviceToHost));
+    CHECK_HIP_ERROR(hipMemcpy(hc.data(), dc, sizeof(_Float16) * size_c, hipMemcpyDeviceToHost));
 
     std::cout << "m, n, k, lda, ldb, ldc = " << m << ", " << n << ", " << k << ", " << lda << ", "
               << ldb << ", " << ldc << std::endl;
@@ -218,8 +218,8 @@ int main()
 
     for(int i = 0; i < size_c; i++)
     {
-        float hc_gold_val = __half2float(hc_gold[i]);
-        float hc_val      = __half2float(hc[i]);
+        float hc_gold_val = float(hc_gold[i]);
+        float hc_val      = float(hc[i]);
         float relative_error
             = hc_gold_val == 0 ? (hc_gold_val - hc_val) : (hc_gold_val - hc_val) / hc_gold_val;
         relative_error = relative_error > 0 ? relative_error : -relative_error;

--- a/clients/samples/example_scal_ex.cpp
+++ b/clients/samples/example_scal_ex.cpp
@@ -79,7 +79,7 @@ int main()
     // Testing scalEx with alpha_type == x_type == f16_r; execution_type = f32_r
     int             N = 10240;
     hipblasStatus_t status;
-    hipblasHalf     alpha = float_to_half(10.0f);
+    hipblasHalf     alpha = hipblasHalf(10.0f);
 
     // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory, plz follow this practice
     std::vector<hipblasHalf> hx(N);
@@ -128,13 +128,13 @@ int main()
     bool error_in_element = false;
     for(int i = 0; i < N; i++)
     {
-        hipblasHalf cpu_res = float_to_half(half_to_float(hz[i]) * half_to_float(alpha));
+        hipblasHalf cpu_res = hipblasHalf(float(hz[i]) * float(alpha));
         if(cpu_res != hx[i])
         {
             printf("error in element %d: CPU=%f, GPU=%f ",
                    i,
-                   half_to_float(cpu_res),
-                   half_to_float(hx[i]));
+                   float(cpu_res),
+                   float(hx[i]));
             error_in_element = true;
             break;
         }

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -100,18 +100,7 @@
 /*! \brief hipblasHanlde_t is a void pointer, to store the library context (either rocBLAS or cuBLAS)*/
 typedef void* hipblasHandle_t;
 
-/*! \brief To specify the datatype to be unsigned short */
-
-#if __cplusplus < 201103L || !defined(HIPBLAS_USE_HIP_HALF)
-
-typedef uint16_t hipblasHalf;
-
-#else
-
-#include <hip/hip_fp16.h>
-typedef __half hipblasHalf;
-
-#endif
+typedef _Float16 hipblasHalf;
 
 /*! \brief  To specify the datatype to be signed char */
 typedef int8_t hipblasInt8;


### PR DESCRIPTION
- rocBLAS uses the _Float16 datatype added in C++11
- hipblasHalf was using typedef to either 
  - __half from HIP
  - uint16_t
- it was using the compile flag -mf16c and the functions _cvtss_sh() and _cvtss_sh() to convert from float_to_half and half_to_float
- **This PR removes** 
  -**mf16c flag**
  -**use of _cvtss_sh() and _cvtss_sh()**
- One complication is that iostream cannot process _Float16, so the iostream operator << is overloaded in file clients/include/argument_model.hpp. The overload casts from _Float16 to float.
