### PR TITLE
explicit install rpath with ORIGIN

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -58,6 +58,18 @@ function( get_cblas cblas_libs cblas_inc )
   set( ${cblas_libs} ${libs} PARENT_SCOPE )
 endfunction( )
 
+function( apply_omp_settings lib_target_ )
+  if (TARGET OpenMP::OpenMP_CXX)
+    set_target_properties( ${lib_target_} PROPERTIES
+      BUILD_RPATH "${HIP_CLANG_ROOT}/lib"
+    )
+    set_target_properties( ${lib_target_} PROPERTIES
+      INSTALL_RPATH "$ORIGIN/../llvm/lib"
+    )
+  endif()
+endfunction()
+
+
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
 if( WIN32 )
@@ -123,7 +135,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     if(HIP_PLATFORM STREQUAL amd)
       list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
       if (NOT WIN32)
-        list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib -lomp")
+        list( APPEND COMMON_LINK_LIBS "-lomp")
       else()
         list( APPEND COMMON_LINK_LIBS "libomp")
       endif()

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -80,6 +80,8 @@ target_compile_options(hipblas-bench PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COMMON_
 target_compile_definitions( hipblas-bench PRIVATE HIPBLAS_BENCH ${COMMON_DEFINES} ${BLIS_DEFINES} )
 
 target_link_libraries( hipblas-bench PRIVATE ${BLAS_LIBRARY} ${COMMON_LINK_LIBS} )
+apply_omp_settings( hipblas-bench )
+
 if (NOT WIN32)
     target_link_libraries( hipblas-bench PRIVATE stdc++fs )
 endif()

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -152,6 +152,8 @@ target_compile_options(hipblas-test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COMMON_C
 target_compile_definitions( hipblas-test PRIVATE ${COMMON_DEFINES} )
 
 target_link_libraries( hipblas-test PRIVATE ${BLAS_LIBRARY} ${COMMON_LINK_LIBS} )
+apply_omp_settings( hipblas-test )
+
 if (NOT WIN32)
     target_link_libraries( hipblas-test PRIVATE stdc++fs )
 endif()


### PR DESCRIPTION
* avoid packaging errors for invalid RUNPATH
* just a test for now as properties rely on llvm openmp
