### PR TITLE
include stddef for offsetof

### DIFF
--- a/library/include/hipblas.h
+++ b/library/include/hipblas.h
@@ -39,6 +39,7 @@
 #include <hip/library_types.h>
 #include <hipblas-common/hipblas-common.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __HIP_PLATFORM_NVCC__
 #include <cublas_v2.h>


### PR DESCRIPTION
- the c function offsetof is defined in stddef.h
- this function offsetof is used in library/include/hipblas.h
- include stddef.h in hipblas.h to provide the definition for offsetof
