### PR TITLE
Disable dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,1 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/docs/sphinx" # Location of package manifests
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+    target-branch: "develop_deprecated"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Disables dependabot PRs

Summary of proposed changes:

- stops dependabot PRs for docs
- dependabot.yml is separate from the settings/advanced security config, but still has to be valid.
- similar to https://github.com/ROCm/rocBLAS/pull/1670