### PR TITLE
ci: remove junit step from test stage

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -69,7 +69,6 @@ def runTestCommand (platform, project)
                     popd
                 """
     platform.runCommand(this, yamlTestCommand)
-    junit "${stagingDir}/*.xml"
 }
 
 def runCoverageCommand (platform, project, String cmdDir = "release-debug")


### PR DESCRIPTION
attempt to resolve Math CI job running indefinitely

Summary of proposed changes:
- remove junit step from test stage for Math CI


