### PR TITLE
Use permalink for hipblas-common.h link

### DIFF
--- a/docs/reference/hipblas-api-functions.rst
+++ b/docs/reference/hipblas-api-functions.rst
@@ -147,7 +147,7 @@ hipBLAS types
 *************
 
 For information about the ``hipblasStatus_t``, ``hipblasComputeType_t``, and ``hipblasOperation_t`` enumerations,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/dfc946b9d56773f44cd107facd2f1cfafcc5b52f/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 Definitions
 ===========


### PR DESCRIPTION
When providing links to files in other projects provide a permalink rather than referencing a branch etc. There are no guarantees that files will never move. To get a permalink navigate to the file in github for the given branch/release/etc and then press "y" and the url will change to a permalink. 