### PR TITLE
define macro HIPBLAS_V2, it was used in hipblasVersionMajor==2 for de…

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -25861,6 +25861,7 @@ HIPBLAS_EXPORT const char* hipblasStatusToString(hipblasStatus_t status);
 #endif
 
 // Macros used before hipBLAS version 3.0
+#define HIPBLAS_V2
 #define HIPBLAS_R_16F HIP_R_16F
 #define HIPBLAS_R_32F HIP_R_32F
 #define HIPBLAS_R_64F HIP_R_64F

--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -25861,7 +25861,9 @@ HIPBLAS_EXPORT const char* hipblasStatusToString(hipblasStatus_t status);
 #endif
 
 // Macros used before hipBLAS version 3.0
+#ifndef HIPBLAS_V2
 #define HIPBLAS_V2
+#endif
 #define HIPBLAS_R_16F HIP_R_16F
 #define HIPBLAS_R_32F HIP_R_32F
 #define HIPBLAS_R_64F HIP_R_64F


### PR DESCRIPTION
- define HIPBLAS_V2 in case other projects are using it in a condition like:
```
#if defined(USE_ROCM) && ((ROCM_VERSION_MAJOR == 6 && defined(HIPBLAS_V2)) || ROCM_VERSION_MAJOR >= 7)
```