### PR TITLE
Install `libhipblas_fortran.so`

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -54,6 +54,7 @@ set (hipblas_f90_source
 # Create hipBLAS Fortran module
 if(NOT WIN32)
     add_library(hipblas_fortran ${hipblas_f90_source})
+    rocm_install(TARGETS hipblas_fortran)
 endif()
 
 if(BUILD_ADDRESS_SANITIZER)


### PR DESCRIPTION
This is required by the test and benchmark clients but was not part of the installation so far.