### PR TITLE
Check if ROCBLAS_PATH var is set before using it.

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -192,7 +192,11 @@ if (WIN32)
     add_custom_command( TARGET hipblas-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging/ )
   endforeach( file_i )
 
-  add_custom_command( TARGET hipblas-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory ${ROCBLAS_PATH}/bin/rocblas/library/ ${PROJECT_BINARY_DIR}/staging/library/)
+  if(DEFINED ${ROCBLAS_PATH})
+    add_custom_command( TARGET hipblas-test POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_directory ${ROCBLAS_PATH}/bin/rocblas/library/ ${PROJECT_BINARY_DIR}/staging/library/)
+  else()
+    message(WARNING "ROCBLAS_PATH not set, tests may be missing .dlls")
+  endif()
 endif()
 
 set_target_properties( hipblas-test PROPERTIES


### PR DESCRIPTION
resolves https://github.com/ROCm/TheRock/issues/530

Summary of proposed changes:
- Check if ROCBLAS_PATH var is set before using it for gtest, otherwise report an error
