### PR TITLE
Cherry-pick to release/rocm-rel-6.4: Docs: Fix broken links to hipblas-common

### DIFF
--- a/docs/reference/hipblas-api-functions.rst
+++ b/docs/reference/hipblas-api-functions.rst
@@ -183,7 +183,7 @@ hipBLAS types
 *************
 
 For information about the ``hipblasStatus_t``, ``hipblasComputeType_t``, and ``hipblasOperation_t`` enumerations,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
+see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/hipBLAS-common>`_ repository.
 
 Definitions
 ===========
@@ -224,13 +224,13 @@ hipblasStatus_t
 -----------------
 
 For information about ``hipblasStatus_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
+see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/hipBLAS-common>`_ repository.
 
 hipblasOperation_t
 ------------------
 
 For information about ``hipblasOperation_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
+see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/hipBLAS-common>`_ repository.
 
 
 hipblasPointerMode_t
@@ -257,7 +257,7 @@ hipblasComputeType_t
 --------------------
 
 For information about ``hipblasComputeType_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
+see ``hipblas-common.h`` in the `hipBLAS-common GitHub <https://github.com/ROCm/hipBLAS-common>`_ repository.
 
 
 hipblasGemmAlgo_t

--- a/docs/reference/hipblas-api-functions.rst
+++ b/docs/reference/hipblas-api-functions.rst
@@ -183,7 +183,7 @@ hipBLAS types
 *************
 
 For information about the ``hipblasStatus_t``, ``hipblasComputeType_t``, and ``hipblasOperation_t`` enumerations,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 Definitions
 ===========
@@ -224,13 +224,13 @@ hipblasStatus_t
 -----------------
 
 For information about ``hipblasStatus_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 hipblasOperation_t
 ------------------
 
 For information about ``hipblasOperation_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 
 hipblasPointerMode_t
@@ -257,7 +257,7 @@ hipblasComputeType_t
 --------------------
 
 For information about ``hipblasComputeType_t``,
-see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common.h>`_ GitHub repository.
+see the `hipblas-common <https://github.com/ROCm/hipBLAS-common/blob/develop/library/include/hipblas-common/hipblas-common.h>`_ GitHub repository.
 
 
 hipblasGemmAlgo_t


### PR DESCRIPTION
resolves #___

Summary of proposed changes:
- Fixed some broken links in reference/hipblas-api-functions.htm to hipblas-common. They were pointing to a page that did not exist.
- I am now just linking to the repository root (https://github.com/ROCm/hipBLAS-common)
- To make the cherry-pick process work, I first picked https://github.com/ROCm/hipBLAS/pull/997, then https://github.com/ROCm/hipBLAS/pull/998