### PR TITLE
fix warning: explicit specialization cannot have a storage class (#1039)

### DIFF
--- a/clients/include/hipblas_arguments.hpp
+++ b/clients/include/hipblas_arguments.hpp
@@ -356,14 +356,14 @@ enum hipblas_argument : int
 namespace ArgumentsHelper
 {
     template <hipblas_argument>
-    static constexpr auto apply = nullptr;
+    inline constexpr auto apply = nullptr;
 
     // Macro defining specializations for specific arguments
     // e_alpha, e_beta, and datatypes get turned into negative sentinel value specializations
     // clang-format off
 #define APPLY(NAME)                                                                         \
     template <>                                                                             \
-    HIPBLAS_CLANG_STATIC constexpr auto                                                     \
+    inline constexpr auto                                                     \
         apply<e_##NAME == e_alpha ? hipblas_argument(-1)                                    \
                                   : e_##NAME == e_beta ? hipblas_argument(-2)               \
                                   : e_##NAME == e_a_type ? hipblas_argument(-3)             \
@@ -379,45 +379,45 @@ namespace ArgumentsHelper
 
     // Specialization for e_alpha
     template <>
-    HIPBLAS_CLANG_STATIC constexpr auto apply<e_alpha> =
+    inline constexpr auto apply<e_alpha> =
         [](auto&& func, const Arguments& arg, auto T) {
             func("alpha", arg.get_alpha<decltype(T)>());
         };
 
     // Specialization for e_beta
     template <>
-    HIPBLAS_CLANG_STATIC constexpr auto apply<e_beta> =
+    inline constexpr auto apply<e_beta> =
         [](auto&& func, const Arguments& arg, auto T) {
             func("beta", arg.get_beta<decltype(T)>());
         };
 
     // Specialization for datatypes
     template <>
-    HIPBLAS_CLANG_STATIC constexpr auto apply<e_a_type> =
+    inline constexpr auto apply<e_a_type> =
         [](auto&& func, const Arguments& arg, auto T) {
             func("a_type", hip_datatype2string(arg.a_type));
         };
 
     template <>
-    HIPBLAS_CLANG_STATIC constexpr auto apply<e_b_type> =
+    inline constexpr auto apply<e_b_type> =
         [](auto&& func, const Arguments& arg, auto T) {
             func("b_type", hip_datatype2string(arg.b_type));
         };
 
     template <>
-    HIPBLAS_CLANG_STATIC constexpr auto apply<e_c_type> =
+    inline constexpr auto apply<e_c_type> =
         [](auto&& func, const Arguments& arg, auto T) {
             func("c_type", hip_datatype2string(arg.c_type));
         };
 
     template <>
-    HIPBLAS_CLANG_STATIC constexpr auto apply<e_d_type> =
+    inline constexpr auto apply<e_d_type> =
         [](auto&& func, const Arguments& arg, auto T) {
             func("d_type", hip_datatype2string(arg.d_type));
         };
 
     template <>
-    HIPBLAS_CLANG_STATIC constexpr auto apply<e_compute_type> =
+    inline constexpr auto apply<e_compute_type> =
         [](auto&& func, const Arguments& arg, auto T) {
             func("compute_type", hip_datatype2string(arg.compute_type));
         };

--- a/clients/include/near.h
+++ b/clients/include/near.h
@@ -81,55 +81,50 @@ void near_check_general(int64_t        M,
 
 // currently only used for half-precision comparisons in dot_ex tests
 template <class T>
-HIPBLAS_CLANG_STATIC constexpr double error_tolerance = 0.0;
+inline constexpr double error_tolerance = 0.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double error_tolerance<hipblasBfloat16> = 1 / 100.0;
+inline constexpr double error_tolerance<hipblasBfloat16> = 1 / 100.0;
 
 // 2 ^ -14, smallest positive normal number for IEEE16
 template <>
-HIPBLAS_CLANG_STATIC constexpr double error_tolerance<hipblasHalf> = 0.000061035;
+inline constexpr double error_tolerance<hipblasHalf> = 0.000061035;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double error_tolerance<std::complex<float>> = 1 / 10000.0;
+inline constexpr double error_tolerance<std::complex<float>> = 1 / 10000.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double error_tolerance<std::complex<double>> = 1 / 1000000.0;
+inline constexpr double error_tolerance<std::complex<double>> = 1 / 1000000.0;
 
 // currently only used for gemm_ex
 template <class Tc, class Ti, class To>
 static constexpr double sum_error_tolerance_for_gfx11 = 0.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
-    sum_error_tolerance_for_gfx11<float, hipblasBfloat16, float> = 1 / 10.0;
+inline constexpr double sum_error_tolerance_for_gfx11<float, hipblasBfloat16, float> = 1 / 10.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
+inline constexpr double
     sum_error_tolerance_for_gfx11<float, hipblasBfloat16, hipblasBfloat16> = 1 / 10.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
-    sum_error_tolerance_for_gfx11<float, hipblasHalf, float> = 1 / 100.0;
+inline constexpr double sum_error_tolerance_for_gfx11<float, hipblasHalf, float> = 1 / 100.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
-    sum_error_tolerance_for_gfx11<float, hipblasHalf, hipblasHalf> = 1 / 100.0;
+inline constexpr double sum_error_tolerance_for_gfx11<float, hipblasHalf, hipblasHalf> = 1 / 100.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
+inline constexpr double
     sum_error_tolerance_for_gfx11<hipblasHalf, hipblasHalf, hipblasHalf> = 1 / 100.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
-    sum_error_tolerance_for_gfx11<std::complex<float>,
-                                  std::complex<float>,
-                                  std::complex<float>> = 1 / 10000.0;
+inline constexpr double sum_error_tolerance_for_gfx11<std::complex<float>,
+                                                      std::complex<float>,
+                                                      std::complex<float>> = 1 / 10000.0;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
-    sum_error_tolerance_for_gfx11<std::complex<double>,
-                                  std::complex<double>,
-                                  std::complex<double>> = 1 / 1000000.0;
+inline constexpr double sum_error_tolerance_for_gfx11<std::complex<double>,
+                                                      std::complex<double>,
+                                                      std::complex<double>> = 1 / 1000000.0;
 
 #endif

--- a/clients/include/type_utils.h
+++ b/clients/include/type_utils.h
@@ -191,13 +191,13 @@ inline int64_t hipblas_abs(const int64_t& x)
 /* =============================================================================================== */
 /* Complex / real helpers.                                                                         */
 template <typename T>
-static constexpr bool is_complex = false;
+inline constexpr bool is_complex = false;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr bool is_complex<std::complex<float>> = true;
+inline constexpr bool is_complex<std::complex<float>> = true;
 
 template <>
-HIPBLAS_CLANG_STATIC constexpr bool is_complex<std::complex<double>> = true;
+inline constexpr bool is_complex<std::complex<double>> = true;
 
 // Get base types from complex types.
 template <typename T>

--- a/clients/include/utility.h
+++ b/clients/include/utility.h
@@ -75,24 +75,22 @@
 /* =============================================================================================== */
 /* Epsilon helpers for near checks.                                                                */
 template <typename>
-HIPBLAS_CLANG_STATIC constexpr double hipblas_type_epsilon = 0;
+inline constexpr double hipblas_type_epsilon = 0;
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
-    hipblas_type_epsilon<float> = std::numeric_limits<float>::epsilon();
+inline constexpr double hipblas_type_epsilon<float> = std::numeric_limits<float>::epsilon();
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
-    hipblas_type_epsilon<double> = std::numeric_limits<double>::epsilon();
+inline constexpr double hipblas_type_epsilon<double> = std::numeric_limits<double>::epsilon();
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
+inline constexpr double
     hipblas_type_epsilon<std::complex<float>> = std::numeric_limits<float>::epsilon();
 template <>
-HIPBLAS_CLANG_STATIC constexpr double
+inline constexpr double
     hipblas_type_epsilon<std::complex<double>> = std::numeric_limits<double>::epsilon();
 template <>
-HIPBLAS_CLANG_STATIC constexpr double hipblas_type_epsilon<
+inline constexpr double hipblas_type_epsilon<
     hipblasHalf> = 0.0009765625; // in fp16 diff between 0x3C00 (1.0) and fp16 0x3C01
 template <>
-HIPBLAS_CLANG_STATIC constexpr double hipblas_type_epsilon<
+inline constexpr double hipblas_type_epsilon<
     hipblasBfloat16> = 0.0078125; // in bf16 diff between 0x3F80 (1.0) and bf16 0x3F81 in double precision
 
 /* =============================================================================================== */


### PR DESCRIPTION
(cherry picked from commit 11257a8140301167a115c403948a10095f2c3807)


