### PR TITLE
Change dep on `roc::hipblas-common` to PUBLIC.

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -70,7 +70,7 @@ add_library( roc::hipblas ALIAS hipblas )
 set(static_depends)
 
 find_package( hipblas-common REQUIRED CONFIG PATHS ${ROCM_PATH})
-target_link_libraries( hipblas INTERFACE roc::hipblas-common )
+target_link_libraries( hipblas PUBLIC roc::hipblas-common )
 
 # Build hipblas from source on AMD platform
 if(HIP_PLATFORM STREQUAL amd)


### PR DESCRIPTION
This was INTERFACE, but the library internally includes `hipblas-common.h`, which means that is should be PUBLIC (which is a superset of INTERFACE like PRIVATE+INTERFACE, advertising the dep to dependents and using its requirements to compile the library itself).

There is some work ongoing on the upstream projects which tightened requirements for this dep, causing something that was accidentally working to fail. This change should be forward+backward compatible with that work.
