### PR TITLE
Openmp cmake config

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -58,6 +58,18 @@ function( get_cblas cblas_libs cblas_inc )
   set( ${cblas_libs} ${libs} PARENT_SCOPE )
 endfunction( )
 
+function( apply_omp_settings lib_target_ )
+  if (TARGET OpenMP::OpenMP_CXX)
+    set_target_properties( ${lib_target_} PROPERTIES
+      BUILD_RPATH "${HIP_CLANG_ROOT}/lib"
+    )
+    set_target_properties( ${lib_target_} PROPERTIES
+      INSTALL_RPATH "$ORIGIN/../llvm/lib"
+    )
+  endif()
+endfunction()
+
+
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
 if( WIN32 )
@@ -123,7 +135,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
     if(HIP_PLATFORM STREQUAL amd)
       list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
       if (NOT WIN32)
-        list( APPEND COMMON_LINK_LIBS "-Wl,-rpath=${HIP_CLANG_ROOT}/lib -lomp")
+        list( APPEND COMMON_LINK_LIBS "-lomp")
       else()
         list( APPEND COMMON_LINK_LIBS "libomp")
       endif()

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -66,6 +66,13 @@ function( apply_omp_settings lib_target_ )
     set_target_properties( ${lib_target_} PROPERTIES
       INSTALL_RPATH "$ORIGIN/../llvm/lib"
     )
+  elseif(TARGET OpenMP::omp)
+    set_target_properties( ${lib_target_} PROPERTIES
+      BUILD_RPATH "${HIP_CLANG_ROOT}/${openmp_LIB_DIR}"
+    )
+    set_target_properties( ${lib_target_} PROPERTIES
+      INSTALL_RPATH "$ORIGIN/../llvm/${openmp_LIB_DIR}"
+    )
   endif()
 endfunction()
 
@@ -126,18 +133,25 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
 
-  # if it fails to find OpenMP compile and link flags in strange configurations it can just use non-parallel reference computation
-  # if there is no omp.h to find the client compilation will fail and this should be obvious, used to be REQUIRED
-  find_package(OpenMP)
+  # Look for openmp config in ROCm install to populate openmp_LIB_DIR and openmp_LIB_INSTALL_DIR
+  find_package(OpenMP CONFIG PATHS "${HIP_CLANG_ROOT}/lib/cmake")
 
-  if (TARGET OpenMP::OpenMP_CXX)
-    set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
-    if(HIP_PLATFORM STREQUAL amd)
-      list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
-      if (NOT WIN32)
-        list( APPEND COMMON_LINK_LIBS "-lomp")
-      else()
-        list( APPEND COMMON_LINK_LIBS "libomp")
+  if (TARGET OpenMP::omp)
+    set( COMMON_LINK_LIBS "OpenMP::omp")
+    message(STATUS "Found openmp-config.cmake at ${OpenMP_DIR}")
+  else()
+    # if it fails to find OpenMP compile and link flags in strange configurations it can just use non-parallel reference computation
+    # if there is no omp.h to find the client compilation will fail and this should be obvious, used to be REQUIRED
+    find_package(OpenMP)
+    if (TARGET OpenMP::OpenMP_CXX)
+      set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
+      if(HIP_PLATFORM STREQUAL amd)
+        list( APPEND COMMON_LINK_LIBS "-L\"${HIP_CLANG_ROOT}/lib\"")
+        if (NOT WIN32)
+          list( APPEND COMMON_LINK_LIBS "-lomp")
+        else()
+          list( APPEND COMMON_LINK_LIBS "libomp")
+        endif()
       endif()
     endif()
   endif()

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -80,6 +80,8 @@ target_compile_options(hipblas-bench PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COMMON_
 target_compile_definitions( hipblas-bench PRIVATE HIPBLAS_BENCH ${COMMON_DEFINES} ${BLIS_DEFINES} )
 
 target_link_libraries( hipblas-bench PRIVATE ${BLAS_LIBRARY} ${COMMON_LINK_LIBS} )
+apply_omp_settings( hipblas-bench )
+
 if (NOT WIN32)
     target_link_libraries( hipblas-bench PRIVATE stdc++fs )
 endif()

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -152,6 +152,8 @@ target_compile_options(hipblas-test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${COMMON_C
 target_compile_definitions( hipblas-test PRIVATE ${COMMON_DEFINES} )
 
 target_link_libraries( hipblas-test PRIVATE ${BLAS_LIBRARY} ${COMMON_LINK_LIBS} )
+apply_omp_settings( hipblas-test )
+
 if (NOT WIN32)
     target_link_libraries( hipblas-test PRIVATE stdc++fs )
 endif()


### PR DESCRIPTION
Summary of proposed changes:
- First search for ROCm's libomp.so via openmp-config.cmake. This is what we would prefer instead of searching for a system libomp.so/libgomp.so and then manually adding in a ROCm lib path.
- This methodology should still be RHEL-10 RPATH compliant.
- This patch is applied ontop of #1015 
