### PR TITLE
cherry-pick addition of HIPBLAS_V2

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -25861,6 +25861,9 @@ HIPBLAS_EXPORT const char* hipblasStatusToString(hipblasStatus_t status);
 #endif
 
 // Macros used before hipBLAS version 3.0
+#ifndef HIPBLAS_V2
+#define HIPBLAS_V2
+#endif
 #define HIPBLAS_R_16F HIP_R_16F
 #define HIPBLAS_R_32F HIP_R_32F
 #define HIPBLAS_R_64F HIP_R_64F


### PR DESCRIPTION
- cherry pick addition of macro HIPBLAS_V2 to hipblas.h
- This could have been used in cpp logic like
```
#if defined(USE_ROCM) && ROCM_VERSION >= 60000 && defined(HIPBLAS_V2)
  //use hipBLAS version 3 API
#else
  // use hipBLAS API before version 3
# endif
```
It would be more correct to use
```
#if (defined HIPBLAS_V2 && hipblasVersionMajor == 2) || hipblasVersionMajor >= 3
  //use hipBLAS version 3 API
#else
  // use hipBLAS API before version 3
# endif
```
