### PR TITLE
Fix bench --help message, remove clients_common.cpp from gtest build unit

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -371,7 +371,7 @@ try
 
         ("workspace",
          value<size_t>(&arg.user_allocated_workspace)->default_value(0),
-         "Set workspace available in handle using xxblasSetWorkspace() API after handle creation"),
+         "Set workspace available in handle using xxblasSetWorkspace() API after handle creation")
 
         ("help,h", "produces this help message");
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -105,7 +105,6 @@ endif( )
 set( hipblas_test_common
   ../common/utility.cpp
   ../common/cblas_interface.cpp
-  ../common/clients_common.cpp
   ../common/norm.cpp
   ../common/unit.cpp
   ../common/near.cpp

--- a/clients/gtest/hipblas_gtest_main.cpp
+++ b/clients/gtest/hipblas_gtest_main.cpp
@@ -78,15 +78,6 @@ static void print_version_info()
     // clang-format on
 }
 
-int hipblas_test_datafile()
-{
-    int ret = 0;
-    for(Arguments arg : HipBLAS_TestData())
-        ret |= run_bench_test(arg, 1, 0);
-    test_cleanup::cleanup();
-    return ret;
-}
-
 using namespace testing;
 
 class ConfigurableEventListener : public TestEventListener


### PR DESCRIPTION
- Fixes --help/-h option for hipblas-bench
- Improves build time: removes unused `hipblas_test_datafile()` function, and thus can remove `clients_common.cpp` from hipblas-test compilation unit. Should probably move/rename clients_common.cpp to benchmark/ folder.

Times provided below for `./install.sh -c`.

On local ryzen9 3900x w/ ROCm 6.3:
| time | tip of develop | this PR |
| --- | --- | --- |
| real | 7m 1s | 2m 19s |
| user | 33m 13s | 27m 11s |
| sys | 40s | 38s |

On epyc 9354 (32 cores) w/ ROCm 7.0 (amdclang 20.0.0):
| time | tip of develop | this PR |
| --- | --- | --- |
| real | 7m 15s | 2m 8s |
| user | 30m 15s | 22m 55s |
| sys | 35s | 30s |

On same machine as above with ROCm 6.4 (amdclang 19.0.0):
| time | tip of develop | this PR |
| --- | --- | --- |
| real | 6m 32s | 1m 39s |
| user | 22m 19s | 15m 55s |
| sys | 32s | 28s |

