### PR TITLE
Include necessary header file

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -38,6 +38,7 @@
 #include <hip/hip_runtime_api.h>
 #include <hip/library_types.h>
 #include <hipblas-common/hipblas-common.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __HIP_PLATFORM_NVCC__


### PR DESCRIPTION
resolves # [SWDEV-539079](https://ontrack-internal.amd.com/browse/SWDEV-539079)

Summary of proposed changes:
- include stddef.h. Earlier stddef.h was coming through hip header files, which has been cleanup now as part of 7.0 breaking changes.
